### PR TITLE
Add Travis build for Raspberry Pi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,7 +82,7 @@ script:
 # prepare qemu
 - docker run --rm --privileged multiarch/qemu-user-static:register --reset
 # build image
-- docker build -t rpi-raspbian .
+- docker build -t rpi-debian .
 # test image
 #- docker run rpi-raspbian
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,26 +53,38 @@ before_script:
     fi
 
 script:
-  # travis-wait seems to stop at 20 mins, regardless if output is being generated
-  - (while true ; do sleep 60 ; echo "ping" ; done ) &
   - cmake -E make_directory build
   - cmake -E chdir build cmake -DCMAKE_BUILD_TYPE=Release -DSWIG_MATLAB=$SWIG_MATLAB -DSWIG_PYTHON=$SWIG_PYTHON ..
-  - cmake --build build --target lint
-  - cmake --build build
+  - cmake --build build --target install --clean-first
   - cmake -E chdir build ctest --output-on-failure
-  - rm -r -f build
+  - rm -r build
+  - rm -r $HOME/local/lib
   - cmake -E make_directory build
   - cmake -E chdir build cmake -DCMAKE_TOOLCHAIN_FILE=cmake/Toolchain-mingw32.cmake ..
   - cmake --build build --clean-first
-  - rm -r -f build
+  - rm -r build
   - cmake -E make_directory build
   - cmake -E chdir build cmake -DCMAKE_BUILD_TYPE=Debug -DUNIT_TESTS=ON -DSWIG_MATLAB=$SWIG_MATLAB -DSWIG_PYTHON=$SWIG_PYTHON -DCOVERAGE=$COVERAGE ..
   - export CXX="$CXX -std=c++11" # needed for octave
-  - cmake --build build
+  - cmake --build build --target install --clean-first
+  - cmake --build build --target lint
   - cmake -E chdir build ctest --output-on-failure
-  - cmake --build build --target install
-  - python -c "import acados" # check installation
   - cmake --build build --target acados_coverage || echo "Coverage report not generated"
+  - pushd experimental/dang/esp32
+  - ./test_all_linux.sh
+
+# add testing for ARM Raspian
+sudo: required
+services:
+- docker
+language: bash
+script:
+# prepare qemu
+- docker run --rm --privileged multiarch/qemu-user-static:register --reset
+# build image
+- docker build -t resin/rpi-raspbian .
+# test image
+- docker run resin/rpi-raspbian
 
 after_success:
   - pushd build

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,9 +82,9 @@ script:
 # prepare qemu
 - docker run --rm --privileged multiarch/qemu-user-static:register --reset
 # build image
-- docker build -t resin/rpi-raspbian .
+- docker build -t rpi-raspbian .
 # test image
-- docker run resin/rpi-raspbian
+#- docker run rpi-raspbian
 
 after_success:
   - pushd build

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,12 @@ python:
   - 3.5
 
 env:
-  - CXX="g++-6" CC="gcc-6" SWIG_PYTHON=ON SWIG_MATLAB=OFF # no MATLAB support for gcc>=5
-  - CXX="g++-5" CC="gcc-5" SWIG_PYTHON=ON SWIG_MATLAB=OFF
-  - CXX="g++-4.9" CC="gcc-4.9" SWIG_PYTHON=ON SWIG_MATLAB=ON COVERAGE="lcov"
-  - CXX="clang++-3.7" CC="clang-3.7" SWIG_PYTHON=ON SWIG_MATLAB=ON
-
+  - PLATFORM="x86_64" CXX="g++-6" CC="gcc-6" SWIG_PYTHON=ON SWIG_MATLAB=OFF # no MATLAB support for gcc>=5
+  - PLATFORM="x86_64" CXX="g++-5" CC="gcc-5" SWIG_PYTHON=ON SWIG_MATLAB=OFF
+  - PLATFORM="x86_64" CXX="g++-4.9" CC="gcc-4.9" SWIG_PYTHON=ON SWIG_MATLAB=ON COVERAGE="lcov"
+  - PLATFORM="x86_64" CXX="clang++-3.7" CC="clang-3.7" SWIG_PYTHON=ON SWIG_MATLAB=ON
+  - PLATFORM="arm_rpi"
+ 
 addons:
   apt:
     sources:
@@ -20,6 +21,9 @@ addons:
 cache:
   directories:
     - /home/travis/octave_download/
+
+services:
+  - docker
 
 before_install:
   - echo "TRAVIS_REPO_SLUG=$TRAVIS_REPO_SLUG TRAVIS_PULL_REQUEST=$TRAVIS_PULL_REQUEST TRAVIS_BRANCH=$TRAVIS_BRANCH"
@@ -34,7 +38,7 @@ install:
       source download_encrypted_files.sh;
     fi'
   - popd
-  - travis_retry source .travis_install.sh
+  - if [ "$PLATFORM" == "x86_64" ]; then travis_retry source .travis_install.sh; fi
   - export MPLBACKEND=Agg # For matplotlib
   - export MATLABPATH=$HOME/local/lib:$MATLABPATH
   - export PYTHONPATH=$HOME/local/lib:$PYTHONPATH
@@ -44,49 +48,52 @@ before_script:
   - set -e
   - mkdir -p /home/travis/octave_download
   - |
-    if [ -z "$(ls -1qA /home/travis/octave_download)" ]; then
-      # directory empty
-      pushd /home/travis/octave_download
-      wget http://packages.octave.org/download/optim-1.5.2.tar.gz
-      wget http://packages.octave.org/download/struct-1.0.14.tar.gz
-      popd
+    if [ "$PLATFORM" == "x86_64" ]; then
+      if [ -z "$(ls -1qA /home/travis/octave_download)" ]; then
+        # directory empty
+        pushd /home/travis/octave_download
+        wget http://packages.octave.org/download/optim-1.5.2.tar.gz
+        wget http://packages.octave.org/download/struct-1.0.14.tar.gz
+        popd
+      fi
     fi
 
 script:
-  - cmake -E make_directory build
-  - cmake -E chdir build cmake -DCMAKE_BUILD_TYPE=Release -DSWIG_MATLAB=$SWIG_MATLAB -DSWIG_PYTHON=$SWIG_PYTHON ..
-  - cmake --build build --target install --clean-first
-  - cmake -E chdir build ctest --output-on-failure
-  - rm -r build
-  - rm -r $HOME/local/lib
-  - cmake -E make_directory build
-  - cmake -E chdir build cmake -DCMAKE_TOOLCHAIN_FILE=cmake/Toolchain-mingw32.cmake ..
-  - cmake --build build --clean-first
-  - rm -r build
-  - cmake -E make_directory build
-  - cmake -E chdir build cmake -DCMAKE_BUILD_TYPE=Debug -DUNIT_TESTS=ON -DSWIG_MATLAB=$SWIG_MATLAB -DSWIG_PYTHON=$SWIG_PYTHON -DCOVERAGE=$COVERAGE ..
-  - export CXX="$CXX -std=c++11" # needed for octave
-  - cmake --build build --target install --clean-first
-  - cmake --build build --target lint
-  - cmake -E chdir build ctest --output-on-failure
-  - cmake --build build --target acados_coverage || echo "Coverage report not generated"
-  - pushd experimental/dang/esp32
-  - ./test_all_linux.sh
-
-# add testing for ARM Raspian
-sudo: required
-services:
-- docker
-language: bash
-script:
-# prepare qemu
-- docker run --rm --privileged multiarch/qemu-user-static:register --reset
-# build image
-- docker build -t rpi-debian .
-# test image
-#- docker run rpi-raspbian
+  - |
+    if [ "$PLATFORM" == "x86_64" ]; then
+      cmake -E make_directory build
+      cmake -E chdir build cmake -DCMAKE_BUILD_TYPE=Release -DSWIG_MATLAB=$SWIG_MATLAB -DSWIG_PYTHON=$SWIG_PYTHON ..
+      cmake --build build --target install --clean-first
+      cmake -E chdir build ctest --output-on-failure
+      rm -r build
+      rm -r $HOME/local/lib
+      cmake -E make_directory build
+      cmake -E chdir build cmake -DCMAKE_TOOLCHAIN_FILE=cmake/Toolchain-mingw32.cmake ..
+      cmake --build build --clean-first
+      rm -r build
+      cmake -E make_directory build
+      cmake -E chdir build cmake -DCMAKE_BUILD_TYPE=Debug -DUNIT_TESTS=ON -DSWIG_MATLAB=$SWIG_MATLAB -DSWIG_PYTHON=$SWIG_PYTHON -DCOVERAGE=$COVERAGE ..
+      export CXX="$CXX -std=c++11" # needed for octave
+      cmake --build build --target install --clean-first
+      cmake --build build --target lint
+      cmake -E chdir build ctest --output-on-failure
+      cmake --build build --target acados_coverage || echo "Coverage report not generated"
+      # - pushd experimental/dang/esp32
+      # - ./test_all_linux.sh
+    fi
+  # build for ARM on Raspberry Pi with QEMU
+  - |
+    if [ "$PLATFORM" == "arm_rpi" ]; then
+      # prepare qemu
+      docker run --rm --privileged multiarch/qemu-user-static:register --reset
+      # build image
+      docker build -t rpi-debian .
+    fi
 
 after_success:
-  - pushd build
-  # Upload report to CodeCov
-  - if [ "$COVERAGE" == "lcov" ]; then bash <(curl -s https://codecov.io/bash); else echo "Codecov did not collect coverage reports"; fi
+  - |
+    if [ "$PLATFORM" == "x86_64" ]; then
+      pushd build
+      # Upload report to CodeCov
+      if [ "$COVERAGE" == "lcov" ]; then bash <(curl -s https://codecov.io/bash); else echo "Codecov did not collect coverage reports"; fi
+    fi

--- a/.travis_install.sh
+++ b/.travis_install.sh
@@ -3,6 +3,7 @@
 sudo add-apt-repository -y ppa:octave/stable
 sudo apt-get update -yqq
 sudo apt-get install -yqq $CXX $CC $COVERAGE libgsl0-dev liblapack-dev libopenblas-dev liboctave-dev mingw-w64 bsdtar
+sudo apt-get install qemu-user-static
 
 pip install numpy scipy matplotlib
 

--- a/.travis_install.sh
+++ b/.travis_install.sh
@@ -3,7 +3,6 @@
 sudo add-apt-repository -y ppa:octave/stable
 sudo apt-get update -yqq
 sudo apt-get install -yqq $CXX $CC $COVERAGE libgsl0-dev liblapack-dev libopenblas-dev liboctave-dev mingw-w64 bsdtar
-sudo apt-get install qemu-user-static
 
 pip install numpy scipy matplotlib
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+
+# Pull base image
+FROM resin/rpi-raspbian:jessie
+
+# Install dependencies
+RUN apt-get update && apt-get install -y \
+    python \
+    python-dev \
+    python-pip \
+    python-virtualenv \
+    --no-install-recommends && \
+    rm -rf /var/lib/apt/lists/*
+
+# Define working directory
+WORKDIR /data
+
+# Define default command
+CMD ["bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,24 @@
 # Pull base image
 FROM doanminhdang/rpi-debian-casadi:latest
 
-# Set PATH environment to let casadi and acados find swig
+# Set PATH environment to let casadi and acados find precompiled swig (duplicate)
 ENV PATH="/home/pi/acados/external/swig:${PATH}"
 
-ENV PYTHONPATH="${PYTHONPATH}:/usr/local/lib:/usr/local/python:~/local/lib"
+# Set PYTHONPATH environment for casadi and acados lib, note that user is root
+ENV PYTHONPATH="${PYTHONPATH}:/usr/local/lib:/usr/local/python:${HOME}/local/lib"
 
-# Compile acados
-RUN cd /home/pi/acados && \
-    mkdir build && \
+# Add current source to docker
+ADD . /app/acados/
+
+# Compile acados with Python interface
+RUN cd /app/acados && \
+    rm -rf build && mkdir build && \
     cd build && \
     cmake -D SWIG_MATLAB=0 -D SWIG_PYTHON=1 .. && \
     make install
 
-# Make port 22 available to the world outside this container
-EXPOSE 22
+# Test
+RUN python3 -c "import acados"
 
 # Define default command
 CMD ["bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Pull base image
-FROM doanminhdang/rpi-raspbian-casadi:jessie
+FROM doanminhdang/rpi-debian-casadi:latest
 
 # Set PATH environment to let casadi and acados find swig
 ENV PATH="/home/pi/acados/external/swig:${PATH}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,56 +1,8 @@
 # Pull base image
-FROM resin/rpi-raspbian:jessie
-
-# Install dependencies update apt
-RUN apt-get update && apt-get install -y --no-install-recommends apt-utils
-RUN apt-get install -qy build-essential \
-    gcc g++ \
-    libgsl0-dev \
-    liblapack-dev \
-    libopenblas-dev \
-    libeigen3-dev \
-    python3-tk \
-    automake \
-    libpcre3-dev \
-    git \
-    cmake \
-    python3-dev \
-    pkg-config
-RUN apt-get install byacc # swig
-RUN apt-get install python3-scipy python3-numpy python3-matplotlib
-RUN rm -rf /var/lib/apt/lists/*
-
-# Define working directory
-WORKDIR /home/pi
-
-RUN git clone https://github.com/casadi/casadi.git -b master casadi
-
-ADD . /home/pi/acados
-
-# Set Python to Python3
-RUN cd /usr/bin && ln -s python3 python
-
-RUN cd /home/pi/acados && git submodule update --recursive --init
-
-# Compile swig
-
-RUN cd /home/pi/acados/external/swig && \
-    ./autogen.sh && \
-    ./configure --prefix=$(pwd)/swig_install --enable-silent-rules && \
-    make && \
-    make install > /dev/null # quiet installation && \
-    export PATH=$(pwd):$PATH
+FROM doanminhdang/rpi-raspbian-casadi:jessie
 
 # Set PATH environment to let casadi and acados find swig
 ENV PATH="/home/pi/acados/external/swig:${PATH}"
-
-# Compile casadi
-RUN cd /home/pi/casadi && \
-    mkdir build && \
-    cd build && \
-    cmake -D WITH_PYTHON=ON .. && \
-    make && \
-    make install
 
 ENV PYTHONPATH="${PYTHONPATH}:/usr/local/lib:/usr/local/python:~/local/lib"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,68 @@
-
 # Pull base image
 FROM resin/rpi-raspbian:jessie
 
-# Install dependencies
-RUN apt-get update && apt-get install -y \
-    python \
-    python-dev \
-    python-pip \
-    python-virtualenv \
-    --no-install-recommends && \
-    rm -rf /var/lib/apt/lists/*
+# Install dependencies update apt
+RUN apt-get update && apt-get install -y --no-install-recommends apt-utils
+RUN apt-get install -qy build-essential \
+    gcc g++ \
+    libgsl0-dev \
+    liblapack-dev \
+    libopenblas-dev \
+    libeigen3-dev \
+    python3-tk \
+    automake \
+    libpcre3-dev \
+    git \
+    cmake \
+    python3-dev \
+    pkg-config
+RUN apt-get install byacc # swig
+RUN apt-get install python3-scipy python3-numpy python3-matplotlib
+RUN rm -rf /var/lib/apt/lists/*
 
 # Define working directory
-WORKDIR /data
+WORKDIR /home/pi
+
+RUN git clone https://github.com/casadi/casadi.git -b master casadi
+
+ADD . /home/pi/acados
+
+# Set Python to Python3
+RUN cd /usr/bin && ln -s python3 python
+
+RUN cd /home/pi/acados && git submodule update --recursive --init
+
+# Compile swig
+
+RUN cd /home/pi/acados/external/swig && \
+    ./autogen.sh && \
+    ./configure --prefix=$(pwd)/swig_install --enable-silent-rules && \
+    make && \
+    make install > /dev/null # quiet installation && \
+    export PATH=$(pwd):$PATH
+
+# Set PATH environment to let casadi and acados find swig
+ENV PATH="/home/pi/acados/external/swig:${PATH}"
+
+# Compile casadi
+RUN cd /home/pi/casadi && \
+    mkdir build && \
+    cd build && \
+    cmake -D WITH_PYTHON=ON .. && \
+    make && \
+    make install
+
+ENV PYTHONPATH="${PYTHONPATH}:/usr/local/lib:/usr/local/python:~/local/lib"
+
+# Compile acados
+RUN cd /home/pi/acados && \
+    mkdir build && \
+    cd build && \
+    cmake -D SWIG_MATLAB=0 -D SWIG_PYTHON=1 .. && \
+    make install
+
+# Make port 22 available to the world outside this container
+EXPOSE 22
 
 # Define default command
 CMD ["bash"]

--- a/experimental/dang/esp32/.gitignore
+++ b/experimental/dang/esp32/.gitignore
@@ -1,2 +1,6 @@
+example_projects
 chen_nmpc_qpoases
 ocp_qp_hpmpc
+mass_spring_hpmpc
+mass_spring_qpoases
+pendulum_partial_tightening


### PR DESCRIPTION
The build for ARM architecture in Raspberry Pi needs to be emulated with qemu, running on a docker container, because Travis only provides x86 machines.

Since it takes much more time to compile with qemu, the test build on Rpi is separated as a new build, with only support for Python. To save build time in order to fit in Travis limitation (50 minutes), steps in building swig and casadi on ARM Rpi was done before, and saved as a pullable docker image.

The Raspbian OS running with qemu introduced a segment fault when importing Casadi in Python (it could be something related to multi-threading stuff, but i don't know how to fix it). Hence, the Debian base image for Rpi was used instead (it is from Resin, they said to have some fix related to that segment fault issue, and Casadi on Python worked).
