### PR TITLE
added cpu timings to QP solvers

### DIFF
--- a/acados/dense_qp/dense_qp_common.c
+++ b/acados/dense_qp/dense_qp_common.c
@@ -72,7 +72,7 @@ int dense_qp_out_calculate_size(dense_qp_dims *dims)
 {
     int size = sizeof(dense_qp_out);
     size += d_memsize_dense_qp_sol(dims);
-
+    size += sizeof(dense_qp_info);
     return size;
 }
 
@@ -89,6 +89,9 @@ dense_qp_out *assign_dense_qp_out(dense_qp_dims *dims, void *raw_memory)
 
     d_create_dense_qp_sol(dims, qp_out, c_ptr);
     c_ptr += d_memsize_dense_qp_sol(dims);
+
+    qp_out->info = (void *) c_ptr;
+    c_ptr += sizeof(dense_qp_info);
 
     assert((char*)raw_memory + dense_qp_out_calculate_size(dims) == c_ptr);
 

--- a/acados/dense_qp/dense_qp_common.c
+++ b/acados/dense_qp/dense_qp_common.c
@@ -90,7 +90,7 @@ dense_qp_out *assign_dense_qp_out(dense_qp_dims *dims, void *raw_memory)
     d_create_dense_qp_sol(dims, qp_out, c_ptr);
     c_ptr += d_memsize_dense_qp_sol(dims);
 
-    qp_out->info = (void *) c_ptr;
+    qp_out->misc = (void *) c_ptr;
     c_ptr += sizeof(dense_qp_info);
 
     assert((char*)raw_memory + dense_qp_out_calculate_size(dims) == c_ptr);

--- a/acados/dense_qp/dense_qp_common.h
+++ b/acados/dense_qp/dense_qp_common.h
@@ -48,6 +48,13 @@ typedef struct {
 } dense_qp_solver;
 
 
+typedef struct {
+    double solve_QP_time;
+    double interface_time;
+    double total_time;
+} dense_qp_info;
+
+
 //
 int dense_qp_in_calculate_size(dense_qp_dims *dims);
 //

--- a/acados/dense_qp/dense_qp_qpoases.c
+++ b/acados/dense_qp/dense_qp_qpoases.c
@@ -166,7 +166,7 @@ int dense_qp_qpoases_calculate_workspace_size(dense_qp_dims *dims, void *args_)
 
 int dense_qp_qpoases(dense_qp_in *qp_in, dense_qp_out *qp_out, void *args_, void *memory_, void *work_)
 {
-    dense_qp_info *info = (dense_qp_info *) qp_out->info;
+    dense_qp_info *info = (dense_qp_info *) qp_out->misc;
     acados_timer tot_timer, qp_timer, interface_timer;
 
     acados_tic(&tot_timer);

--- a/acados/dense_qp/dense_qp_qpoases.c
+++ b/acados/dense_qp/dense_qp_qpoases.c
@@ -29,6 +29,7 @@
 #include "acados/dense_qp/dense_qp_qpoases.h"
 #include "acados/dense_qp/dense_qp_common.h"
 #include "acados/utils/mem.h"
+#include "acados/utils/timing.h"
 
 
 int dense_qp_qpoases_calculate_args_size(dense_qp_dims *dims)
@@ -165,6 +166,12 @@ int dense_qp_qpoases_calculate_workspace_size(dense_qp_dims *dims, void *args_)
 
 int dense_qp_qpoases(dense_qp_in *qp_in, dense_qp_out *qp_out, void *args_, void *memory_, void *work_)
 {
+    dense_qp_info *info = (dense_qp_info *) qp_out->info;
+    acados_timer tot_timer, qp_timer, interface_timer;
+
+    acados_tic(&tot_timer);
+    acados_tic(&interface_timer);
+
     // cast structures
     dense_qp_qpoases_args *args = (dense_qp_qpoases_args *)args_;
     dense_qp_qpoases_memory *memory = (dense_qp_qpoases_memory *)memory_;
@@ -235,6 +242,9 @@ int dense_qp_qpoases(dense_qp_in *qp_in, dense_qp_out *qp_out, void *args_, void
             dual_sol[ii] = 0;
     }
 
+    info->interface_time = acados_toc(&interface_timer);
+    acados_tic(&qp_timer);
+
     // solve dense qp
     int nwsr = args->max_nwsr;
     double cputime = args->max_cputime;
@@ -268,6 +278,9 @@ int dense_qp_qpoases(dense_qp_in *qp_in, dense_qp_out *qp_out, void *args_, void
     exit(1);
 #endif
 
+    info->solve_QP_time = acados_toc(&qp_timer);
+    acados_tic(&interface_timer);
+
     // copy prim_sol and dual_sol to qpd_sol
     d_cvt_vec2strvec(nvd, prim_sol, qp_out->v, 0);
     for (int ii = 0; ii < 2*nbd+2*ngd; ii++)
@@ -288,5 +301,15 @@ int dense_qp_qpoases(dense_qp_in *qp_in, dense_qp_out *qp_out, void *args_, void
     // return
     // TODO(dimitris): cast qpoases return to acados return
     acados_status = return_flag;
+
+    info->interface_time += acados_toc(&interface_timer);
+    info->total_time = acados_toc(&tot_timer);
+
+    // printf("total time = \t\t\t%f\n", 1000*info->total_time);
+    // printf("interface time = \t\t%f\n", 1000*info->interface_time);
+    // printf("qp time = \t\t\t%f\n", 1000*info->solve_QP_time);
+    // printf("total time from qpOASES = \t%f\n", 1000*cputime);  // does not include getSolution
+    // printf("**************\n");
+
     return acados_status;
 }

--- a/acados/ocp_qp/ocp_qp_common.c
+++ b/acados/ocp_qp/ocp_qp_common.c
@@ -102,7 +102,7 @@ ocp_qp_out *assign_ocp_qp_out(ocp_qp_dims *dims, void *raw_memory)
     d_create_ocp_qp_sol(dims, qp_out, c_ptr);
     c_ptr += d_memsize_ocp_qp_sol(dims);
 
-    qp_out->info = (void *) c_ptr;
+    qp_out->misc = (void *) c_ptr;
     c_ptr += sizeof(ocp_qp_info);
 
     assert((char*) raw_memory + ocp_qp_out_calculate_size(dims) == c_ptr);

--- a/acados/ocp_qp/ocp_qp_common.c
+++ b/acados/ocp_qp/ocp_qp_common.c
@@ -86,6 +86,7 @@ int ocp_qp_out_calculate_size(ocp_qp_dims *dims)
 {
     int size = sizeof(ocp_qp_out);
     size += d_memsize_ocp_qp_sol(dims);
+    size += sizeof(ocp_qp_info);
     return size;
 }
 
@@ -100,6 +101,9 @@ ocp_qp_out *assign_ocp_qp_out(ocp_qp_dims *dims, void *raw_memory)
 
     d_create_ocp_qp_sol(dims, qp_out, c_ptr);
     c_ptr += d_memsize_ocp_qp_sol(dims);
+
+    qp_out->info = (void *) c_ptr;
+    c_ptr += sizeof(ocp_qp_info);
 
     assert((char*) raw_memory + ocp_qp_out_calculate_size(dims) == c_ptr);
 

--- a/acados/ocp_qp/ocp_qp_common.h
+++ b/acados/ocp_qp/ocp_qp_common.h
@@ -71,6 +71,15 @@ typedef struct {
 } ocp_qp_xcond_solver;
 
 
+
+typedef struct {
+    double solve_QP_time;
+    double condensing_time;
+    double interface_time;
+    double total_time;
+} ocp_qp_info;
+
+
 //
 int ocp_qp_in_calculate_size(ocp_qp_dims *dims);
 //

--- a/acados/ocp_qp/ocp_qp_condensing_solver.c
+++ b/acados/ocp_qp/ocp_qp_condensing_solver.c
@@ -166,6 +166,7 @@ int ocp_qp_condensing_solver(ocp_qp_in *qp_in, ocp_qp_out *qp_out, void *args_, 
     acados_timer tot_timer, qp_timer, interface_timer, cond_timer;
     acados_tic(&tot_timer);
 
+    // cast data structures
     ocp_qp_condensing_solver_args *args = (ocp_qp_condensing_solver_args *) args_;
     ocp_qp_condensing_solver_memory *memory = (ocp_qp_condensing_solver_memory *) mem_;
     ocp_qp_condensing_solver_workspace *work = (ocp_qp_condensing_solver_workspace *) work_;

--- a/acados/ocp_qp/ocp_qp_condensing_solver.c
+++ b/acados/ocp_qp/ocp_qp_condensing_solver.c
@@ -26,8 +26,9 @@
 #include "acados/ocp_qp/ocp_qp_condensing.h"
 #include "acados/ocp_qp/ocp_qp_common.h"
 #include "acados/dense_qp/dense_qp_common.h"
-#include "acados/utils/types.h"
 #include "acados/utils/mem.h"
+#include "acados/utils/timing.h"
+#include "acados/utils/types.h"
 
 
 int ocp_qp_condensing_solver_calculate_args_size(ocp_qp_dims *dims, void *solver_)
@@ -161,20 +162,30 @@ int ocp_qp_condensing_solver_calculate_workspace_size(ocp_qp_dims *dims, void *a
 
 int ocp_qp_condensing_solver(ocp_qp_in *qp_in, ocp_qp_out *qp_out, void *args_, void *mem_, void *work_)
 {
+    ocp_qp_info *info = (ocp_qp_info *)qp_out->info;
+    acados_timer tot_timer, qp_timer, interface_timer, cond_timer;
+    acados_tic(&tot_timer);
+
     ocp_qp_condensing_solver_args *args = (ocp_qp_condensing_solver_args *) args_;
     ocp_qp_condensing_solver_memory *memory = (ocp_qp_condensing_solver_memory *) mem_;
-    // TODO(dimitris): also assign workspace once it contains data that need to be casted..
     ocp_qp_condensing_solver_workspace *work = (ocp_qp_condensing_solver_workspace *) work_;
 
     // condense
+    acados_tic(&cond_timer);
     ocp_qp_condensing(qp_in, memory->qpd_in, args->cond_args, memory->cond_memory, work->cond_work);
+    info->condensing_time = acados_toc(&cond_timer);
 
     // solve qp
     int solver_status = args->solver->fun(memory->qpd_in, memory->qpd_out, args->solver_args, memory->solver_memory, work->solver_workspace);
 
     // expand
+    acados_tic(&cond_timer);
     ocp_qp_expansion(memory->qpd_out, qp_out, args->cond_args, memory->cond_memory, work->cond_work);
+    info->condensing_time += acados_toc(&cond_timer);
 
+    info->total_time = acados_toc(&tot_timer);
+    info->solve_QP_time = ((dense_qp_info *)(memory->qpd_out->info))->solve_QP_time;
+    info->interface_time = ((dense_qp_info *)(memory->qpd_out->info))->interface_time;
     // return
     return solver_status;
 }

--- a/acados/ocp_qp/ocp_qp_condensing_solver.c
+++ b/acados/ocp_qp/ocp_qp_condensing_solver.c
@@ -162,7 +162,7 @@ int ocp_qp_condensing_solver_calculate_workspace_size(ocp_qp_dims *dims, void *a
 
 int ocp_qp_condensing_solver(ocp_qp_in *qp_in, ocp_qp_out *qp_out, void *args_, void *mem_, void *work_)
 {
-    ocp_qp_info *info = (ocp_qp_info *)qp_out->info;
+    ocp_qp_info *info = (ocp_qp_info *)qp_out->misc;
     acados_timer tot_timer, qp_timer, interface_timer, cond_timer;
     acados_tic(&tot_timer);
 
@@ -184,8 +184,8 @@ int ocp_qp_condensing_solver(ocp_qp_in *qp_in, ocp_qp_out *qp_out, void *args_, 
     info->condensing_time += acados_toc(&cond_timer);
 
     info->total_time = acados_toc(&tot_timer);
-    info->solve_QP_time = ((dense_qp_info *)(memory->qpd_out->info))->solve_QP_time;
-    info->interface_time = ((dense_qp_info *)(memory->qpd_out->info))->interface_time;
+    info->solve_QP_time = ((dense_qp_info *)(memory->qpd_out->misc))->solve_QP_time;
+    info->interface_time = ((dense_qp_info *)(memory->qpd_out->misc))->interface_time;
     // return
     return solver_status;
 }

--- a/acados/ocp_qp/ocp_qp_hpipm.c
+++ b/acados/ocp_qp/ocp_qp_hpipm.c
@@ -26,6 +26,7 @@
 // acados
 #include "acados/ocp_qp/ocp_qp_common.h"
 #include "acados/ocp_qp/ocp_qp_hpipm.h"
+#include "acados/utils/timing.h"
 #include "acados/utils/types.h"
 #include "acados/utils/mem.h"
 
@@ -138,8 +139,18 @@ int ocp_qp_hpipm_calculate_workspace_size(ocp_qp_dims *dims, void *args_)
 
 int ocp_qp_hpipm(ocp_qp_in *qp_in, ocp_qp_out *qp_out, void *args_, void *mem_, void *work_)
 {
+    ocp_qp_info *info = (ocp_qp_info *) qp_out->misc;
+    acados_timer tot_timer, qp_timer, interface_timer;
+
+    acados_tic(&tot_timer);
+    acados_tic(&interface_timer);
+
+    // cast data structures
     ocp_qp_hpipm_args *args = (ocp_qp_hpipm_args *) args_;
     ocp_qp_hpipm_memory *memory = (ocp_qp_hpipm_memory *) mem_;
+
+    info->interface_time = acados_toc(&interface_timer);
+    acados_tic(&qp_timer);
 
     // initialize return code
     int acados_status = ACADOS_SUCCESS;
@@ -147,6 +158,9 @@ int ocp_qp_hpipm(ocp_qp_in *qp_in, ocp_qp_out *qp_out, void *args_, void *mem_, 
     int hpipm_status = d_solve_ocp_qp_ipm(qp_in, qp_out, args->hpipm_args, memory->hpipm_workspace);
 
     // printf("HPIPM iter = %d\n", memory->hpipm_workspace->iter);
+
+    info->solve_QP_time = acados_toc(&qp_timer);
+    info->total_time = acados_toc(&tot_timer);
 
     // check max number of iterations
     // TODO(dimitris): check ACADOS_MIN_STEP (not implemented in HPIPM yet)

--- a/acados/utils/create.c
+++ b/acados/utils/create.c
@@ -21,6 +21,8 @@
 
 #include "acados/utils/create.h"
 
+#include <stdlib.h>
+
 #include "acados/dense_qp/dense_qp_common.h"
 #include "acados/dense_qp/dense_qp_qpoases.h"
 #include "acados/dense_qp/dense_qp_hpipm.h"

--- a/acados/utils/create.c
+++ b/acados/utils/create.c
@@ -288,6 +288,10 @@ ocp_nlp_gn_sqp_args *ocp_nlp_gn_sqp_create_args(ocp_nlp_dims *dims, qp_solver_t 
 
     set_xcond_qp_solver_fun_ptrs(qp_solver_name, &qp_solver);
 
+    // NOTE(dimitris): can also directly pass sparse solver
+    // ocp_qp_solver qp_solver;
+    // set_qp_solver_fun_ptrs(qp_solver_name, &qp_solver);
+
     int return_value;
     sim_solver *sim_solvers = acados_malloc(sizeof(sim_solver), dims->N);
 

--- a/acados/utils/print.c
+++ b/acados/utils/print.c
@@ -18,6 +18,7 @@
  */
 
 // external
+#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -350,4 +351,20 @@ void print_dense_qp_in(dense_qp_in *qp_in)
     printf("H =\n");
     d_print_strmat(nv, nv, qp_in->Hg, 0, 0);
     // TODO(dimitris): print all data
+}
+
+
+
+void print_ocp_qp_info(ocp_qp_info *info)
+{
+    double misc = info->total_time - info->condensing_time - info->solve_QP_time - info->interface_time;
+    assert(misc > 0 && "sum of timings larger than total time!");
+
+    printf("\n***************************************************************\n");
+    printf("total time \t=\t%7.3f ms \t=\t %6.2f %%\n", 1000*info->total_time, 100.0);
+    printf("condensing time =\t%7.3f ms \t=\t %6.2f %%\n", 1000*info->condensing_time, 100*info->condensing_time/info->total_time);
+    printf("QP time \t=\t%7.3f ms \t=\t %6.2f %%\n", 1000*info->solve_QP_time, 100*info->solve_QP_time/info->total_time);
+    printf("interface time \t=\t%7.3f ms \t=\t %6.2f %%\n", 1000*info->interface_time, 100*info->interface_time/info->total_time);
+    printf("misc \t\t=\t%7.3f ms \t=\t %6.2f %%\n", 1000*misc, 100*misc/info->total_time);
+    printf("***************************************************************\n\n");
 }

--- a/acados/utils/print.h
+++ b/acados/utils/print.h
@@ -60,6 +60,8 @@ void print_colmaj_ocp_qp_out(char *filename, colmaj_ocp_qp_in *qp, colmaj_ocp_qp
 
 void print_dense_qp_in(dense_qp_in *qp_in);
 
+void print_ocp_qp_info(ocp_qp_info *info);
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/examples/c/mass_spring_condensing_hpipm.c
+++ b/examples/c/mass_spring_condensing_hpipm.c
@@ -76,8 +76,17 @@ int main() {
     acados_timer timer;
     acados_tic(&timer);
 
+    ocp_qp_info *info = (ocp_qp_info *)qp_out->misc;
+    ocp_qp_info min_info;
+    min_info.total_time = min_info.condensing_time = min_info.solve_QP_time = min_info.interface_time = 1e10;
+
 	for (int rep = 0; rep < NREP; rep++) {
         acados_return = ocp_qp_condensing_solver(qp_in, qp_out, arg, mem, work);
+
+        if (info->total_time < min_info.total_time) min_info.total_time = info->total_time;
+        if (info->condensing_time < min_info.condensing_time) min_info.condensing_time = info->condensing_time;
+        if (info->solve_QP_time < min_info.solve_QP_time) min_info.solve_QP_time = info->solve_QP_time;
+        if (info->interface_time < min_info.interface_time) min_info.interface_time = info->interface_time;
     }
 
     double time = acados_toc(&timer)/NREP;
@@ -113,6 +122,8 @@ int main() {
 
     printf("\nSolution time for %d IPM iterations, averaged over %d runs: %5.2e seconds\n\n\n",
         tmp_mem->hpipm_workspace->iter, NREP, time);
+
+    print_ocp_qp_info(&min_info);
 
     /************************************************
     * free memory

--- a/examples/c/mass_spring_condensing_hpipm.c
+++ b/examples/c/mass_spring_condensing_hpipm.c
@@ -26,6 +26,7 @@
 #include "acados/ocp_qp/ocp_qp_common_frontend.h"
 #include "acados/ocp_qp/ocp_qp_condensing_solver.h"
 #include "acados/utils/create.h"
+#include "acados/utils/print.h"
 #include "acados/utils/timing.h"
 #include "acados/utils/types.h"
 

--- a/examples/c/mass_spring_condensing_qore.c
+++ b/examples/c/mass_spring_condensing_qore.c
@@ -79,8 +79,17 @@ int main() {
     acados_timer timer;
     acados_tic(&timer);
 
+    ocp_qp_info *info = (ocp_qp_info *)qp_out->misc;
+    ocp_qp_info min_info;
+    min_info.total_time = min_info.condensing_time = min_info.solve_QP_time = min_info.interface_time = 1e10;
+
 	for (int rep = 0; rep < NREP; rep++) {
         acados_return = ocp_qp_condensing_solver(qp_in, qp_out, arg, mem, work);
+
+        if (info->total_time < min_info.total_time) min_info.total_time = info->total_time;
+        if (info->condensing_time < min_info.condensing_time) min_info.condensing_time = info->condensing_time;
+        if (info->solve_QP_time < min_info.solve_QP_time) min_info.solve_QP_time = info->solve_QP_time;
+        if (info->interface_time < min_info.interface_time) min_info.interface_time = info->interface_time;
     }
 
     double time = acados_toc(&timer)/NREP;
@@ -113,6 +122,8 @@ int main() {
     for (int ii = 0; ii <= N; ii++) d_print_mat(1, 2*nb[ii]+2*ng[ii], sol->lam[ii], 1);
 
     printf("\nSolution time averaged over %d runs: %5.2e seconds\n\n\n", NREP, time);
+
+    print_ocp_qp_info(&min_info);
 
     /************************************************
     * free memory

--- a/examples/c/mass_spring_condensing_qore.c
+++ b/examples/c/mass_spring_condensing_qore.c
@@ -26,6 +26,7 @@
 #include "acados/ocp_qp/ocp_qp_common_frontend.h"
 #include "acados/ocp_qp/ocp_qp_condensing_solver.h"
 #include "acados/utils/create.h"
+#include "acados/utils/print.h"
 #include "acados/utils/timing.h"
 #include "acados/utils/types.h"
 

--- a/examples/c/mass_spring_condensing_qpoases.c
+++ b/examples/c/mass_spring_condensing_qpoases.c
@@ -80,7 +80,7 @@ int main() {
     acados_timer timer;
     acados_tic(&timer);
 
-    ocp_qp_info *info = (ocp_qp_info *)qp_out->info;
+    ocp_qp_info *info = (ocp_qp_info *)qp_out->misc;
     ocp_qp_info min_info;
     min_info.total_time = min_info.condensing_time = min_info.solve_QP_time = min_info.interface_time = 1e10;
 

--- a/examples/c/mass_spring_condensing_qpoases.c
+++ b/examples/c/mass_spring_condensing_qpoases.c
@@ -26,6 +26,7 @@
 #include "acados/ocp_qp/ocp_qp_common_frontend.h"
 #include "acados/ocp_qp/ocp_qp_condensing_solver.h"
 #include "acados/utils/create.h"
+#include "acados/utils/print.h"
 #include "acados/utils/timing.h"
 #include "acados/utils/types.h"
 
@@ -79,8 +80,17 @@ int main() {
     acados_timer timer;
     acados_tic(&timer);
 
+    ocp_qp_info *info = (ocp_qp_info *)qp_out->info;
+    ocp_qp_info min_info;
+    min_info.total_time = min_info.condensing_time = min_info.solve_QP_time = min_info.interface_time = 1e10;
+
 	for (int rep = 0; rep < NREP; rep++) {
         acados_return = ocp_qp_condensing_solver(qp_in, qp_out, arg, mem, work);
+
+        if (info->total_time < min_info.total_time) min_info.total_time = info->total_time;
+        if (info->condensing_time < min_info.condensing_time) min_info.condensing_time = info->condensing_time;
+        if (info->solve_QP_time < min_info.solve_QP_time) min_info.solve_QP_time = info->solve_QP_time;
+        if (info->interface_time < min_info.interface_time) min_info.interface_time = info->interface_time;
     }
 
     double time = acados_toc(&timer)/NREP;
@@ -116,6 +126,8 @@ int main() {
 
     printf("\nSolution time for %d NWSR, averaged over %d runs: %5.2e seconds\n\n\n",
         tmp_mem->nwsr, NREP, time);
+
+    print_ocp_qp_info(&min_info);
 
     /************************************************
     * free memory

--- a/examples/c/mass_spring_hpipm.c
+++ b/examples/c/mass_spring_hpipm.c
@@ -118,9 +118,9 @@ int main() {
     printf("\nlam = \n");
     for (int ii = 0; ii <= N; ii++) d_print_mat(1, 2*nb[ii]+2*ng[ii], sol->lam[ii], 1);
 
-    printf("\ninf norm res: %e, %e, %e, %e, %e\n", mem->hpipm_workspace->qp_res[0],
+    printf("\ninf norm res: %e, %e, %e, %e\n", mem->hpipm_workspace->qp_res[0],
            mem->hpipm_workspace->qp_res[1], mem->hpipm_workspace->qp_res[2],
-           mem->hpipm_workspace->qp_res[3], mem->hpipm_workspace->res_workspace->res_mu);
+           mem->hpipm_workspace->qp_res[3]);
 
     printf("\nSolution time for %d IPM iterations, averaged over %d runs: %5.2e seconds\n\n\n",
         mem->hpipm_workspace->iter, NREP, time);

--- a/examples/c/mass_spring_pcond_hpipm_split.c
+++ b/examples/c/mass_spring_pcond_hpipm_split.c
@@ -145,9 +145,9 @@ int main() {
     printf("\nlam = \n");
     for (int ii = 0; ii <= N; ii++) d_print_mat(1, 2*nb[ii]+2*ng[ii], sol->lam[ii], 1);
 
-    printf("\ninf norm res: %e, %e, %e, %e, %e\n", mem->hpipm_workspace->qp_res[0],
+    printf("\ninf norm res: %e, %e, %e, %e\n", mem->hpipm_workspace->qp_res[0],
            mem->hpipm_workspace->qp_res[1], mem->hpipm_workspace->qp_res[2],
-           mem->hpipm_workspace->qp_res[3], mem->hpipm_workspace->res_workspace->res_mu);
+           mem->hpipm_workspace->qp_res[3]);
 
     printf("\nSolution time for %d IPM iterations, averaged over %d runs: %5.2e seconds\n\n\n",
         mem->hpipm_workspace->iter, NREP, time);


### PR DESCRIPTION
example output (cond_qpoases):

***************************************************************
total time      =         0.930 ms      =        100.00 %
condensing time =         0.044 ms      =          4.74 %
QP time         =         0.875 ms      =         94.08 %
interface time  =         0.009 ms      =          1.00 %
misc            =         0.002 ms      =          0.19 %
***************************************************************