### PR TITLE
Infinity norm of KKT residuals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,4 @@ cmakelint
 *.srctrldb
 *.srctrlprj
 .vs
+examples/python/__pycache__/

--- a/acados/dense_qp/dense_qp_common.c
+++ b/acados/dense_qp/dense_qp_common.c
@@ -189,3 +189,19 @@ void compute_dense_qp_res(dense_qp_in *qp_in, dense_qp_out *qp_out, dense_qp_res
     // compute residuals
     d_compute_res_dense_qp(qp_in, qp_out, qp_res, res_ws);
 }
+
+
+
+void compute_dense_qp_res_nrm_inf(dense_qp_res *qp_res, double res[4])
+{
+    int nv = qp_res->dim->nv;
+    int nb = qp_res->dim->nb;
+    int ne = qp_res->dim->ne;
+    int ng = qp_res->dim->ng;
+    int ns = qp_res->dim->ns;
+
+    dvecnrm_inf_libstr(nv+2*ns, qp_res->res_g, 0, &res[0]);
+    dvecnrm_inf_libstr(ne, qp_res->res_b, 0, &res[1]);
+    dvecnrm_inf_libstr(2*nb+2*ng+2*ns, qp_res->res_d, 0, &res[2]);
+    dvecnrm_inf_libstr(2*nb+2*ng+2*ns, qp_res->res_m, 0, &res[3]);
+}

--- a/acados/dense_qp/dense_qp_common.h
+++ b/acados/dense_qp/dense_qp_common.h
@@ -77,6 +77,8 @@ dense_qp_res_ws *assign_dense_qp_res_ws(dense_qp_dims *dims, void *raw_memory);
 //
 void compute_dense_qp_res(dense_qp_in *qp_in, dense_qp_out *qp_out, dense_qp_res *qp_res, dense_qp_res_ws *res_ws);
 //
+void compute_dense_qp_res_nrm_inf(dense_qp_res *qp_res, double res[4]);
+//
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/acados/ocp_qp/ocp_qp_common.c
+++ b/acados/ocp_qp/ocp_qp_common.c
@@ -222,6 +222,42 @@ void compute_ocp_qp_res(ocp_qp_in *qp_in, ocp_qp_out *qp_out, ocp_qp_res *qp_res
 
 
 
+void compute_ocp_qp_res_nrm_inf(ocp_qp_res *qp_res, double res[4])
+{
+    // loop index
+	int ii;
+
+	// extract ocp qp size
+	int N = qp_res->dim->N;
+	int *nx = qp_res->dim->nx;
+	int *nu = qp_res->dim->nu;
+	int *nb = qp_res->dim->nb;
+	int *ng = qp_res->dim->ng;
+    int *ns = qp_res->dim->ns;
+
+    // compute size of res_q, res_b, res_d and res_m
+    int nvt = 0;
+	int net = 0;
+    int nct = 0;
+
+    for(ii=0; ii<N; ii++)
+	{
+		nvt += nx[ii]+nu[ii]+2*ns[ii];
+		net += nx[ii+1];
+		nct += 2*nb[ii]+2*ng[ii]+2*ns[ii];
+	}
+	nvt += nx[ii]+nu[ii]+2*ns[ii];
+    nct += 2*nb[ii]+2*ng[ii]+2*ns[ii];
+
+    // compute infinity norms of residuals
+    dvecnrm_inf_libstr(nvt, qp_res->res_g, 0, &res[0]);
+	dvecnrm_inf_libstr(net, qp_res->res_b, 0, &res[1]);
+	dvecnrm_inf_libstr(nct, qp_res->res_d, 0, &res[2]);
+	dvecnrm_inf_libstr(nct, qp_res->res_m, 0, &res[3]);
+}
+
+
+
 // void form_nbu_nbx_rev(int N, int *nbu, int *nbx, int *nb, int* nx, int *nu, int **idxb_rev)
 // {
 //     for (int ii = 0; ii < N+1; ii++)

--- a/acados/ocp_qp/ocp_qp_common.h
+++ b/acados/ocp_qp/ocp_qp_common.h
@@ -102,6 +102,8 @@ ocp_qp_res_ws *assign_ocp_qp_res_ws(ocp_qp_dims *dims, void *raw_memory);
 //
 void compute_ocp_qp_res(ocp_qp_in *qp_in, ocp_qp_out *qp_out, ocp_qp_res *qp_res, ocp_qp_res_ws *res_ws);
 //
+void compute_ocp_qp_res_nrm_inf(ocp_qp_res *qp_res, double res[4]);
+//
 int set_qp_solver_fun_ptrs(qp_solver_t qp_solver_name, void *qp_solver);
 //
 void set_xcond_qp_solver_fun_ptrs(qp_solver_t qp_solver_name, ocp_qp_xcond_solver *qp_solver);

--- a/acados/ocp_qp/ocp_qp_common_frontend.c
+++ b/acados/ocp_qp/ocp_qp_common_frontend.c
@@ -523,6 +523,8 @@ void convert_ocp_qp_res_to_colmaj(ocp_qp_res *qp_res, colmaj_ocp_qp_res *cm_qp_r
     double **res_m_ls = cm_qp_res->res_m_ls;
     double **res_m_us = cm_qp_res->res_m_us;
 
+    compute_ocp_qp_res_nrm_inf(qp_res, cm_qp_res->res_nrm_inf);
+
     d_cvt_ocp_qp_res_to_colmaj(qp_res, res_r, res_q, res_ls, res_us, res_b,
                                res_d_lb, res_d_ub, res_d_lg, res_d_ug, res_d_ls, res_d_us,
                                res_m_lb, res_m_ub, res_m_lg, res_m_ug, res_m_ls, res_m_us);

--- a/acados/ocp_qp/ocp_qp_common_frontend.h
+++ b/acados/ocp_qp/ocp_qp_common_frontend.h
@@ -77,6 +77,7 @@ typedef struct {
     double **res_m_ug;
     double **res_m_ls;
     double **res_m_us;
+    double res_nrm_inf[4];
 } colmaj_ocp_qp_res;
 
 

--- a/examples/c/mass_spring_cond_solver.c
+++ b/examples/c/mass_spring_cond_solver.c
@@ -19,6 +19,7 @@
 
 // external
 #include <stdio.h>
+#include <assert.h>
 #include <stdlib.h>
 // acados
 #include "acados/dense_qp/dense_qp_common.h"
@@ -122,6 +123,9 @@ int main() {
 
     double res[4];
     compute_ocp_qp_res_nrm_inf(qp_res, res);
+    double max_res = 0.0;
+    for (int ii = 0; ii < 4; ii++) max_res = (res[ii] > max_res) ? res[ii] : max_res;
+    assert(max_res <= ACADOS_EPS && "The largest KKT residual greater than ACADOS_EPS");
 
     /************************************************
     * print solution and stats

--- a/examples/c/mass_spring_cond_solver.c
+++ b/examples/c/mass_spring_cond_solver.c
@@ -109,6 +109,21 @@ int main() {
     convert_ocp_qp_out_to_colmaj(qp_out, sol);
 
     /************************************************
+    * compute residuals
+    ************************************************/
+
+    ocp_qp_res *qp_res = create_ocp_qp_res(dims);
+    ocp_qp_res_ws *res_ws = create_ocp_qp_res_ws(dims);
+    compute_ocp_qp_res(qp_in, qp_out, qp_res, res_ws);
+
+    /************************************************
+    * compute infinity norm of residuals
+    ************************************************/
+
+    double res[4];
+    compute_ocp_qp_res_nrm_inf(qp_res, res);
+
+    /************************************************
     * print solution and stats
     ************************************************/
 
@@ -124,6 +139,8 @@ int main() {
     printf("\nlam = \n");
     for (int ii = 0; ii <= N; ii++) d_print_mat(1, 2*nb[ii]+2*ng[ii], sol->lam[ii], 1);
 
+    printf("\ninf norm res: %e, %e, %e, %e\n", res[0], res[1], res[2], res[3]);
+
     printf("\nSolution time with SOLVER = %d, averaged over %d runs: %5.2e seconds\n\n\n",
         qp_solver_name, NREP, time);
 
@@ -134,6 +151,8 @@ int main() {
     free(qp_in);
     free(qp_out);
     free(sol);
+    free(qp_res);
+    free(res_ws);
     free(arg);
     free(mem);
     free(work);

--- a/examples/c/mass_spring_condensing_hpipm.c
+++ b/examples/c/mass_spring_condensing_hpipm.c
@@ -105,14 +105,6 @@ int main() {
     convert_ocp_qp_out_to_colmaj(qp_out, sol);
 
     /************************************************
-    * compute residuals
-    ************************************************/
-
-    ocp_qp_res *qp_res = create_ocp_qp_res(qp_in->dim);
-    ocp_qp_res_ws *res_ws = create_ocp_qp_res_ws(qp_in->dim);
-    compute_ocp_qp_res(qp_in, qp_out, qp_res, res_ws);
-
-    /************************************************
     * print solution and stats
     ************************************************/
 

--- a/examples/c/mass_spring_condensing_hpipm.c
+++ b/examples/c/mass_spring_condensing_hpipm.c
@@ -128,23 +128,13 @@ int main() {
     printf("\nlam = \n");
     for (int ii = 0; ii <= N; ii++) d_print_mat(1, 2*nb[ii]+2*ng[ii], sol->lam[ii], 1);
 
-    printf("\nres_g = \n");
-    for (int ii = 0; ii <= N; ii++) d_print_tran_strvec(nu[ii]+nx[ii]+2*ns[ii], qp_res->res_g+ii, 0);
-
-    printf("\nres_b = \n");
-    for (int ii = 0; ii < N; ii++) d_print_tran_strvec(nx[ii+1], qp_res->res_b+ii, 0);
-
-    printf("\nres_d = \n");
-    for (int ii = 0; ii <= N; ii++) d_print_tran_strvec(2*nb[ii]+2*ng[ii]+2*ns[ii], qp_res->res_d+ii, 0);
-
-    printf("\nres_m = \n");
-    for (int ii = 0; ii <= N; ii++) d_print_tran_strvec(2*nb[ii]+2*ng[ii]+2*ns[ii], qp_res->res_m+ii, 0);
-
-
     dense_qp_hpipm_memory *tmp_mem = (dense_qp_hpipm_memory *) mem->solver_memory;
 
-    printf("\nSolution time for %d IPM iterations, averaged over %d runs: %5.2e seconds\n\n\n",
-        tmp_mem->hpipm_workspace->iter, NREP, time);
+    printf("\ninf norm res: %e, %e, %e, %e\n", tmp_mem->hpipm_workspace->qp_res[0],
+           tmp_mem->hpipm_workspace->qp_res[1], tmp_mem->hpipm_workspace->qp_res[2],
+           tmp_mem->hpipm_workspace->qp_res[3]);
+
+    printf("\nNumber of IPM iterations = %d\n\n\n", tmp_mem->hpipm_workspace->iter);
 
     print_ocp_qp_info(&min_info);
 

--- a/examples/c/mass_spring_condensing_hpipm_split.c
+++ b/examples/c/mass_spring_condensing_hpipm_split.c
@@ -19,6 +19,7 @@
 
 // external
 #include <stdio.h>
+#include <assert.h>
 #include <stdlib.h>
 // acados
 #include "acados/dense_qp/dense_qp_common.h"
@@ -117,6 +118,24 @@ int main() {
     convert_ocp_qp_out_to_colmaj(qp_out, sol);
 
     /************************************************
+    * compute residuals
+    ************************************************/
+
+    ocp_qp_res *qp_res = create_ocp_qp_res(dims);
+    ocp_qp_res_ws *res_ws = create_ocp_qp_res_ws(dims);
+    compute_ocp_qp_res(qp_in, qp_out, qp_res, res_ws);
+
+    /************************************************
+    * compute infinity norm of residuals
+    ************************************************/
+
+    double res[4];
+    compute_ocp_qp_res_nrm_inf(qp_res, res);
+    double max_res = 0.0;
+    for (int ii = 0; ii < 4; ii++) max_res = (res[ii] > max_res) ? res[ii] : max_res;
+    assert(max_res <= 1e6*ACADOS_EPS && "The largest KKT residual greater than 1e6*ACADOS_EPS");
+
+    /************************************************
     * print solution and stats
     ************************************************/
 
@@ -132,9 +151,7 @@ int main() {
     printf("\nlam = \n");
     for (int ii = 0; ii <= N; ii++) d_print_mat(1, 2*nb[ii]+2*ng[ii], sol->lam[ii], 1);
 
-    printf("\ninf norm res: %e, %e, %e, %e\n", mem->hpipm_workspace->qp_res[0],
-           mem->hpipm_workspace->qp_res[1], mem->hpipm_workspace->qp_res[2],
-           mem->hpipm_workspace->qp_res[3]);
+    printf("\ninf norm res: %e, %e, %e, %e\n", res[0], res[1], res[2], res[3]);
 
     printf("\nSolution time for %d IPM iterations, averaged over %d runs: %5.2e seconds\n\n\n",
         mem->hpipm_workspace->iter, NREP, time);
@@ -148,6 +165,8 @@ int main() {
     free(qp_out);
     free(qpd_out);
     free(sol);
+    free(qp_res);
+    free(res_ws);
     free(argd);
     free(mem);
     free(cond_memory);

--- a/examples/c/mass_spring_condensing_hpipm_split.c
+++ b/examples/c/mass_spring_condensing_hpipm_split.c
@@ -132,6 +132,10 @@ int main() {
     printf("\nlam = \n");
     for (int ii = 0; ii <= N; ii++) d_print_mat(1, 2*nb[ii]+2*ng[ii], sol->lam[ii], 1);
 
+    printf("\ninf norm res: %e, %e, %e, %e\n", mem->hpipm_workspace->qp_res[0],
+           mem->hpipm_workspace->qp_res[1], mem->hpipm_workspace->qp_res[2],
+           mem->hpipm_workspace->qp_res[3]);
+
     printf("\nSolution time for %d IPM iterations, averaged over %d runs: %5.2e seconds\n\n\n",
         mem->hpipm_workspace->iter, NREP, time);
 

--- a/examples/c/mass_spring_condensing_qore.c
+++ b/examples/c/mass_spring_condensing_qore.c
@@ -116,13 +116,11 @@ int main() {
     compute_ocp_qp_res(qp_in, qp_out, qp_res, res_ws);
 
     /************************************************
-    * extract residuals
+    * compute infinity norm of residuals
     ************************************************/
 
-    colmaj_ocp_qp_res *cm_qp_res;
-    void *memres = malloc(colmaj_ocp_qp_res_calculate_size(dims));
-    assign_colmaj_ocp_qp_res(dims, &cm_qp_res, memres);
-    convert_ocp_qp_res_to_colmaj(qp_res, cm_qp_res);
+    double res[4];
+    compute_ocp_qp_res_nrm_inf(qp_res, res);
 
     /************************************************
     * print solution and stats
@@ -140,56 +138,7 @@ int main() {
     printf("\nlam = \n");
     for (int ii = 0; ii <= N; ii++) d_print_mat(1, 2*nb[ii]+2*ng[ii], sol->lam[ii], 1);
 
-    printf("\nres_r = \n");
-    for (int ii = 0; ii <= N; ii++) d_print_mat(1, nu[ii], cm_qp_res->res_r[ii], 1);
-
-    printf("\nres_q = \n");
-    for (int ii = 0; ii <= N; ii++) d_print_mat(1, nx[ii], cm_qp_res->res_q[ii], 1);
-
-    printf("\nres_ls = \n");
-    for (int ii = 0; ii <= N; ii++) d_print_mat(1, ns[ii], cm_qp_res->res_ls[ii], 1);
-
-    printf("\nres_us = \n");
-    for (int ii = 0; ii <= N; ii++) d_print_mat(1, ns[ii], cm_qp_res->res_us[ii], 1);
-
-    printf("\nres_b = \n");
-    for (int ii = 0; ii < N; ii++) d_print_mat(1, nx[ii+1], cm_qp_res->res_b[ii], 1);
-
-    printf("\nres_d_lb = \n");
-    for (int ii = 0; ii <= N; ii++) d_print_mat(1, nb[ii], cm_qp_res->res_d_lb[ii], 1);
-
-    printf("\nres_d_ub = \n");
-    for (int ii = 0; ii <= N; ii++) d_print_mat(1, nb[ii], cm_qp_res->res_d_ub[ii], 1);
-
-    printf("\nres_d_lg = \n");
-    for (int ii = 0; ii <= N; ii++) d_print_mat(1, ng[ii], cm_qp_res->res_d_lg[ii], 1);
-
-    printf("\nres_d_ug = \n");
-    for (int ii = 0; ii <= N; ii++) d_print_mat(1, ng[ii], cm_qp_res->res_d_ug[ii], 1);
-
-    printf("\nres_d_ls = \n");
-    for (int ii = 0; ii <= N; ii++) d_print_mat(1, ns[ii], cm_qp_res->res_d_ls[ii], 1);
-
-    printf("\nres_d_us = \n");
-    for (int ii = 0; ii <= N; ii++) d_print_mat(1, ns[ii], cm_qp_res->res_d_us[ii], 1);
-
-    printf("\nres_m_lb = \n");
-    for (int ii = 0; ii <= N; ii++) d_print_mat(1, nb[ii], cm_qp_res->res_m_lb[ii], 1);
-
-    printf("\nres_m_ub = \n");
-    for (int ii = 0; ii <= N; ii++) d_print_mat(1, nb[ii], cm_qp_res->res_m_ub[ii], 1);
-
-    printf("\nres_m_lg = \n");
-    for (int ii = 0; ii <= N; ii++) d_print_mat(1, ng[ii], cm_qp_res->res_m_lg[ii], 1);
-
-    printf("\nres_m_ug = \n");
-    for (int ii = 0; ii <= N; ii++) d_print_mat(1, ng[ii], cm_qp_res->res_m_ug[ii], 1);
-
-    printf("\nres_m_ls = \n");
-    for (int ii = 0; ii <= N; ii++) d_print_mat(1, ns[ii], cm_qp_res->res_m_ls[ii], 1);
-
-    printf("\nres_m_us = \n");
-    for (int ii = 0; ii <= N; ii++) d_print_mat(1, ns[ii], cm_qp_res->res_m_us[ii], 1);
+    printf("\ninf norm res: %e, %e, %e, %e\n", res[0], res[1], res[2], res[3]);
 
     dense_qp_qore_memory *tmp_mem = (dense_qp_qore_memory *) mem->solver_memory;
 
@@ -204,7 +153,6 @@ int main() {
     free(qp_in);
     free(qp_out);
     free(sol);
-    free(cm_qp_res);
     free(qp_res);
     free(res_ws);
     free(arg);

--- a/examples/c/mass_spring_condensing_qore.c
+++ b/examples/c/mass_spring_condensing_qore.c
@@ -19,6 +19,7 @@
 
 // external
 #include <stdio.h>
+#include <assert.h>
 #include <stdlib.h>
 // acados
 #include "acados/dense_qp/dense_qp_common.h"
@@ -121,6 +122,9 @@ int main() {
 
     double res[4];
     compute_ocp_qp_res_nrm_inf(qp_res, res);
+    double max_res = 0.0;
+    for (int ii = 0; ii < 4; ii++) max_res = (res[ii] > max_res) ? res[ii] : max_res;
+    assert(max_res <= ACADOS_EPS && "The largest KKT residual greater than ACADOS_EPS");
 
     /************************************************
     * print solution and stats

--- a/examples/c/mass_spring_condensing_qpoases.c
+++ b/examples/c/mass_spring_condensing_qpoases.c
@@ -19,6 +19,7 @@
 
 // external
 #include <stdio.h>
+#include <assert.h>
 #include <stdlib.h>
 // acados
 #include "acados/dense_qp/dense_qp_common.h"
@@ -121,6 +122,9 @@ int main() {
 
     double res[4];
     compute_ocp_qp_res_nrm_inf(qp_res, res);
+    double max_res = 0.0;
+    for (int ii = 0; ii < 4; ii++) max_res = (res[ii] > max_res) ? res[ii] : max_res;
+    assert(max_res <= ACADOS_EPS && "The largest KKT residual greater than ACADOS_EPS");
 
     /************************************************
     * print solution and stats

--- a/examples/c/mass_spring_condensing_qpoases.c
+++ b/examples/c/mass_spring_condensing_qpoases.c
@@ -142,7 +142,7 @@ int main() {
 
     dense_qp_qpoases_memory *tmp_mem = (dense_qp_qpoases_memory *) mem->solver_memory;
 
-    printf("\nNumber of workspace recalculations = %d\n\n\n", tmp_mem->nwsr);
+    printf("\nNumber of working-set recalculations = %d\n\n\n", tmp_mem->nwsr);
 
     print_ocp_qp_info(&min_info);
 

--- a/examples/c/mass_spring_condensing_qpoases.c
+++ b/examples/c/mass_spring_condensing_qpoases.c
@@ -116,13 +116,11 @@ int main() {
     compute_ocp_qp_res(qp_in, qp_out, qp_res, res_ws);
 
     /************************************************
-    * extract residuals
+    * compute infinity norm of residuals
     ************************************************/
 
-    colmaj_ocp_qp_res *cm_qp_res;
-    void *memres = malloc(colmaj_ocp_qp_res_calculate_size(dims));
-    assign_colmaj_ocp_qp_res(dims, &cm_qp_res, memres);
-    convert_ocp_qp_res_to_colmaj(qp_res, cm_qp_res);
+    double res[4];
+    compute_ocp_qp_res_nrm_inf(qp_res, res);
 
     /************************************************
     * print solution and stats
@@ -140,56 +138,7 @@ int main() {
     printf("\nlam = \n");
     for (int ii = 0; ii <= N; ii++) d_print_mat(1, 2*nb[ii]+2*ng[ii], sol->lam[ii], 1);
 
-    printf("\nres_r = \n");
-    for (int ii = 0; ii <= N; ii++) d_print_mat(1, nu[ii], cm_qp_res->res_r[ii], 1);
-
-    printf("\nres_q = \n");
-    for (int ii = 0; ii <= N; ii++) d_print_mat(1, nx[ii], cm_qp_res->res_q[ii], 1);
-
-    printf("\nres_ls = \n");
-    for (int ii = 0; ii <= N; ii++) d_print_mat(1, ns[ii], cm_qp_res->res_ls[ii], 1);
-
-    printf("\nres_us = \n");
-    for (int ii = 0; ii <= N; ii++) d_print_mat(1, ns[ii], cm_qp_res->res_us[ii], 1);
-
-    printf("\nres_b = \n");
-    for (int ii = 0; ii < N; ii++) d_print_mat(1, nx[ii+1], cm_qp_res->res_b[ii], 1);
-
-    printf("\nres_d_lb = \n");
-    for (int ii = 0; ii <= N; ii++) d_print_mat(1, nb[ii], cm_qp_res->res_d_lb[ii], 1);
-
-    printf("\nres_d_ub = \n");
-    for (int ii = 0; ii <= N; ii++) d_print_mat(1, nb[ii], cm_qp_res->res_d_ub[ii], 1);
-
-    printf("\nres_d_lg = \n");
-    for (int ii = 0; ii <= N; ii++) d_print_mat(1, ng[ii], cm_qp_res->res_d_lg[ii], 1);
-
-    printf("\nres_d_ug = \n");
-    for (int ii = 0; ii <= N; ii++) d_print_mat(1, ng[ii], cm_qp_res->res_d_ug[ii], 1);
-
-    printf("\nres_d_ls = \n");
-    for (int ii = 0; ii <= N; ii++) d_print_mat(1, ns[ii], cm_qp_res->res_d_ls[ii], 1);
-
-    printf("\nres_d_us = \n");
-    for (int ii = 0; ii <= N; ii++) d_print_mat(1, ns[ii], cm_qp_res->res_d_us[ii], 1);
-
-    printf("\nres_m_lb = \n");
-    for (int ii = 0; ii <= N; ii++) d_print_mat(1, nb[ii], cm_qp_res->res_m_lb[ii], 1);
-
-    printf("\nres_m_ub = \n");
-    for (int ii = 0; ii <= N; ii++) d_print_mat(1, nb[ii], cm_qp_res->res_m_ub[ii], 1);
-
-    printf("\nres_m_lg = \n");
-    for (int ii = 0; ii <= N; ii++) d_print_mat(1, ng[ii], cm_qp_res->res_m_lg[ii], 1);
-
-    printf("\nres_m_ug = \n");
-    for (int ii = 0; ii <= N; ii++) d_print_mat(1, ng[ii], cm_qp_res->res_m_ug[ii], 1);
-
-    printf("\nres_m_ls = \n");
-    for (int ii = 0; ii <= N; ii++) d_print_mat(1, ns[ii], cm_qp_res->res_m_ls[ii], 1);
-
-    printf("\nres_m_us = \n");
-    for (int ii = 0; ii <= N; ii++) d_print_mat(1, ns[ii], cm_qp_res->res_m_us[ii], 1);
+    printf("\ninf norm res: %e, %e, %e, %e\n", res[0], res[1], res[2], res[3]);
 
     dense_qp_qpoases_memory *tmp_mem = (dense_qp_qpoases_memory *) mem->solver_memory;
 
@@ -204,7 +153,6 @@ int main() {
     free(qp_in);
     free(qp_out);
     free(sol);
-    free(cm_qp_res);
     free(qp_res);
     free(res_ws);
     free(arg);

--- a/examples/c/mass_spring_hpipm.c
+++ b/examples/c/mass_spring_hpipm.c
@@ -104,14 +104,6 @@ int main() {
     convert_ocp_qp_out_to_colmaj(qp_out, sol);
 
     /************************************************
-    * compute residuals
-    ************************************************/
-
-    ocp_qp_res *qp_res = create_ocp_qp_res(qp_in->dim);
-    ocp_qp_res_ws *res_ws = create_ocp_qp_res_ws(qp_in->dim);
-    compute_ocp_qp_res(qp_in, qp_out, qp_res, res_ws);
-
-    /************************************************
     * print solution and stats
     ************************************************/
 
@@ -127,19 +119,6 @@ int main() {
     printf("\nlam = \n");
     for (int ii = 0; ii <= N; ii++) d_print_mat(1, 2*nb[ii]+2*ng[ii], sol->lam[ii], 1);
 
-    printf("\nres_g = \n");
-    for (int ii = 0; ii <= N; ii++) d_print_tran_strvec(nu[ii]+nx[ii]+2*ns[ii], qp_res->res_g+ii, 0);
-
-    printf("\nres_b = \n");
-    for (int ii = 0; ii < N; ii++) d_print_tran_strvec(nx[ii+1], qp_res->res_b+ii, 0);
-
-    printf("\nres_d = \n");
-    for (int ii = 0; ii <= N; ii++) d_print_tran_strvec(2*nb[ii]+2*ng[ii]+2*ns[ii], qp_res->res_d+ii, 0);
-
-    printf("\nres_m = \n");
-    for (int ii = 0; ii <= N; ii++) d_print_tran_strvec(2*nb[ii]+2*ng[ii]+2*ns[ii], qp_res->res_m+ii, 0);
-
-
     printf("\ninf norm res: %e, %e, %e, %e\n", mem->hpipm_workspace->qp_res[0],
            mem->hpipm_workspace->qp_res[1], mem->hpipm_workspace->qp_res[2],
            mem->hpipm_workspace->qp_res[3]);
@@ -153,8 +132,6 @@ int main() {
 
     free(qp_in);
     free(qp_out);
-    free(qp_res);
-    free(res_ws);
     free(sol);
     free(arg);
     free(mem);

--- a/examples/c/mass_spring_hpipm.c
+++ b/examples/c/mass_spring_hpipm.c
@@ -19,6 +19,7 @@
 
 // external
 #include <stdio.h>
+#include <assert.h>
 #include <stdlib.h>
 // acados
 #include "acados/ocp_qp/ocp_qp_common.h"
@@ -88,20 +89,30 @@ int main() {
     * extract solution
     ************************************************/
 
-    // ocp_qp_dims dims;
-    // dims.N = N;
-    // dims.nx = nx;
-    // dims.nu = nu;
-    // dims.nb = nb;
-    // dims.ns = ns;
-    // dims.ng = ng;
-
     ocp_qp_dims *dims = qp_in->dim;
 
     colmaj_ocp_qp_out *sol;
     void *memsol = malloc(colmaj_ocp_qp_out_calculate_size(dims));
     assign_colmaj_ocp_qp_out(dims, &sol, memsol);
     convert_ocp_qp_out_to_colmaj(qp_out, sol);
+
+    /************************************************
+    * compute residuals
+    ************************************************/
+
+    ocp_qp_res *qp_res = create_ocp_qp_res(dims);
+    ocp_qp_res_ws *res_ws = create_ocp_qp_res_ws(dims);
+    compute_ocp_qp_res(qp_in, qp_out, qp_res, res_ws);
+
+    /************************************************
+    * compute infinity norm of residuals
+    ************************************************/
+
+    double res[4];
+    compute_ocp_qp_res_nrm_inf(qp_res, res);
+    double max_res = 0.0;
+    for (int ii = 0; ii < 4; ii++) max_res = (res[ii] > max_res) ? res[ii] : max_res;
+    assert(max_res <= 1e6*ACADOS_EPS && "The largest KKT residual greater than 1e6*ACADOS_EPS");
 
     /************************************************
     * print solution and stats
@@ -119,9 +130,7 @@ int main() {
     printf("\nlam = \n");
     for (int ii = 0; ii <= N; ii++) d_print_mat(1, 2*nb[ii]+2*ng[ii], sol->lam[ii], 1);
 
-    printf("\ninf norm res: %e, %e, %e, %e\n", mem->hpipm_workspace->qp_res[0],
-           mem->hpipm_workspace->qp_res[1], mem->hpipm_workspace->qp_res[2],
-           mem->hpipm_workspace->qp_res[3]);
+    printf("\ninf norm res: %e, %e, %e, %e\n", res[0], res[1], res[2], res[3]);
 
     printf("\nSolution time for %d IPM iterations, averaged over %d runs: %5.2e seconds\n\n\n",
         mem->hpipm_workspace->iter, NREP, time);
@@ -133,6 +142,8 @@ int main() {
     free(qp_in);
     free(qp_out);
     free(sol);
+    free(qp_res);
+    free(res_ws);
     free(arg);
     free(mem);
 

--- a/examples/c/mass_spring_pcond_hpipm_split.c
+++ b/examples/c/mass_spring_pcond_hpipm_split.c
@@ -149,7 +149,7 @@ int main() {
            mem->hpipm_workspace->qp_res[1], mem->hpipm_workspace->qp_res[2],
            mem->hpipm_workspace->qp_res[3]);
 
-    printf("\nSolution time for %d IPM iterations, averaged over %d runs: %5.2e seconds\n\n\n",
+    printf("\nNumber of %d IPM iterations, averaged over %d runs: %5.2e seconds\n\n\n",
         mem->hpipm_workspace->iter, NREP, time);
 
     /************************************************

--- a/examples/c/mass_spring_pcond_solver.c
+++ b/examples/c/mass_spring_pcond_solver.c
@@ -19,6 +19,7 @@
 
 // external
 #include <stdio.h>
+#include <assert.h>
 #include <stdlib.h>
 // acados
 #include "acados/ocp_qp/ocp_qp_common.h"
@@ -135,6 +136,9 @@ int main() {
 
     double res[4];
     compute_ocp_qp_res_nrm_inf(qp_res, res);
+    double max_res = 0.0;
+    for (int ii = 0; ii < 4; ii++) max_res = (res[ii] > max_res) ? res[ii] : max_res;
+    assert(max_res <= 1e6*ACADOS_EPS && "The largest KKT residual greater than 1e6*ACADOS_EPS");
 
     /************************************************
     * print solution and stats

--- a/examples/c/mass_spring_pcond_solver.c
+++ b/examples/c/mass_spring_pcond_solver.c
@@ -122,6 +122,21 @@ int main() {
     convert_ocp_qp_out_to_colmaj(qp_out, sol);
 
     /************************************************
+    * compute residuals
+    ************************************************/
+
+    ocp_qp_res *qp_res = create_ocp_qp_res(dims);
+    ocp_qp_res_ws *res_ws = create_ocp_qp_res_ws(dims);
+    compute_ocp_qp_res(qp_in, qp_out, qp_res, res_ws);
+
+    /************************************************
+    * compute infinity norm of residuals
+    ************************************************/
+
+    double res[4];
+    compute_ocp_qp_res_nrm_inf(qp_res, res);
+
+    /************************************************
     * print solution and stats
     ************************************************/
 
@@ -137,8 +152,9 @@ int main() {
     printf("\nlam = \n");
     for (int ii = 0; ii <= N; ii++) d_print_mat(1, 2*nb[ii]+2*ng[ii], sol->lam[ii], 1);
 
-    printf("\nSolution time for N2 = %d, averaged over %d runs: %5.2e seconds\n\n\n",
-        arg->pcond_args->N2, NREP, time);
+    printf("\ninf norm res: %e, %e, %e, %e\n", res[0], res[1], res[2], res[3]);
+
+    printf("\nN2 = %d\n\n\n", arg->pcond_args->N2);
 
     print_ocp_qp_info(&min_info);
 
@@ -149,6 +165,8 @@ int main() {
     free(qp_in);
     free(qp_out);
     free(sol);
+    free(qp_res);
+    free(res_ws);
     free(arg);
     free(mem);
     free(work);


### PR DESCRIPTION
Summary of changes:
- added functions to compute inf norm of KKT residuals for dense/OCP QP
- added the computation of inf norm of residuals to the OCP QP frontend
- updated C mass spring examples to print only the inf norm of residuals
- added assert to C mass spring examples to check that the largest KKT residual is smaller than some tolerance

I used the following tolerances:
- QORE/qpOASES: ACADOS_EPS, i.e. 1e-12
- HPIPM: 1e6*ACADOS_EPS, i.e. 1e-6