### PR TITLE
Fix cmake get Casadi version for Casadi 3.3.0

### DIFF
--- a/cmake/FindCasadiPython.cmake
+++ b/cmake/FindCasadiPython.cmake
@@ -32,7 +32,7 @@ endif()
 
 # Determine the version number
 execute_process(
-    COMMAND "${PYTHON_EXECUTABLE}" -c "from sys import path; path.insert(0, r'${CASADI_PYTHON_ROOT}');import casadi; print(casadi.CasadiMeta_getVersion())"
+    COMMAND "${PYTHON_EXECUTABLE}" -c "from sys import path; path.insert(0, r'${CASADI_PYTHON_ROOT}');import casadi; print(casadi.__version__)"
     OUTPUT_VARIABLE CASADI_PYTHON_VERSION)
 
 string(STRIP "${CASADI_PYTHON_VERSION}" CASADI_PYTHON_VERSION)


### PR DESCRIPTION
In Casadi 3.3.0, casadi.CasadiMeta_getVersion() was removed. Use `casadi.__version__` instead.