### PR TITLE
Bounds from the interfaces

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ enable_testing(true)
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99 -Wall -fdiagnostics-show-option")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -fdiagnostics-show-option")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -Wall -fdiagnostics-show-option")
 endif()
 
 message(STATUS "Installation directory is ${CMAKE_INSTALL_PREFIX}")

--- a/acados/dense_qp/dense_qp_qore.c
+++ b/acados/dense_qp/dense_qp_qore.c
@@ -251,7 +251,8 @@ int dense_qp_qore(dense_qp_in *qp_in, dense_qp_out *qp_out, void *args_, void *m
     QPDenseSetInt(QP, "maxiter", args->max_iter);
     QPDenseSetInt(QP, "prtfreq", args->print_freq);
     QPDenseOptimize( QP, lb, ub, g, 0, 0 );
-    int qore_status = QP->status;
+    int qore_status;
+    QPDenseGetInt(QP, "status", &qore_status);
 
     double *prim_sol = memory->prim_sol;
     double *dual_sol = memory->dual_sol;

--- a/acados/dense_qp/dense_qp_qore.c
+++ b/acados/dense_qp/dense_qp_qore.c
@@ -32,8 +32,6 @@
 #include "acados/dense_qp/dense_qp_common.h"
 #include "acados/utils/mem.h"
 #include "acados/utils/timing.h"
-// qore
-#include "qproblem_dense.h"
 
 int dense_qp_qore_calculate_args_size(dense_qp_dims *dims)
 {

--- a/acados/utils/types.h
+++ b/acados/utils/types.h
@@ -28,6 +28,8 @@ extern "C" {
 
 #define MAX_STR_LEN 256
 #define ACADOS_EPS 1e-12
+#define ACADOS_NEG_INFTY -1.0e9
+#define ACADOS_POS_INFTY +1.0e9
 
 typedef double real_t;
 typedef unsigned int uint;

--- a/examples/matlab/ocp_qp_example.m
+++ b/examples/matlab/ocp_qp_example.m
@@ -8,13 +8,18 @@ qp.set('B', [0; 1]);
 qp.set('Q', eye(2));
 qp.set('R', 1);
 
+% specify bounds
+qp.set('lbx', [0.5; -inf]);
+qp.set('ubx', [2.0; +inf]);
+
 % specify initial condition
 x0 = [1; 1];
 qp.set('lbx', 0, x0);
 qp.set('ubx', 0, x0);
 
 % solve QP
-output = qp.solve('qpoases');
+qp.initialize_solver('qpoases');
+output = qp.solve();
 
 xopt = output.states();
 

--- a/examples/python/ocp_qp.py
+++ b/examples/python/ocp_qp.py
@@ -3,7 +3,7 @@ from numpy import array, diag, inf
 
 from acados import ocp_qp
 
-qp = ocp_qp(N=5, nx=2, nu=1, nbx=2)
+qp = ocp_qp(N=5, nx=2, nu=1)
 
 # specify OCP
 qp.set('A', array([[0, 1], [0, 0]]))
@@ -14,6 +14,9 @@ qp.set('R', diag([1]))
 # specify bounds
 qp.set("lbx", array([0.5, 0.5]))
 qp.set("ubx", array([2, 2]))
+
+qp.set("lbu", array([-100]))
+qp.set("ubu", array([+100]))
 
 # specify initial condition
 x0 = array([1, 1])

--- a/examples/python/ocp_qp.py
+++ b/examples/python/ocp_qp.py
@@ -12,11 +12,11 @@ qp.set('Q', diag([1, 1]))
 qp.set('R', diag([1]))
 
 # specify bounds
-qp.set("lbx", array([0.5, -inf]))
-qp.set("ubx", array([2.0, +inf]))
+# qp.set("lbx", array([0.5, -inf]))
+# qp.set("ubx", array([2.0, +inf]))
 
-qp.set("lbu", array([-100]))
-qp.set("ubu", array([+100]))
+# qp.set("lbu", array([-inf]))
+# qp.set("ubu", array([+inf]))
 
 # specify initial condition
 x0 = array([1, 1])

--- a/examples/python/ocp_qp.py
+++ b/examples/python/ocp_qp.py
@@ -12,8 +12,8 @@ qp.set('Q', diag([1, 1]))
 qp.set('R', diag([1]))
 
 # specify bounds
-qp.set("lbx", array([0.5, 0.5]))
-qp.set("ubx", array([2, 2]))
+qp.set("lbx", array([0.5, -inf]))
+qp.set("ubx", array([2.0, +inf]))
 
 qp.set("lbu", array([-100]))
 qp.set("ubu", array([+100]))
@@ -24,7 +24,8 @@ qp.set('lbx', 0, x0)
 qp.set('ubx', 0, x0)
 
 # solve QP and print solution
-for solver_name in ("sparse_hpipm", "condensing_hpipm", "hpmpc", "qpdunes", "qore", "qpoases"):
+# for solver_name in ("sparse_hpipm", "condensing_hpipm", "hpmpc", "qpdunes", "qore", "qpoases"):
+for solver_name in ("sparse_hpipm",):
     print(solver_name + ": ")
     qp.initialize_solver(solver_name)
     output = qp.solve()

--- a/interfaces/acados_cpp/ocp_qp.cpp
+++ b/interfaces/acados_cpp/ocp_qp.cpp
@@ -2,6 +2,7 @@
 #include <algorithm>
 #include <iostream>
 #include <iterator>
+#include <numeric>
 #include <stdexcept>
 #include <cstdlib>
 #include <cmath>
@@ -58,6 +59,17 @@ ocp_qp::ocp_qp(std::vector<uint> nx, std::vector<uint> nu, std::vector<uint> nbx
     std::copy_n(std::begin(ns), N+1, dim->ns);
 
     qp = std::unique_ptr<ocp_qp_in>(create_ocp_qp_in(dim.get()));
+
+    for (int stage = 0; stage <= N; ++stage) {
+        auto lbx = vector<double>(qp->dim->nbx[stage], -INFINITY);
+        set("lbx", stage, lbx);
+        auto ubx = vector<double>(qp->dim->nbx[stage], +INFINITY);
+        set("ubx", stage, ubx);
+        auto lbu = vector<double>(qp->dim->nbu[stage], -INFINITY);
+        set("lbu", stage, lbu);
+        auto ubu = vector<double>(qp->dim->nbu[stage], +INFINITY);
+        set("ubu", stage, ubu);
+    }
 }
 
 ocp_qp::ocp_qp(map<string, vector<uint>> dims)
@@ -143,19 +155,20 @@ void ocp_qp::initialize_solver(string solver_name, map<string, option_t *> optio
 }
 
 void ocp_qp::squeeze_dimensions() {
-    vector<vector<double>> lbx = extract("lbx");
-    vector<vector<double>> ubx = extract("ubx");
-    vector<vector<double>> lbu = extract("lbu");
-    vector<vector<double>> ubu = extract("ubu");
+    auto all_lbx = extract("lbx");
+    auto all_ubx = extract("ubx");
+    auto all_lbu = extract("lbu");
+    auto all_ubu = extract("ubu");
     
-    vector<uint> nbx;
-    vector<vector<uint>> idxb;
-    vector<vector<double>> lower_bound, upper_bound;
+    // States
+    vector<int> nbx;
+    vector<vector<uint>> idxbx;
+    vector<vector<double>> lower_boundx, upper_boundx;
     for (int stage = 0; stage <= N; ++stage) {
         vector<uint> idxb_stage;
         vector<double> lower_bound_stage, upper_bound_stage;
-        for (int idx = 0; idx < qp->dim->nx[stage]; ++idx) {
-            double lb = lbx.at(stage).at(idx), ub = ubx.at(stage).at(idx);
+        for (int idx = 0; idx < dimensions()["nbx"].at(stage); ++idx) {
+            double lb = all_lbx.at(stage).at(idx), ub = all_ubx.at(stage).at(idx);
             if (lb != -INFINITY || ub != +INFINITY) {
                 // we have a double-sided bound at this index
                 idxb_stage.push_back(idx);
@@ -163,21 +176,119 @@ void ocp_qp::squeeze_dimensions() {
                 upper_bound_stage.push_back(isfinite(ub) ? ub : ACADOS_POS_INFTY);
             }
         }
-        lower_bound.push_back(lower_bound_stage);
-        upper_bound.push_back(upper_bound_stage);
+        lower_boundx.push_back(lower_bound_stage);
+        upper_boundx.push_back(upper_bound_stage);
         nbx.push_back(idxb_stage.size());
-        idxb.push_back(idxb_stage);
+        idxbx.push_back(idxb_stage);
     }
-    d_change_bounds_dimensions_ocp_qp(qp->dim->nbu, reinterpret_cast<int *>(nbx.data()), qp.get());
+
+    // Controls
+    vector<int> nbu;
+    vector<vector<uint>> idxbu;
+    vector<vector<double>> lower_boundu, upper_boundu;
     for (int stage = 0; stage <= N; ++stage) {
-        set("lbx", stage, lower_bound.at(stage));
-        set("ubx", stage, upper_bound.at(stage));
-        set("lbu", stage, lbu.at(stage));
-        set("ubu", stage, ubu.at(stage));
-        state_bounds_indices(stage, idxb.at(stage));
+        vector<uint> idxb_stage;
+        vector<double> lower_bound_stage, upper_bound_stage;
+        for (int idx = 0; idx < dimensions()["nbu"].at(stage); ++idx) {
+            double lb = all_lbu.at(stage).at(idx), ub = all_ubu.at(stage).at(idx);
+            if (lb != -INFINITY || ub != +INFINITY) {
+                // we have a double-sided bound at this index
+                idxb_stage.push_back(idx);
+                lower_bound_stage.push_back(isfinite(lb) ? lb : ACADOS_NEG_INFTY);
+                upper_bound_stage.push_back(isfinite(ub) ? ub : ACADOS_POS_INFTY);
+            }
+        }
+        lower_boundu.push_back(lower_bound_stage);
+        upper_boundu.push_back(upper_bound_stage);
+        nbu.push_back(idxb_stage.size());
+        idxbu.push_back(idxb_stage);
+    }
+    d_change_bounds_dimensions_ocp_qp(nbu.data(), nbx.data(), qp.get());
+    for (int stage = 0; stage <= N; ++stage) {
+        set("lbx", stage, lower_boundx.at(stage));
+        set("ubx", stage, upper_boundx.at(stage));
+        bounds_indices("x", stage, idxbx.at(stage));
+        set("lbu", stage, lower_boundu.at(stage));
+        set("ubu", stage, upper_boundu.at(stage));
+        bounds_indices("u", stage, idxbu.at(stage));
     }
     // Re-assign the memory, because the internal structure depends on the dimensions.
     solver->fcn_ptrs->assign_memory(qp->dim, solver->args, solver->mem);
+}
+
+void ocp_qp::expand_dimensions() {
+
+    auto all_lbx = extract("lbx");
+    auto all_ubx = extract("ubx");
+
+    // States
+
+    auto idxbx = bounds_indices("x");
+
+    vector<vector<double>> lower_boundx, upper_boundx;
+    for (int stage = 0; stage <= N; ++stage) {
+        vector<double> lower_bound_stage, upper_bound_stage;
+        int bound_index = 0;
+        for (int state_idx = 0; state_idx < qp->dim->nx[stage]; ++state_idx) {
+            double lb, ub;
+            if (bound_index < qp->dim->nbx[stage] && state_idx == idxbx.at(stage).at(bound_index)) {
+                lb = all_lbx.at(stage).at(bound_index);
+                ub = all_ubx.at(stage).at(bound_index);
+                ++bound_index;
+            } else {
+                lb = -INFINITY;
+                ub = +INFINITY;
+            }
+            lower_bound_stage.push_back(lb);
+            upper_bound_stage.push_back(ub);
+        }
+        lower_boundx.push_back(lower_bound_stage);
+        upper_boundx.push_back(upper_bound_stage);
+    }
+
+    // Controls
+
+    auto all_lbu = extract("lbu");
+    auto all_ubu = extract("ubu");
+
+    auto idxbu = bounds_indices("x");
+
+    vector<vector<double>> lower_boundu, upper_boundu;
+    for (int stage = 0; stage <= N; ++stage) {
+        vector<double> lower_bound_control, upper_bound_control;
+        int bound_index = 0;
+        for (int control_idx = 0; control_idx < qp->dim->nu[stage]; ++control_idx) {
+            double lb, ub;
+            if (bound_index < qp->dim->nbu[stage] && control_idx == idxbu.at(stage).at(bound_index)) {
+                lb = all_lbu.at(stage).at(bound_index);
+                ub = all_ubu.at(stage).at(bound_index);
+                ++bound_index;
+            } else {
+                lb = -INFINITY;
+                ub = +INFINITY;
+            }
+            lower_bound_control.push_back(lb);
+            upper_bound_control.push_back(ub);
+        }
+        lower_boundu.push_back(lower_bound_control);
+        upper_boundu.push_back(upper_bound_control);
+    }
+
+    d_change_bounds_dimensions_ocp_qp(qp->dim->nu, qp->dim->nx, qp.get());
+    
+    for (int stage = 0; stage <= N; ++stage) {
+        set("lbx", stage, lower_boundx.at(stage));
+        set("ubx", stage, upper_boundx.at(stage));
+        vector<uint> idx_states(qp->dim->nx[stage]);
+        std::iota(std::begin(idx_states), std::end(idx_states), 0);
+        bounds_indices("x", stage, idx_states);
+
+        set("lbu", stage, lower_boundu.at(stage));
+        set("ubu", stage, upper_boundu.at(stage));
+        vector<uint> idx_controls(qp->dim->nu[stage]);
+        std::iota(std::begin(idx_controls), std::end(idx_controls), 0);
+        bounds_indices("u", stage, idx_controls);
+    }
 }
 
 ocp_qp_solution ocp_qp::solve() {
@@ -186,12 +297,9 @@ ocp_qp_solution ocp_qp::solve() {
 
     auto result = std::unique_ptr<ocp_qp_out>(create_ocp_qp_out(qp->dim));
 
-    std::cout << *this;
-
     int_t return_code = ocp_qp_solve(solver.get(), qp.get(), result.get());
 
-    // expand again
-    d_change_bounds_dimensions_ocp_qp(qp->dim->nu, qp->dim->nx, qp.get());
+    expand_dimensions();
 
     if (return_code != ACADOS_SUCCESS) {
         if (return_code == ACADOS_MAXITER)
@@ -220,22 +328,42 @@ void ocp_qp::flatten(map<string, option_t *>& input, map<string, option_t *>& ou
     }
 }
 
-void ocp_qp::state_bounds_indices(uint stage, vector<uint> v) {
-    uint nb_state_bounds = qp->dim->nbx[stage];
-    if (nb_state_bounds != v.size())
-        throw std::invalid_argument("I need " + std::to_string(nb_state_bounds) + " indices.");
-    for (uint i = 0; i < nb_state_bounds; ++i)
-        qp->idxb[stage][qp->dim->nbu[stage]+i] = qp->dim->nu[stage]+v.at(i);
+vector<vector<uint>> ocp_qp::bounds_indices(string name) {
+    
+    vector<vector<uint>> idxb;
+    if (name == "x") {
+        for (uint stage = 0; stage <= N; ++stage) {
+            int nb_bounds = qp->dim->nbx[stage];
+            idxb.push_back(vector<uint>(nb_bounds));
+            std::copy_n(qp->idxb[stage], nb_bounds, std::begin(idxb.at(stage)));
+        }
+    } else if (name == "u") {
+        for (uint stage = 0; stage <= N; ++stage) {
+            int nb_bounds = qp->dim->nbu[stage];
+            idxb.push_back(vector<uint>(nb_bounds));
+            std::copy_n(qp->idxb[stage], nb_bounds, std::begin(idxb.at(stage)));
+        }
+    } else throw std::invalid_argument("Can only get bounds from x and u, you gave: '" + name + "'.");
+    return idxb;
 }
 
-void ocp_qp::control_bounds_indices(uint stage, vector<uint> v) {
-    uint nb_control_bounds = qp->dim->nbu[stage];
-    if (nb_control_bounds != v.size())
-        throw std::invalid_argument("I need " + std::to_string(nb_control_bounds) + " indices.");
-    for (uint i = 0; i < nb_control_bounds; ++i)
-        qp->idxb[stage][i] = v.at(i);
+void ocp_qp::bounds_indices(string name, uint stage, vector<uint> v) {
+    uint nb_bounds;
+    if (name == "x")
+        nb_bounds = qp->dim->nbx[stage];
+    else if (name == "u")
+        nb_bounds = qp->dim->nbu[stage];
+    else
+        throw std::invalid_argument("Can only set bounds on x and u, you gave: '" + name + "'.");
+    
+    if (nb_bounds != v.size())
+        throw std::invalid_argument("I need " + std::to_string(nb_bounds) + " indices, you gave " + std::to_string(v.size()) + ".");
+    for (uint i = 0; i < nb_bounds; ++i)
+        if (name == "x")
+            qp->idxb[stage][qp->dim->nbu[stage]+i] = qp->dim->nu[stage]+v.at(i);
+        else if (name == "u")
+            qp->idxb[stage][i] = v.at(i);
 }
-
 
 map<string, std::function<void(int, ocp_qp_in *, double *)>> ocp_qp::extract_functions = {
         {"Q", d_cvt_ocp_qp_to_colmaj_Q},
@@ -272,36 +400,36 @@ vector< vector<double> > ocp_qp::extract(std::string field) {
 }
 
 
-const map<string, vector<uint>> ocp_qp::dimensions() const {
+map<string, vector<uint>> ocp_qp::dimensions() {
     return {{"nx", nx()}, {"nu", nu()}, {"nbx", nbx()}, {"nbu", nbu()}, {"ng", ng()}};
 }
 
 
-std::vector<uint> ocp_qp::nx() const {
+std::vector<uint> ocp_qp::nx() {
     std::vector<uint> tmp(N+1);
     std::copy_n(qp->dim->nx, N+1, tmp.begin());
     return tmp;
 }
 
-std::vector<uint> ocp_qp::nu() const {
+std::vector<uint> ocp_qp::nu() {
     std::vector<uint> tmp(N+1);
     std::copy_n(qp->dim->nu, N+1, tmp.begin());
     return tmp;
 }
 
-std::vector<uint> ocp_qp::nbx() const {
+std::vector<uint> ocp_qp::nbx() {
     std::vector<uint> tmp(N+1);
     std::copy_n(qp->dim->nbx, N+1, tmp.begin());
     return tmp;
 }
 
-std::vector<uint> ocp_qp::nbu() const {
+std::vector<uint> ocp_qp::nbu() {
     std::vector<uint> tmp(N+1);
     std::copy_n(qp->dim->nbu, N+1, tmp.begin());
     return tmp;
 }
 
-std::vector<uint> ocp_qp::ng() const {
+std::vector<uint> ocp_qp::ng() {
     std::vector<uint> tmp(N+1);
     std::copy_n(qp->dim->ng, N+1, tmp.begin());
     return tmp;
@@ -376,7 +504,7 @@ static bool match(std::pair<uint, uint> dims, uint nb_elems) {
 
 void ocp_qp::check_nb_elements(std::string field, uint stage, uint nb_elems) {
     if (!match(dimensions(field, stage), nb_elems))
-        throw std::invalid_argument("Need " + std::to_string(dimensions(field, stage)) + " elements.");
+        throw std::invalid_argument("I need " + std::to_string(dimensions(field, stage)) + " elements but got " + std::to_string(nb_elems) + ".");
 }
 
 ocp_qp_solver_plan string_to_plan(string solver) {

--- a/interfaces/acados_cpp/ocp_qp.cpp
+++ b/interfaces/acados_cpp/ocp_qp.cpp
@@ -21,11 +21,16 @@ ocp_qp::ocp_qp(std::vector<uint> nx, std::vector<uint> nu, std::vector<uint> nbx
 
     if (N <= 0) throw std::invalid_argument("Number of stages must be positive");
 
+    if (nu.at(N) != 0 || nbu.at(N) != 0) {
+        nu.at(N) = 0;
+        nbu.at(N) = 0;
+    }
+
     uint expected_size = nx.size();
     bool is_valid_nu = (nu.size() == expected_size || nu.size() == expected_size-1);
-    if (!is_valid_nu || nbx.size() != expected_size || nbu.size() != expected_size
-        || ng.size() != expected_size)
-            throw std::invalid_argument("Number of stages should be N");
+    bool is_valid_nbu = (nbu.size() == expected_size || nbu.size() == expected_size-1);
+    if (!is_valid_nu || nbx.size() != expected_size || !is_valid_nbu || ng.size() != expected_size)
+        throw std::invalid_argument("All dimensions should have length N+1");
 
     dim = std::unique_ptr<ocp_qp_dims>(create_ocp_qp_dims(N));
 
@@ -33,7 +38,6 @@ ocp_qp::ocp_qp(std::vector<uint> nx, std::vector<uint> nu, std::vector<uint> nbx
     std::copy_n(std::begin(nx), N+1, dim->nx);
 
     // controls
-    if (nu.size() == (N+1)) nu.at(N) = 0;
     std::copy_n(std::begin(nu), N+1, dim->nu);
 
     // bounds
@@ -137,7 +141,22 @@ void ocp_qp::initialize_solver(string solver_name, map<string, option_t *> optio
     solver.reset(ocp_qp_create(&plan, dim.get(), args.get()));
 }
 
+// void ocp_qp::fit_bounds() {
+    // vector<vector<double>> lbx = extract("lbx");
+    // vector<vector<double>> ubx = extract("ubx");
+    // vector<vector<double>> lbu = extract("lbu");
+    // vector<vector<double>> ubu = extract("ubu");
+    // for (int i = 0; i <= N; ++i) {
+    //     int nbx = 0;
+    //     for (int j = 0; j < lbx.size(); ++j)
+
+    // }
+// }
+
 ocp_qp_solution ocp_qp::solve() {
+
+    // fit_bounds();
+
     auto result = std::unique_ptr<ocp_qp_out>(create_ocp_qp_out(dim.get()));
     int_t return_code = ocp_qp_solve(solver.get(), qp.get(), result.get());
     if (return_code != ACADOS_SUCCESS) {

--- a/interfaces/acados_cpp/ocp_qp.hpp
+++ b/interfaces/acados_cpp/ocp_qp.hpp
@@ -38,12 +38,13 @@ public:
 
     vector< vector<double> > extract(string field);
 
-    const map<string, vector<uint>> dimensions() const;
+    map<string, vector<uint>> dimensions();
 
     std::pair<uint, uint> dimensions(string field, uint stage);
 
-    void state_bounds_indices(uint stage, vector<uint> v);
-    void control_bounds_indices(uint stage, vector<uint> v);
+    void bounds_indices(std::string name, uint stage, vector<uint> v);
+
+    std::vector<std::vector<uint>> bounds_indices(string name);
 
     const uint N;
 
@@ -51,17 +52,19 @@ private:
     
     void squeeze_dimensions();
 
+    void expand_dimensions();
+
     void check_range(string field, uint stage);
     
     void check_nb_elements(string, uint stage, uint nb_elems);
 
     void flatten(map<string, option_t *>& input, map<string, option_t *>& output);
 
-    vector<uint> nx() const;
-    vector<uint> nu() const;
-    vector<uint> nbx() const;
-    vector<uint> nbu() const;
-    vector<uint> ng() const;
+    vector<uint> nx();
+    vector<uint> nu();
+    vector<uint> nbx();
+    vector<uint> nbu();
+    vector<uint> ng();
 
     std::unique_ptr<ocp_qp_in> qp;
 

--- a/interfaces/acados_cpp/ocp_qp.hpp
+++ b/interfaces/acados_cpp/ocp_qp.hpp
@@ -49,6 +49,8 @@ public:
 
 private:
     
+    void squeeze_dimensions();
+
     void check_range(string field, uint stage);
     
     void check_nb_elements(string, uint stage, uint nb_elems);
@@ -66,8 +68,6 @@ private:
     std::unique_ptr<ocp_qp_solver> solver;
 
     std::string cached_solver;
-
-    std::unique_ptr<ocp_qp_dims> dim;
 
     static std::map<string, std::function<void(int, ocp_qp_in *, double *)>> extract_functions;
 

--- a/interfaces/acados_cpp/utils.hpp
+++ b/interfaces/acados_cpp/utils.hpp
@@ -12,11 +12,11 @@ namespace std {
 
     template<typename T>
     std::string to_string(std::vector<T> v) {
-        std::string result_string;
+        std::string result_string = " vector of length " + std::to_string(v.size()) + ": [\n ";
         for(auto it : v) {
             result_string += std::to_string(it) + ", ";
         }
-        return result_string;
+        return result_string + "]\n";
     }
 }  // namespace std
 

--- a/interfaces/acados_cpp/utils.hpp
+++ b/interfaces/acados_cpp/utils.hpp
@@ -2,9 +2,21 @@
 #ifndef ACADOS_INTERFACES_ACADOS_CPP_PAIR_HPP_
 #define ACADOS_INTERFACES_ACADOS_CPP_PAIR_HPP_
 
+#include <utility>
+#include <vector>
+
 namespace std {
     std::string to_string(std::pair<uint, uint> p) {
         return "( " + std::to_string(p.first) + ", " + std::to_string(p.second) + " )";
+    }
+
+    template<typename T>
+    std::string to_string(std::vector<T> v) {
+        std::string result_string;
+        for(auto it : v) {
+            result_string += std::to_string(it) + ", ";
+        }
+        return result_string;
     }
 }  // namespace std
 

--- a/swig/ocp_qp.i
+++ b/swig/ocp_qp.i
@@ -120,12 +120,12 @@ using std::string;
         std::vector<uint> idx_states(nx);
         std::iota(std::begin(idx_states), std::end(idx_states), 0);
         for (int i = 0; i <= N; ++i)
-            qp->state_bounds_indices(i, idx_states);
+            qp->bounds_indices("x", i, idx_states);
 
         std::vector<uint> idx_controls(nu);
         std::iota(std::begin(idx_controls), std::end(idx_controls), 0);
         for (int i = 0; i < N; ++i)
-            qp->control_bounds_indices(i, idx_controls);
+            qp->bounds_indices("u", i, idx_controls);
 
         return qp;
     }

--- a/swig/ocp_qp.i
+++ b/swig/ocp_qp.i
@@ -113,26 +113,20 @@ using std::string;
 
 %extend acados::ocp_qp {
 
-    ocp_qp(uint N = 10, uint nx = 2, uint nu = 1, uint nbx = 0, uint nbu = 0, uint ng = 0, bool fix_x0 = true) {
-        if (fix_x0 == false)
-            return new acados::ocp_qp(N, nx, nu, nbx, nbu, ng);
-        vector<uint> nbx_v(N+1, 0);
-        if (nbx == 0)
-            nbx_v.at(0) = nx;
-        else
-            std::fill(std::begin(nbx_v), std::end(nbx_v), nbx);
-        acados::ocp_qp *qp = new acados::ocp_qp(vector<uint>(N+1, nx), vector<uint>(N+1, nu), nbx_v,
-                                  vector<uint>(N+1, nbu), vector<uint>(N+1, ng));
-        for (int i = 0; i <= N; ++i) {
-            std::vector<uint> idx_states(nbx);
-            std::iota(std::begin(idx_states), std::end(idx_states), 0);
+    ocp_qp(uint N = 10, uint nx = 2, uint nu = 1, uint ng = 0, bool fix_x0 = true) {
+
+        auto qp = new acados::ocp_qp(N, nx, nu, nx, nu, ng);
+
+        std::vector<uint> idx_states(nx);
+        std::iota(std::begin(idx_states), std::end(idx_states), 0);
+        for (int i = 0; i <= N; ++i)
             qp->state_bounds_indices(i, idx_states);
-        }
-        for (int i = 0; i <= N; ++i) {
-            std::vector<uint> idx_controls(nbu);
-            std::iota(std::begin(idx_controls), std::end(idx_controls), 0);
+
+        std::vector<uint> idx_controls(nu);
+        std::iota(std::begin(idx_controls), std::end(idx_controls), 0);
+        for (int i = 0; i < N; ++i)
             qp->control_bounds_indices(i, idx_controls);
-        }
+
         return qp;
     }
 


### PR DESCRIPTION
It is now possible to set bounds from Python and/or MATLAB, like so

    qp.set('lbx', [-inf; lb1; lb2])
    qp.set('ubx', [+inf; ub1; ub2])

and so on. It is assumed that all states and constraints have bounds, they are initialized at -/+ infinity.