### PR TITLE
Bump minimum version of cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@
 #
 #
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.1)
 
 if(CMAKE_MAKE_PROGRAM)
     file(TO_CMAKE_PATH ${CMAKE_MAKE_PROGRAM} CMAKE_MAKE_PROGRAM)


### PR DESCRIPTION
Command [`target_sources`](https://cmake.org/cmake/help/v3.1/command/target_sources.html) is available only from cmake 3.1.
With cmake 3.0.0-rc3 I get this error:
```
-->~/build/cmake-3.0.0-rc2-Linux-i386/bin/cmake -D SWIG_MATLAB=0 -D SWIG_PYTHON=0 -D ACADOS_WITH_QORE=0 ..                                           
-- The C compiler identification is GNU 4.9.2
-- The CXX compiler identification is GNU 4.9.2
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Build type is Release
-- Installation directory is /usr/local
CMake Error at interfaces/acados_c/dense_qp/CMakeLists.txt:13 (target_sources):
  Unknown CMake command "target_sources".


-- Configuring incomplete, errors occurred!
See also "/home/tom/sources/acados/build/CMakeFiles/CMakeOutput.log".
```