### PR TITLE
add TODO (opts->sens_adj = false)

### DIFF
--- a/acados/sim/sim_lifted_irk_integrator.c
+++ b/acados/sim/sim_lifted_irk_integrator.c
@@ -209,7 +209,7 @@ void sim_lifted_irk_opts_initialize_default(void *config_, sim_dims *dims, void 
     opts->num_steps = 2;
     opts->num_forw_sens = dims->nx + dims->nu;
     opts->sens_forw = true;
-    opts->sens_adj = false;
+    opts->sens_adj = false; // TODO(andrea): this effectively disables the expansion step in lifted integrators !!!!!
     opts->sens_hess = false;
 
 	return;


### PR DESCRIPTION
no expansion step is performed if opts->sens_adj = false, i.e. multiple shooting + lifted integrators (Newton step) != direct collocation (Newton step) @giaf @dkouzoup @FreyJo 