### PR TITLE
Fix for #225

### DIFF
--- a/interfaces/acados_cpp/ocp_qp/ocp_qp.cpp
+++ b/interfaces/acados_cpp/ocp_qp/ocp_qp.cpp
@@ -391,7 +391,7 @@ vector< vector<double> > ocp_qp::extract(std::string field) {
         last_index = N-1;
     vector< vector<double> > result;
     for (uint i = 0; i <= last_index; i++) {
-        auto dims = dimensions(field, i);
+        auto dims = shape_of(field, i);
         vector<double> v(dims.first * dims.second);
         extract_functions[field](i, qp.get(), v.data());
         result.push_back(v);
@@ -455,7 +455,7 @@ void ocp_qp::check_range(std::string field, uint stage) {
               std::to_string(lower_bound) + ", " + std::to_string(upper_bound) + "].");
 }
 
-std::pair<uint, uint> ocp_qp::dimensions(std::string field, uint stage) {
+std::pair<uint, uint> ocp_qp::shape_of(std::string field, uint stage) {
 
     check_range(field, stage);
 
@@ -503,8 +503,8 @@ static bool match(std::pair<uint, uint> dims, uint nb_elems) {
 }
 
 void ocp_qp::check_num_elements(std::string field, uint stage, uint nb_elems) {
-    if (!match(dimensions(field, stage), nb_elems))
-        throw std::invalid_argument("I need " + std::to_string(dimensions(field, stage)) + " elements but got " + std::to_string(nb_elems) + ".");
+    if (!match(shape_of(field, stage), nb_elems))
+        throw std::invalid_argument("I need " + std::to_string(shape_of(field, stage)) + " elements but got " + std::to_string(nb_elems) + ".");
 }
 
 ocp_qp_solver_plan string_to_plan(string solver) {

--- a/interfaces/acados_cpp/ocp_qp/ocp_qp.hpp
+++ b/interfaces/acados_cpp/ocp_qp/ocp_qp.hpp
@@ -38,7 +38,7 @@ public:
 
     std::map<std::string, std::vector<uint>> dimensions();
 
-    std::pair<uint, uint> dimensions(std::string field, uint stage);
+    std::pair<uint, uint> shape_of(std::string field, uint stage);
 
     void set_bounds_indices(std::string name, uint stage, std::vector<uint> v);
 

--- a/swig/acados.i
+++ b/swig/acados.i
@@ -40,6 +40,7 @@ typedef PyObject LangObject;
 %include "std_vector.i"
 namespace std {
     %template(vector_i) vector<int>;
+    %template(vector_u) vector<uint>;
     %template(vector_string) vector<string>;
     %template(vector_O) vector<LangObject *>;
 };
@@ -47,6 +48,11 @@ namespace std {
 %include "std_pair.i"
 namespace std {
     %template(pair_ii) pair<uint, uint>;
+}
+
+%include "std_map.i"
+namespace std {
+    %template(map_si) map< string, vector<uint> >;
 }
 
 #if defined(SWIGPYTHON)

--- a/swig/conversions.i
+++ b/swig/conversions.i
@@ -76,6 +76,8 @@ mxClassID get_numeric_type() {
         return mxDOUBLE_CLASS;
     else if (typeid(T) == typeid(int_t))
         return mxDOUBLE_CLASS;
+    else if (typeid(T) == typeid(uint))
+        return mxDOUBLE_CLASS;
     throw std::invalid_argument("Matrix can only have integer or floating point entries");
     return mxUNKNOWN_CLASS;
 }
@@ -216,20 +218,20 @@ LangObject *new_matrix(std::pair<int, int> dimensions, const T *data) {
     int_t nb_cols = dimensions.second;
 #if defined(SWIGMATLAB)
     mxArray *matrix = mxCreateNumericMatrix(nb_rows, nb_cols, get_numeric_type<T>(), mxREAL);
-    T *new_array = (T *) mxCalloc(nb_rows*nb_cols, sizeof(T));
+    double *new_array = (double *) mxCalloc(nb_rows*nb_cols, sizeof(double));
     for (int_t i = 0; i < nb_rows*nb_cols; i++)
-        new_array[i] = data[i];
+        new_array[i] = (double) data[i];
     mxSetData(matrix, new_array);
     return matrix;
 #elif defined(SWIGPYTHON)
     PyObject *matrix = NULL;
     if (nb_cols == 1) {
-        T *data_copy = (T *) calloc(nb_rows, sizeof(T));
+        double *data_copy = (double *) calloc(nb_rows, sizeof(double));
         std::copy_n(data, nb_rows, data_copy);
         npy_intp npy_dims[1] = {nb_rows};
         matrix = PyArray_NewFromDataF(1, npy_dims, data_copy);
     } else {
-        T *data_copy = (T *) calloc(nb_rows * nb_cols, sizeof(T));
+        double *data_copy = (double *) calloc(nb_rows * nb_cols, sizeof(double));
         std::copy_n(data, nb_rows * nb_cols, data_copy);
         npy_intp npy_dims[2] = {nb_rows, nb_cols};
         matrix = PyArray_NewFromDataF(2, npy_dims, data_copy);

--- a/swig/ocp_qp.i
+++ b/swig/ocp_qp.i
@@ -117,7 +117,7 @@ LangObject *ocp_qp_output(const ocp_qp_in *in, const ocp_qp_out *out) {
         std::vector<std::vector<double>> tmp = $self->extract(field);
         std::vector<LangObject *> result;
         for (int i = 0; i < tmp.size(); ++i)
-            result.push_back(new_matrix($self->dimensions(field, i), tmp.at(i).data()));
+            result.push_back(new_matrix($self->shape_of(field, i), tmp.at(i).data()));
         return swig::from(result);
     }
 


### PR DESCRIPTION
It should be possible now to read out dimensions. Took a while because of the following caveats:

- SWIG is apparently not able to automatically wrap `std::map` as MATLAB structs
- to be consistent, I manually coded a conversion to Python `dict` as well
- `%template` clauses still necessary