### PR TITLE
Proof-of-concept of xxx_calculate_size_self and xxx_assign_self, to facilitate bottom-up approach

### DIFF
--- a/acados/ocp_nlp/ocp_nlp_common.c
+++ b/acados/ocp_nlp/ocp_nlp_common.c
@@ -335,8 +335,6 @@ ocp_nlp_in *ocp_nlp_in_assign(ocp_nlp_solver_config *config, ocp_nlp_dims *dims,
     ocp_nlp_in *in = (ocp_nlp_in *) c_ptr;
     c_ptr += sizeof(ocp_nlp_in);
 
-    in->dims = dims;
-
     // Ts
     in->Ts = (double *) c_ptr;
     c_ptr += N * sizeof(double);

--- a/acados/ocp_nlp/ocp_nlp_common.c
+++ b/acados/ocp_nlp/ocp_nlp_common.c
@@ -112,11 +112,13 @@ ocp_nlp_solver_config *ocp_nlp_solver_config_assign(int N, void *raw_memory)
     return config;
 }
 
+
+
 /************************************************
  * dims
  ************************************************/
 
-int ocp_nlp_dims_calculate_size(void *config_)
+int ocp_nlp_dims_calculate_size_self(void *config_)
 {
     ocp_nlp_solver_config *config = config_;
 
@@ -131,19 +133,14 @@ int ocp_nlp_dims_calculate_size(void *config_)
     // nlp sizes
     size += 4 * (N + 1) * sizeof(int);  // nv, nx, nu, ni
 
-    // dynamics_dims
+    // dynamics
     size += N * sizeof(void *);
-    for (ii = 0; ii < N; ii++)
-        size += config->dynamics[ii]->dims_calculate_size(config->dynamics[ii]);
 
-    // cost_dims
+    // cost
     size += (N + 1) * sizeof(void *);
-    for (ii = 0; ii <= N; ii++) size += config->cost[ii]->dims_calculate_size(config->cost[ii]);
 
-    // constraints_dims
-    size += (N + 1) * sizeof(ocp_nlp_constraints_dims *);
-    for (ii = 0; ii <= N; ii++)
-        size += config->constraints[ii]->dims_calculate_size(config->constraints[ii]);
+    // constraints
+    size += (N + 1) * sizeof(void *);
 
     // qp solver
     size += ocp_qp_dims_calculate_size(N);
@@ -153,7 +150,39 @@ int ocp_nlp_dims_calculate_size(void *config_)
     return size;
 }
 
-ocp_nlp_dims *ocp_nlp_dims_assign(void *config_, void *raw_memory)
+
+
+int ocp_nlp_dims_calculate_size(void *config_)
+{
+    ocp_nlp_solver_config *config = config_;
+
+    int N = config->N;
+
+    int ii;
+
+    int size = 0;
+
+    // self
+    size += ocp_nlp_dims_calculate_size_self(config_);
+
+    // dynamics
+    for (ii = 0; ii < N; ii++)
+        size += config->dynamics[ii]->dims_calculate_size(config->dynamics[ii]);
+
+    // cost
+    for (ii = 0; ii <= N; ii++)
+        size += config->cost[ii]->dims_calculate_size(config->cost[ii]);
+
+    // constraints
+    for (ii = 0; ii <= N; ii++)
+        size += config->constraints[ii]->dims_calculate_size(config->constraints[ii]);
+
+    return size;
+}
+
+
+
+ocp_nlp_dims *ocp_nlp_dims_assign_self(void *config_, void *raw_memory)
 {
     ocp_nlp_solver_config *config = config_;
 
@@ -183,32 +212,13 @@ ocp_nlp_dims *ocp_nlp_dims_assign(void *config_, void *raw_memory)
     dims->dynamics = (void **) c_ptr;
     c_ptr += N * sizeof(void *);
 
-    for (ii = 0; ii < N; ii++)
-    {
-        dims->dynamics[ii] = config->dynamics[ii]->dims_assign(config->dynamics[ii], c_ptr);
-        c_ptr += config->dynamics[ii]->dims_calculate_size(config->dynamics[ii]);
-    }
-
     // cost
     dims->cost = (void **) c_ptr;
     c_ptr += (N + 1) * sizeof(void *);
 
-    for (ii = 0; ii <= N; ii++)
-    {
-        dims->cost[ii] = config->cost[ii]->dims_assign(config->cost[ii], c_ptr);
-        c_ptr += config->cost[ii]->dims_calculate_size(config->cost[ii]);
-    }
-
     // constraints
     dims->constraints = (void **) c_ptr;
     c_ptr += (N + 1) * sizeof(void *);
-
-    for (ii = 0; ii <= N; ii++)
-    {
-        dims->constraints[ii] =
-            config->constraints[ii]->dims_assign(config->constraints[ii], c_ptr);
-        c_ptr += config->constraints[ii]->dims_calculate_size(config->constraints[ii]);
-    }
 
     // qp solver
     dims->qp_solver = ocp_qp_dims_assign(N, c_ptr);
@@ -218,10 +228,56 @@ ocp_nlp_dims *ocp_nlp_dims_assign(void *config_, void *raw_memory)
     dims->N = N;
 
     // assert
+    assert((char *) raw_memory + ocp_nlp_dims_calculate_size_self(config_) >= c_ptr);
+
+    return dims;
+}
+
+
+
+ocp_nlp_dims *ocp_nlp_dims_assign(void *config_, void *raw_memory)
+{
+    ocp_nlp_solver_config *config = config_;
+
+    int N = config->N;
+
+    int ii;
+
+    char *c_ptr = (char *) raw_memory;
+
+    // self
+    ocp_nlp_dims *dims = ocp_nlp_dims_assign_self(config_, c_ptr);
+    c_ptr += ocp_nlp_dims_calculate_size_self(config_);
+
+    // dynamics
+    for (ii = 0; ii < N; ii++)
+    {
+        dims->dynamics[ii] = config->dynamics[ii]->dims_assign(config->dynamics[ii], c_ptr);
+        c_ptr += config->dynamics[ii]->dims_calculate_size(config->dynamics[ii]);
+    }
+
+    // cost
+    for (ii = 0; ii <= N; ii++)
+    {
+        dims->cost[ii] = config->cost[ii]->dims_assign(config->cost[ii], c_ptr);
+        c_ptr += config->cost[ii]->dims_calculate_size(config->cost[ii]);
+    }
+
+    // constraints
+    for (ii = 0; ii <= N; ii++)
+    {
+        dims->constraints[ii] =
+            config->constraints[ii]->dims_assign(config->constraints[ii], c_ptr);
+        c_ptr += config->constraints[ii]->dims_calculate_size(config->constraints[ii]);
+    }
+
+    // assert
     assert((char *) raw_memory + ocp_nlp_dims_calculate_size(config_) >= c_ptr);
 
     return dims;
 }
+
+
 
 void ocp_nlp_dims_initialize(void *config_, int *nx, int *nu, int *ny, int *nbx, int *nbu, int *ng,
                              int *nh, int *nq, int *ns, ocp_nlp_dims *dims)
@@ -275,6 +331,8 @@ void ocp_nlp_dims_initialize(void *config_, int *nx, int *nu, int *ny, int *nbx,
 
     return;
 }
+
+
 
 /************************************************
  * in

--- a/acados/ocp_nlp/ocp_nlp_common.h
+++ b/acados/ocp_nlp/ocp_nlp_common.h
@@ -70,10 +70,6 @@ typedef struct
     void **cost;
     void **dynamics;
     void **constraints;
-
-    // TODO(rien): what about invariants, e.g., algebraic constraints?
-
-    bool freezeSens;  // TODO(dimitris): shouldn't this be in the integrator args?
 } ocp_nlp_in;
 
 /************************************************

--- a/acados/ocp_nlp/ocp_nlp_common.h
+++ b/acados/ocp_nlp/ocp_nlp_common.h
@@ -50,7 +50,11 @@ typedef struct
 } ocp_nlp_dims;
 
 //
+int ocp_nlp_dims_calculate_size_self(void *config);
+//
 int ocp_nlp_dims_calculate_size(void *config);
+//
+ocp_nlp_dims *ocp_nlp_dims_assign_self(void *config, void *raw_memory);
 //
 ocp_nlp_dims *ocp_nlp_dims_assign(void *config, void *raw_memory);
 //

--- a/acados/ocp_nlp/ocp_nlp_common.h
+++ b/acados/ocp_nlp/ocp_nlp_common.h
@@ -63,8 +63,6 @@ void ocp_nlp_dims_initialize(void *config, int *nx, int *nu, int *ny, int *nbx, 
 
 typedef struct
 {
-    ocp_nlp_dims *dims;  // pointer to nlp dimensions
-
     double *Ts;  // length of sampling intervals
 
     void **cost;

--- a/acados/ocp_nlp/ocp_nlp_dynamics_cont.c
+++ b/acados/ocp_nlp/ocp_nlp_dynamics_cont.c
@@ -348,9 +348,6 @@ void *ocp_nlp_dynamics_cont_model_assign(void *config_, void *dims_, void *raw_m
     ocp_nlp_dynamics_cont_model *model = (ocp_nlp_dynamics_cont_model *) c_ptr;
     c_ptr += sizeof(ocp_nlp_dynamics_cont_model);
 
-    // dims
-    model->dims = dims;
-
     model->sim_model = config->sim_solver->model_assign(config->sim_solver, dims->sim, c_ptr);
     c_ptr += config->sim_solver->model_calculate_size(config->sim_solver, dims->sim);
 

--- a/acados/ocp_nlp/ocp_nlp_dynamics_cont.h
+++ b/acados/ocp_nlp/ocp_nlp_dynamics_cont.h
@@ -123,7 +123,6 @@ int ocp_nlp_dynamics_cont_workspace_calculate_size(void *config, void *dims, voi
 
 typedef struct
 {
-    void *dims;
     void *sim_model;
     // double *state_transition; // TODO
     double T;  // simulation time

--- a/examples/c/nonlinear_chain_ocp_nlp.c
+++ b/examples/c/nonlinear_chain_ocp_nlp.c
@@ -1438,9 +1438,6 @@ int main()
 		}
 	}
 
-    nlp_in->freezeSens = false;
-	// if (scheme > 2)
-    //     nlp_in->freezeSens = true;
 
     /* constraints */
 	ocp_nlp_constraints_model **constraints = (ocp_nlp_constraints_model **) nlp_in->constraints;

--- a/examples/c/nonlinear_chain_ocp_nlp_no_interface.c
+++ b/examples/c/nonlinear_chain_ocp_nlp_no_interface.c
@@ -1714,12 +1714,6 @@ int main() {
 
 
 
-    nlp_in->freezeSens = false;
-    if (scheme > 2)
-        nlp_in->freezeSens = true;
-
-
-
     /* box constraints */
 
 	ocp_nlp_constraints_model **constraints = (ocp_nlp_constraints_model **) nlp_in->constraints;

--- a/examples/c/wind_turbine_nmpc.c
+++ b/examples/c/wind_turbine_nmpc.c
@@ -673,7 +673,6 @@ int main()
 		}
 	}
 
-    nlp_in->freezeSens = false;
 
     /* constraints */
 

--- a/interfaces/acados_c/ocp_nlp_interface.c
+++ b/interfaces/acados_c/ocp_nlp_interface.c
@@ -266,6 +266,6 @@ ocp_nlp_solver *ocp_nlp_create(ocp_nlp_solver_config *config, ocp_nlp_dims *dims
 
 int ocp_nlp_solve(ocp_nlp_solver *solver, ocp_nlp_in *nlp_in, ocp_nlp_out *nlp_out)
 {
-    return solver->config->evaluate(solver->config, nlp_in->dims, nlp_in, nlp_out, solver->opts,
+    return solver->config->evaluate(solver->config, solver->dims, nlp_in, nlp_out, solver->opts,
                                     solver->mem, solver->work);
 }


### PR DESCRIPTION
This PR contains a proof-of-concept (for the ocp_nlp_dims) of a feature facilitating the bottom-up approach that @roversch plans to use in the python and matlab interfaces.

The idea to increase code-reuse between core and these interfaces it to create for each module xxx_calculate_size_self and xxx_assign_self, which handle all memory needed by the structure itself, excluding sub-modules. The functions xxx_calculate_size and xxx_assign internally call their _self counterparts, avoiding code duplication.

No changes are needed in the current acados solvers, C interface or examples, as they can still use the non_self functions as before.