### PR TITLE
Installation instructions casadi download path fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,20 +24,20 @@ Both a CMake and a Makefile based build system are supported at the moment.
     and, depending on your preferred CasADi interface (Python, MATLAB, Octave):
 
     ```
-    wget -q -nc http://files.casadi.org/download/3.4.0/casadi-linux-py35-v3.4.0-64bit.tar.gz
+    wget -q -nc --show-progress https://github.com/casadi/casadi/releases/download/3.4.0/casadi-linux-py35-v3.4.0-64bit.tar.gz
     mkdir -p casadi-py35-v3.4.0-64bit
     tar -xf casadi-linux-py35-v3.4.0-64bit.tar.gz -C casadi-py35-v3.4.0-64bit
     ```
 
     ```
-    wget -q -nc http://files.casadi.org/download/3.4.0/casadi-linux-matlabR2014b-v3.4.0.tar.gz
+    wget -q -nc --show-progress https://github.com/casadi/casadi/releases/download/3.4.0/casadi-linux-matlabR2014b-v3.4.0.tar.gz
     mkdir -p casadi-matlabR2014b-v3.4.0
     tar -xf casadi-linux-matlabR2014b-v3.4.0.tar.gz -C casadi-matlabR2014b-v3.4.0
     cd ..
     ```
 
     ```
-    wget -q -nc http://files.casadi.org/download/3.4.0/casadi-linux-octave-v3.4.0.tar.gz
+    wget -q -nc --show-progress https://github.com/casadi/casadi/releases/download/3.4.0/casadi-linux-octave-v3.4.0.tar.gz
     mkdir -p casadi-octave-v3.4.0
     tar -xf casadi-linux-octave-v3.4.0.tar.gz -C casadi-octave-v3.4.0
     ```

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Both a CMake and a Makefile based build system are supported at the moment.
     wget -q -nc --show-progress https://github.com/casadi/casadi/releases/download/3.4.0/casadi-linux-py35-v3.4.0-64bit.tar.gz
     mkdir -p casadi-py35-v3.4.0-64bit
     tar -xf casadi-linux-py35-v3.4.0-64bit.tar.gz -C casadi-py35-v3.4.0-64bit
+    cd ..
     ```
 
     ```
@@ -40,6 +41,7 @@ Both a CMake and a Makefile based build system are supported at the moment.
     wget -q -nc --show-progress https://github.com/casadi/casadi/releases/download/3.4.0/casadi-linux-octave-v3.4.0.tar.gz
     mkdir -p casadi-octave-v3.4.0
     tar -xf casadi-linux-octave-v3.4.0.tar.gz -C casadi-octave-v3.4.0
+    cd ..
     ```
 
 1. Build and install `acados`.


### PR DESCRIPTION
fixed the download paths, and added --show-progress to wget that you are able to see if the download succeeded