### PR TITLE
Portability: wrong alignments on 32-bit systems

### DIFF
--- a/acados/ocp_nlp/ocp_nlp_common.c
+++ b/acados/ocp_nlp/ocp_nlp_common.c
@@ -644,6 +644,7 @@ int ocp_nlp_in_calculate_size(ocp_nlp_config *config, ocp_nlp_dims *dims)
     {
         size +=
             config->dynamics[ii]->model_calculate_size(config->dynamics[ii], dims->dynamics[ii]);
+        size += 8;
     }
 
     // cost
@@ -719,6 +720,7 @@ ocp_nlp_in *ocp_nlp_in_assign(ocp_nlp_config *config, ocp_nlp_dims *dims, void *
             config->dynamics[ii]->model_assign(config->dynamics[ii], dims->dynamics[ii], c_ptr);
         c_ptr +=
             config->dynamics[ii]->model_calculate_size(config->dynamics[ii], dims->dynamics[ii]);
+        align_char_to(8, &c_ptr);
     }
 
     // cost

--- a/acados/ocp_qp/ocp_qp_common.c
+++ b/acados/ocp_qp/ocp_qp_common.c
@@ -168,6 +168,7 @@ int ocp_qp_in_calculate_size(void *config, ocp_qp_dims *dims)
     int size = sizeof(ocp_qp_in);
     size += d_memsize_ocp_qp(dims);
     size += ocp_qp_dims_calculate_size(dims->N);  // TODO(all): remove !!!
+    size += 8;
     return size;
 }
 
@@ -182,6 +183,8 @@ ocp_qp_in *ocp_qp_in_assign(void *config, ocp_qp_dims *dims, void *raw_memory)
 
     d_create_ocp_qp(dims, qp_in, c_ptr);
     c_ptr += d_memsize_ocp_qp(dims);
+
+    align_char_to(8, &c_ptr);
 
     ocp_qp_dims *dims_copy = ocp_qp_dims_assign(dims->N, c_ptr);  // TODO(all): remove !!!
     c_ptr += ocp_qp_dims_calculate_size(dims->N);                 // TODO(all): remove !!!

--- a/acados/ocp_qp/ocp_qp_common.c
+++ b/acados/ocp_qp/ocp_qp_common.c
@@ -32,6 +32,7 @@
 
 // acados
 #include "acados/ocp_qp/ocp_qp_common.h"
+#include "acados/utils/mem.h"
 #include "acados/utils/types.h"
 
 

--- a/acados/ocp_qp/ocp_qp_hpipm.c
+++ b/acados/ocp_qp/ocp_qp_hpipm.c
@@ -61,11 +61,11 @@ void *ocp_qp_hpipm_opts_assign(void *config_, void *dims_, void *raw_memory)
     opts = (ocp_qp_hpipm_opts *) c_ptr;
     c_ptr += sizeof(ocp_qp_hpipm_opts);
 
-    opts->hpipm_opts = (struct d_ocp_qp_ipm_arg *) c_ptr;
-    c_ptr += sizeof(struct d_ocp_qp_ipm_arg);
-
     align_char_to(8, &c_ptr);
     assert((size_t) c_ptr % 8 == 0 && "memory not 8-byte aligned!");
+
+    opts->hpipm_opts = (struct d_ocp_qp_ipm_arg *) c_ptr;
+    c_ptr += sizeof(struct d_ocp_qp_ipm_arg);
 
     d_create_ocp_qp_ipm_arg(dims, opts->hpipm_opts, c_ptr);
     c_ptr += d_memsize_ocp_qp_ipm_arg(dims);
@@ -178,7 +178,7 @@ int ocp_qp_hpipm_memory_calculate_size(void *config_, void *dims_, void *opts_)
 
     size += d_memsize_ocp_qp_ipm(dims, opts->hpipm_opts);
 
-    size += 1 * 8;
+    size += 2 * 8;
     return size;
 }
 
@@ -195,6 +195,8 @@ void *ocp_qp_hpipm_memory_assign(void *config_, void *dims_, void *opts_, void *
 
     mem = (ocp_qp_hpipm_memory *) c_ptr;
     c_ptr += sizeof(ocp_qp_hpipm_memory);
+
+    align_char_to(8, &c_ptr);
 
     mem->hpipm_workspace = (struct d_ocp_qp_ipm_workspace *) c_ptr;
     c_ptr += sizeof(struct d_ocp_qp_ipm_workspace);


### PR DESCRIPTION
When porting acados to a 32-bit system, I encountered wrong alignment of nested structs. More general, we should think more carefully of alignment of memory, especially in the case of structs. 

This PR fixes some of the issues.