### PR TITLE
Fixed make command for creating shared libraries in the documentation.

### DIFF
--- a/docs/interfaces/index.md
+++ b/docs/interfaces/index.md
@@ -22,7 +22,7 @@ Some examples for the use of this interface can be found in `<acados_root>/examp
 This interface uses the shared libraries created using the make command from the main acados folder
 
 ```bash
-make acados_c_shared
+make acados_shared
 ```
 
 To run the examples, navigate into the selected folder, and there run the command


### PR DESCRIPTION
"acados_c_shared" is not existing. The correct should be "make acados_shared".