### PR TITLE
Use mbuild to build ocp model ext fun

### DIFF
--- a/interfaces/acados_matlab/ocp_generate_casadi_ext_fun.m
+++ b/interfaces/acados_matlab/ocp_generate_casadi_ext_fun.m
@@ -99,15 +99,15 @@ end
 lib_name = 'ocp_model';
 
 if ispc
-  mbuild(c_files{:}, '-output', lib_name, 'CFLAGS="-fPIC $CFLAGS"', 'LDTYPE="-shared"', ['LDEXT=', ldext]);
+  mbuild(c_files{:}, '-output', lib_name, 'CFLAGS="$CFLAGS"', 'LDTYPE="-shared"', ['LDEXT=', ldext]);
 else
   system(['gcc -O2 -fPIC -shared ', c_sources, ' -o ', [lib_name, ldext]]);
 end
 
-movefile([lib_name, ldext], fullfile(opts_struct.output_dir, [lib_name, ldext]));
-
 for k=1:length(c_files)
   movefile(c_files{k}, opts_struct.output_dir);
 end
+
+movefile([lib_name, ldext], fullfile(opts_struct.output_dir, [lib_name, ldext]));
 
 

--- a/interfaces/acados_matlab/ocp_generate_casadi_ext_fun.m
+++ b/interfaces/acados_matlab/ocp_generate_casadi_ext_fun.m
@@ -96,17 +96,15 @@ else
   ldext = '.so';
 end
 
+lib_name_out = ['ocp_model', ldext];
+
 FID = fopen('ocp_model.c', 'w');
 fclose(FID);
 
 mbuild('ocp_model.c', c_files{:}, 'CFLAGS="-fPIC $CFLAGS"', 'LDTYPE="-shared"', ['LDEXT=', ldext]);
 % mex('ocp_model.c', c_files{:}, 'LINKEXPORT=', 'LINKEXPORTVER=','LINKLIBS=','CFLAGS=-fPIC $CFLAGS','LDTYPE=-shared', ['LDEXT=', ldext])
 
-% the first of c_files determines the name of the output .so file
-% [~,lib_name,~] = fileparts(c_files{1});
-
-% lib_name_out = [lib_name, ldext];
-movefile(['ocp_model', ldext], fullfile(opts_struct.output_dir, ['ocp_model', ldext]));
+movefile(lib_name_out, fullfile(opts_struct.output_dir, lib_name_out));
 
 for k=1:length(c_files)
   movefile(c_files{k}, opts_struct.output_dir);

--- a/interfaces/acados_matlab/ocp_generate_casadi_ext_fun.m
+++ b/interfaces/acados_matlab/ocp_generate_casadi_ext_fun.m
@@ -96,19 +96,18 @@ else
   ldext = '.so';
 end
 
-lib_name_out = ['ocp_model', ldext];
+lib_name = 'ocp_model';
 
-FID = fopen('ocp_model.c', 'w');
-fclose(FID);
+if ispc
+  mbuild(c_files{:}, '-output', lib_name, 'CFLAGS="-fPIC $CFLAGS"', 'LDTYPE="-shared"', ['LDEXT=', ldext]);
+else
+  system(['gcc -O2 -fPIC -shared ', c_sources, ' -o ', [lib_name, ldext]]);
+end
 
-mbuild('ocp_model.c', c_files{:}, 'CFLAGS="-fPIC $CFLAGS"', 'LDTYPE="-shared"', ['LDEXT=', ldext]);
-% mex('ocp_model.c', c_files{:}, 'LINKEXPORT=', 'LINKEXPORTVER=','LINKLIBS=','CFLAGS=-fPIC $CFLAGS','LDTYPE=-shared', ['LDEXT=', ldext])
-
-movefile(lib_name_out, fullfile(opts_struct.output_dir, lib_name_out));
+movefile([lib_name, ldext], fullfile(opts_struct.output_dir, [lib_name, ldext]));
 
 for k=1:length(c_files)
   movefile(c_files{k}, opts_struct.output_dir);
 end
 
-delete ocp_model.c
 

--- a/interfaces/acados_matlab/ocp_generate_casadi_ext_fun.m
+++ b/interfaces/acados_matlab/ocp_generate_casadi_ext_fun.m
@@ -3,35 +3,35 @@ function ocp_generate_casadi_ext_fun(model_struct, opts_struct)
 model_name = model_struct.name;
 
 % select files to compile
-c_sources = ' ';
+c_files = {};
 % dynamics
 if (strcmp(model_struct.dyn_type, 'explicit'))
 	% generate c for function and derivatives using casadi
 	generate_c_code_explicit_ode(model_struct, opts_struct);
 	% sources list
-	c_sources = [c_sources, model_name, '_dyn_expl_ode_fun.c '];
-	c_sources = [c_sources, model_name, '_dyn_expl_vde_for.c '];
-	c_sources = [c_sources, model_name, '_dyn_expl_vde_adj.c '];
-	c_sources = [c_sources, model_name, '_dyn_expl_ode_hes.c '];
+	c_files{end+1} = [model_name, '_dyn_expl_ode_fun.c '];
+	c_files{end+1} = [model_name, '_dyn_expl_vde_for.c '];
+	c_files{end+1} = [model_name, '_dyn_expl_vde_adj.c '];
+	c_files{end+1} = [model_name, '_dyn_expl_ode_hes.c '];
 elseif (strcmp(model_struct.dyn_type, 'implicit'))
 	if (strcmp(opts_struct.sim_method, 'irk'))
 		% generate c for function and derivatives using casadi
 		generate_c_code_implicit_ode(model_struct, opts_struct);
 		% sources list
-		c_sources = [c_sources, model_name, '_dyn_impl_ode_fun.c '];
-		c_sources = [c_sources, model_name, '_dyn_impl_ode_fun_jac_x_xdot.c '];
-		c_sources = [c_sources, model_name, '_dyn_impl_ode_fun_jac_x_xdot_u.c '];
-		c_sources = [c_sources, model_name, '_dyn_impl_ode_jac_x_xdot_u.c '];
-		c_sources = [c_sources, model_name, '_dyn_impl_ode_hess.c '];
+		c_files{end+1} = [model_name, '_dyn_impl_ode_fun.c '];
+		c_files{end+1} = [model_name, '_dyn_impl_ode_fun_jac_x_xdot.c '];
+		c_files{end+1} = [model_name, '_dyn_impl_ode_fun_jac_x_xdot_u.c '];
+		c_files{end+1} = [model_name, '_dyn_impl_ode_jac_x_xdot_u.c '];
+		c_files{end+1} = [model_name, '_dyn_impl_ode_hess.c '];
 	elseif (strcmp(opts_struct.sim_method, 'irk_gnsf'))
 		% generate c for function and derivatives using casadi
 		generate_c_code_gnsf(model_struct); %, opts_struct);
 		% compile the code in a shared library
-		c_sources = [c_sources, model_name, '_dyn_gnsf_f_lo_fun_jac_x1k1uz.c '];
-		c_sources = [c_sources, model_name, '_dyn_gnsf_get_matrices_fun.c '];
-		c_sources = [c_sources, model_name, '_dyn_gnsf_phi_fun.c '];
-		c_sources = [c_sources, model_name, '_dyn_gnsf_phi_fun_jac_y.c '];
-		c_sources = [c_sources, model_name, '_dyn_gnsf_phi_jac_y_uhat.c '];
+		c_files{end+1} = [model_name, '_dyn_gnsf_f_lo_fun_jac_x1k1uz.c '];
+		c_files{end+1} = [model_name, '_dyn_gnsf_get_matrices_fun.c '];
+		c_files{end+1} = [model_name, '_dyn_gnsf_phi_fun.c '];
+		c_files{end+1} = [model_name, '_dyn_gnsf_phi_fun_jac_y.c '];
+		c_files{end+1} = [model_name, '_dyn_gnsf_phi_jac_y_uhat.c '];
 	else
 		fprintf('\nocp_generate_casadi_ext_fun: sim_method not supported: %s\n', opts_struct.sim_method);
 		return;
@@ -40,8 +40,8 @@ elseif (strcmp(model_struct.dyn_type, 'discrete'))
 	% generate c for function and derivatives using casadi
 	generate_c_code_disc_dyn(model_struct, opts_struct);
 	% sources list
-	c_sources = [c_sources, model_name, '_dyn_disc_phi_fun_jac.c '];
-	c_sources = [c_sources, model_name, '_dyn_disc_phi_fun_jac_hess.c '];
+	c_files{end+1} = [model_name, '_dyn_disc_phi_fun_jac.c '];
+	c_files{end+1} = [model_name, '_dyn_disc_phi_fun_jac_hess.c '];
 else
 	fprintf('\ncodegen_model: dyn_type not supported: %s\n', model_struct.dyn_type);
 	return;
@@ -52,12 +52,12 @@ if (strcmp(model_struct.constr_type, 'bgh') && (isfield(model_struct, 'constr_ex
 	generate_c_code_nonlinear_constr(model_struct, opts_struct);
 	% sources list
 	if isfield(model_struct, 'constr_expr_h')
-		c_sources = [c_sources, model_name, '_constr_h_fun_jac_ut_xt.c '];
-		c_sources = [c_sources, model_name, '_constr_h_fun_jac_ut_xt_hess.c '];
+		c_files{end+1} = [model_name, '_constr_h_fun_jac_ut_xt.c '];
+		c_files{end+1} = [model_name, '_constr_h_fun_jac_ut_xt_hess.c '];
 	end
 	if isfield(model_struct, 'constr_expr_h_e')
-		c_sources = [c_sources, model_name, '_constr_h_e_fun_jac_ut_xt.c '];
-		c_sources = [c_sources, model_name, '_constr_h_e_fun_jac_ut_xt_hess.c '];
+		c_files{end+1} = [model_name, '_constr_h_e_fun_jac_ut_xt.c '];
+		c_files{end+1} = [model_name, '_constr_h_e_fun_jac_ut_xt_hess.c '];
 	end
 end
 % nonlinear least squares
@@ -66,12 +66,12 @@ if (strcmp(model_struct.cost_type, 'nonlinear_ls') || strcmp(model_struct.cost_t
 	generate_c_code_nonlinear_least_squares(model_struct, opts_struct);
 	% sources list
 	if isfield(model_struct, 'cost_expr_y')
-		c_sources = [c_sources, model_name, '_cost_y_fun_jac_ut_xt.c '];
-		c_sources = [c_sources, model_name, '_cost_y_hess.c '];
+		c_files{end+1} = [model_name, '_cost_y_fun_jac_ut_xt.c '];
+		c_files{end+1} = [model_name, '_cost_y_hess.c '];
 	end
 	if isfield(model_struct, 'cost_expr_y_e')
-		c_sources = [c_sources, model_name, '_cost_y_e_fun_jac_ut_xt.c '];
-		c_sources = [c_sources, model_name, '_cost_y_e_hess.c '];
+		c_files{end+1} = [model_name, '_cost_y_e_fun_jac_ut_xt.c '];
+		c_files{end+1} = [model_name, '_cost_y_e_hess.c '];
 	end
 end
 % external cost
@@ -80,15 +80,12 @@ if (strcmp(model_struct.cost_type, 'ext_cost') || strcmp(model_struct.cost_type_
 	generate_c_code_ext_cost(model_struct, opts_struct);
 	% sources list
 	if isfield(model_struct, 'cost_expr_ext_cost')
-		c_sources = [c_sources, model_name, '_cost_ext_cost_jac_hes.c '];
+		c_files{end+1} = [model_name, '_cost_ext_cost_jac_hes.c '];
 	end
 	if isfield(model_struct, 'cost_expr_ext_cost_e')
-		c_sources = [c_sources, model_name, '_cost_ext_cost_e_jac_hes.c '];
+		c_files{end+1} = [model_name, '_cost_ext_cost_e_jac_hes.c '];
 	end
 end
-
-c_files = strsplit(c_sources);
-c_files = c_files(~cellfun(@isempty, c_files)); % remove empty cells
 
 if ispc
   ldext = '.lib';
@@ -101,7 +98,7 @@ lib_name = 'ocp_model';
 if ispc
   mbuild(c_files{:}, '-output', lib_name, 'CFLAGS="$CFLAGS"', 'LDTYPE="-shared"', ['LDEXT=', ldext]);
 else
-  system(['gcc -O2 -fPIC -shared ', c_sources, ' -o ', [lib_name, ldext]]);
+  system(['gcc -O2 -fPIC -shared ', strjoin(c_files, ' '), ' -o ', [lib_name, ldext]]);
 end
 
 for k=1:length(c_files)

--- a/interfaces/acados_matlab/sim_generate_casadi_ext_fun.m
+++ b/interfaces/acados_matlab/sim_generate_casadi_ext_fun.m
@@ -2,52 +2,54 @@ function sim_generate_casadi_ext_fun(model_struct, opts_struct)
 
 model_name = model_struct.name;
 
-c_sources = ' ';
+c_files = {};
 if (strcmp(opts_struct.method, 'erk'))
 	% generate c for function and derivatives using casadi
 	generate_c_code_explicit_ode(model_struct, opts_struct);
 	% compile the code in a shared library
-	c_sources = [c_sources, model_name, '_dyn_expl_ode_fun.c '];
-	c_sources = [c_sources, model_name, '_dyn_expl_vde_for.c '];
-	c_sources = [c_sources, model_name, '_dyn_expl_vde_adj.c '];
-	c_sources = [c_sources, model_name, '_dyn_expl_ode_hes.c '];
+	c_files{end+1} = [model_name, '_dyn_expl_ode_fun.c '];
+	c_files{end+1} = [model_name, '_dyn_expl_vde_for.c '];
+	c_files{end+1} = [model_name, '_dyn_expl_vde_adj.c '];
+	c_files{end+1} = [model_name, '_dyn_expl_ode_hes.c '];
 elseif (strcmp(opts_struct.method, 'irk'))
 	% generate c for function and derivatives using casadi
 	generate_c_code_implicit_ode(model_struct, opts_struct);
 	% compile the code in a shared library
-	c_sources = [c_sources, model_name, '_dyn_impl_ode_fun.c '];
-	c_sources = [c_sources, model_name, '_dyn_impl_ode_fun_jac_x_xdot.c '];
-	c_sources = [c_sources, model_name, '_dyn_impl_ode_fun_jac_x_xdot_u.c '];
-	c_sources = [c_sources, model_name, '_dyn_impl_ode_jac_x_xdot_u.c '];
-	c_sources = [c_sources, model_name, '_dyn_impl_ode_hess.c '];
+	c_files{end+1} = [model_name, '_dyn_impl_ode_fun.c '];
+	c_files{end+1} = [model_name, '_dyn_impl_ode_fun_jac_x_xdot.c '];
+	c_files{end+1} = [model_name, '_dyn_impl_ode_fun_jac_x_xdot_u.c '];
+	c_files{end+1} = [model_name, '_dyn_impl_ode_jac_x_xdot_u.c '];
+	c_files{end+1} = [model_name, '_dyn_impl_ode_hess.c '];
 elseif (strcmp(opts_struct.method, 'irk_gnsf'))
 	% generate c for function and derivatives using casadi
 	generate_c_code_gnsf(model_struct); %, opts_struct);
 	% compile the code in a shared library
-	c_sources = [c_sources, model_name, '_dyn_gnsf_f_lo_fun_jac_x1k1uz.c '];
-	c_sources = [c_sources, model_name, '_dyn_gnsf_get_matrices_fun.c '];
-	c_sources = [c_sources, model_name, '_dyn_gnsf_phi_fun.c '];
-	c_sources = [c_sources, model_name, '_dyn_gnsf_phi_fun_jac_y.c '];
-	c_sources = [c_sources, model_name, '_dyn_gnsf_phi_jac_y_uhat.c '];
+	c_files{end+1} = [model_name, '_dyn_gnsf_f_lo_fun_jac_x1k1uz.c '];
+	c_files{end+1} = [model_name, '_dyn_gnsf_get_matrices_fun.c '];
+	c_files{end+1} = [model_name, '_dyn_gnsf_phi_fun.c '];
+	c_files{end+1} = [model_name, '_dyn_gnsf_phi_fun_jac_y.c '];
+	c_files{end+1} = [model_name, '_dyn_gnsf_phi_jac_y_uhat.c '];
 else
 	fprintf('\nsim_generate_casadi_ext_fun: method not supported: %s\n', opts_struct.method);
 	return;
 end
 
 if ispc
-	lib_name = ['lib', model_name, '.lib'];
+  ldext = '.lib';
 else
-	lib_name = ['lib', model_name, '.so'];
+  ldext = '.so';
 end
 
-% works also on windows if mingw64 is setup properly
-system(['gcc -O2 -fPIC -shared ', c_sources, ' -o ', lib_name]);
+lib_name = ['lib', model_name];
 
-c_files = strsplit(c_sources);
+if ispc
+  mbuild(c_files{:}, '-output', lib_name, 'CFLAGS="$CFLAGS"', 'LDTYPE="-shared"', ['LDEXT=', ldext]);
+else
+  system(['gcc -O2 -fPIC -shared ', strjoin(c_files, ' '), ' -o ', [lib_name, ldext]]);
+end
+
 for k=1:length(c_files)
-	if ~isempty(c_files{k})
 		movefile(c_files{k}, opts_struct.output_dir);
-	end
 end
 
-movefile(lib_name, opts_struct.output_dir);
+movefile([lib_name, ldext], fullfile(opts_struct.output_dir, [lib_name, ldext]));


### PR DESCRIPTION
Notes:
 - ~Need to create a temporary empty file `ocp_model.c` to set the output name of the shared library to `ocp_model.so`. Renaming is not possible somehow. `mbuild` uses the first c-file to determine the output name. Any idea how to set the output name with `mbuild` or `mex`?~
 - There are two possible commands using `mbuild` or `mex`. The `mbuild` command is a bit simpler thus preferred i guess, but we need to test if it works on all platforms.