### PR TITLE
Running tests with appveyor, compile on appveyor with mingw

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,7 +29,8 @@ build_script:
   # MinGW files need to be at the beginning of the PATH
   - set PATH=C:\msys64\usr\bin;%PATH%
   # Workaround for CMake not wanting sh.exe on PATH for MinGW
-  - rm "C:/Program Files/Git/usr/bin/sh.exe"
+  - rm "C:\msys64\usr\bin\sh.exe"
+  - rm "C:\Program Files\Git\usr\bin\sh.exe"
   - cmake -E make_directory build
   - cmake -E chdir build cmake -DCMAKE_PREFIX_PATH=C:\mingw64 -D ACADOS_WITH_QPOASES=ON -D BLASFEO_TARGET=GENERIC -D HPIPM_TARGET=GENERIC -D BUILD_SHARED_LIBS=OFF -D ACADOS_EXAMPLES=ON -D ACADOS_UNIT_TESTS=ON -DEIGEN3_INCLUDE_DIR="C:\dev\Eigen3\include\eigen3" -G "MinGW Makefiles" ..
   - cmake --build build --config Release

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,7 +15,7 @@ build_script:
   - rm "C:/Program Files/Git/usr/bin/sh.exe"
   - cmake -E make_directory build
   # TODO: make this work
-  # - cmake -E chdir build cmake -D ACADOS_WITH_QPOASES=ON -D BLASFEO_TARGET=GENERIC -D HPIPM_TARGET=GENERIC -D BUILD_SHARED_LIBS=OFF  -D ACADOS_EXAMPLES=ON ..
-  - cmake -E chdir build cmake -D ACADOS_WITH_QPOASES=ON -D BLASFEO_TARGET=GENERIC -D HPIPM_TARGET=GENERIC -D BUILD_SHARED_LIBS=OFF -G "MinGW Makefiles" ..
+  # - cmake -E chdir build cmake -D ACADOS_WITH_QPOASES=ON -D BLASFEO_TARGET=GENERIC -D HPIPM_TARGET=GENERIC -D BUILD_SHARED_LIBS=OFF   ..
+  - cmake -E chdir build cmake -D ACADOS_WITH_QPOASES=ON -D BLASFEO_TARGET=GENERIC -D HPIPM_TARGET=GENERIC -D BUILD_SHARED_LIBS=OFF -D ACADOS_EXAMPLES=ON -G "MinGW Makefiles" ..
   - cmake --build build --config Release
   - cmake -E chdir build ctest -V

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,6 +2,9 @@ branches:
   only:
     - master
 
+cache:
+  - c:\dev\Eigen3\
+
 environment:
   matrix:
     - BUILD_TYPE: Release

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -27,11 +27,11 @@ install:
 build_script:
   - git submodule update --init --recursive
   # MinGW files need to be at the beginning of the PATH
-  - set PATH=C:\msys64\usr\bin;%PATH%
+  - set PATH=C:\mingw-w64\x86_64-7.3.0-posix-seh-rt_v5-rev0\usr\bin;%PATH%
   # Workaround for CMake not wanting sh.exe on PATH for MinGW
-  - rm "C:\msys64\usr\bin\sh.exe"
+  - rm "C:\mingw-w64\x86_64-7.3.0-posix-seh-rt_v5-rev0\usr\bin\sh.exe"
   - rm "C:\Program Files\Git\usr\bin\sh.exe"
   - cmake -E make_directory build
-  - cmake -E chdir build cmake -DCMAKE_PREFIX_PATH=C:\mingw64 -D ACADOS_WITH_QPOASES=ON -D BLASFEO_TARGET=GENERIC -D HPIPM_TARGET=GENERIC -D BUILD_SHARED_LIBS=OFF -D ACADOS_EXAMPLES=ON -D ACADOS_UNIT_TESTS=ON -DEIGEN3_INCLUDE_DIR="C:\dev\Eigen3\include\eigen3" -G "MinGW Makefiles" ..
+  - cmake -E chdir build cmake -DCMAKE_PREFIX_PATH=C:\mingw-w64\x86_64-7.3.0-posix-seh-rt_v5-rev0 -D ACADOS_WITH_QPOASES=ON -D BLASFEO_TARGET=GENERIC -D HPIPM_TARGET=GENERIC -D BUILD_SHARED_LIBS=OFF -D ACADOS_EXAMPLES=ON -D ACADOS_UNIT_TESTS=ON -DEIGEN3_INCLUDE_DIR="C:\dev\Eigen3\include\eigen3" -G "MinGW Makefiles" ..
   - cmake --build build --config Release
   - cmake -E chdir build ctest -V

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,6 +4,7 @@ branches:
 
 environment:
   EIGEN3_ROOT:       C:\dev\Eigen3\include\eigen3
+  EIGEN3_INCLUDE_DIR: C:\dev\Eigen3\include
 
 install:
   - cmd: if not exist c:\dev\Eigen3\include\eigen3\Eigen\Core (

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,6 +13,6 @@ build_script:
   # Workaround for CMake not wanting sh.exe on PATH for MinGW
   - rm "C:/Program Files/Git/usr/bin/sh.exe"
   - cmake -E make_directory build
-  - cmake -E chdir build cmake -D ACADOS_WITH_QPOASES=ON -D BLASFEO_TARGET=GENERIC -D HPIPM_TARGET=GENERIC -D BUILD_SHARED_LIBS=OFF -D ACADOS_EXAMPLES=ON -G "MinGW Makefiles" ..
+  - cmake -E chdir build cmake -D ACADOS_WITH_QPOASES=ON -D BLASFEO_TARGET=GENERIC -D HPIPM_TARGET=GENERIC -D BUILD_SHARED_LIBS=OFF -D ACADOS_EXAMPLES=ON -D ACADOS_UNIT_TESTS=ON -G "MinGW Makefiles" ..
   - cmake --build build --config Release
   - cmake -E chdir build ctest -V

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -36,4 +36,4 @@ build_script:
   - cmake -E make_directory build
   - cmake -E chdir build cmake -DCMAKE_PREFIX_PATH=C:\mingw-w64\x86_64-7.3.0-posix-seh-rt_v5-rev0 -D ACADOS_WITH_QPOASES=ON -D BLASFEO_TARGET=GENERIC -D HPIPM_TARGET=GENERIC -D BUILD_SHARED_LIBS=OFF -D ACADOS_EXAMPLES=ON -D ACADOS_UNIT_TESTS=ON -DEIGEN3_INCLUDE_DIR="C:\dev\Eigen3\include\eigen3" -G "MinGW Makefiles" ..
   - cmake --build build --config Release
-  - cmake -E chdir build ctest -V
+  - cmake -E chdir build ctest --output-on-failure

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,9 +11,11 @@ build_script:
   # Workaround for CMake not wanting sh.exe on PATH for MinGW
   # - set PATH=%PATH:C:/Program_Files/Git/usr/bin/;=%
   # - rm "C:/Program Files/Git/usr/bin/sh.exe"
+  - set PATH=C:\MinGW\bin;%PATH%
+  - rm "C:/Program Files/Git/usr/bin/sh.exe"
   - cmake -E make_directory build
   # TODO: make this work
-  # - cmake -E chdir build cmake -D ACADOS_WITH_QPOASES=ON -D BLASFEO_TARGET=GENERIC -D HPIPM_TARGET=GENERIC -D BUILD_SHARED_LIBS=OFF -D ACADOS_EXAMPLES=ON -G "MinGW Makefiles" ..
-  - cmake -E chdir build cmake -D ACADOS_WITH_QPOASES=ON -D BLASFEO_TARGET=GENERIC -D HPIPM_TARGET=GENERIC -D BUILD_SHARED_LIBS=OFF ..
+  # - cmake -E chdir build cmake -D ACADOS_WITH_QPOASES=ON -D BLASFEO_TARGET=GENERIC -D HPIPM_TARGET=GENERIC -D BUILD_SHARED_LIBS=OFF  -D ACADOS_EXAMPLES=ON ..
+  - cmake -E chdir build cmake -D ACADOS_WITH_QPOASES=ON -D BLASFEO_TARGET=GENERIC -D HPIPM_TARGET=GENERIC -D BUILD_SHARED_LIBS=OFF -G "MinGW Makefiles" ..
   - cmake --build build --config Release
   - cmake -E chdir build ctest -V

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,9 +2,6 @@ branches:
   only:
     - master
 
-environment:
-  EIGEN3_INCLUDE_DIR: C:\dev\Eigen3\include\eigen3
-
 install:
   - cmd: if not exist c:\dev\Eigen3\include\eigen3\Eigen\Core (
             curl -L -o eigen-eigen-dc6cfdf9bcec.tar.gz https://bitbucket.org/eigen/eigen/get/3.2.9.tar.gz &&
@@ -28,6 +25,6 @@ build_script:
   # Workaround for CMake not wanting sh.exe on PATH for MinGW
   - rm "C:/Program Files/Git/usr/bin/sh.exe"
   - cmake -E make_directory build
-  - cmake -E chdir build cmake -D ACADOS_WITH_QPOASES=ON -D BLASFEO_TARGET=GENERIC -D HPIPM_TARGET=GENERIC -D BUILD_SHARED_LIBS=OFF -D ACADOS_EXAMPLES=ON -D ACADOS_UNIT_TESTS=ON -G "MinGW Makefiles" ..
+  - cmake -E chdir build cmake -D ACADOS_WITH_QPOASES=ON -D BLASFEO_TARGET=GENERIC -D HPIPM_TARGET=GENERIC -D BUILD_SHARED_LIBS=OFF -D ACADOS_EXAMPLES=ON -D ACADOS_UNIT_TESTS=ON -DEIGEN3_INCLUDE_DIR="C:\dev\Eigen3\include\eigen3" -G "MinGW Makefiles" ..
   - cmake --build build --config Release
   - cmake -E chdir build ctest -V

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,14 +8,11 @@ branches:
 
 build_script:
   - git submodule update --init --recursive
-  # Workaround for CMake not wanting sh.exe on PATH for MinGW
-  # - set PATH=%PATH:C:/Program_Files/Git/usr/bin/;=%
-  # - rm "C:/Program Files/Git/usr/bin/sh.exe"
+  # MinGW files need to be at the beginning of the PATH
   - set PATH=C:\MinGW\bin;%PATH%
+  # Workaround for CMake not wanting sh.exe on PATH for MinGW
   - rm "C:/Program Files/Git/usr/bin/sh.exe"
   - cmake -E make_directory build
-  # TODO: make this work
-  # - cmake -E chdir build cmake -D ACADOS_WITH_QPOASES=ON -D BLASFEO_TARGET=GENERIC -D HPIPM_TARGET=GENERIC -D BUILD_SHARED_LIBS=OFF   ..
   - cmake -E chdir build cmake -D ACADOS_WITH_QPOASES=ON -D BLASFEO_TARGET=GENERIC -D HPIPM_TARGET=GENERIC -D BUILD_SHARED_LIBS=OFF -D ACADOS_EXAMPLES=ON -G "MinGW Makefiles" ..
   - cmake --build build --config Release
   - cmake -E chdir build ctest -V

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,6 +2,21 @@ branches:
   only:
     - master
 
+environment:
+  EIGEN3_ROOT:       C:\dev\Eigen3\include\eigen3
+
+install:
+  - cmd: if not exist c:\dev\Eigen3\include\eigen3\Eigen\Core (
+            curl -L -o eigen-eigen-dc6cfdf9bcec.tar.gz https://bitbucket.org/eigen/eigen/get/3.2.9.tar.gz &&
+            cmake -E tar zxf eigen-eigen-dc6cfdf9bcec.tar.gz &&
+            cd eigen-eigen-dc6cfdf9bcec &&
+            mkdir build &&
+            cd build &&
+            cmake -G "Visual Studio 12" -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX="c:\dev\Eigen3" .. &&
+            cmake --build . --target install --config Release &&
+            cd ..\..
+         ) else (echo Using cached Eigen3)
+
 # NOTE: only static linking, i.e. via .lib file supported
 #  -D BUILD_SHARED_LIBS=OFF;
 # extern "C" {  would have to be added to subprojects

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,8 +3,7 @@ branches:
     - master
 
 environment:
-  EIGEN3_ROOT:       C:\dev\Eigen3\include\eigen3
-  EIGEN3_INCLUDE_DIR: C:\dev\Eigen3\include
+  EIGEN3_INCLUDE_DIR: C:\dev\Eigen3\include\eigen3
 
 install:
   - cmd: if not exist c:\dev\Eigen3\include\eigen3\Eigen\Core (

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,7 +29,6 @@ build_script:
   # MinGW files need to be at the beginning of the PATH
   - set PATH=C:\mingw-w64\x86_64-7.3.0-posix-seh-rt_v5-rev0\mingw64\bin;%PATH%
   # Workaround for CMake not wanting sh.exe on PATH for MinGW
-  - rm "C:\mingw-w64\x86_64-7.3.0-posix-seh-rt_v5-rev0\mingw64\bin\sh.exe"
   - rm "C:\Program Files\Git\usr\bin\sh.exe"
   - cmake -E make_directory build
   - cmake -E chdir build cmake -DCMAKE_PREFIX_PATH=C:\mingw-w64\x86_64-7.3.0-posix-seh-rt_v5-rev0 -D ACADOS_WITH_QPOASES=ON -D BLASFEO_TARGET=GENERIC -D HPIPM_TARGET=GENERIC -D BUILD_SHARED_LIBS=OFF -D ACADOS_EXAMPLES=ON -D ACADOS_UNIT_TESTS=ON -DEIGEN3_INCLUDE_DIR="C:\dev\Eigen3\include\eigen3" -G "MinGW Makefiles" ..

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -27,9 +27,9 @@ install:
 build_script:
   - git submodule update --init --recursive
   # MinGW files need to be at the beginning of the PATH
-  - set PATH=C:\mingw-w64\x86_64-7.3.0-posix-seh-rt_v5-rev0\usr\bin;%PATH%
+  - set PATH=C:\mingw-w64\x86_64-7.3.0-posix-seh-rt_v5-rev0\mingw64\bin;%PATH%
   # Workaround for CMake not wanting sh.exe on PATH for MinGW
-  - rm "C:\mingw-w64\x86_64-7.3.0-posix-seh-rt_v5-rev0\usr\bin\sh.exe"
+  - rm "C:\mingw-w64\x86_64-7.3.0-posix-seh-rt_v5-rev0\mingw64\bin\sh.exe"
   - rm "C:\Program Files\Git\usr\bin\sh.exe"
   - cmake -E make_directory build
   - cmake -E chdir build cmake -DCMAKE_PREFIX_PATH=C:\mingw-w64\x86_64-7.3.0-posix-seh-rt_v5-rev0 -D ACADOS_WITH_QPOASES=ON -D BLASFEO_TARGET=GENERIC -D HPIPM_TARGET=GENERIC -D BUILD_SHARED_LIBS=OFF -D ACADOS_EXAMPLES=ON -D ACADOS_UNIT_TESTS=ON -DEIGEN3_INCLUDE_DIR="C:\dev\Eigen3\include\eigen3" -G "MinGW Makefiles" ..

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,6 +2,12 @@ branches:
   only:
     - master
 
+environment:
+  matrix:
+    - BUILD_TYPE: Release
+      COMPILER: MinGW-w64
+      PLATFORM: x64
+
 install:
   - cmd: if not exist c:\dev\Eigen3\include\eigen3\Eigen\Core (
             curl -L -o eigen-eigen-dc6cfdf9bcec.tar.gz https://bitbucket.org/eigen/eigen/get/3.2.9.tar.gz &&
@@ -21,10 +27,10 @@ install:
 build_script:
   - git submodule update --init --recursive
   # MinGW files need to be at the beginning of the PATH
-  - set PATH=C:\MinGW\bin;%PATH%
+  - set PATH=C:\msys64\usr\bin;%PATH%
   # Workaround for CMake not wanting sh.exe on PATH for MinGW
   - rm "C:/Program Files/Git/usr/bin/sh.exe"
   - cmake -E make_directory build
-  - cmake -E chdir build cmake -D ACADOS_WITH_QPOASES=ON -D BLASFEO_TARGET=GENERIC -D HPIPM_TARGET=GENERIC -D BUILD_SHARED_LIBS=OFF -D ACADOS_EXAMPLES=ON -D ACADOS_UNIT_TESTS=ON -DEIGEN3_INCLUDE_DIR="C:\dev\Eigen3\include\eigen3" -G "MinGW Makefiles" ..
+  - cmake -E chdir build cmake -DCMAKE_PREFIX_PATH=C:\mingw64 -D ACADOS_WITH_QPOASES=ON -D BLASFEO_TARGET=GENERIC -D HPIPM_TARGET=GENERIC -D BUILD_SHARED_LIBS=OFF -D ACADOS_EXAMPLES=ON -D ACADOS_UNIT_TESTS=ON -DEIGEN3_INCLUDE_DIR="C:\dev\Eigen3\include\eigen3" -G "MinGW Makefiles" ..
   - cmake --build build --config Release
   - cmake -E chdir build ctest -V

--- a/acados/sim/sim_gnsf.c
+++ b/acados/sim/sim_gnsf.c
@@ -19,6 +19,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <math.h>
 
 // acados
 #include "acados/utils/mem.h"
@@ -1715,9 +1716,10 @@ int sim_gnsf(void *config, sim_in *in, sim_out *out, void *args, void *mem_, voi
     int nxz2 = nx2 + nz2;
 
     // assert - only use supported features
-    if (mem->dt != in->T / opts->num_steps)
+    double epsilon = 1e-10 * fmax( fabs(mem->dt), fabs(in->T) );
+    if ( fabs(mem->dt - in->T / opts->num_steps) > epsilon )
     {
-        printf("ERROR sim_gnsf: mem->dt n!= in->T/opts->num_steps, check initialization\n");
+        printf("ERROR sim_gnsf: mem->dt - in->T/opts->num_steps > epsilon, check initialization\n");
         return ACADOS_FAILURE;
     }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,9 +16,6 @@
 
 # Check if external libraries are present; these are needed for the unit tests
 
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
 find_package(Eigen3)
 
 include_directories(${EIGEN3_INCLUDE_DIR})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,7 +18,7 @@
 
 find_package(Eigen3)
 
-include_directories(${EIGEN3_INCLUDE_DIR})
+include_directories(SYSTEM ${EIGEN3_INCLUDE_DIR})
 
 # add_subdirectory(ocp_nlp)
 add_subdirectory(ocp_qp)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,6 +16,9 @@
 
 # Check if external libraries are present; these are needed for the unit tests
 
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 find_package(Eigen3)
 
 include_directories(${EIGEN3_INCLUDE_DIR})


### PR DESCRIPTION
- Use MinGW to compile acados on appveyor
- Fix for sh.exe and PATH to MinGW in appveyor script
- Build examples on appveyor
- Run examples on appveyor
- Floating point comparison fix in sim_gnsf (by @FreyJo)