### PR TITLE
acados_matlab: introduced acados_sim_detect_dims - detect dimensions …

### DIFF
--- a/examples/matlab_mex/pendulum_on_cart_model/example_sim.m
+++ b/examples/matlab_mex/pendulum_on_cart_model/example_sim.m
@@ -46,9 +46,9 @@ end
 compile_mex = 'true';
 codgen_model = 'true';
 gnsf_detect_struct = 'true';
-%method = 'erk';
-%method = 'irk';
-method = 'irk_gnsf';
+method = 'erk';
+% method = 'irk';
+% method = 'irk_gnsf';
 sens_forw = 'true';
 num_stages = 4;
 num_steps = 4;
@@ -76,9 +76,6 @@ end
 if isfield(model, 'sym_p')
     sim_model.set('sym_p', model.sym_p);
 end
-sim_model.set('dim_nx', model.nx);
-sim_model.set('dim_nu', model.nu);
-
 
 if (strcmp(method, 'erk'))
 	sim_model.set('dyn_type', 'explicit');
@@ -90,7 +87,6 @@ else % irk irk_gnsf
 %	if isfield(model, 'sym_z')
 %		sim_model.set('sym_z', model.sym_z);
 %	end
-%	sim_model.set('nz', model.nz);
 end
 
 

--- a/examples/matlab_mex/test/test_sens_adj.m
+++ b/examples/matlab_mex/test/test_sens_adj.m
@@ -70,8 +70,6 @@ for integrator = {'irk_gnsf', 'irk', 'erk'}
     if isfield(model, 'sym_p')
         sim_model.set('sym_p', model.sym_p);
     end
-    sim_model.set('dim_nx', model.nx);
-    sim_model.set('dim_nu', model.nu);
 
 
     if (strcmp(method, 'erk'))
@@ -84,7 +82,6 @@ for integrator = {'irk_gnsf', 'irk', 'erk'}
     %	if isfield(model, 'sym_z')
     %		sim_model.set('sym_z', model.sym_z);
     %	end
-    %	sim_model.set('nz', model.nz);
     end
 
 	%% acados sim opts

--- a/examples/matlab_mex/test/test_sens_forw.m
+++ b/examples/matlab_mex/test/test_sens_forw.m
@@ -75,9 +75,6 @@ for integrator = {'irk_gnsf', 'irk', 'erk'}
     if isfield(model, 'sym_p')
         sim_model.set('sym_p', model.sym_p);
     end
-    sim_model.set('dim_nx', model.nx);
-    sim_model.set('dim_nu', model.nu);
-
 
     if (strcmp(method, 'erk'))
         sim_model.set('dyn_type', 'explicit');

--- a/examples/matlab_mex/test/test_sens_hess.m
+++ b/examples/matlab_mex/test/test_sens_hess.m
@@ -72,9 +72,6 @@ for integrator = {'erk', 'irk'} %, 'irk_gnsf'}
     if isfield(model, 'sym_p')
         sim_model.set('sym_p', model.sym_p);
     end
-    sim_model.set('dim_nx', model.nx);
-    sim_model.set('dim_nu', model.nu);
-
 
     if (strcmp(method, 'erk'))
         sim_model.set('dyn_type', 'explicit');
@@ -86,7 +83,6 @@ for integrator = {'erk', 'irk'} %, 'irk_gnsf'}
     %	if isfield(model, 'sym_z')
     %		sim_model.set('sym_z', model.sym_z);
     %	end
-    %	sim_model.set('nz', model.nz);
     end
 
 

--- a/interfaces/acados_matlab/acados_sim.m
+++ b/interfaces/acados_matlab/acados_sim.m
@@ -46,6 +46,7 @@ classdef acados_sim < handle
 
 
 		function obj = acados_sim(model, opts)
+			model.model_struct = acados_sim_detect_dims( model.model_struct );
 			obj.model_struct = model.model_struct;
 			obj.opts_struct = opts.opts_struct;
 

--- a/interfaces/acados_matlab/acados_sim_detect_dims.m
+++ b/interfaces/acados_matlab/acados_sim_detect_dims.m
@@ -1,0 +1,75 @@
+%
+% Copyright 2019 Gianluca Frison, Dimitris Kouzoupis, Robin Verschueren,
+% Andrea Zanelli, Niels van Duijkeren, Jonathan Frey, Tommaso Sartor,
+% Branimir Novoselnik, Rien Quirynen, Rezart Qelibari, Dang Doan,
+% Jonas Koenemann, Yutao Chen, Tobias Schöls, Jonas Schlagenhauf, Moritz Diehl
+%
+% This file is part of acados.
+%
+% The 2-Clause BSD License
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%
+% 1. Redistributions of source code must retain the above copyright notice,
+% this list of conditions and the following disclaimer.
+%
+% 2. Redistributions in binary form must reproduce the above copyright notice,
+% this list of conditions and the following disclaimer in the documentation
+% and/or other materials provided with the distribution.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.;
+%
+
+function [ model ] = acados_sim_detect_dims( model )
+
+
+if isfield(model, 'sym_x')
+    if ~isempty(model.sym_x)
+        nx = length(model.sym_x);
+    else
+        nx = 0;
+    end
+    model.dim_nx = nx;
+end
+
+if isfield(model, 'sym_u')
+    if ~isempty(model.sym_u)
+        nu = length(model.sym_u);
+    else
+        nu = 0;
+    end
+    model.dim_nu = nu;
+end
+
+
+if isfield(model, 'sym_z')
+    if ~isempty(model.sym_z)
+        nz = length(model.sym_z);
+    else
+        nz = 0;
+    end
+    model.dim_nz = nz;
+end
+
+
+if isfield(model, 'sym_p')
+    if ~isempty(model.sym_p)
+        np = length(model.sym_p);
+    else
+        np = 0;
+    end
+    model.dim_np = np;
+end
+
+end


### PR DESCRIPTION
…from CasADi symbolics

I thought it would be nice to remove the necessity for the user to specify the model dimensions when using our Matlab/Octave interface.

The same should be possible for the OCP module.
But I would like to get some feedback first.