### PR TITLE
add binaries to releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,6 +82,7 @@ script:
 
 after_success:
   - SECTION='after_success'
+  - export DEPLOY_FOLDER="${DEPLOY_FOLDER:-${HOME}/deploy}"
   - mkdir -p "${DEPLOY_FOLDER}"
   - source "${SCRIPT_DIR}/dispatch.sh"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,7 +89,7 @@ deploy:
   provider: releases
   api_key: "${GITHUB_OAUTH_TOKEN}"
   file_glob: true
-  file: "${DEPLOY_FOLDER}/*"
+  file: "${ACADOS_INSTALL_DIR}/*"
   skip_cleanup: true
   on:
     tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,8 +82,7 @@ script:
 
 after_success:
   - SECTION='after_success'
-  - export DEPLOY_FOLDER="${DEPLOY_FOLDER:-${HOME}/deploy}"
-  - mkdir -p "${DEPLOY_FOLDER}"
+  # - mkdir -p "${DEPLOY_FOLDER}"
   - source "${SCRIPT_DIR}/dispatch.sh"
 
 deploy:

--- a/ci/linux/dispatch.sh
+++ b/ci/linux/dispatch.sh
@@ -99,7 +99,7 @@ elif [ "${SECTION}" = 'script' ]; then
 	source "${SHARED_SCRIPT_DIR}/script_acados_release.sh";
 
 elif [ "${SECTION}" = 'after_success' ]; then
-	source "${SHARED_SCRIPT_DIR}/after_success_package_release.sh";
+	# source "${SHARED_SCRIPT_DIR}/after_success_package_release.sh";
 	source "${SHARED_SCRIPT_DIR}/upload_coverage.sh";
 
 fi

--- a/ci/linux/dispatch.sh
+++ b/ci/linux/dispatch.sh
@@ -32,6 +32,8 @@
 # POSSIBILITY OF SUCH DAMAGE.;
 #
 
+echo "SECTION ="
+echo ${SECTION}
 
 if [ "${SECTION}" = 'before_install' ]; then
     export ACADOS_INSTALL_DIR="$(pwd)";

--- a/ci/shared/after_success_package_release.sh
+++ b/ci/shared/after_success_package_release.sh
@@ -36,7 +36,7 @@
 ACADOS_INSTALL_DIR="${ACADOS_INSTALL_DIR:-${HOME}/acados}";
 DEPLOY_FOLDER="${DEPLOY_FOLDER:-${HOME}/deploy}";
 DEPLOY_NAME="${DEPLOY_NAME:-default}";
-echo "in after_success_package_script"
+echo "in after_success_package_release.sh script"
 echo ${ACADOS_INSTALL_DIR}
 pushd "${ACADOS_INSTALL_DIR}";
 tar -zcf ${DEPLOY_FOLDER}/${DEPLOY_NAME}.tar.gz ./lib ./include;

--- a/ci/shared/after_success_package_release.sh
+++ b/ci/shared/after_success_package_release.sh
@@ -36,7 +36,8 @@
 ACADOS_INSTALL_DIR="${ACADOS_INSTALL_DIR:-${HOME}/acados}";
 DEPLOY_FOLDER="${DEPLOY_FOLDER:-${HOME}/deploy}";
 DEPLOY_NAME="${DEPLOY_NAME:-default}";
-
+echo "in after_success_package_script"
+echo ${ACADOS_INSTALL_DIR}
 pushd "${ACADOS_INSTALL_DIR}";
 tar -zcf ${DEPLOY_FOLDER}/${DEPLOY_NAME}.tar.gz ./lib ./include;
 popd;


### PR DESCRIPTION
The after_success section in .travis.yml does not seem to be running successfully (DEPLOY_FOLDER is not defined by default). With these few changes, it should be possible to obtain GitHub Releases that include binaries and source code by simply tagging the desired commits.