### PR TITLE
CMake: default to creating shared lib on linux and static lib on windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,11 @@ set(BLASFEO_TARGET "X64_INTEL_HASWELL" CACHE STRING "BLASFEO Target architecture
 set(HPIPM_TARGET "AVX" CACHE STRING "HPIPM Target architecture")
 set(LA "HIGH_PERFORMANCE" CACHE STRING "Linear algebra optimization level")
 
-set(BUILD_SHARED_LIBS ON CACHE STRING "Build shared libraries")
+if (CMAKE_SYSTEM_NAME MATCHES "Windows")
+	set(BUILD_SHARED_LIBS OFF CACHE STRING "Build shared libraries")
+else()
+  set(BUILD_SHARED_LIBS ON CACHE STRING "Build shared libraries")
+endif()
 
 # Additional targets
 option(ACADOS_UNIT_TESTS "Compile Unit tests" OFF)


### PR DESCRIPTION
On Windows mex can only link to static .lib files.
If BUILD_SHARED_LIBS is set ON then it will create .dll and .a files that are not found by the mex command,