### PR TITLE
Implement exact output of algebraic variables and corresponding sensitivities in IRK

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,5 +1,8 @@
 ## Roadmap
 
+#### core
+- [ ] propagate cost in integrator
+
 #### documentation
 - [ ] provide OCP NLP formulation that is handled by `ocp_nlp` as a formula in docs
     - [ ] closely stick to setter names!
@@ -8,10 +11,10 @@
     - [ ] MacOS Matlab
 
 #### `matlab interface`
-- [ ] separate `acados_ocp()` into generating the C object and setting the numerical data
 - [ ] code generation workflow!
-- [ ] support nonuniform grids?
-- [ ] OCP with DAEs
+- [x] separate `acados_ocp()` into generating the C object and setting the numerical data
+- [x] support nonuniform grids
+- [x] OCP with DAEs
 
 #### build
 - [ ] cmake: add openmp parallelization

--- a/acados/dense_qp/dense_qp_qpoases.c
+++ b/acados/dense_qp/dense_qp_qpoases.c
@@ -75,9 +75,9 @@
 #include "acados/utils/mem.h"
 #include "acados/utils/timing.h"
 #include "acados/utils/print.h"
+#include "acados/utils/math.h"
 
 #include "acados_c/dense_qp_interface.h"
-
 
 
 /************************************************
@@ -121,6 +121,7 @@ void dense_qp_qpoases_opts_initialize_default(void *config_, dense_qp_dims *dims
     opts->hotstart = 0;
     opts->set_acado_opts = 1;
     opts->compute_t = 1;
+    opts->tolerance = 1e-4;
 
     return;
 }
@@ -142,19 +143,23 @@ void dense_qp_qpoases_opts_set(void *config_, void *opts_, const char *field, vo
 
     if (!strcmp(field, "tol_stat"))
     {
-        // TODO set solver exit tolerance
+        double *tol = value;
+        opts->tolerance = MIN(opts->tolerance, *tol);
     }
     else if (!strcmp(field, "tol_eq"))
     {
-        // TODO set solver exit tolerance
+        double *tol = value;
+        opts->tolerance = MIN(opts->tolerance, *tol);
     }
     else if (!strcmp(field, "tol_ineq"))
     {
-        // TODO set solver exit tolerance
+        double *tol = value;
+        opts->tolerance = MIN(opts->tolerance, *tol);
     }
     else if (!strcmp(field, "tol_comp"))
     {
-        // TODO set solver exit tolerance
+        double *tol = value;
+        opts->tolerance = MIN(opts->tolerance, *tol);
     }
     else if (!strcmp(field, "warm_start"))
     {
@@ -467,6 +472,7 @@ int dense_qp_qpoases(void *config_, dense_qp_in *qp_in, dense_qp_out *qp_out, vo
                 {
                     static Options options;
                     Options_setToMPC(&options);
+                    options.terminationTolerance = opts->tolerance;
                     QProblem_setOptions(QP, options);
                 }
 
@@ -499,6 +505,7 @@ int dense_qp_qpoases(void *config_, dense_qp_in *qp_in, dense_qp_out *qp_out, vo
                 {
                     static Options options;
                     Options_setToMPC(&options);
+                    options.terminationTolerance = opts->tolerance;
                     QProblem_setOptions(QP, options);
                 }
                 QProblemB_init(QPB, H, g, d_lb, d_ub, &nwsr, &cputime);
@@ -526,10 +533,13 @@ int dense_qp_qpoases(void *config_, dense_qp_in *qp_in, dense_qp_out *qp_out, vo
             QProblem_printProperties(QP);
             if (opts->use_precomputed_cholesky == 1)
             {
+                // NOTE(oj): why are there no options set in this case?
                 // static Options options;
                 // Options_setToDefault( &options );
                 // options.initialStatusBounds = ST_INACTIVE;
+                // options.terminationTolerance = opts->tolerance;
                 // QProblem_setOptions( QP, options );
+
 
                 qpoases_status = (ns > 0) ?
                     QProblem_initW(QP, HH, gg, CC, d_lb, d_ub, d_lg, d_ug, &nwsr, &cputime,
@@ -547,6 +557,7 @@ int dense_qp_qpoases(void *config_, dense_qp_in *qp_in, dense_qp_out *qp_out, vo
                 {
                     static Options options;
                     Options_setToMPC(&options);
+                    options.terminationTolerance = opts->tolerance;
                     QProblem_setOptions(QP, options);
                 }
                 if (opts->warm_start)
@@ -575,6 +586,7 @@ int dense_qp_qpoases(void *config_, dense_qp_in *qp_in, dense_qp_out *qp_out, vo
             QProblemB_printProperties(QPB);
             if (opts->use_precomputed_cholesky == 1)
             {
+                // NOTE(oj): why are there no options set in this case?
                 // static Options options;
                 // Options_setToDefault( &options );
                 // options.initialStatusBounds = ST_INACTIVE;
@@ -590,6 +602,7 @@ int dense_qp_qpoases(void *config_, dense_qp_in *qp_in, dense_qp_out *qp_out, vo
                 {
                     static Options options;
                     Options_setToMPC(&options);
+                    options.terminationTolerance = opts->tolerance;
                     QProblemB_setOptions(QPB, options);
                 }
                 if (opts->warm_start)

--- a/acados/dense_qp/dense_qp_qpoases.h
+++ b/acados/dense_qp/dense_qp_qpoases.h
@@ -56,6 +56,7 @@ typedef struct dense_qp_qpoases_opts_
                    // with frozen sensitivities)
     int set_acado_opts;  // use same options as in acado code generation
     int compute_t;       // compute t in qp_out (to have correct residuals in NLP)
+    double tolerance;  // terminationTolerance
 } dense_qp_qpoases_opts;
 
 typedef struct dense_qp_qpoases_memory_

--- a/acados/ocp_nlp/ocp_nlp_dynamics_cont.c
+++ b/acados/ocp_nlp/ocp_nlp_dynamics_cont.c
@@ -59,7 +59,7 @@ int ocp_nlp_dynamics_cont_dims_calculate_size(void *config_)
 
     size += sizeof(ocp_nlp_dynamics_cont_dims);
 
-    size += sim_sol_config->dims_calculate_size(sim_sol_config);
+    size += sim_sol_config->dims_calculate_size();
 
     return size;
 }

--- a/acados/ocp_nlp/ocp_nlp_sqp.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp.c
@@ -199,21 +199,21 @@ void ocp_nlp_sqp_opts_initialize_default(void *config_, void *dims_, void *opts_
     opts->num_threads = ACADOS_NUM_THREADS;
 #endif
 
-	opts->ext_qp_res = 0;
+    opts->ext_qp_res = 0;
 
-	opts->qp_warm_start = 0;
+    opts->qp_warm_start = 0;
 
-	opts->step_length = 1.0;
+    opts->step_length = 1.0;
 
     // submodules opts
 
     // qp solver
     qp_solver->opts_initialize_default(qp_solver, dims->qp_solver, opts->qp_solver_opts);
-	// overwrite default
-	qp_solver->opts_set(qp_solver, opts->qp_solver_opts, "tol_stat", &opts->tol_stat);
-	qp_solver->opts_set(qp_solver, opts->qp_solver_opts, "tol_eq", &opts->tol_eq);
-	qp_solver->opts_set(qp_solver, opts->qp_solver_opts, "tol_ineq", &opts->tol_ineq);
-	qp_solver->opts_set(qp_solver, opts->qp_solver_opts, "tol_comp", &opts->tol_comp);
+    // overwrite default
+    qp_solver->opts_set(qp_solver, opts->qp_solver_opts, "tol_stat", &opts->tol_stat);
+    qp_solver->opts_set(qp_solver, opts->qp_solver_opts, "tol_eq", &opts->tol_eq);
+    qp_solver->opts_set(qp_solver, opts->qp_solver_opts, "tol_ineq", &opts->tol_ineq);
+    qp_solver->opts_set(qp_solver, opts->qp_solver_opts, "tol_comp", &opts->tol_comp);
 
     // regularization
     regularize->opts_initialize_default(regularize, dims->regularize, opts->regularize);
@@ -287,110 +287,110 @@ void ocp_nlp_sqp_opts_set(void *config_, void *opts_, const char *field, void* v
     ocp_nlp_sqp_opts *opts = (ocp_nlp_sqp_opts *) opts_;
     ocp_nlp_config *config = config_;
 
-	int ii;
+    int ii;
 
-	char module[MAX_STR_LEN];
-	char *ptr_module = NULL;
-	int module_length = 0;
+    char module[MAX_STR_LEN];
+    char *ptr_module = NULL;
+    int module_length = 0;
 
-	// extract module name
-	char *char_ = strchr(field, '_');
-	if(char_!=NULL)
-	{
-		module_length = char_-field;
-		for(ii=0; ii<module_length; ii++)
-			module[ii] = field[ii];
-		module[module_length] = '\0'; // add end of string
-		ptr_module = module;
-	}
+    // extract module name
+    char *char_ = strchr(field, '_');
+    if(char_!=NULL)
+    {
+        module_length = char_-field;
+        for(ii=0; ii<module_length; ii++)
+            module[ii] = field[ii];
+        module[module_length] = '\0'; // add end of string
+        ptr_module = module;
+    }
 
-	// pass options to QP module
-	if( ptr_module!=NULL && (!strcmp(ptr_module, "qp")) )
-	{
-		config->qp_solver->opts_set(config->qp_solver, opts->qp_solver_opts, field+module_length+1, value);
+    // pass options to QP module
+    if( ptr_module!=NULL && (!strcmp(ptr_module, "qp")) )
+    {
+        config->qp_solver->opts_set(config->qp_solver, opts->qp_solver_opts, field+module_length+1, value);
 
-		if(!strcmp(field, "qp_warm_start"))
-		{
-			int* i_ptr = (int *) value;
-			opts->qp_warm_start = *i_ptr;
-		}
-	}
-	else // nlp opts
-	{
-		if (!strcmp(field, "max_iter"))
-		{
-			int* max_iter = (int *) value;
-			opts->max_iter = *max_iter;
-		}
-		else if (!strcmp(field, "reuse_workspace"))
-		{
-			int* reuse_workspace = (int *) value;
-			opts->reuse_workspace = *reuse_workspace;
-		}
-		else if (!strcmp(field, "num_threads"))
-		{
-			int* num_threads = (int *) value;
-			opts->num_threads = *num_threads;
-		}
-		else if (!strcmp(field, "tol_stat")) // TODO rename !!! to be what?!
-		{
-			double* tol_stat = (double *) value;
-			opts->tol_stat = *tol_stat;
-			// TODO: set accuracy of the qp_solver to the minimum of current QP accuracy and the one specified.
-			config->qp_solver->opts_set(config->qp_solver, opts->qp_solver_opts, "tol_stat", value);
-		}
-		else if (!strcmp(field, "tol_eq")) // TODO rename !!!
-		{
-			double* tol_eq = (double *) value;
-			opts->tol_eq = *tol_eq;
-			// TODO: set accuracy of the qp_solver to the minimum of current QP accuracy and the one specified.
-			config->qp_solver->opts_set(config->qp_solver, opts->qp_solver_opts, "tol_eq", value);
-		}
-		else if (!strcmp(field, "tol_ineq")) // TODO rename !!!
-		{
-			double* tol_ineq = (double *) value;
-			opts->tol_ineq = *tol_ineq;
-			// TODO: set accuracy of the qp_solver to the minimum of current QP accuracy and the one specified.
-			config->qp_solver->opts_set(config->qp_solver, opts->qp_solver_opts, "tol_ineq", value);
-		}
-		else if (!strcmp(field, "tol_comp")) // TODO rename !!!
-		{
-			double* tol_comp = (double *) value;
-			opts->tol_comp = *tol_comp;
-			// TODO: set accuracy of the qp_solver to the minimum of current QP accuracy and the one specified.
-			config->qp_solver->opts_set(config->qp_solver, opts->qp_solver_opts, "tol_comp", value);
-		}
-		else if (!strcmp(field, "exact_hess"))
-		{
-			int N = config->N;
-			// cost
-			for (ii=0; ii<=N; ii++)
-				config->cost[ii]->opts_set(config->cost[ii], opts->cost[ii], "exact_hess", value);
-			// dynamics
-			for (ii=0; ii<N; ii++)
-				config->dynamics[ii]->opts_set(config->dynamics[ii], opts->dynamics[ii], "compute_hess", value);
-			// constraints TODO disabled for now as prevents convergence !!!
-//			for (ii=0; ii<=N; ii++)
-//				config->constraints[ii]->opts_set(config->constraints[ii], opts->constraints[ii], "compute_hess", value);
-		}
-		else if (!strcmp(field, "ext_qp_res"))
-		{
-			int* ext_qp_res = (int *) value;
-			opts->ext_qp_res = *ext_qp_res;
-		}
-		else if (!strcmp(field, "step_length"))
-		{
-			double* step_length = (double *) value;
-			opts->step_length = *step_length;
-		}
-		else
-		{
-			printf("\nerror: ocp_nlp_sqp_opts_set: wrong field: %s\n", field);
-			exit(1);
-		}
-	}
+        if(!strcmp(field, "qp_warm_start"))
+        {
+            int* i_ptr = (int *) value;
+            opts->qp_warm_start = *i_ptr;
+        }
+    }
+    else // nlp opts
+    {
+        if (!strcmp(field, "max_iter"))
+        {
+            int* max_iter = (int *) value;
+            opts->max_iter = *max_iter;
+        }
+        else if (!strcmp(field, "reuse_workspace"))
+        {
+            int* reuse_workspace = (int *) value;
+            opts->reuse_workspace = *reuse_workspace;
+        }
+        else if (!strcmp(field, "num_threads"))
+        {
+            int* num_threads = (int *) value;
+            opts->num_threads = *num_threads;
+        }
+        else if (!strcmp(field, "tol_stat")) // TODO rename !!! to be what?!
+        {
+            double* tol_stat = (double *) value;
+            opts->tol_stat = *tol_stat;
+            // TODO: set accuracy of the qp_solver to the minimum of current QP accuracy and the one specified.
+            config->qp_solver->opts_set(config->qp_solver, opts->qp_solver_opts, "tol_stat", value);
+        }
+        else if (!strcmp(field, "tol_eq")) // TODO rename !!!
+        {
+            double* tol_eq = (double *) value;
+            opts->tol_eq = *tol_eq;
+            // TODO: set accuracy of the qp_solver to the minimum of current QP accuracy and the one specified.
+            config->qp_solver->opts_set(config->qp_solver, opts->qp_solver_opts, "tol_eq", value);
+        }
+        else if (!strcmp(field, "tol_ineq")) // TODO rename !!!
+        {
+            double* tol_ineq = (double *) value;
+            opts->tol_ineq = *tol_ineq;
+            // TODO: set accuracy of the qp_solver to the minimum of current QP accuracy and the one specified.
+            config->qp_solver->opts_set(config->qp_solver, opts->qp_solver_opts, "tol_ineq", value);
+        }
+        else if (!strcmp(field, "tol_comp")) // TODO rename !!!
+        {
+            double* tol_comp = (double *) value;
+            opts->tol_comp = *tol_comp;
+            // TODO: set accuracy of the qp_solver to the minimum of current QP accuracy and the one specified.
+            config->qp_solver->opts_set(config->qp_solver, opts->qp_solver_opts, "tol_comp", value);
+        }
+        else if (!strcmp(field, "exact_hess"))
+        {
+            int N = config->N;
+            // cost
+            for (ii=0; ii<=N; ii++)
+                config->cost[ii]->opts_set(config->cost[ii], opts->cost[ii], "exact_hess", value);
+            // dynamics
+            for (ii=0; ii<N; ii++)
+                config->dynamics[ii]->opts_set(config->dynamics[ii], opts->dynamics[ii], "compute_hess", value);
+            // constraints TODO disabled for now as prevents convergence !!!
+//            for (ii=0; ii<=N; ii++)
+//                config->constraints[ii]->opts_set(config->constraints[ii], opts->constraints[ii], "compute_hess", value);
+        }
+        else if (!strcmp(field, "ext_qp_res"))
+        {
+            int* ext_qp_res = (int *) value;
+            opts->ext_qp_res = *ext_qp_res;
+        }
+        else if (!strcmp(field, "step_length"))
+        {
+            double* step_length = (double *) value;
+            opts->step_length = *step_length;
+        }
+        else
+        {
+            printf("\nerror: ocp_nlp_sqp_opts_set: wrong field: %s\n", field);
+            exit(1);
+        }
+    }
 
-	return;
+    return;
 
 }
 
@@ -457,15 +457,15 @@ int ocp_nlp_sqp_memory_calculate_size(void *config_, void *dims_, void *opts_)
     ocp_nlp_constraints_config **constraints = config->constraints;
 
     // loop index
-	int ii;
+    int ii;
 
     // extract dims
     int N = dims->N;
     // ocp_nlp_cost_dims **cost_dims = dims->cost;
     // int ny;
-	int *nx = dims->nx;
-	int *nu = dims->nu;
-	int *nz = dims->nz;
+    int *nx = dims->nx;
+    int *nu = dims->nu;
+    int *nz = dims->nz;
 
     int size = 0;
 
@@ -507,26 +507,26 @@ int ocp_nlp_sqp_memory_calculate_size(void *config_, void *dims_, void *opts_)
     }
 
     // nlp res
-	size += ocp_nlp_res_calculate_size(dims);
+    size += ocp_nlp_res_calculate_size(dims);
 
     // nlp mem
     size += ocp_nlp_memory_calculate_size(config, dims);
 
-	// stat
-	int stat_m = opts->max_iter+1;
-	int stat_n = 6;
-	if(opts->ext_qp_res)
-		stat_n += 4;
-	size += stat_n*stat_m*sizeof(double);
+    // stat
+    int stat_m = opts->max_iter+1;
+    int stat_n = 6;
+    if(opts->ext_qp_res)
+        stat_n += 4;
+    size += stat_n*stat_m*sizeof(double);
 
-	// dzduxt
-	size += (N+1)*sizeof(struct blasfeo_dmat);
-	for(ii=0; ii<=N; ii++)
-		size += blasfeo_memsize_dmat(nu[ii]+nx[ii], nz[ii]);
-	// z_alg
-	size += (N+1)*sizeof(struct blasfeo_dvec);
-	for(ii=0; ii<=N; ii++)
-		size += blasfeo_memsize_dvec(nz[ii]);
+    // dzduxt
+    size += (N+1)*sizeof(struct blasfeo_dmat);
+    for(ii=0; ii<=N; ii++)
+        size += blasfeo_memsize_dmat(nu[ii]+nx[ii], nz[ii]);
+    // z_alg
+    size += (N+1)*sizeof(struct blasfeo_dvec);
+    for(ii=0; ii<=N; ii++)
+        size += blasfeo_memsize_dvec(nz[ii]);
 
     size += 1*8;  // blasfeo_str align
     size += 1*64;  // blasfeo_mem align
@@ -557,9 +557,9 @@ void *ocp_nlp_sqp_memory_assign(void *config_, void *dims_, void *opts_, void *r
     int N = dims->N;
     // ocp_nlp_cost_dims **cost_dims = dims->cost;
     // int ny;
-	int *nx = dims->nx;
-	int *nu = dims->nu;
-	int *nz = dims->nz;
+    int *nx = dims->nx;
+    int *nu = dims->nu;
+    int *nz = dims->nz;
 
     // initial align
     align_char_to(8, &c_ptr);
@@ -622,38 +622,38 @@ void *ocp_nlp_sqp_memory_assign(void *config_, void *dims_, void *opts_, void *r
                                                         opts->constraints[ii]);
     }
 
-	// stat
-	mem->stat = (double *) c_ptr;
-	mem->stat_m = opts->max_iter+1;
-	mem->stat_n = 6;
-	if (opts->ext_qp_res)
-		mem->stat_n += 4;
-	c_ptr += mem->stat_m*mem->stat_n*sizeof(double);
+    // stat
+    mem->stat = (double *) c_ptr;
+    mem->stat_m = opts->max_iter+1;
+    mem->stat_n = 6;
+    if (opts->ext_qp_res)
+        mem->stat_n += 4;
+    c_ptr += mem->stat_m*mem->stat_n*sizeof(double);
 
     // blasfeo_str align
     align_char_to(8, &c_ptr);
 
-	// dzduxt
-	mem->dzduxt = (struct blasfeo_dmat *) c_ptr;
-	c_ptr += (N+1)*sizeof(struct blasfeo_dmat);
-	// z_alg
-	mem->z_alg = (struct blasfeo_dvec *) c_ptr;
-	c_ptr += (N+1)*sizeof(struct blasfeo_dvec);
+    // dzduxt
+    mem->dzduxt = (struct blasfeo_dmat *) c_ptr;
+    c_ptr += (N+1)*sizeof(struct blasfeo_dmat);
+    // z_alg
+    mem->z_alg = (struct blasfeo_dvec *) c_ptr;
+    c_ptr += (N+1)*sizeof(struct blasfeo_dvec);
 
     // blasfeo_mem align
     align_char_to(64, &c_ptr);
 
-	// dzduxt
-	for (int ii=0; ii<=N; ii++)
+    // dzduxt
+    for (int ii=0; ii<=N; ii++)
     {
-		blasfeo_create_dmat(nu[ii]+nx[ii], nz[ii], mem->dzduxt+ii, c_ptr);
-		c_ptr += blasfeo_memsize_dmat(nu[ii]+nx[ii], nz[ii]);
+        blasfeo_create_dmat(nu[ii]+nx[ii], nz[ii], mem->dzduxt+ii, c_ptr);
+        c_ptr += blasfeo_memsize_dmat(nu[ii]+nx[ii], nz[ii]);
     }
-	// z_alg
-	for (int ii=0; ii<=N; ii++)
+    // z_alg
+    for (int ii=0; ii<=N; ii++)
     {
-		blasfeo_create_dvec(nz[ii], mem->z_alg+ii, c_ptr);
-		c_ptr += blasfeo_memsize_dvec(nz[ii]);
+        blasfeo_create_dvec(nz[ii], mem->z_alg+ii, c_ptr);
+        c_ptr += blasfeo_memsize_dvec(nz[ii]);
     }
 
     mem->status = ACADOS_READY;
@@ -685,9 +685,9 @@ int ocp_nlp_sqp_workspace_calculate_size(void *config_, void *dims_, void *opts_
 
     // extract dims
     int N = dims->N;
-	// int *nx = dims->nx;
-	// int *nu = dims->nu;
-	// int *nz = dims->nz;
+    // int *nx = dims->nx;
+    // int *nu = dims->nu;
+    // int *nz = dims->nz;
 
     int size = 0;
     int size_tmp = 0;
@@ -710,14 +710,14 @@ int ocp_nlp_sqp_workspace_calculate_size(void *config_, void *dims_, void *opts_
     // constraints
     size += (N + 1) * sizeof(void *);
 
-	if(opts->ext_qp_res)
-	{
-		// qp res
-		size += ocp_qp_res_calculate_size(dims->qp_solver->orig_dims);
+    if(opts->ext_qp_res)
+    {
+        // qp res
+        size += ocp_qp_res_calculate_size(dims->qp_solver->orig_dims);
 
-		// qp res ws
-		size += ocp_qp_res_workspace_calculate_size(dims->qp_solver->orig_dims);
-	}
+        // qp res ws
+        size += ocp_qp_res_workspace_calculate_size(dims->qp_solver->orig_dims);
+    }
 
     if (opts->reuse_workspace)
     {
@@ -828,9 +828,9 @@ static void ocp_nlp_sqp_cast_workspace(void *config_, ocp_nlp_dims *dims, ocp_nl
 
     // extract dims
     int N = dims->N;
-	// int *nx = dims->nx;
-	// int *nu = dims->nu;
-	// int *nz = dims->nz;
+    // int *nx = dims->nx;
+    // int *nu = dims->nu;
+    // int *nz = dims->nz;
 
     // sqp
     char *c_ptr = (char *) work;
@@ -855,16 +855,16 @@ static void ocp_nlp_sqp_cast_workspace(void *config_, ocp_nlp_dims *dims, ocp_nl
     work->constraints = (void **) c_ptr;
     c_ptr += (N + 1) * sizeof(void *);
 
-	if(opts->ext_qp_res)
-	{
-		// qp res
-		work->qp_res = ocp_qp_res_assign(dims->qp_solver->orig_dims, c_ptr);
-		c_ptr += ocp_qp_res_calculate_size(dims->qp_solver->orig_dims);
+    if(opts->ext_qp_res)
+    {
+        // qp res
+        work->qp_res = ocp_qp_res_assign(dims->qp_solver->orig_dims, c_ptr);
+        c_ptr += ocp_qp_res_calculate_size(dims->qp_solver->orig_dims);
 
-		// qp res ws
-		work->qp_res_ws = ocp_qp_res_workspace_assign(dims->qp_solver->orig_dims, c_ptr);
-		c_ptr += ocp_qp_res_workspace_calculate_size(dims->qp_solver->orig_dims);
-	}
+        // qp res ws
+        work->qp_res_ws = ocp_qp_res_workspace_assign(dims->qp_solver->orig_dims, c_ptr);
+        c_ptr += ocp_qp_res_workspace_calculate_size(dims->qp_solver->orig_dims);
+    }
 
     if (opts->reuse_workspace)
     {
@@ -901,8 +901,8 @@ static void ocp_nlp_sqp_cast_workspace(void *config_, ocp_nlp_dims *dims, ocp_nl
 
 #else
 
-		int size_tmp = 0;
-		int tmp;
+        int size_tmp = 0;
+        int tmp;
 
         // qp solver
         work->qp_work = (void *) c_ptr;
@@ -1203,7 +1203,7 @@ static void sqp_update_variables(void *config_, ocp_nlp_dims *dims, ocp_nlp_out 
     //        }
     //    }
 
-	double alpha = opts->step_length;
+    double alpha = opts->step_length;
 
 #if defined(ACADOS_WITH_OPENMP)
     #pragma omp parallel for
@@ -1213,27 +1213,27 @@ static void sqp_update_variables(void *config_, ocp_nlp_dims *dims, ocp_nlp_out 
         // (full) step in primal variables
 
         blasfeo_daxpy(nv[i], alpha, mem->qp_out->ux + i, 0, nlp_out->ux + i, 0, nlp_out->ux + i, 0);
-
+    
         // absolute in dual variables
 
         if (i < N)
-		{
-			blasfeo_dvecsc(nx[i+1], 1.0-alpha, nlp_out->pi+i, 0);
+        {
+            blasfeo_dvecsc(nx[i+1], 1.0-alpha, nlp_out->pi+i, 0);
             blasfeo_daxpy(nx[i+1], alpha, mem->qp_out->pi+i, 0, nlp_out->pi+i, 0, nlp_out->pi+i, 0);
-		}
+        }
 
-		blasfeo_dvecsc(2*ni[i], 1.0-alpha, nlp_out->lam+i, 0);
+        blasfeo_dvecsc(2*ni[i], 1.0-alpha, nlp_out->lam+i, 0);
         blasfeo_daxpy(2*ni[i], alpha, mem->qp_out->lam+i, 0, nlp_out->lam+i, 0, nlp_out->lam+i, 0);
 
-		blasfeo_dvecsc(2*ni[i], 1.0-alpha, nlp_out->t+i, 0);
+        blasfeo_dvecsc(2*ni[i], 1.0-alpha, nlp_out->t+i, 0);
         blasfeo_daxpy(2*ni[i], alpha, mem->qp_out->t+i, 0, nlp_out->t+i, 0, nlp_out->t+i, 0);
 
-		// linear update of algebraic variables using state and input sensitivity
+        // linear update of algebraic variables using state and input sensitivity
 
         if (i < N)
-		{
-			blasfeo_dgemv_t(nu[i]+nx[i], nz[i], 1.0, mem->dzduxt+i, 0, 0, nlp_out->ux+i, 0, 1.0, mem->z_alg+i, 0, nlp_out->z+i, 0); 
-		}
+        {
+            blasfeo_dgemv_t(nu[i]+nx[i], nz[i], 1.0, mem->dzduxt+i, 0, 0, nlp_out->ux+i, 0, 1.0, mem->z_alg+i, 0, nlp_out->z+i, 0); 
+        }
 
     }
 
@@ -1277,8 +1277,8 @@ int ocp_nlp_sqp(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
 
     int ii;
 
-	int qp_iter = 0;
-	int qp_status = 0;
+    int qp_iter = 0;
+    int qp_status = 0;
 
 #if defined(ACADOS_WITH_OPENMP)
     // backup number of threads
@@ -1313,8 +1313,8 @@ int ocp_nlp_sqp(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
     for (ii = 0; ii <= N; ii++)
     {
         config->cost[ii]->memory_set_ux_ptr(nlp_out->ux + ii, mem->cost[ii]);
-		config->cost[ii]->memory_set_z_alg_ptr(mem->z_alg+ii, mem->cost[ii]);
-		config->cost[ii]->memory_set_dzdux_tran_ptr(mem->dzduxt+ii, mem->cost[ii]);
+        config->cost[ii]->memory_set_z_alg_ptr(mem->z_alg+ii, mem->cost[ii]);
+        config->cost[ii]->memory_set_dzdux_tran_ptr(mem->dzduxt+ii, mem->cost[ii]);
         config->cost[ii]->memory_set_RSQrq_ptr(mem->qp_in->RSQrq + ii, mem->cost[ii]);
         config->cost[ii]->memory_set_Z_ptr(mem->qp_in->Z + ii, mem->cost[ii]);
     }
@@ -1325,8 +1325,8 @@ int ocp_nlp_sqp(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
     for (ii = 0; ii <= N; ii++)
     {
         config->constraints[ii]->memory_set_ux_ptr(nlp_out->ux+ii, mem->constraints[ii]);
-		config->constraints[ii]->memory_set_z_alg_ptr(mem->z_alg+ii, mem->constraints[ii]);
-		config->constraints[ii]->memory_set_dzdux_tran_ptr(mem->dzduxt+ii, mem->constraints[ii]);
+        config->constraints[ii]->memory_set_z_alg_ptr(mem->z_alg+ii, mem->constraints[ii]);
+        config->constraints[ii]->memory_set_dzdux_tran_ptr(mem->dzduxt+ii, mem->constraints[ii]);
         config->constraints[ii]->memory_set_lam_ptr(nlp_out->lam+ii, mem->constraints[ii]);
         config->constraints[ii]->memory_set_DCt_ptr(mem->qp_in->DCt+ii, mem->constraints[ii]);
         config->constraints[ii]->memory_set_RSQrq_ptr(mem->qp_in->RSQrq+ii, mem->constraints[ii]);
@@ -1339,7 +1339,7 @@ int ocp_nlp_sqp(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
     config->regularize->memory_set_rq_ptr(dims->regularize, mem->qp_in->rqz, mem->regularize_mem);
     config->regularize->memory_set_BAbt_ptr(dims->regularize, mem->qp_in->BAbt, mem->regularize_mem);
     config->regularize->memory_set_b_ptr(dims->regularize, mem->qp_in->b, mem->regularize_mem);
-	config->regularize->memory_set_idxb_ptr(dims->regularize, mem->qp_in->idxb, mem->regularize_mem);
+    config->regularize->memory_set_idxb_ptr(dims->regularize, mem->qp_in->idxb, mem->regularize_mem);
     config->regularize->memory_set_DCt_ptr(dims->regularize, mem->qp_in->DCt, mem->regularize_mem);
     config->regularize->memory_set_ux_ptr(dims->regularize, mem->qp_out->ux, mem->regularize_mem);
     config->regularize->memory_set_pi_ptr(dims->regularize, mem->qp_out->pi, mem->regularize_mem);
@@ -1395,16 +1395,16 @@ int ocp_nlp_sqp(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
                                     mem->nlp_res->inf_norm_res_m :
                                     nlp_out->inf_norm_res;
 
-		// save statistics
-		if (sqp_iter < mem->stat_m)
-		{
-			mem->stat[mem->stat_n*sqp_iter+0] = mem->nlp_res->inf_norm_res_g;
-			mem->stat[mem->stat_n*sqp_iter+1] = mem->nlp_res->inf_norm_res_b;
-			mem->stat[mem->stat_n*sqp_iter+2] = mem->nlp_res->inf_norm_res_d;
-			mem->stat[mem->stat_n*sqp_iter+3] = mem->nlp_res->inf_norm_res_m;
-			mem->stat[mem->stat_n*sqp_iter+4] = qp_status;
-			mem->stat[mem->stat_n*sqp_iter+5] = qp_iter;
-		}
+        // save statistics
+        if (sqp_iter < mem->stat_m)
+        {
+            mem->stat[mem->stat_n*sqp_iter+0] = mem->nlp_res->inf_norm_res_g;
+            mem->stat[mem->stat_n*sqp_iter+1] = mem->nlp_res->inf_norm_res_b;
+            mem->stat[mem->stat_n*sqp_iter+2] = mem->nlp_res->inf_norm_res_d;
+            mem->stat[mem->stat_n*sqp_iter+3] = mem->nlp_res->inf_norm_res_m;
+            mem->stat[mem->stat_n*sqp_iter+4] = qp_status;
+            mem->stat[mem->stat_n*sqp_iter+5] = qp_iter;
+        }
 
         // exit conditions on residuals
         if ((mem->nlp_res->inf_norm_res_g < opts->tol_stat) &
@@ -1447,16 +1447,16 @@ int ocp_nlp_sqp(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
 //        if(sqp_iter==1)
 //        exit(1);
 
-		// no warm start at first iteration
-		if(sqp_iter==0)
-		{
-			int tmp_int = 0;
-			config->qp_solver->opts_set(config->qp_solver, opts->qp_solver_opts, "warm_start", &tmp_int);
-		}
+        // no warm start at first iteration
+        if(sqp_iter==0)
+        {
+            int tmp_int = 0;
+            config->qp_solver->opts_set(config->qp_solver, opts->qp_solver_opts, "warm_start", &tmp_int);
+        }
 
         // start timer
         acados_tic(&timer1);
-		// TODO move qp_out in memory !!!!! (it has to be preserved to do warm start)
+        // TODO move qp_out in memory !!!!! (it has to be preserved to do warm start)
         qp_status = qp_solver->evaluate(qp_solver, dims->qp_solver, mem->qp_in, mem->qp_out, opts->qp_solver_opts, mem->qp_solver_mem, work->qp_work);
         // stop timer
         mem->time_qp_sol += acados_toc(&timer1);
@@ -1468,26 +1468,26 @@ int ocp_nlp_sqp(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
         // stop timer
         mem->time_reg += acados_toc(&timer1);
 
-		// restore default warm start
-		if(sqp_iter==0)
-		{
-			config->qp_solver->opts_set(config->qp_solver, opts->qp_solver_opts, "warm_start", &opts->qp_warm_start);
-		}
+        // restore default warm start
+        if(sqp_iter==0)
+        {
+            config->qp_solver->opts_set(config->qp_solver, opts->qp_solver_opts, "warm_start", &opts->qp_warm_start);
+        }
 
-		// TODO move into QP solver memory ???
-		qp_info *qp_info_;
-		ocp_qp_out_get(mem->qp_out, "qp_info", &qp_info_);
+        // TODO move into QP solver memory ???
+        qp_info *qp_info_;
+        ocp_qp_out_get(mem->qp_out, "qp_info", &qp_info_);
         nlp_out->qp_iter = qp_info_->num_iter;
         qp_iter = qp_info_->num_iter;
 
-		// compute external QP residuals (for debugging)
-		if(opts->ext_qp_res)
-		{
-			ocp_qp_res_compute(mem->qp_in, mem->qp_out, work->qp_res, work->qp_res_ws);
-			if (sqp_iter+1 < mem->stat_m)
-				ocp_qp_res_compute_nrm_inf(work->qp_res, mem->stat+(mem->stat_n*(sqp_iter+1)+6));
-//			printf("\nsqp_iter %d, res %e %e %e %e\n", sqp_iter, inf_norm_qp_res[0], inf_norm_qp_res[1], inf_norm_qp_res[2], inf_norm_qp_res[3]);
-		}
+        // compute external QP residuals (for debugging)
+        if(opts->ext_qp_res)
+        {
+            ocp_qp_res_compute(mem->qp_in, mem->qp_out, work->qp_res, work->qp_res_ws);
+            if (sqp_iter+1 < mem->stat_m)
+                ocp_qp_res_compute_nrm_inf(work->qp_res, mem->stat+(mem->stat_n*(sqp_iter+1)+6));
+//            printf("\nsqp_iter %d, res %e %e %e %e\n", sqp_iter, inf_norm_qp_res[0], inf_norm_qp_res[1], inf_norm_qp_res[2], inf_norm_qp_res[3]);
+        }
 
 //        printf("\n------- qp_out (sqp iter %d) ---------\n", sqp_iter);
 //        print_ocp_qp_out(mem->qp_out);
@@ -1625,50 +1625,50 @@ void ocp_nlp_sqp_eval_param_sens(void *config_, void *dims_, void *opts_, void *
 
     ocp_nlp_sqp_cast_workspace(config, dims, work, mem, opts);
 
-	d_ocp_qp_copy_all(mem->qp_in, work->tmp_qp_in);
-	d_ocp_qp_set_rhs_zero(work->tmp_qp_in);
+    d_ocp_qp_copy_all(mem->qp_in, work->tmp_qp_in);
+    d_ocp_qp_set_rhs_zero(work->tmp_qp_in);
 
-	double one = 1.0;
+    double one = 1.0;
 
     if ((!strcmp("ex", field)) & (stage==0))
     {
-		d_ocp_qp_set_el("lbx", stage, index, &one, work->tmp_qp_in);
-		d_ocp_qp_set_el("ubx", stage, index, &one, work->tmp_qp_in);
+        d_ocp_qp_set_el("lbx", stage, index, &one, work->tmp_qp_in);
+        d_ocp_qp_set_el("ubx", stage, index, &one, work->tmp_qp_in);
 
-//		d_ocp_qp_print(work->tmp_qp_in->dim, work->tmp_qp_in);
+//        d_ocp_qp_print(work->tmp_qp_in->dim, work->tmp_qp_in);
 
-		config->qp_solver->eval_sens(config->qp_solver, dims->qp_solver, work->tmp_qp_in, work->tmp_qp_out, opts->qp_solver_opts, mem->qp_solver_mem, work->qp_work);
+        config->qp_solver->eval_sens(config->qp_solver, dims->qp_solver, work->tmp_qp_in, work->tmp_qp_out, opts->qp_solver_opts, mem->qp_solver_mem, work->qp_work);
 
-//		d_ocp_qp_sol_print(work->tmp_qp_out->dim, work->tmp_qp_out);
-//		exit(1);
-		
-		// copy tmp_qp_out into sens_nlp_out
+//        d_ocp_qp_sol_print(work->tmp_qp_out->dim, work->tmp_qp_out);
+//        exit(1);
+        
+        // copy tmp_qp_out into sens_nlp_out
 
-		// loop index
-		int i;
+        // loop index
+        int i;
 
-		// extract dims
-		int N = dims->N;
-		int *nv = dims->nv;
-		int *nx = dims->nx;
-		// int *nu = dims->nu;
-		int *ni = dims->ni;
-		// int *nz = dims->nz;
+        // extract dims
+        int N = dims->N;
+        int *nv = dims->nv;
+        int *nx = dims->nx;
+        // int *nu = dims->nu;
+        int *ni = dims->ni;
+        // int *nz = dims->nz;
 
-		for (i = 0; i <= N; i++)
-		{
-			blasfeo_dveccp(nv[i], work->tmp_qp_out->ux + i, 0, sens_nlp_out->ux + i, 0);
+        for (i = 0; i <= N; i++)
+        {
+            blasfeo_dveccp(nv[i], work->tmp_qp_out->ux + i, 0, sens_nlp_out->ux + i, 0);
 
-			if (i < N)
-				blasfeo_dveccp(nx[i + 1], work->tmp_qp_out->pi + i, 0, sens_nlp_out->pi + i, 0);
+            if (i < N)
+                blasfeo_dveccp(nx[i + 1], work->tmp_qp_out->pi + i, 0, sens_nlp_out->pi + i, 0);
 
-			blasfeo_dveccp(2 * ni[i], work->tmp_qp_out->lam + i, 0, sens_nlp_out->lam + i, 0);
+            blasfeo_dveccp(2 * ni[i], work->tmp_qp_out->lam + i, 0, sens_nlp_out->lam + i, 0);
 
-			blasfeo_dveccp(2 * ni[i], work->tmp_qp_out->t + i, 0, sens_nlp_out->t + i, 0);
+            blasfeo_dveccp(2 * ni[i], work->tmp_qp_out->t + i, 0, sens_nlp_out->t + i, 0);
 
-		}
+        }
 
-	}
+    }
     else
     {
         printf("\nerror: field %s at stage %d not available in ocp_nlp_sqp_eval_param_sens\n", field, stage);

--- a/acados/ocp_nlp/ocp_nlp_sqp.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp.c
@@ -1229,10 +1229,9 @@ static void sqp_update_variables(void *config_, ocp_nlp_dims *dims, ocp_nlp_out 
         blasfeo_daxpy(2*ni[i], alpha, mem->qp_out->t+i, 0, nlp_out->t+i, 0, nlp_out->t+i, 0);
 
         // linear update of algebraic variables using state and input sensitivity
-
         if (i < N)
         {
-            blasfeo_dgemv_t(nu[i]+nx[i], nz[i], 1.0, mem->dzduxt+i, 0, 0, nlp_out->ux+i, 0, 1.0, mem->z_alg+i, 0, nlp_out->z+i, 0); 
+            blasfeo_dgemv_t(nu[i]+nx[i], nz[i], 1.0, mem->dzduxt+i, 0, 0, nlp_out->ux+i, 0, 0.0, mem->z_alg+i, 0, nlp_out->z+i, 0); 
         }
 
     }

--- a/acados/ocp_nlp/ocp_nlp_sqp.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp.c
@@ -1231,9 +1231,11 @@ static void sqp_update_variables(void *config_, ocp_nlp_dims *dims, ocp_nlp_out 
         // linear update of algebraic variables using state and input sensitivity
         if (i < N)
         {
-            blasfeo_dgemv_t(nu[i]+nx[i], nz[i], 1.0, mem->dzduxt+i, 0, 0, nlp_out->ux+i, 0, 0.0, mem->z_alg+i, 0, nlp_out->z+i, 0); 
+            blasfeo_dgemv_t(nu[i]+nx[i], nz[i], 1.0, mem->dzduxt+i, 0, 0, nlp_out->ux+i, 0,
+                            0.0, mem->z_alg+i, 0, nlp_out->z+i, 0);
+            // copy z into z_alg
+            blasfeo_dveccp(nz[i], nlp_out->z+i, 0, mem->z_alg+i, 0);
         }
-
     }
 
     return;

--- a/acados/ocp_nlp/ocp_nlp_sqp_rti.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp_rti.c
@@ -194,9 +194,9 @@ void ocp_nlp_sqp_rti_opts_initialize_default(void *config_, void *dims_, void *o
     opts->num_threads = ACADOS_NUM_THREADS;
 #endif
 
-	opts->ext_qp_res = 0;
+    opts->ext_qp_res = 0;
 
-	opts->step_length = 1.0;
+    opts->step_length = 1.0;
 
     // submodules opts
 
@@ -280,72 +280,72 @@ void ocp_nlp_sqp_rti_opts_set(void *config_, void *opts_, const char *field, voi
     ocp_nlp_sqp_rti_opts *opts = (ocp_nlp_sqp_rti_opts *) opts_;
     ocp_nlp_config *config = config_;
 
-	int ii;
+    int ii;
 
-	char module[MAX_STR_LEN];
-	char *ptr_module = NULL;
-	int module_length = 0;
+    char module[MAX_STR_LEN];
+    char *ptr_module = NULL;
+    int module_length = 0;
 
-	// extract module name
-	char *char_ = strchr(field, '_');
-	if(char_!=NULL)
-	{
-		module_length = char_-field;
-		for(ii=0; ii<module_length; ii++)
-			module[ii] = field[ii];
-		module[module_length] = '\0'; // add end of string
-		ptr_module = module;
-	}
+    // extract module name
+    char *char_ = strchr(field, '_');
+    if(char_!=NULL)
+    {
+        module_length = char_-field;
+        for(ii=0; ii<module_length; ii++)
+            module[ii] = field[ii];
+        module[module_length] = '\0'; // add end of string
+        ptr_module = module;
+    }
 
-	// pass options to QP module
-	if( ptr_module!=NULL && (!strcmp(ptr_module, "qp")) )
-	{
-		config->qp_solver->opts_set(config->qp_solver, opts->qp_solver_opts, field+module_length+1, value);
+    // pass options to QP module
+    if( ptr_module!=NULL && (!strcmp(ptr_module, "qp")) )
+    {
+        config->qp_solver->opts_set(config->qp_solver, opts->qp_solver_opts, field+module_length+1, value);
 
-		if(!strcmp(field, "qp_warm_start"))
-		{
-			int* i_ptr = (int *) value;
-			opts->qp_warm_start = *i_ptr;
-		}
-	}
-	else // nlp opts
-	{
-		if (!strcmp(field, "num_threads"))
-		{
-			int* num_threads = (int *) value;
-			opts->num_threads = *num_threads;
-		}
-		else if (!strcmp(field, "exact_hess"))
-		{
-			int N = config->N;
-			// cost
-			for (ii=0; ii<=N; ii++)
-				config->cost[ii]->opts_set(config->cost[ii], opts->cost[ii], "exact_hess", value);
-			// dynamics
-			for (ii=0; ii<N; ii++)
-				config->dynamics[ii]->opts_set(config->dynamics[ii], opts->dynamics[ii], "compute_hess", value);
-//			// constraints TODO disabled for now as prevents convergence !!!
-//			for (ii=0; ii<=N; ii++)
-//				config->constraints[ii]->opts_set(config->constraints[ii], opts->constraints[ii], "compute_hess", value);
-		}
-		else if (!strcmp(field, "ext_qp_res"))
-		{
-			int* ext_qp_res = (int *) value;
-			opts->ext_qp_res = *ext_qp_res;
-		}
-		else if (!strcmp(field, "step_length"))
-		{
-			double* step_length = (double *) value;
-			opts->step_length = *step_length;
-		}
-		else
-		{
-			printf("\nerror: ocp_nlp_sqp_rti_opts_set: wrong field: %s\n", field);
-			exit(1);
-		}
-	}
+        if(!strcmp(field, "qp_warm_start"))
+        {
+            int* i_ptr = (int *) value;
+            opts->qp_warm_start = *i_ptr;
+        }
+    }
+    else // nlp opts
+    {
+        if (!strcmp(field, "num_threads"))
+        {
+            int* num_threads = (int *) value;
+            opts->num_threads = *num_threads;
+        }
+        else if (!strcmp(field, "exact_hess"))
+        {
+            int N = config->N;
+            // cost
+            for (ii=0; ii<=N; ii++)
+                config->cost[ii]->opts_set(config->cost[ii], opts->cost[ii], "exact_hess", value);
+            // dynamics
+            for (ii=0; ii<N; ii++)
+                config->dynamics[ii]->opts_set(config->dynamics[ii], opts->dynamics[ii], "compute_hess", value);
+//            // constraints TODO disabled for now as prevents convergence !!!
+//            for (ii=0; ii<=N; ii++)
+//                config->constraints[ii]->opts_set(config->constraints[ii], opts->constraints[ii], "compute_hess", value);
+        }
+        else if (!strcmp(field, "ext_qp_res"))
+        {
+            int* ext_qp_res = (int *) value;
+            opts->ext_qp_res = *ext_qp_res;
+        }
+        else if (!strcmp(field, "step_length"))
+        {
+            double* step_length = (double *) value;
+            opts->step_length = *step_length;
+        }
+        else
+        {
+            printf("\nerror: ocp_nlp_sqp_rti_opts_set: wrong field: %s\n", field);
+            exit(1);
+        }
+    }
 
-	return;
+    return;
 
 }
 
@@ -418,9 +418,9 @@ int ocp_nlp_sqp_rti_memory_calculate_size(void *config_, void *dims_, void *opts
     int N = dims->N;
     // ocp_nlp_cost_dims **cost_dims = dims->cost;
     // int ny;
-	int *nx = dims->nx;
-	int *nu = dims->nu;
-	int *nz = dims->nz;
+    int *nx = dims->nx;
+    int *nu = dims->nu;
+    int *nz = dims->nz;
 
     int size = 0;
 
@@ -432,7 +432,7 @@ int ocp_nlp_sqp_rti_memory_calculate_size(void *config_, void *dims_, void *opts
     // qp out
     size += ocp_qp_out_calculate_size(dims->qp_solver->orig_dims);
 
-	// qp solver
+    // qp solver
     size += qp_solver->memory_calculate_size(qp_solver, dims->qp_solver, opts->qp_solver_opts);
 
     size += config->regularize->memory_calculate_size(config->regularize, dims->regularize, opts->regularize);
@@ -463,21 +463,21 @@ int ocp_nlp_sqp_rti_memory_calculate_size(void *config_, void *dims_, void *opts
     // nlp mem
     size += ocp_nlp_memory_calculate_size(config, dims);
 
-	// stat
-	int stat_m = 1+1;
-	int stat_n = 2;
-	if(opts->ext_qp_res)
-		stat_n += 4;
-	size += stat_n*stat_m*sizeof(double);
+    // stat
+    int stat_m = 1+1;
+    int stat_n = 2;
+    if(opts->ext_qp_res)
+        stat_n += 4;
+    size += stat_n*stat_m*sizeof(double);
 
-	// dzduxt
-	size += (N+1)*sizeof(struct blasfeo_dmat);
-	for(ii=0; ii<=N; ii++)
-		size += blasfeo_memsize_dmat(nu[ii]+nx[ii], nz[ii]);
-	// z_alg
-	size += (N+1)*sizeof(struct blasfeo_dvec);
-	for(ii=0; ii<=N; ii++)
-		size += blasfeo_memsize_dvec(nz[ii]);
+    // dzduxt
+    size += (N+1)*sizeof(struct blasfeo_dmat);
+    for(ii=0; ii<=N; ii++)
+        size += blasfeo_memsize_dmat(nu[ii]+nx[ii], nz[ii]);
+    // z_alg
+    size += (N+1)*sizeof(struct blasfeo_dvec);
+    for(ii=0; ii<=N; ii++)
+        size += blasfeo_memsize_dvec(nz[ii]);
 
     size += 1*8;  // blasfeo_str align
     size += 1*64;  // blasfeo_mem align
@@ -511,9 +511,9 @@ void *ocp_nlp_sqp_rti_memory_assign(void *config_, void *dims_, void *opts_, voi
     int N = dims->N;
     // ocp_nlp_cost_dims **cost_dims = dims->cost;
     // int ny;
-	int *nx = dims->nx;
-	int *nu = dims->nu;
-	int *nz = dims->nz;
+    int *nx = dims->nx;
+    int *nu = dims->nu;
+    int *nz = dims->nz;
 
     // initial align
     align_char_to(8, &c_ptr);
@@ -573,39 +573,39 @@ void *ocp_nlp_sqp_rti_memory_assign(void *config_, void *dims_, void *opts_, voi
                                                         opts->constraints[ii]);
     }
 
-	// stat
-	mem->stat = (double *) c_ptr;
-	mem->stat_m = 1+1;
-	mem->stat_n = 2;
-	if(opts->ext_qp_res)
-		mem->stat_n += 4;
-	c_ptr += mem->stat_m*mem->stat_n*sizeof(double);
+    // stat
+    mem->stat = (double *) c_ptr;
+    mem->stat_m = 1+1;
+    mem->stat_n = 2;
+    if(opts->ext_qp_res)
+        mem->stat_n += 4;
+    c_ptr += mem->stat_m*mem->stat_n*sizeof(double);
 
     // blasfeo_str align
     align_char_to(8, &c_ptr);
 
-	// dzduxt
-	mem->dzduxt = (struct blasfeo_dmat *) c_ptr;
-	c_ptr += (N+1)*sizeof(struct blasfeo_dmat);
-	// z_alg
-	mem->z_alg = (struct blasfeo_dvec *) c_ptr;
-	c_ptr += (N+1)*sizeof(struct blasfeo_dvec);
+    // dzduxt
+    mem->dzduxt = (struct blasfeo_dmat *) c_ptr;
+    c_ptr += (N+1)*sizeof(struct blasfeo_dmat);
+    // z_alg
+    mem->z_alg = (struct blasfeo_dvec *) c_ptr;
+    c_ptr += (N+1)*sizeof(struct blasfeo_dvec);
 
     // blasfeo_mem align
     align_char_to(64, &c_ptr);
 
-	// dzduxt
-	for(ii=0; ii<=N; ii++)
-		{
-		blasfeo_create_dmat(nu[ii]+nx[ii], nz[ii], mem->dzduxt+ii, c_ptr);
-		c_ptr += blasfeo_memsize_dmat(nu[ii]+nx[ii], nz[ii]);
-		}
-	// z_alg
-	for(ii=0; ii<=N; ii++)
-		{
-		blasfeo_create_dvec(nz[ii], mem->z_alg+ii, c_ptr);
-		c_ptr += blasfeo_memsize_dvec(nz[ii]);
-		}
+    // dzduxt
+    for(ii=0; ii<=N; ii++)
+        {
+        blasfeo_create_dmat(nu[ii]+nx[ii], nz[ii], mem->dzduxt+ii, c_ptr);
+        c_ptr += blasfeo_memsize_dmat(nu[ii]+nx[ii], nz[ii]);
+        }
+    // z_alg
+    for(ii=0; ii<=N; ii++)
+        {
+        blasfeo_create_dvec(nz[ii], mem->z_alg+ii, c_ptr);
+        c_ptr += blasfeo_memsize_dvec(nz[ii]);
+        }
 
     mem->status = ACADOS_READY;
 
@@ -636,9 +636,9 @@ int ocp_nlp_sqp_rti_workspace_calculate_size(void *config_, void *dims_, void *o
 
     // extract dims
     int N = dims->N;
-	// int *nx = dims->nx;
-	// int *nu = dims->nu;
-	// int *nz = dims->nz;
+    // int *nx = dims->nx;
+    // int *nu = dims->nu;
+    // int *nz = dims->nz;
 
     int size = 0;
     int size_tmp = 0;
@@ -661,14 +661,14 @@ int ocp_nlp_sqp_rti_workspace_calculate_size(void *config_, void *dims_, void *o
     // constraints
     size += (N + 1) * sizeof(void *);
 
-	if(opts->ext_qp_res)
-	{
-		// qp res
-		size += ocp_qp_res_calculate_size(dims->qp_solver->orig_dims);
+    if(opts->ext_qp_res)
+    {
+        // qp res
+        size += ocp_qp_res_calculate_size(dims->qp_solver->orig_dims);
 
-		// qp res ws
-		size += ocp_qp_res_workspace_calculate_size(dims->qp_solver->orig_dims);
-	}
+        // qp res ws
+        size += ocp_qp_res_workspace_calculate_size(dims->qp_solver->orig_dims);
+    }
 
     if (opts->reuse_workspace)
     {
@@ -782,9 +782,9 @@ static void ocp_nlp_sqp_rti_cast_workspace(void *config_, ocp_nlp_dims *dims,
 
     // extract dims
     int N = dims->N;
-	// int *nx = dims->nx;
-	// int *nu = dims->nu;
-	// int *nz = dims->nz;
+    // int *nx = dims->nx;
+    // int *nu = dims->nu;
+    // int *nz = dims->nz;
 
     // sqp
     char *c_ptr = (char *) work;
@@ -809,16 +809,16 @@ static void ocp_nlp_sqp_rti_cast_workspace(void *config_, ocp_nlp_dims *dims,
     work->constraints = (void **) c_ptr;
     c_ptr += (N + 1) * sizeof(void *);
 
-	if(opts->ext_qp_res)
-	{
-		// qp res
-		work->qp_res = ocp_qp_res_assign(dims->qp_solver->orig_dims, c_ptr);
-		c_ptr += ocp_qp_res_calculate_size(dims->qp_solver->orig_dims);
+    if(opts->ext_qp_res)
+    {
+        // qp res
+        work->qp_res = ocp_qp_res_assign(dims->qp_solver->orig_dims, c_ptr);
+        c_ptr += ocp_qp_res_calculate_size(dims->qp_solver->orig_dims);
 
-		// qp res ws
-		work->qp_res_ws = ocp_qp_res_workspace_assign(dims->qp_solver->orig_dims, c_ptr);
-		c_ptr += ocp_qp_res_workspace_calculate_size(dims->qp_solver->orig_dims);
-	}
+        // qp res ws
+        work->qp_res_ws = ocp_qp_res_workspace_assign(dims->qp_solver->orig_dims, c_ptr);
+        c_ptr += ocp_qp_res_workspace_calculate_size(dims->qp_solver->orig_dims);
+    }
 
     if (opts->reuse_workspace)
     {
@@ -855,8 +855,8 @@ static void ocp_nlp_sqp_rti_cast_workspace(void *config_, ocp_nlp_dims *dims,
 
 #else
 
-		int size_tmp = 0;
-		int tmp;
+        int size_tmp = 0;
+        int tmp;
 
         // qp solver
         work->qp_work = (void *) c_ptr;
@@ -1153,7 +1153,7 @@ static void sqp_update_variables(ocp_nlp_dims *dims, ocp_nlp_out *nlp_out,
     //        }
     //    }
 
-	double alpha = opts->step_length;
+    double alpha = opts->step_length;
 
 #if defined(ACADOS_WITH_OPENMP)
     #pragma omp parallel for
@@ -1167,23 +1167,23 @@ static void sqp_update_variables(ocp_nlp_dims *dims, ocp_nlp_out *nlp_out,
         // absolute in dual variables
 
         if (i < N)
-		{
-			blasfeo_dvecsc(nx[i+1], 1.0-alpha, nlp_out->pi+i, 0);
+        {
+            blasfeo_dvecsc(nx[i+1], 1.0-alpha, nlp_out->pi+i, 0);
             blasfeo_daxpy(nx[i+1], alpha, mem->qp_out->pi+i, 0, nlp_out->pi+i, 0, nlp_out->pi+i, 0);
-		}
+        }
 
-		blasfeo_dvecsc(2*ni[i], 1.0-alpha, nlp_out->lam+i, 0);
+        blasfeo_dvecsc(2*ni[i], 1.0-alpha, nlp_out->lam+i, 0);
         blasfeo_daxpy(2*ni[i], alpha, mem->qp_out->lam+i, 0, nlp_out->lam+i, 0, nlp_out->lam+i, 0);
 
-		blasfeo_dvecsc(2*ni[i], 1.0-alpha, nlp_out->t+i, 0);
+        blasfeo_dvecsc(2*ni[i], 1.0-alpha, nlp_out->t+i, 0);
         blasfeo_daxpy(2*ni[i], alpha, mem->qp_out->t+i, 0, nlp_out->t+i, 0, nlp_out->t+i, 0);
 
-		// linear update of algebraic variables using state and input sensitivity
+        // linear update of algebraic variables using state and input sensitivity
 
         if (i < N)
-		{
-			blasfeo_dgemv_t(nu[i]+nx[i], nz[i], 1.0, mem->dzduxt+i, 0, 0, nlp_out->ux+i, 0, 1.0, mem->z_alg+i, 0, nlp_out->z+i, 0); 
-		}
+        {
+            blasfeo_dgemv_t(nu[i]+nx[i], nz[i], 1.0, mem->dzduxt+i, 0, 0, nlp_out->ux+i, 0, 1.0, mem->z_alg+i, 0, nlp_out->z+i, 0); 
+        }
 
     }
 
@@ -1228,8 +1228,8 @@ int ocp_nlp_sqp_rti(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
 
     int ii;
 
-	int qp_iter = 0;
-	int qp_status = 0;
+    int qp_iter = 0;
+    int qp_status = 0;
 
 #if defined(ACADOS_WITH_OPENMP)
     // backup number of threads
@@ -1264,8 +1264,8 @@ int ocp_nlp_sqp_rti(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
     for (ii = 0; ii <= N; ii++)
     {
         config->cost[ii]->memory_set_ux_ptr(nlp_out->ux + ii, mem->cost[ii]);
-		config->cost[ii]->memory_set_z_alg_ptr(mem->z_alg+ii, mem->cost[ii]);
-		config->cost[ii]->memory_set_dzdux_tran_ptr(mem->dzduxt+ii, mem->cost[ii]);
+        config->cost[ii]->memory_set_z_alg_ptr(mem->z_alg+ii, mem->cost[ii]);
+        config->cost[ii]->memory_set_dzdux_tran_ptr(mem->dzduxt+ii, mem->cost[ii]);
         config->cost[ii]->memory_set_RSQrq_ptr(mem->qp_in->RSQrq + ii, mem->cost[ii]);
         config->cost[ii]->memory_set_Z_ptr(mem->qp_in->Z + ii, mem->cost[ii]);
     }
@@ -1277,8 +1277,8 @@ int ocp_nlp_sqp_rti(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
     for (ii = 0; ii <= N; ii++)
     {
         config->constraints[ii]->memory_set_ux_ptr(nlp_out->ux+ii, mem->constraints[ii]);
-		config->constraints[ii]->memory_set_z_alg_ptr(mem->z_alg+ii, mem->constraints[ii]);
-		config->constraints[ii]->memory_set_dzdux_tran_ptr(mem->dzduxt+ii, mem->constraints[ii]);
+        config->constraints[ii]->memory_set_z_alg_ptr(mem->z_alg+ii, mem->constraints[ii]);
+        config->constraints[ii]->memory_set_dzdux_tran_ptr(mem->dzduxt+ii, mem->constraints[ii]);
         config->constraints[ii]->memory_set_lam_ptr(nlp_out->lam+ii, mem->constraints[ii]);
         config->constraints[ii]->memory_set_DCt_ptr(mem->qp_in->DCt+ii, mem->constraints[ii]);
         config->constraints[ii]->memory_set_RSQrq_ptr(mem->qp_in->RSQrq+ii, mem->constraints[ii]);
@@ -1291,7 +1291,7 @@ int ocp_nlp_sqp_rti(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
     config->regularize->memory_set_rq_ptr(dims->regularize, mem->qp_in->rqz, mem->regularize_mem);
     config->regularize->memory_set_BAbt_ptr(dims->regularize, mem->qp_in->BAbt, mem->regularize_mem);
     config->regularize->memory_set_b_ptr(dims->regularize, mem->qp_in->b, mem->regularize_mem);
-	config->regularize->memory_set_idxb_ptr(dims->regularize, mem->qp_in->idxb, mem->regularize_mem);
+    config->regularize->memory_set_idxb_ptr(dims->regularize, mem->qp_in->idxb, mem->regularize_mem);
     config->regularize->memory_set_DCt_ptr(dims->regularize, mem->qp_in->DCt, mem->regularize_mem);
     config->regularize->memory_set_ux_ptr(dims->regularize, mem->qp_out->ux, mem->regularize_mem);
     config->regularize->memory_set_pi_ptr(dims->regularize, mem->qp_out->pi, mem->regularize_mem);
@@ -1329,63 +1329,63 @@ int ocp_nlp_sqp_rti(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
     // update QP rhs for SQP (step prim var, abs dual var)
     sqp_update_qp_vectors(config, dims, nlp_in, nlp_out, opts, mem, work);
 
-	// save statistics
-//	mem->stat[mem->stat_n*1+0] = qp_status;
-//	mem->stat[mem->stat_n*1+1] = qp_iter;
+    // save statistics
+//    mem->stat[mem->stat_n*1+0] = qp_status;
+//    mem->stat[mem->stat_n*1+1] = qp_iter;
 
-	// start timer
-	acados_tic(&timer1);
+    // start timer
+    acados_tic(&timer1);
     // regularize Hessian
     config->regularize->regularize_hessian(config->regularize, dims->regularize, opts->regularize, mem->regularize_mem);
-	// stop timer
-	mem->time_reg += acados_toc(&timer1);
+    // stop timer
+    mem->time_reg += acados_toc(&timer1);
 
     // printf("\n------- qp_in (sqp iter %d) --------\n", sqp_iter);
     // print_ocp_qp_in(mem->qp_in);
     // exit(1);
 
-	// TODO no warm start across NLP solutions (yet)
-	int tmp_int = 0;
-	config->qp_solver->opts_set(config->qp_solver, opts->qp_solver_opts, "warm_start", &tmp_int);
+    // TODO no warm start across NLP solutions (yet)
+    int tmp_int = 0;
+    config->qp_solver->opts_set(config->qp_solver, opts->qp_solver_opts, "warm_start", &tmp_int);
 
     // start timer
     acados_tic(&timer1);
-	// TODO move qp_out in memory !!!!! (it has to be preserved to do warm start)
+    // TODO move qp_out in memory !!!!! (it has to be preserved to do warm start)
     qp_status = qp_solver->evaluate(qp_solver, dims->qp_solver, mem->qp_in, mem->qp_out, opts->qp_solver_opts, mem->qp_solver_mem, work->qp_work);
     // stop timer
     mem->time_qp_sol += acados_toc(&timer1);
 
-	// start timer
-	acados_tic(&timer1);
+    // start timer
+    acados_tic(&timer1);
     // compute correct dual solution in case of Hessian regularization
     config->regularize->correct_dual_sol(config->regularize, dims->regularize, opts->regularize, mem->regularize_mem);
-	// stop timer
-	mem->time_reg += acados_toc(&timer1);
+    // stop timer
+    mem->time_reg += acados_toc(&timer1);
 
-	// TODO move into QP solver memory ???
-	qp_info *qp_info_;
-	ocp_qp_out_get(mem->qp_out, "qp_info", &qp_info_);
-	nlp_out->qp_iter = qp_info_->num_iter;
-	qp_iter = qp_info_->num_iter;
+    // TODO move into QP solver memory ???
+    qp_info *qp_info_;
+    ocp_qp_out_get(mem->qp_out, "qp_info", &qp_info_);
+    nlp_out->qp_iter = qp_info_->num_iter;
+    qp_iter = qp_info_->num_iter;
 
-	// compute external QP residuals (for debugging)
-	if(opts->ext_qp_res)
-	{
-		ocp_qp_res_compute(mem->qp_in, mem->qp_out, work->qp_res, work->qp_res_ws);
-		ocp_qp_res_compute_nrm_inf(work->qp_res, mem->stat+(mem->stat_n*1+2));
-//		printf("\nsqp_iter %d, res %e %e %e %e\n", sqp_iter, inf_norm_qp_res[0], inf_norm_qp_res[1], inf_norm_qp_res[2], inf_norm_qp_res[3]);
-	}
+    // compute external QP residuals (for debugging)
+    if(opts->ext_qp_res)
+    {
+        ocp_qp_res_compute(mem->qp_in, mem->qp_out, work->qp_res, work->qp_res_ws);
+        ocp_qp_res_compute_nrm_inf(work->qp_res, mem->stat+(mem->stat_n*1+2));
+//        printf("\nsqp_iter %d, res %e %e %e %e\n", sqp_iter, inf_norm_qp_res[0], inf_norm_qp_res[1], inf_norm_qp_res[2], inf_norm_qp_res[3]);
+    }
 
     // printf("\n------- qp_out (sqp iter %d) ---------\n", sqp_iter);
     //  print_ocp_qp_out(mem->qp_out);
     //  if(sqp_iter==1)
     //  exit(1);
 
-	// save statistics
-	mem->stat[mem->stat_n*1+0] = qp_status;
-	mem->stat[mem->stat_n*1+1] = qp_iter;
+    // save statistics
+    mem->stat[mem->stat_n*1+0] = qp_status;
+    mem->stat[mem->stat_n*1+1] = qp_iter;
 
-	if ((qp_status!=ACADOS_SUCCESS) & (qp_status!=ACADOS_MAXITER))
+    if ((qp_status!=ACADOS_SUCCESS) & (qp_status!=ACADOS_MAXITER))
     {
         //   print_ocp_qp_in(mem->qp_in);
 
@@ -1495,50 +1495,50 @@ void ocp_nlp_sqp_rti_eval_param_sens(void *config_, void *dims_, void *opts_, vo
 
 //    int ii;
 
-	d_ocp_qp_copy_all(mem->qp_in, work->tmp_qp_in);
-	d_ocp_qp_set_rhs_zero(work->tmp_qp_in);
+    d_ocp_qp_copy_all(mem->qp_in, work->tmp_qp_in);
+    d_ocp_qp_set_rhs_zero(work->tmp_qp_in);
 
-	double one = 1.0;
+    double one = 1.0;
 
     if ((!strcmp("ex", field)) & (stage==0))
     {
-		d_ocp_qp_set_el("lbx", stage, index, &one, work->tmp_qp_in);
-		d_ocp_qp_set_el("ubx", stage, index, &one, work->tmp_qp_in);
+        d_ocp_qp_set_el("lbx", stage, index, &one, work->tmp_qp_in);
+        d_ocp_qp_set_el("ubx", stage, index, &one, work->tmp_qp_in);
 
-//		d_ocp_qp_print(work->tmp_qp_in->dim, work->tmp_qp_in);
+//        d_ocp_qp_print(work->tmp_qp_in->dim, work->tmp_qp_in);
 
-		config->qp_solver->eval_sens(config->qp_solver, dims->qp_solver, work->tmp_qp_in, work->tmp_qp_out, opts->qp_solver_opts, mem->qp_solver_mem, work->qp_work);
+        config->qp_solver->eval_sens(config->qp_solver, dims->qp_solver, work->tmp_qp_in, work->tmp_qp_out, opts->qp_solver_opts, mem->qp_solver_mem, work->qp_work);
 
-//		d_ocp_qp_sol_print(work->tmp_qp_out->dim, work->tmp_qp_out);
-//		exit(1);
+//        d_ocp_qp_sol_print(work->tmp_qp_out->dim, work->tmp_qp_out);
+//        exit(1);
 
-		// copy tmp_qp_out into sens_nlp_out
+        // copy tmp_qp_out into sens_nlp_out
 
-		// loop index
-		int i;
+        // loop index
+        int i;
 
-		// extract dims
-		int N = dims->N;
-		int *nv = dims->nv;
-		int *nx = dims->nx;
-		// int *nu = dims->nu;
-		int *ni = dims->ni;
-		// int *nz = dims->nz;
+        // extract dims
+        int N = dims->N;
+        int *nv = dims->nv;
+        int *nx = dims->nx;
+        // int *nu = dims->nu;
+        int *ni = dims->ni;
+        // int *nz = dims->nz;
 
-		for (i = 0; i <= N; i++)
-		{
-			blasfeo_dveccp(nv[i], work->tmp_qp_out->ux + i, 0, sens_nlp_out->ux + i, 0);
+        for (i = 0; i <= N; i++)
+        {
+            blasfeo_dveccp(nv[i], work->tmp_qp_out->ux + i, 0, sens_nlp_out->ux + i, 0);
 
-			if (i < N)
-				blasfeo_dveccp(nx[i + 1], work->tmp_qp_out->pi + i, 0, sens_nlp_out->pi + i, 0);
+            if (i < N)
+                blasfeo_dveccp(nx[i + 1], work->tmp_qp_out->pi + i, 0, sens_nlp_out->pi + i, 0);
 
-			blasfeo_dveccp(2 * ni[i], work->tmp_qp_out->lam + i, 0, sens_nlp_out->lam + i, 0);
+            blasfeo_dveccp(2 * ni[i], work->tmp_qp_out->lam + i, 0, sens_nlp_out->lam + i, 0);
 
-			blasfeo_dveccp(2 * ni[i], work->tmp_qp_out->t + i, 0, sens_nlp_out->t + i, 0);
+            blasfeo_dveccp(2 * ni[i], work->tmp_qp_out->t + i, 0, sens_nlp_out->t + i, 0);
 
-		}
+        }
 
-	}
+    }
     else
     {
         printf("\nerror: field %s at stage %d not available in ocp_nlp_sqp_rti_eval_param_sens\n", field, stage);

--- a/acados/ocp_nlp/ocp_nlp_sqp_rti.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp_rti.c
@@ -1181,9 +1181,11 @@ static void sqp_update_variables(ocp_nlp_dims *dims, ocp_nlp_out *nlp_out,
         // linear update of algebraic variables using state and input sensitivity
         if (i < N)
         {
-            blasfeo_dgemv_t(nu[i]+nx[i], nz[i], 1.0, mem->dzduxt+i, 0, 0, nlp_out->ux+i, 0, 0.0, mem->z_alg+i, 0, nlp_out->z+i, 0); 
+            blasfeo_dgemv_t(nu[i]+nx[i], nz[i], 1.0, mem->dzduxt+i, 0, 0, nlp_out->ux+i, 0,
+                            0.0, mem->z_alg+i, 0, nlp_out->z+i, 0);
+            // copy z into z_alg
+            blasfeo_dveccp(nz[i], nlp_out->z+i, 0, mem->z_alg+i, 0);
         }
-
     }
 
     return;

--- a/acados/ocp_nlp/ocp_nlp_sqp_rti.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp_rti.c
@@ -1179,10 +1179,9 @@ static void sqp_update_variables(ocp_nlp_dims *dims, ocp_nlp_out *nlp_out,
         blasfeo_daxpy(2*ni[i], alpha, mem->qp_out->t+i, 0, nlp_out->t+i, 0, nlp_out->t+i, 0);
 
         // linear update of algebraic variables using state and input sensitivity
-
         if (i < N)
         {
-            blasfeo_dgemv_t(nu[i]+nx[i], nz[i], 1.0, mem->dzduxt+i, 0, 0, nlp_out->ux+i, 0, 1.0, mem->z_alg+i, 0, nlp_out->z+i, 0); 
+            blasfeo_dgemv_t(nu[i]+nx[i], nz[i], 1.0, mem->dzduxt+i, 0, 0, nlp_out->ux+i, 0, 0.0, mem->z_alg+i, 0, nlp_out->z+i, 0); 
         }
 
     }

--- a/acados/sim/sim_common.c
+++ b/acados/sim/sim_common.c
@@ -449,6 +449,11 @@ int sim_opts_set_(sim_opts *opts, const char *field, void *value)
         bool *output_z = (bool *) value;
         opts->output_z = *output_z;
     }
+    else if (!strcmp(field, "exact_z_output"))
+    {
+        bool *exact_z_output = (bool *) value;
+        opts->exact_z_output = *exact_z_output;
+    }
     else if (!strcmp(field, "sens_algebraic"))
     {
         bool *sens_algebraic = (bool *) value;

--- a/acados/sim/sim_common.h
+++ b/acados/sim/sim_common.h
@@ -140,6 +140,7 @@ typedef struct
 
     bool output_z;        // 1 -- if zn should be computed
     bool sens_algebraic;  // 1 -- if S_algebraic should be computed
+    bool exact_z_output;  // 1 -- if z, S_algebraic should be computed exactly, extra Newton iterations
 
     // for explicit integrators: newton_iter == 0 && scheme == NULL
     // && jac_reuse=false

--- a/acados/sim/sim_gnsf.c
+++ b/acados/sim/sim_gnsf.c
@@ -327,6 +327,7 @@ void sim_gnsf_opts_initialize_default(void *config_, void *dims_, void *opts_)
     opts->sens_adj = false;
     opts->sens_hess = false;
     opts->jac_reuse = true;
+    opts->exact_z_output = false;
 
     // TODO(oj): check if constr h or cost depend on z, turn on in this case only.
     if (dims->nz > 0)
@@ -1776,7 +1777,12 @@ int sim_gnsf(void *config, sim_in *in, sim_out *out, void *args, void *mem_, voi
 
     if ( opts->ns != opts->tableau_size )
     {
-        printf("Error in sim_gnsf: the Butcher tableau size does not match ns");
+        printf("Error in sim_gnsf: the Butcher tableau size does not match ns.");
+        exit(1);
+    }
+    if (opts->exact_z_output)
+    {
+        printf("Error in sim_gnsf: option exact_z_output = true not supported.");
         exit(1);
     }
 

--- a/acados/sim/sim_irk_integrator.c
+++ b/acados/sim/sim_irk_integrator.c
@@ -286,7 +286,7 @@ void sim_irk_opts_initialize_default(void *config_, void *dims_, void *opts_)
     opts->sens_adj = false;
     opts->sens_hess = false;
     opts->jac_reuse = true;
-    opts->exact_z_output = true;
+    opts->exact_z_output = false;
 
     // TODO(oj): check if constr h or cost depend on z, turn on in this case only.
     if (dims->nz > 0)

--- a/acados/sim/sim_irk_integrator.c
+++ b/acados/sim/sim_irk_integrator.c
@@ -1152,98 +1152,111 @@ int sim_irk(void *config_, sim_in *in, sim_out *out, void *opts_, void *mem_, vo
                     }
                 }
             }  // end if sens_algebraic
-            if (opts->sens_algebraic && opts->exact_z_output)
+
+
+            if (opts->exact_z_output)
             {
                 // printf("\nz output before newton:\n");
                 // d_print_mat(1, nz, out->zn, 1);
-                // initial guess for xdot0
-                for (int ii = 0; ii < nx; ii++)
+
+                // set input for impl_ode
+                impl_ode_type_in[0] = COLMAJ;
+                impl_ode_type_in[1] = BLASFEO_DVEC;
+                impl_ode_type_in[3] = COLMAJ;
+                impl_ode_in[0] = in->x;  // 1st input is always xn
+                impl_ode_in[1] = xtdot;
+                impl_ode_in[3] = &out->zn[0];
+
+                impl_ode_res_out.xi = 0;
+
+                if (opts->output_z || opts->sens_algebraic)
                 {
-                    double interpolated_value;
-                    for (int jj = 0; jj < ns; jj++)
+                    // initial guess for xdot0
+                    for (int ii = 0; ii < nx; ii++)
                     {
-                        Z_work[jj] = blasfeo_dvecex1(K, nx * jj + ii);
-                            // copy values of k_ii in first step, into Z_work
+                        double interpolated_value;
+                        for (int jj = 0; jj < ns; jj++)
+                        {
+                            Z_work[jj] = blasfeo_dvecex1(K, nx * jj + ii);
+                                // copy values of k_ii in first step, into Z_work
+                        }
+                        neville_algorithm(0.0, ns - 1, opts->c_vec, Z_work, &interpolated_value);
+                                    // eval polynomial through (c_jj, k_jj) at 0.
+                        blasfeo_pack_dvec(1, &interpolated_value, xtdot, ii);
                     }
-                    neville_algorithm(0.0, ns - 1, opts->c_vec, Z_work, &interpolated_value);
-                                // eval polynomial through (c_jj, k_jj) at 0.
-                    blasfeo_pack_dvec(1, &interpolated_value, xtdot, ii);
+                    // perform extra newton iterations to get xdot0, z0 more precisely.
+                    for (int ii = 0; ii < opts->newton_iter; ii++)
+                    {
+
+                        if (ii == 0 || !opts->jac_reuse)
+                        {
+                            // eval jacobians at interpolated values
+                            acados_tic(&timer_ad);
+                            model->impl_ode_fun_jac_x_xdot_z->evaluate(
+                                model->impl_ode_fun_jac_x_xdot_z, impl_ode_type_in, impl_ode_in,
+                                impl_ode_fun_jac_x_xdot_z_type_out, impl_ode_fun_jac_x_xdot_z_out);
+                            timing_ad += acados_toc(&timer_ad);
+
+                            // set up df_dxdotz
+                            blasfeo_dgecp(nx + nz, nx, df_dxdot, 0, 0, df_dxdotz, 0, 0);
+                            blasfeo_dgecp(nx + nz, nz, df_dz,    0, 0, df_dxdotz, 0, nx);
+                            // factorize
+                            blasfeo_dgetrf_rp(nx + nz, nx + nz, df_dxdotz, 0, 0, df_dxdotz, 0, 0,
+                                                                                        ipiv_one_stage);
+                        }
+
+                        // permute rhs
+                        blasfeo_dvecpe(nx + nz, ipiv_one_stage, rG, 0);
+                        // backsolve
+                        blasfeo_dtrsv_lnu(nx + nz, df_dxdotz, 0, 0, rG, 0, rG, 0);
+                        blasfeo_dtrsv_unn(nx + nz, df_dxdotz, 0, 0, rG, 0, rG, 0);
+
+                        blasfeo_daxpy(nx, -1.0, rG, 0, xtdot, 0, xtdot, 0);
+                        blasfeo_dveccp(nx, rG, 0, xtdot, 0);
+                        blasfeo_unpack_dvec(nz, rG, nx, mem->z);
+                        for (int jj = 0; jj < nz; jj++)
+                        {
+                            out->zn[jj] -= mem->z[jj];
+                        }
+                    }
                 }
-                // perform extra newton iterations to get xdot0, z0 more precisely.
-                int z_newton_iter = 1;
-                for (int ii = 0; ii < z_newton_iter; ii++)
+                // printf("\nz output after newton:\n");
+                // d_print_mat(1, nz, out->zn, 1);
+
+                if (opts->sens_algebraic)
                 {
-                    // set input for impl_ode
-                    impl_ode_type_in[0] = COLMAJ;
-                    impl_ode_type_in[1] = BLASFEO_DVEC;
-                    impl_ode_type_in[3] = COLMAJ;
-                    impl_ode_in[0] = in->x;  // 1st input is always xn
-                    impl_ode_in[1] = xtdot;
-                    impl_ode_in[3] = &out->zn[0];
-
-                    impl_ode_res_out.xi = 0;
-
+                    /* implicit function theorem to get S_alg */
                     // eval jacobians at interpolated values
                     acados_tic(&timer_ad);
-                    model->impl_ode_fun_jac_x_xdot_z->evaluate(
-                        model->impl_ode_fun_jac_x_xdot_z, impl_ode_type_in, impl_ode_in,
-                        impl_ode_fun_jac_x_xdot_z_type_out, impl_ode_fun_jac_x_xdot_z_out);
+                    model->impl_ode_jac_x_xdot_u_z->evaluate(
+                            model->impl_ode_jac_x_xdot_u_z, impl_ode_type_in, impl_ode_in,
+                            impl_ode_jac_x_xdot_u_z_type_out, impl_ode_jac_x_xdot_u_z_out);
                     timing_ad += acados_toc(&timer_ad);
 
                     // set up df_dxdotz
                     blasfeo_dgecp(nx + nz, nx, df_dxdot, 0, 0, df_dxdotz, 0, 0);
                     blasfeo_dgecp(nx + nz, nz, df_dz,    0, 0, df_dxdotz, 0, nx);
-                    // factorize
+                    // set up right hand side dk0_dxu
+                    blasfeo_dgecp(nx + nz, nx, df_dx, 0, 0, dk0_dxu, 0, 0);
+                    blasfeo_dgecp(nx + nz, nu, df_du, 0, 0, dk0_dxu, 0, nx);
+
+                    // solve linear system
+                    acados_tic(&timer_la);
                     blasfeo_dgetrf_rp(nx + nz, nx + nz, df_dxdotz, 0, 0, df_dxdotz, 0, 0,
                                                                                 ipiv_one_stage);
-                    // permute rhs
-                    blasfeo_dvecpe(nx + nz, ipiv_one_stage, rG, 0);
-                    // backsolve
-                    blasfeo_dtrsv_lnu(nx + nz, df_dxdotz, 0, 0, rG, 0, rG, 0);
-                    blasfeo_dtrsv_unn(nx + nz, df_dxdotz, 0, 0, rG, 0, rG, 0);
+                    blasfeo_drowpe(nx + nz, ipiv_one_stage, dk0_dxu);
+                    blasfeo_dtrsm_llnu(nx + nz, nx + nu, 1.0, df_dxdotz, 0, 0,
+                                    dk0_dxu, 0, 0, dk0_dxu, 0, 0);
+                    blasfeo_dtrsm_lunn(nx + nz, nx + nu, 1.0, df_dxdotz, 0, 0,
+                                    dk0_dxu, 0, 0, dk0_dxu, 0, 0);
+                    timing_la += acados_toc(&timer_la);
 
-                    blasfeo_daxpy(nx, -1.0, rG, 0, xtdot, 0, xtdot, 0);
-                    blasfeo_dveccp(nx, rG, 0, xtdot, 0);
-                    blasfeo_unpack_dvec(nz, rG, nx, mem->z);
-                    for (int jj = 0; jj < nz; jj++)
-                    {
-                        out->zn[jj] -= mem->z[jj];
-                    }
-                }
-                // printf("\nz output after newton:\n");
-                // d_print_mat(1, nz, out->zn, 1);
-                /* implicit function theorem to get S_alg */
-                // eval jacobians at interpolated values
-                acados_tic(&timer_ad);
-                model->impl_ode_jac_x_xdot_u_z->evaluate(
-                        model->impl_ode_jac_x_xdot_u_z, impl_ode_type_in, impl_ode_in,
-                        impl_ode_jac_x_xdot_u_z_type_out, impl_ode_jac_x_xdot_u_z_out);
-                timing_ad += acados_toc(&timer_ad);
+                    // solution has different sign
+                    blasfeo_dgesc(nx + nz, nx + nu, -1.0, dk0_dxu, 0, 0);
 
-                // set up df_dxdotz
-                blasfeo_dgecp(nx + nz, nx, df_dxdot, 0, 0, df_dxdotz, 0, 0);
-                blasfeo_dgecp(nx + nz, nz, df_dz,    0, 0, df_dxdotz, 0, nx);
-                // set up right hand side dk0_dxu
-                blasfeo_dgecp(nx + nz, nx, df_dx, 0, 0, dk0_dxu, 0, 0);
-                blasfeo_dgecp(nx + nz, nu, df_du, 0, 0, dk0_dxu, 0, nx);
-
-                // solve linear system
-                acados_tic(&timer_la);
-                blasfeo_dgetrf_rp(nx + nz, nx + nz, df_dxdotz, 0, 0, df_dxdotz, 0, 0,
-                                                                            ipiv_one_stage);
-                blasfeo_drowpe(nx + nz, ipiv_one_stage, dk0_dxu);
-                blasfeo_dtrsm_llnu(nx + nz, nx + nu, 1.0, df_dxdotz, 0, 0,
-                                dk0_dxu, 0, 0, dk0_dxu, 0, 0);
-                blasfeo_dtrsm_lunn(nx + nz, nx + nu, 1.0, df_dxdotz, 0, 0,
-                                dk0_dxu, 0, 0, dk0_dxu, 0, 0);
-                timing_la += acados_toc(&timer_la);
-
-                // solution has different sign
-                blasfeo_dgesc(nx + nz, nx + nu, -1.0, dk0_dxu, 0, 0);
-
-                // extract output
-                blasfeo_unpack_dmat(nz, nx + nu, dk0_dxu, nx, 0, S_algebraic, nz);
-
+                    // extract output
+                    blasfeo_unpack_dmat(nz, nx + nu, dk0_dxu, nx, 0, S_algebraic, nz);
+                } // if sens_algebraic
                 // Reset impl_ode inputs
                 impl_ode_type_in[0] = BLASFEO_DVEC;       // xt
                 impl_ode_type_in[1] = BLASFEO_DVEC_ARGS;  // k_i
@@ -1251,7 +1264,7 @@ int sim_irk(void *config_, sim_in *in, sim_out *out, void *opts_, void *mem_, vo
                 impl_ode_in[0] = xt;  // 1st input is always xt
                 impl_ode_in[1] = &impl_ode_xdot_in;
                 impl_ode_in[3] = &impl_ode_z_in;     // 4th input is part of Z[ss]
-            }
+            } // if exact_z_output
         }  //  end if (ss == 0)
         if (ss == num_steps-1)
         {

--- a/acados/sim/sim_irk_integrator.h
+++ b/acados/sim/sim_irk_integrator.h
@@ -92,10 +92,10 @@ typedef struct
     int *ipiv_one_stage;  // index of pivot vector (nx + nz)
     double *Z_work;  // used to perform computations to get out->zn (ns)
 
-    // df_dxdotz, dk0_dxu, only allocated if (opts->sens_algebraic)
+    // df_dxdotz, dk0_dxu, only allocated if (opts->sens_algebraic && opts->exact_z_output)
     //      used for algebraic sensitivity generation
-    // struct blasfeo_dmat df_dxdotz;  // temporary Jacobian of ode w.r.t. xdot,z (nx+nz, nx+nz);
-    // struct blasfeo_dmat dk0_dxu;    // intermediate result, (nx+nz, nx+nu)
+    struct blasfeo_dmat df_dxdotz;  // temporary Jacobian of ode w.r.t. xdot,z (nx+nz, nx+nz);
+    struct blasfeo_dmat dk0_dxu;    // intermediate result, (nx+nz, nx+nu)
 
     // dK_dxu: if (!opts->sens_hess) - single blasfeo_dmat that is reused
     //         if ( opts->sens_hess) - array of (num_steps) blasfeo_dmat

--- a/acados/utils/math.h
+++ b/acados/utils/math.h
@@ -44,6 +44,9 @@ extern "C" {
 double fmax(double a, double b);
 #endif
 
+#define MIN(a,b) (((a)<(b))?(a):(b))
+#define MAX(a,b) (((a)>(b))?(a):(b))
+
 void dgemm_nn_3l(int m, int n, int k, double *A, int lda, double *B, int ldb, double *C, int ldc);
 void dgemv_n_3l(int m, int n, double *A, int lda, double *x, double *y);
 void dgemv_t_3l(int m, int n, double *A, int lda, double *x, double *y);

--- a/examples/acados_matlab_octave/pendulum_on_cart_model/example_ocp.m
+++ b/examples/acados_matlab_octave/pendulum_on_cart_model/example_ocp.m
@@ -297,7 +297,7 @@ for ii=1:N+1
 %	visualize;
 end
 
-figure(2);
+figure;
 subplot(2,1,1);
 plot(0:N, x);
 xlim([0 N]);
@@ -309,7 +309,7 @@ legend('F');
 
 stat = ocp.get('stat');
 if (strcmp(nlp_solver, 'sqp'))
-	figure(3);
+	figure;
 % 	plot([0: size(stat,1)-1], log10(stat(:,2)), 'r-x');
 % 	hold on
 % 	plot([0: size(stat,1)-1], log10(stat(:,3)), 'b-x');
@@ -345,7 +345,7 @@ sens_u = ocp.get('sens_u');
 sens_x = ocp.get('sens_x');
 
 % plot sensitivity
-figure(4);
+figure
 subplot(2,1,1);
 plot(0:N, sens_x);
 xlim([0 N]);
@@ -356,7 +356,7 @@ xlim([0 N]);
 legend('F');
 
 % plot predicted solution
-figure(5);
+figure
 subplot(2,1,1);
 plot(0:N, x+sens_x);
 xlim([0 N]);

--- a/examples/acados_matlab_octave/pendulum_on_cart_model/experiment_dae_formulation.m
+++ b/examples/acados_matlab_octave/pendulum_on_cart_model/experiment_dae_formulation.m
@@ -1,0 +1,297 @@
+%
+% Copyright 2019 Gianluca Frison, Dimitris Kouzoupis, Robin Verschueren,
+% Andrea Zanelli, Niels van Duijkeren, Jonathan Frey, Tommaso Sartor,
+% Branimir Novoselnik, Rien Quirynen, Rezart Qelibari, Dang Doan,
+% Jonas Koenemann, Yutao Chen, Tobias Schöls, Jonas Schlagenhauf, Moritz Diehl
+%
+% This file is part of acados.
+%
+% The 2-Clause BSD License
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%
+% 1. Redistributions of source code must retain the above copyright notice,
+% this list of conditions and the following disclaimer.
+%
+% 2. Redistributions in binary form must reproduce the above copyright notice,
+% this list of conditions and the following disclaimer in the documentation
+% and/or other materials provided with the distribution.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.;
+%
+
+%% test of native matlab interface
+clear VARIABLES
+
+% check that env.sh has been run
+env_run = getenv('ENV_RUN');
+if (~strcmp(env_run, 'true'))
+	error('env.sh has not been sourced! Before executing this example, run: source env.sh');
+end
+tic
+for i = 1:3
+    %% arguments
+    compile_mex = 'true';
+    codgen_model = 'true';
+    gnsf_detect_struct = 'true';
+
+    % discretization
+    param_scheme = 'multiple_shooting_unif_grid';
+    N = 100;
+    h = 0.01;
+
+    nlp_solver = 'sqp';
+    %nlp_solver = 'sqp_rti';
+    nlp_solver_exact_hessian = 'false';
+    %nlp_solver_exact_hessian = 'true';
+    regularize_method = 'no_regularize';
+    nlp_solver_max_iter = 100;
+    tol = 1e-12;
+    nlp_solver_tol_stat = tol;
+    nlp_solver_tol_eq   = tol;
+    nlp_solver_tol_ineq = tol;
+    nlp_solver_tol_comp = tol;
+    nlp_solver_ext_qp_res = 1;
+    qp_solver = 'partial_condensing_hpipm';
+    %qp_solver = 'full_condensing_hpipm';
+    %qp_solver = 'full_condensing_qpoases';
+    qp_solver_cond_N = 5;
+    qp_solver_cond_ric_alg = 0;
+    qp_solver_ric_alg = 0;
+    qp_solver_warm_start = 2;
+    sim_method = 'irk';
+    sim_method_num_stages = 2;
+    sim_method_num_steps = 1;
+
+    if i == 3
+        sim_method_exact_z_output = 1;
+    else
+        sim_method_exact_z_output = 0;
+    end
+    % cost_type = 'linear_ls';
+    cost_type = 'ext_cost';
+    model_name = ['ocp_pendulum_' num2str(i)];
+
+
+    %% create model entries
+    if i==1
+        model = pendulum_on_cart_model;
+    elseif i==2
+        model = pendulum_on_cart_model_dae;
+%     else
+%         model = pendulum_on_cart_model_algebraic_constraints;
+    end
+
+    % dims
+    T = N*h; % horizon length time
+    nx = length(model.sym_x);
+    nu = length(model.sym_u);
+    if isfield(model, 'sym_z')
+        nz = length(model.sym_z);
+    else
+        nz = 0;
+    end
+
+    if 0
+        nbx = 0;
+        nbu = nu;
+        ng = 0;
+        ng_e = 0;
+        nh = 0;
+        nh_e = 0;
+    else
+        nbx = 0;
+        nbu = 0;
+        ng = 0;
+        ng_e = 0;
+        nh = nu;
+        nh_e = 0;
+    end
+
+    % constraints
+    x0 = [0; pi; 0; 0];
+    %Jbx = zeros(nbx, nx); for ii=1:nbx Jbx(ii,ii)=1.0; end
+    %lbx = -4*ones(nbx, 1);
+    %ubx =  4*ones(nbx, 1);
+    Jbu = zeros(nbu, nu); for ii=1:nbu Jbu(ii,ii)=1.0; end
+    lbu = -80*ones(nu, 1);
+    ubu =  80*ones(nu, 1);
+
+
+    %% acados ocp model
+    ocp_model = acados_ocp_model();
+    ocp_model.set('name', model_name);
+    % dims
+    ocp_model.set('T', T);
+    ocp_model.set('dim_nx', nx);
+    ocp_model.set('dim_nu', nu);
+    ocp_model.set('dim_nz', nz);
+
+    %constr
+    ocp_model.set('dim_nbx', nbx);
+    ocp_model.set('dim_nbu', nbu);
+    ocp_model.set('dim_ng', ng);
+    ocp_model.set('dim_ng_e', ng_e);
+    ocp_model.set('dim_nh', nh);
+    ocp_model.set('dim_nh_e', nh_e);
+    % symbolics
+    ocp_model.set('sym_x', model.sym_x);
+    if isfield(model, 'sym_u')
+        ocp_model.set('sym_u', model.sym_u);
+    end
+    if isfield(model, 'sym_xdot')
+        ocp_model.set('sym_xdot', model.sym_xdot);
+    end
+    if isfield(model, 'sym_z')
+        ocp_model.set('sym_z', model.sym_z);
+    end
+    % cost
+    ocp_model.set('cost_type', cost_type);
+    ocp_model.set('cost_type_e', cost_type);
+
+    ocp_model.set('cost_expr_ext_cost', model.expr_ext_cost);
+    ocp_model.set('cost_expr_ext_cost_e', model.expr_ext_cost_e);
+
+    % dynamics
+    if (strcmp(sim_method, 'erk'))
+        ocp_model.set('dyn_type', 'explicit');
+        ocp_model.set('dyn_expr_f', model.expr_f_expl);
+    else % irk irk_gnsf
+        ocp_model.set('dyn_type', 'implicit');
+        ocp_model.set('dyn_expr_f', model.expr_f_impl);
+    end
+    % constraints
+    ocp_model.set('constr_x0', x0);
+    if (ng>0)
+        ocp_model.set('constr_C', C);
+        ocp_model.set('constr_D', D);
+        ocp_model.set('constr_lg', lg);
+        ocp_model.set('constr_ug', ug);
+        ocp_model.set('constr_C_e', C_e);
+        ocp_model.set('constr_lg_e', lg_e);
+        ocp_model.set('constr_ug_e', ug_e);
+    elseif (nh>0)
+        ocp_model.set('constr_expr_h', model.expr_h);
+        ocp_model.set('constr_lh', lbu);
+        ocp_model.set('constr_uh', ubu);
+    %	ocp_model.set('constr_expr_h_e', model.expr_h_e);
+    %	ocp_model.set('constr_lh_e', lh_e);
+    %	ocp_model.set('constr_uh_e', uh_e);
+    else
+    %	ocp_model.set('constr_Jbx', Jbx);
+    %	ocp_model.set('constr_lbx', lbx);
+    %	ocp_model.set('constr_ubx', ubx);
+        ocp_model.set('constr_Jbu', Jbu);
+        ocp_model.set('constr_lbu', lbu);
+        ocp_model.set('constr_ubu', ubu);
+    end
+    disp('ocp_model.model_struct')
+    disp(ocp_model.model_struct)
+
+
+    %% acados ocp opts
+    ocp_opts = acados_ocp_opts();
+    ocp_opts.set('compile_mex', compile_mex);
+    ocp_opts.set('codgen_model', codgen_model);
+    ocp_opts.set('param_scheme', param_scheme);
+    ocp_opts.set('param_scheme_N', N);
+    ocp_opts.set('nlp_solver', nlp_solver);
+    ocp_opts.set('nlp_solver_exact_hessian', nlp_solver_exact_hessian);
+    ocp_opts.set('regularize_method', regularize_method);
+    ocp_opts.set('nlp_solver_ext_qp_res', nlp_solver_ext_qp_res);
+    if (strcmp(nlp_solver, 'sqp'))
+        ocp_opts.set('nlp_solver_max_iter', nlp_solver_max_iter);
+        ocp_opts.set('nlp_solver_tol_stat', nlp_solver_tol_stat);
+        ocp_opts.set('nlp_solver_tol_eq', nlp_solver_tol_eq);
+        ocp_opts.set('nlp_solver_tol_ineq', nlp_solver_tol_ineq);
+        ocp_opts.set('nlp_solver_tol_comp', nlp_solver_tol_comp);
+    end
+    ocp_opts.set('qp_solver', qp_solver);
+    if (strcmp(qp_solver, 'partial_condensing_hpipm'))
+        ocp_opts.set('qp_solver_cond_N', qp_solver_cond_N);
+        ocp_opts.set('qp_solver_ric_alg', qp_solver_ric_alg);
+    end
+    ocp_opts.set('qp_solver_cond_ric_alg', qp_solver_cond_ric_alg);
+    ocp_opts.set('qp_solver_warm_start', qp_solver_warm_start);
+    ocp_opts.set('sim_method', sim_method);
+    ocp_opts.set('sim_method_num_stages', sim_method_num_stages);
+    ocp_opts.set('sim_method_num_steps', sim_method_num_steps);
+    ocp_opts.set('sim_method_exact_z_output', sim_method_exact_z_output);
+    
+    
+    if (strcmp(sim_method, 'irk_gnsf'))
+        ocp_opts.set('gnsf_detect_struct', gnsf_detect_struct);
+    end
+
+    disp('ocp_opts');
+    disp(ocp_opts.opts_struct);
+
+
+    %% acados ocp
+    % create ocp
+    ocp = acados_ocp(ocp_model, ocp_opts);
+    ocp
+    disp('ocp.C_ocp');
+    disp(ocp.C_ocp);
+    disp('ocp.C_ocp_ext_fun');
+    disp(ocp.C_ocp_ext_fun);
+    %ocp.model_struct
+
+
+    % set trajectory initialization
+    %x_traj_init = zeros(nx, N+1);
+    %for ii=1:N x_traj_init(:,ii) = [0; pi; 0; 0]; end
+    x_traj_init = [linspace(0, 0, N+1); linspace(pi, 0, N+1); linspace(0, 0, N+1); linspace(0, 0, N+1)];
+    u_traj_init = zeros(nu, N);
+
+    % if not set, the trajectory is initialized with the previous solution
+    ocp.set('init_x', x_traj_init);
+    ocp.set('init_u', u_traj_init);
+
+    ocp.solve();
+
+    % get solution
+    u = ocp.get('u');
+    x = ocp.get('x');
+
+    %% evaluation
+    status = ocp.get('status');
+    sqp_iter = ocp.get('sqp_iter');
+    time_tot = ocp.get('time_tot');
+    time_lin = ocp.get('time_lin');
+    time_reg = ocp.get('time_reg');
+    time_qp_sol = ocp.get('time_qp_sol');
+
+    fprintf('\nstatus = %d, sqp_iter = %d, time_ext = %f [ms], time_int = %f [ms] (time_lin = %f [ms], time_qp_sol = %f [ms], time_reg = %f [ms])\n', status, sqp_iter, time_ext*1e3, time_tot*1e3, time_lin*1e3, time_qp_sol*1e3, time_reg*1e3);
+
+    ocp.print('stat');
+    
+    if i == 1
+        xref = x;
+        uref = u;
+    else
+        err_x = norm(x - xref)
+        err_u = norm(u - uref)
+    end
+    
+    % compare z accuracy to respective value obtained from x
+    if i > 1
+        z = ocp.get('z');
+        thetas = xref(2,:);
+        omegas = xref(4,:);
+        z_fromx = cos(thetas).*sin(thetas).*omegas.^2;
+        err_z_zfromx(i) = norm( z - z_fromx(1:end-1) )
+    end
+end
+toc

--- a/examples/acados_matlab_octave/pendulum_on_cart_model/experiment_dae_formulation.m
+++ b/examples/acados_matlab_octave/pendulum_on_cart_model/experiment_dae_formulation.m
@@ -51,9 +51,12 @@ constr_vals = zeros(N, ncases);
 for i = 1:3
     %% arguments
     compile_mex = 'true';
-    if exist('build/ocp_create.mexa64', 'file')
+    if ~is_octave && exist('build/ocp_create.mexa64', 'file')
+        compile_mex = 'false';
+    elseif is_octave && exist('build/ocp_create.mex', 'file')
         compile_mex = 'false';
     end
+
     codgen_model = 'true';
     gnsf_detect_struct = 'true';
 

--- a/examples/acados_matlab_octave/pendulum_on_cart_model/pendulum_on_cart_model.m
+++ b/examples/acados_matlab_octave/pendulum_on_cart_model/pendulum_on_cart_model.m
@@ -85,3 +85,4 @@ model.expr_h = expr_h;
 model.expr_ext_cost = expr_ext_cost;
 model.expr_ext_cost_e = expr_ext_cost_e;
 
+end

--- a/examples/acados_matlab_octave/pendulum_on_cart_model/pendulum_on_cart_model_dae.m
+++ b/examples/acados_matlab_octave/pendulum_on_cart_model/pendulum_on_cart_model_dae.m
@@ -1,0 +1,91 @@
+%
+% Copyright 2019 Gianluca Frison, Dimitris Kouzoupis, Robin Verschueren,
+% Andrea Zanelli, Niels van Duijkeren, Jonathan Frey, Tommaso Sartor,
+% Branimir Novoselnik, Rien Quirynen, Rezart Qelibari, Dang Doan,
+% Jonas Koenemann, Yutao Chen, Tobias Schöls, Jonas Schlagenhauf, Moritz Diehl
+%
+% This file is part of acados.
+%
+% The 2-Clause BSD License
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%
+% 1. Redistributions of source code must retain the above copyright notice,
+% this list of conditions and the following disclaimer.
+%
+% 2. Redistributions in binary form must reproduce the above copyright notice,
+% this list of conditions and the following disclaimer in the documentation
+% and/or other materials provided with the distribution.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.;
+%
+
+function model = pendulum_on_cart_model_dae()
+
+import casadi.*
+
+%% system dimensions
+nx = 4;
+nu = 1;
+
+%% system parameters
+M = 1;    % mass of the cart [kg]
+m = 0.1;  % mass of the ball [kg]
+l = 0.8;  % length of the rod [m]
+g = 9.81; % gravity constant [m/s^2]
+
+%% named symbolic variables
+p = SX.sym('p');         % horizontal displacement of cart [m]
+theta = SX.sym('theta'); % angle of rod with the vertical [rad]
+v = SX.sym('v');         % horizontal velocity of cart [m/s]
+omega = SX.sym('omega'); % angular velocity of rod [rad/s]
+F = SX.sym('F');         % horizontal force acting on cart [N]
+
+sym_z = SX.sym('z');
+
+%% (unnamed) symbolic variables
+sym_x = vertcat(p, theta, v, omega);
+sym_xdot = SX.sym('xdot', nx, 1);
+sym_u = F;
+
+%% dynamics
+expr_f_impl = vertcat(v, ...
+                      omega, ...
+                      (- l*m*sin(theta)*omega.^2 + F + g*m*cos(theta)*sin(theta))/(M + m - m*cos(theta).^2), ...
+                      (- l*m*sym_z + F*cos(theta) + g*m*sin(theta) + M*g*sin(theta))/(l*(M + m - m*cos(theta).^2)), ...
+                      cos(theta)*sin(theta)*omega.^2) ...
+                  - [sym_xdot; sym_z];
+               
+%% constraints
+expr_h = sym_u;
+
+%% cost
+W_x = diag([1e3, 1e3, 1e-2, 1e-2]);
+W_u = 1e-2;
+expr_ext_cost_e = sym_x'* W_x * sym_x;
+expr_ext_cost = expr_ext_cost_e + sym_u' * W_u * sym_u;
+
+%% populate structure
+model.nx = nx;
+model.nu = nu;
+model.sym_x = sym_x;
+model.sym_xdot = sym_xdot;
+model.sym_z = sym_z;
+model.sym_u = sym_u;
+model.expr_f_impl = expr_f_impl;
+model.expr_h = expr_h;
+model.expr_ext_cost = expr_ext_cost;
+model.expr_ext_cost_e = expr_ext_cost_e;
+
+end

--- a/examples/acados_matlab_octave/swarming/example_ocp.m
+++ b/examples/acados_matlab_octave/swarming/example_ocp.m
@@ -13,9 +13,7 @@ close all;
 % Check that env.sh has been runz2
 env_run = getenv('ENV_RUN');
 if (~strcmp(env_run, 'true'))
-	disp('ERROR: env.sh has not been sourced! Before executing this example, run:');
-	disp('source env.sh');
-	return;
+	error('env.sh has not been sourced! Before executing this example, run: source env.sh');
 end
 
 %% Arguments
@@ -305,6 +303,7 @@ ylabel('Control inputs [m/s^2]','fontsize',fontsize);
 
 if (strcmp(nlp_solver, 'sqp'))
 	figure;
+    stat = ocp.get('stat');
 	plot([0: sqp_iter], log10(stat(:,2)), 'r-x');
 	hold on
 	plot([0: sqp_iter], log10(stat(:,3)), 'b-x');
@@ -322,5 +321,6 @@ else
 	fprintf('\nsolution failed!\n\n');
 end
 
-waitforbuttonpress;
-return;
+if is_octave
+    waitforbuttonpress;
+end

--- a/interfaces/acados_matlab_octave/acados_ocp_opts.m
+++ b/interfaces/acados_matlab_octave/acados_ocp_opts.m
@@ -136,6 +136,8 @@ classdef acados_ocp_opts < handle
 				obj.opts_struct.sim_method_num_steps = value;
 			elseif (strcmp(field, 'sim_method_newton_iter'))
 				obj.opts_struct.sim_method_newton_iter = value;
+			elseif (strcmp(field, 'sim_method_exact_z_output'))
+				obj.opts_struct.sim_method_exact_z_output = value;
 			elseif (strcmp(field, 'sim_method_jac_reuse'))
 				obj.opts_struct.sim_method_jac_reuse = value;
             elseif (strcmp(field, 'gnsf_detect_struct'))

--- a/interfaces/acados_matlab_octave/acados_ocp_opts.m
+++ b/interfaces/acados_matlab_octave/acados_ocp_opts.m
@@ -72,6 +72,7 @@ classdef acados_ocp_opts < handle
 			obj.opts_struct.sim_method_num_stages = 4;
 			obj.opts_struct.sim_method_num_steps = 1;
 			obj.opts_struct.sim_method_newton_iter = 3;
+			obj.opts_struct.sim_method_jac_reuse = 1;
 			obj.opts_struct.gnsf_detect_struct = 'true';
 			obj.opts_struct.regularize_method = 'no_regularize';
 			obj.opts_struct.output_dir = fullfile(pwd, 'build');
@@ -127,7 +128,9 @@ classdef acados_ocp_opts < handle
 				obj.opts_struct.sim_method_num_steps = value;
 			elseif (strcmp(field, 'sim_method_newton_iter'))
 				obj.opts_struct.sim_method_newton_iter = value;
-			elseif (strcmp(field, 'gnsf_detect_struct'))
+			elseif (strcmp(field, 'sim_method_jac_reuse'))
+				obj.opts_struct.sim_method_jac_reuse = value;
+            elseif (strcmp(field, 'gnsf_detect_struct'))
 				obj.opts_struct.gnsf_detect_struct = value;
 			elseif (strcmp(field, 'regularize_method'))
 				obj.opts_struct.regularize_method = value;

--- a/interfaces/acados_matlab_octave/ocp_create.c
+++ b/interfaces/acados_matlab_octave/ocp_create.c
@@ -826,6 +826,33 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         }
     }
 
+    // sim_method_jac_reuse
+    sprintf(matlab_field_name, "sim_method_jac_reuse");
+    matlab_array = mxGetField( matlab_opts, 0, matlab_field_name );
+    if (matlab_array!=NULL)
+    {
+        int matlab_size = (int) mxGetNumberOfElements( matlab_array );
+        MEX_DIM_CHECK_VEC_TWO(fun_name, matlab_field_name, matlab_size, 1, N);
+
+        if (matlab_size == 1)
+        {
+            bool sim_method_jac_reuse = mxGetScalar( matlab_array );
+            for (int ii=0; ii<N; ii++)
+            {
+                ocp_nlp_dynamics_opts_set(config, opts, ii, "jac_reuse", &sim_method_jac_reuse);
+            }
+        }
+        else
+        {
+            double *values = mxGetPr(matlab_array);
+            for (int ii=0; ii<N; ii++)
+            {
+                bool sim_method_jac_reuse = (int) values[ii];
+                // mexPrintf("\nsim_method_jac_reuse[%d] = %d", ii, sim_method_jac_reuse);
+                ocp_nlp_dynamics_opts_set(config, opts, ii, "jac_reuse", &sim_method_jac_reuse);
+            }
+        }
+    }
 
     /* in */
     ocp_nlp_in *in = ocp_nlp_in_create(config, dims);

--- a/interfaces/acados_matlab_octave/ocp_create.c
+++ b/interfaces/acados_matlab_octave/ocp_create.c
@@ -627,7 +627,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     if (ns_e!=nsbx+nsg_e+nsh_e)
     {
         sprintf(buffer,"ocp_create: ns_e!=nsbx+nsg_e+nsh_e, got ns_e=%d, nsbx=%d nsg_e=%d nsh_e=%d\n",
-            ns, nsbx, nsg_e, nsh_e);
+            ns_e, nsbx, nsg_e, nsh_e);
         mexErrMsgTxt(buffer);
     }
 

--- a/interfaces/acados_matlab_octave/ocp_create.c
+++ b/interfaces/acados_matlab_octave/ocp_create.c
@@ -877,6 +877,34 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         }
     }
 
+    // sim_method_exact_z_output
+    sprintf(matlab_field_name, "sim_method_exact_z_output");
+    matlab_array = mxGetField( matlab_opts, 0, matlab_field_name );
+    if (matlab_array!=NULL)
+    {
+        int matlab_size = (int) mxGetNumberOfElements( matlab_array );
+        MEX_DIM_CHECK_VEC_TWO(fun_name, matlab_field_name, matlab_size, 1, N);
+
+        if (matlab_size == 1)
+        {
+            bool sim_method_exact_z_output = mxGetScalar( matlab_array );
+            for (int ii=0; ii<N; ii++)
+            {
+                ocp_nlp_dynamics_opts_set(config, opts, ii, "exact_z_output", &sim_method_exact_z_output);
+            }
+        }
+        else
+        {
+            double *values = mxGetPr(matlab_array);
+            for (int ii=0; ii<N; ii++)
+            {
+                bool sim_method_exact_z_output = (int) values[ii];
+                // mexPrintf("\nsim_method_exact_z_output[%d] = %d", ii, sim_method_exact_z_output);
+                ocp_nlp_dynamics_opts_set(config, opts, ii, "exact_z_output", &sim_method_exact_z_output);
+            }
+        }
+    }
+
     /* in */
     ocp_nlp_in *in = ocp_nlp_in_create(config, dims);
 

--- a/interfaces/acados_matlab_octave/ocp_set.c
+++ b/interfaces/acados_matlab_octave/ocp_set.c
@@ -422,6 +422,13 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         int nlp_solver_max_iter = (int) value[0];
         ocp_nlp_opts_set(config, opts, "max_iter", &nlp_solver_max_iter);
     }
+    else if (!strcmp(field, "qp_warm_start"))
+    {
+        acados_size = 1;
+        MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
+        int qp_warm_start = (int) value[0];
+        ocp_nlp_opts_set(config, opts, "qp_warm_start", &qp_warm_start);
+    }
     else
     {
         MEX_FIELD_NOT_SUPPORTED(fun_name, field);


### PR DESCRIPTION


Outdated:
<del>There was a mistake when updating the `z` variables in the `ocp_nlp_sqp_[rti]` solver.
The fix is in this commit: https://github.com/acados/acados/commit/b394ad5e53067aa1d64aeb0cc5c2be7565350d95

fixed in https://github.com/acados/acados/pull/478 instead..