### PR TITLE
Quickfix template

### DIFF
--- a/interfaces/acados_template/acados_template/acados_ocp_nlp.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_nlp.py
@@ -124,7 +124,7 @@ class ocp_nlp_dims:
 
     @property
     def nsbx_e(self):
-        return self.__nsbx
+        return self.__nsbx_e
 
     @property
     def nsbu(self):
@@ -250,14 +250,14 @@ class ocp_nlp_dims:
             raise Exception('Invalid nbu value. Exiting.')
 
     @nsbx.setter
-    def nsbx(self, nbx):
+    def nsbx(self, nsbx):
         if type(nsbx) == int and nsbx > -1:
             self.__nsbx = nsbx
         else:
             raise Exception('Invalid nsbx value. Exiting.')
 
     @nsbx_e.setter
-    def nsbx_e(self, nbx_e):
+    def nsbx_e(self, nsbx_e):
         if type(nsbx_e) == int and nsbx_e > -1:
             self.__nsbx_e = nsbx_e
         else:

--- a/interfaces/acados_template/acados_template/c_templates/Makefile.in
+++ b/interfaces/acados_template/acados_template/c_templates/Makefile.in
@@ -112,7 +112,7 @@ solver:
 	-I $(INCLUDE_PATH) -I $(INCLUDE_PATH)/acados/ -I $(INCLUDE_PATH)/qpOASES_e/
 
 sim_solver:
-	gcc $(ACADOS_FLAGS) -c acados_sim_solver_{{ ocp.model_name}}.c -I $(INCLUDE_PATH)/blasfeo/include/ -I $(INCLUDE_PATH)/hpipm/include/ \
+	gcc $(ACADOS_FLAGS) -c acados_sim_solver_{{ ocp.model.name}}.c -I $(INCLUDE_PATH)/blasfeo/include/ -I $(INCLUDE_PATH)/hpipm/include/ \
 	-I $(INCLUDE_PATH) -I $(INCLUDE_PATH)/acados/ -I $(INCLUDE_PATH)/qpOASES_e/
 
 example:
@@ -130,7 +130,6 @@ example:
 
 shared_lib: casadi_fun solver sim_solver
 	gcc $(ACADOS_FLAGS) -shared -o libacados_solver_{{ ocp.model.name }}.so $(OBJ) -L $(LIB_PATH)/acados \
-
 	-L $(LIB_PATH) \
 	-L $(LIB_PATH)/external/blasfeo \
 	-L $(LIB_PATH)/external/hpipm  \

--- a/interfaces/acados_template/acados_template/c_templates/acados_sim_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates/acados_sim_solver.in.c
@@ -37,8 +37,8 @@
 
 // example specific
 
-#include "{{ ocp.model_name }}_model/{{ ocp.model_name }}_model.h"
-#include "acados_sim_solver_{{ ocp.model_name }}.h"
+#include "{{ ocp.model.name }}_model/{{ ocp.model.name }}_model.h"
+#include "acados_sim_solver_{{ ocp.model.name }}.h"
 
 #define NX_    {{ ocp.dims.nx }}
 #define NZ_    {{ ocp.dims.nz }}
@@ -50,7 +50,7 @@
 #define NU   NU_
 #define NP   NP_
 
-int {{ ocp.model_name}}_acados_sim_create() {
+int {{ ocp.model.name}}_acados_sim_create() {
 
 	// initialize
 
@@ -76,12 +76,12 @@ int {{ ocp.model_name}}_acados_sim_create() {
     {% endif %}
 
 	// external functions (implicit model)
-	sim_impl_dae_fun->casadi_fun  = &{{ ocp.model_name }}_impl_dae_fun;
-	sim_impl_dae_fun->casadi_work = &{{ ocp.model_name }}_impl_dae_fun_work;
-	sim_impl_dae_fun->casadi_sparsity_in = &{{ ocp.model_name }}_impl_dae_fun_sparsity_in;
-	sim_impl_dae_fun->casadi_sparsity_out = &{{ ocp.model_name }}_impl_dae_fun_sparsity_out;
-	sim_impl_dae_fun->casadi_n_in = &{{ ocp.model_name }}_impl_dae_fun_n_in;
-	sim_impl_dae_fun->casadi_n_out = &{{ ocp.model_name }}_impl_dae_fun_n_out;
+	sim_impl_dae_fun->casadi_fun  = &{{ ocp.model.name }}_impl_dae_fun;
+	sim_impl_dae_fun->casadi_work = &{{ ocp.model.name }}_impl_dae_fun_work;
+	sim_impl_dae_fun->casadi_sparsity_in = &{{ ocp.model.name }}_impl_dae_fun_sparsity_in;
+	sim_impl_dae_fun->casadi_sparsity_out = &{{ ocp.model.name }}_impl_dae_fun_sparsity_out;
+	sim_impl_dae_fun->casadi_n_in = &{{ ocp.model.name }}_impl_dae_fun_n_in;
+	sim_impl_dae_fun->casadi_n_out = &{{ ocp.model.name }}_impl_dae_fun_n_out;
 
     {% if ocp.dims.np < 1 %}
     external_function_casadi_create(sim_impl_dae_fun);
@@ -90,12 +90,12 @@ int {{ ocp.model_name}}_acados_sim_create() {
     {% endif %}
 
 	// external_function_casadi impl_dae_fun_jac_x_xdot_z;
-	sim_impl_dae_fun_jac_x_xdot_z->casadi_fun = &{{ ocp.model_name }}_impl_dae_fun_jac_x_xdot_z;
-	sim_impl_dae_fun_jac_x_xdot_z->casadi_work = &{{ ocp.model_name }}_impl_dae_fun_jac_x_xdot_z_work;
-	sim_impl_dae_fun_jac_x_xdot_z->casadi_sparsity_in = &{{ ocp.model_name }}_impl_dae_fun_jac_x_xdot_z_sparsity_in;
-	sim_impl_dae_fun_jac_x_xdot_z->casadi_sparsity_out = &{{ ocp.model_name }}_impl_dae_fun_jac_x_xdot_z_sparsity_out;
-	sim_impl_dae_fun_jac_x_xdot_z->casadi_n_in = &{{ ocp.model_name }}_impl_dae_fun_jac_x_xdot_z_n_in;
-	sim_impl_dae_fun_jac_x_xdot_z->casadi_n_out = &{{ ocp.model_name }}_impl_dae_fun_jac_x_xdot_z_n_out;
+	sim_impl_dae_fun_jac_x_xdot_z->casadi_fun = &{{ ocp.model.name }}_impl_dae_fun_jac_x_xdot_z;
+	sim_impl_dae_fun_jac_x_xdot_z->casadi_work = &{{ ocp.model.name }}_impl_dae_fun_jac_x_xdot_z_work;
+	sim_impl_dae_fun_jac_x_xdot_z->casadi_sparsity_in = &{{ ocp.model.name }}_impl_dae_fun_jac_x_xdot_z_sparsity_in;
+	sim_impl_dae_fun_jac_x_xdot_z->casadi_sparsity_out = &{{ ocp.model.name }}_impl_dae_fun_jac_x_xdot_z_sparsity_out;
+	sim_impl_dae_fun_jac_x_xdot_z->casadi_n_in = &{{ ocp.model.name }}_impl_dae_fun_jac_x_xdot_z_n_in;
+	sim_impl_dae_fun_jac_x_xdot_z->casadi_n_out = &{{ ocp.model.name }}_impl_dae_fun_jac_x_xdot_z_n_out;
 
     {% if ocp.dims.np < 1 %}
     external_function_casadi_create(sim_impl_dae_fun_jac_x_xdot_z);
@@ -104,12 +104,12 @@ int {{ ocp.model_name}}_acados_sim_create() {
     {% endif %}
 
 	// external_function_casadi impl_dae_jac_x_xdot_u_z;
-	sim_impl_dae_jac_x_xdot_u_z->casadi_fun = &{{ ocp.model_name }}_impl_dae_jac_x_xdot_u_z;
-	sim_impl_dae_jac_x_xdot_u_z->casadi_work = &{{ ocp.model_name }}_impl_dae_jac_x_xdot_u_z_work;
-	sim_impl_dae_jac_x_xdot_u_z->casadi_sparsity_in = &{{ ocp.model_name }}_impl_dae_jac_x_xdot_u_z_sparsity_in;
-	sim_impl_dae_jac_x_xdot_u_z->casadi_sparsity_out = &{{ ocp.model_name }}_impl_dae_jac_x_xdot_u_z_sparsity_out;
-	sim_impl_dae_jac_x_xdot_u_z->casadi_n_in = &{{ ocp.model_name }}_impl_dae_jac_x_xdot_u_z_n_in;
-	sim_impl_dae_jac_x_xdot_u_z->casadi_n_out = &{{ ocp.model_name }}_impl_dae_jac_x_xdot_u_z_n_out;
+	sim_impl_dae_jac_x_xdot_u_z->casadi_fun = &{{ ocp.model.name }}_impl_dae_jac_x_xdot_u_z;
+	sim_impl_dae_jac_x_xdot_u_z->casadi_work = &{{ ocp.model.name }}_impl_dae_jac_x_xdot_u_z_work;
+	sim_impl_dae_jac_x_xdot_u_z->casadi_sparsity_in = &{{ ocp.model.name }}_impl_dae_jac_x_xdot_u_z_sparsity_in;
+	sim_impl_dae_jac_x_xdot_u_z->casadi_sparsity_out = &{{ ocp.model.name }}_impl_dae_jac_x_xdot_u_z_sparsity_out;
+	sim_impl_dae_jac_x_xdot_u_z->casadi_n_in = &{{ ocp.model.name }}_impl_dae_jac_x_xdot_u_z_n_in;
+	sim_impl_dae_jac_x_xdot_u_z->casadi_n_out = &{{ ocp.model.name }}_impl_dae_jac_x_xdot_u_z_n_out;
 
     {% if ocp.dims.np < 1 %}
     external_function_casadi_create(sim_impl_dae_jac_x_xdot_u_z);
@@ -127,12 +127,12 @@ int {{ ocp.model_name}}_acados_sim_create() {
     sim_expl_ode_fun_casadi = (external_function_param_casadi *) malloc(sizeof(external_function_param_casadi));
     {% endif %}
 
-    sim_forw_vde_casadi->casadi_fun = &{{ ocp.model_name }}_expl_vde_forw;
-    sim_forw_vde_casadi->casadi_n_in = &{{ ocp.model_name }}_expl_vde_forw_n_in;
-    sim_forw_vde_casadi->casadi_n_out = &{{ ocp.model_name }}_expl_vde_forw_n_out;
-    sim_forw_vde_casadi->casadi_sparsity_in = &{{ ocp.model_name }}_expl_vde_forw_sparsity_in;
-    sim_forw_vde_casadi->casadi_sparsity_out = &{{ ocp.model_name }}_expl_vde_forw_sparsity_out;
-    sim_forw_vde_casadi->casadi_work = &{{ ocp.model_name }}_expl_vde_forw_work;
+    sim_forw_vde_casadi->casadi_fun = &{{ ocp.model.name }}_expl_vde_forw;
+    sim_forw_vde_casadi->casadi_n_in = &{{ ocp.model.name }}_expl_vde_forw_n_in;
+    sim_forw_vde_casadi->casadi_n_out = &{{ ocp.model.name }}_expl_vde_forw_n_out;
+    sim_forw_vde_casadi->casadi_sparsity_in = &{{ ocp.model.name }}_expl_vde_forw_sparsity_in;
+    sim_forw_vde_casadi->casadi_sparsity_out = &{{ ocp.model.name }}_expl_vde_forw_sparsity_out;
+    sim_forw_vde_casadi->casadi_work = &{{ ocp.model.name }}_expl_vde_forw_work;
 
     {% if ocp.dims.np < 1 %}
     external_function_casadi_create(sim_forw_vde_casadi);
@@ -140,12 +140,12 @@ int {{ ocp.model_name}}_acados_sim_create() {
     external_function_param_casadi_create(sim_forw_vde_casadi, {{ ocp.dims.np }});
     {% endif %}
 
-    sim_expl_ode_fun_casadi->casadi_fun = &{{ ocp.model_name }}_expl_ode_fun;
-    sim_expl_ode_fun_casadi->casadi_n_in = &{{ ocp.model_name }}_expl_ode_fun_n_in;
-    sim_expl_ode_fun_casadi->casadi_n_out = &{{ ocp.model_name }}_expl_ode_fun_n_out;
-    sim_expl_ode_fun_casadi->casadi_sparsity_in = &{{ ocp.model_name }}_expl_ode_fun_sparsity_in;
-    sim_expl_ode_fun_casadi->casadi_sparsity_out = &{{ ocp.model_name }}_expl_ode_fun_sparsity_out;
-    sim_expl_ode_fun_casadi->casadi_work = &{{ ocp.model_name }}_expl_ode_fun_work;
+    sim_expl_ode_fun_casadi->casadi_fun = &{{ ocp.model.name }}_expl_ode_fun;
+    sim_expl_ode_fun_casadi->casadi_n_in = &{{ ocp.model.name }}_expl_ode_fun_n_in;
+    sim_expl_ode_fun_casadi->casadi_n_out = &{{ ocp.model.name }}_expl_ode_fun_n_out;
+    sim_expl_ode_fun_casadi->casadi_sparsity_in = &{{ ocp.model.name }}_expl_ode_fun_sparsity_in;
+    sim_expl_ode_fun_casadi->casadi_sparsity_out = &{{ ocp.model.name }}_expl_ode_fun_sparsity_out;
+    sim_expl_ode_fun_casadi->casadi_work = &{{ ocp.model.name }}_expl_ode_fun_work;
 
     {% if ocp.dims.np < 1 %}
     external_function_casadi_create(sim_expl_ode_fun_casadi);
@@ -163,86 +163,86 @@ int {{ ocp.model_name}}_acados_sim_create() {
     plan.sim_solver = {{ ocp.solver_config.integrator_type }};
 
     // create correct config based on plan
-    {{ ocp.model_name }}_sim_config = sim_config_create(plan);
+    {{ ocp.model.name }}_sim_config = sim_config_create(plan);
 
     // sim dims
 
-    {{ ocp.model_name }}_sim_dims = sim_dims_create({{ ocp.model_name }}_sim_config);
-    sim_dims_set({{ ocp.model_name }}_sim_config, {{ ocp.model_name }}_sim_dims, "nx", &nx);
-    sim_dims_set({{ ocp.model_name }}_sim_config, {{ ocp.model_name }}_sim_dims, "nu", &nu);
-    sim_dims_set({{ ocp.model_name }}_sim_config, {{ ocp.model_name }}_sim_dims, "nz", &nz);
+    {{ ocp.model.name }}_sim_dims = sim_dims_create({{ ocp.model.name }}_sim_config);
+    sim_dims_set({{ ocp.model.name }}_sim_config, {{ ocp.model.name }}_sim_dims, "nx", &nx);
+    sim_dims_set({{ ocp.model.name }}_sim_config, {{ ocp.model.name }}_sim_dims, "nu", &nu);
+    sim_dims_set({{ ocp.model.name }}_sim_config, {{ ocp.model.name }}_sim_dims, "nz", &nz);
 
     // sim opts
 
-    {{ ocp.model_name }}_sim_opts = sim_opts_create({{ ocp.model_name }}_sim_config, {{ ocp.model_name }}_sim_dims);
+    {{ ocp.model.name }}_sim_opts = sim_opts_create({{ ocp.model.name }}_sim_config, {{ ocp.model.name }}_sim_dims);
 
-    {{ ocp.model_name }}_sim_opts->ns = 1; // number of stages in rk integrator
-    {{ ocp.model_name }}_sim_opts->num_steps = 1; // number of integration steps
-    {{ ocp.model_name }}_sim_opts->sens_adj = false;
-    {{ ocp.model_name }}_sim_opts->sens_forw = true;
+    {{ ocp.model.name }}_sim_opts->ns = 1; // number of stages in rk integrator
+    {{ ocp.model.name }}_sim_opts->num_steps = 1; // number of integration steps
+    {{ ocp.model.name }}_sim_opts->sens_adj = false;
+    {{ ocp.model.name }}_sim_opts->sens_forw = true;
     {% if ocp.solver_config.integrator_type == "IRK" %}
-    {{ ocp.model_name }}_sim_opts->sens_algebraic = false;
-    {{ ocp.model_name }}_sim_opts->output_z = false;
-    {{ ocp.model_name }}_sim_opts->newton_iter = 5;
-    {{ ocp.model_name }}_sim_opts->jac_reuse = false;
+    {{ ocp.model.name }}_sim_opts->sens_algebraic = false;
+    {{ ocp.model.name }}_sim_opts->output_z = false;
+    {{ ocp.model.name }}_sim_opts->newton_iter = 5;
+    {{ ocp.model.name }}_sim_opts->jac_reuse = false;
     {% endif %}
 
     // sim in / out
 
-    {{ ocp.model_name }}_sim_in  = sim_in_create({{ ocp.model_name }}_sim_config, {{ ocp.model_name }}_sim_dims);
-    {{ ocp.model_name }}_sim_out = sim_out_create({{ ocp.model_name }}_sim_config, {{ ocp.model_name }}_sim_dims);
+    {{ ocp.model.name }}_sim_in  = sim_in_create({{ ocp.model.name }}_sim_config, {{ ocp.model.name }}_sim_dims);
+    {{ ocp.model.name }}_sim_out = sim_out_create({{ ocp.model.name }}_sim_config, {{ ocp.model.name }}_sim_dims);
 
-    {{ ocp.model_name }}_sim_in->T = Td;
+    {{ ocp.model.name }}_sim_in->T = Td;
 
     // external functions
     {% if ocp.solver_config.integrator_type == "IRK" %}
-    {{ ocp.model_name }}_sim_config->model_set({{ ocp.model_name }}_sim_in->model, "impl_ode_fun", sim_impl_dae_fun);
-    {{ ocp.model_name }}_sim_config->model_set({{ ocp.model_name }}_sim_in->model, "impl_ode_fun_jac_x_xdot", sim_impl_dae_fun_jac_x_xdot_z);
-    {{ ocp.model_name }}_sim_config->model_set({{ ocp.model_name }}_sim_in->model, "impl_ode_jac_x_xdot_u", sim_impl_dae_jac_x_xdot_u_z);
+    {{ ocp.model.name }}_sim_config->model_set({{ ocp.model.name }}_sim_in->model, "impl_ode_fun", sim_impl_dae_fun);
+    {{ ocp.model.name }}_sim_config->model_set({{ ocp.model.name }}_sim_in->model, "impl_ode_fun_jac_x_xdot", sim_impl_dae_fun_jac_x_xdot_z);
+    {{ ocp.model.name }}_sim_config->model_set({{ ocp.model.name }}_sim_in->model, "impl_ode_jac_x_xdot_u", sim_impl_dae_jac_x_xdot_u_z);
 
     {% else %}
     {% if ocp.solver_config.integrator_type == "ERK" %} 
-    {{ ocp.model_name }}_sim_config->model_set({{ ocp.model_name }}_sim_in->model, "expl_vde_for", sim_forw_vde_casadi);
-    {{ ocp.model_name }}_sim_config->model_set({{ ocp.model_name }}_sim_in->model, "expl_ode_fun", sim_expl_ode_fun_casadi);
+    {{ ocp.model.name }}_sim_config->model_set({{ ocp.model.name }}_sim_in->model, "expl_vde_for", sim_forw_vde_casadi);
+    {{ ocp.model.name }}_sim_config->model_set({{ ocp.model.name }}_sim_in->model, "expl_ode_fun", sim_expl_ode_fun_casadi);
     {% endif %}
     {% endif %}
 
     // sim solver
 
-    {{ ocp.model_name }}_sim_solver = sim_solver_create({{ ocp.model_name }}_sim_config, {{ ocp.model_name }}_sim_dims, {{ ocp.model_name }}_sim_opts);
+    {{ ocp.model.name }}_sim_solver = sim_solver_create({{ ocp.model.name }}_sim_config, {{ ocp.model.name }}_sim_dims, {{ ocp.model.name }}_sim_opts);
     
     // initialize state and input to zero
     // x
     for (ii = 0; ii < NX; ii++)
-        {{ ocp.model_name }}_sim_in->x[ii] = 0.0;
+        {{ ocp.model.name }}_sim_in->x[ii] = 0.0;
     
     // u
     for (ii = 0; ii < NU; ii++)
-        {{ ocp.model_name }}_sim_in->u[ii] = 0.0;
+        {{ ocp.model.name }}_sim_in->u[ii] = 0.0;
     int status = 0;
 
     return status;
 }
 
-int {{ ocp.model_name }}_acados_sim_solve() {
+int {{ ocp.model.name }}_acados_sim_solve() {
 
     // integrate dynamics using acados sim_solver 
-    int status = sim_solve({{ ocp.model_name }}_sim_solver, {{ ocp.model_name }}_sim_in, {{ ocp.model_name }}_sim_out);
+    int status = sim_solve({{ ocp.model.name }}_sim_solver, {{ ocp.model.name }}_sim_in, {{ ocp.model.name }}_sim_out);
     if (status != 0)
-        printf("error in {{ ocp.model_name }}_acados_sim_solve()! Exiting.\n");
+        printf("error in {{ ocp.model.name }}_acados_sim_solve()! Exiting.\n");
 
     return status;
 }
 
-int {{ ocp.model_name }}_acados_sim_free() {
+int {{ ocp.model.name }}_acados_sim_free() {
 
     // free memory
-    sim_solver_destroy({{ ocp.model_name }}_sim_solver);
-    sim_in_destroy({{ ocp.model_name }}_sim_in);
-    sim_out_destroy({{ ocp.model_name }}_sim_out);
-    sim_opts_destroy({{ ocp.model_name }}_sim_opts);
-    sim_dims_destroy({{ ocp.model_name }}_sim_dims);
-    sim_config_destroy({{ ocp.model_name }}_sim_config);
+    sim_solver_destroy({{ ocp.model.name }}_sim_solver);
+    sim_in_destroy({{ ocp.model.name }}_sim_in);
+    sim_out_destroy({{ ocp.model.name }}_sim_out);
+    sim_opts_destroy({{ ocp.model.name }}_sim_opts);
+    sim_dims_destroy({{ ocp.model.name }}_sim_dims);
+    sim_config_destroy({{ ocp.model.name }}_sim_config);
 
     // free external function 
     {% if ocp.solver_config.integrator_type == "IRK" %}
@@ -268,21 +268,21 @@ int {{ ocp.model_name }}_acados_sim_free() {
     return 0;
 }
 
-sim_config  * {{ocp.model_name}}_acados_get_sim_config() {  
-    return {{ocp.model_name}}_sim_config; };
+sim_config  * {{ocp.model.name}}_acados_get_sim_config() {  
+    return {{ocp.model.name}}_sim_config; };
 
-sim_in      * {{ocp.model_name}}_acados_get_sim_in(){       
-    return {{ocp.model_name}}_sim_in; };
+sim_in      * {{ocp.model.name}}_acados_get_sim_in(){       
+    return {{ocp.model.name}}_sim_in; };
 
-sim_out     * {{ocp.model_name}}_acados_get_sim_out(){      
-    return {{ocp.model_name}}_sim_out; };
+sim_out     * {{ocp.model.name}}_acados_get_sim_out(){      
+    return {{ocp.model.name}}_sim_out; };
 
-void        * {{ocp.model_name}}_acados_get_sim_dims(){     
-    return {{ocp.model_name}}_sim_dims; };
+void        * {{ocp.model.name}}_acados_get_sim_dims(){     
+    return {{ocp.model.name}}_sim_dims; };
 
-sim_opts    * {{ocp.model_name}}_acados_get_sim_opts(){     
-    return {{ocp.model_name}}_sim_opts; };
+sim_opts    * {{ocp.model.name}}_acados_get_sim_opts(){     
+    return {{ocp.model.name}}_sim_opts; };
 
-sim_solver  * {{ocp.model_name}}_acados_get_sim_solver(){   
-    return {{ocp.model_name}}_sim_solver; };
+sim_solver  * {{ocp.model.name}}_acados_get_sim_solver(){   
+    return {{ocp.model.name}}_sim_solver; };
 

--- a/interfaces/acados_template/acados_template/c_templates/acados_sim_solver.in.h
+++ b/interfaces/acados_template/acados_template/c_templates/acados_sim_solver.in.h
@@ -1,5 +1,5 @@
-#ifndef ACADOS_SIM_{{ocp.model_name}}_H_
-#define ACADOS_SIM_{{ocp.model_name}}_H_
+#ifndef ACADOS_SIM_{{ocp.model.name}}_H_
+#define ACADOS_SIM_{{ocp.model.name}}_H_
 
 #include "acados_c/sim_interface.h"
 #include "acados_c/external_function_interface.h"
@@ -8,24 +8,24 @@
 extern "C" {
 #endif
 
-int {{ocp.model_name}}_acados_sim_create();
-int {{ocp.model_name}}_acados_sim_solve();
-int {{ocp.model_name}}_acados_sim_free();
+int {{ocp.model.name}}_acados_sim_create();
+int {{ocp.model.name}}_acados_sim_solve();
+int {{ocp.model.name}}_acados_sim_free();
 
-sim_config  * {{ocp.model_name}}_acados_get_sim_config();
-sim_in      * {{ocp.model_name}}_acados_get_sim_in();
-sim_out     * {{ocp.model_name}}_acados_get_sim_out();
-void        * {{ocp.model_name}}_acados_get_sim_dims();
-sim_opts    * {{ocp.model_name}}_acados_get_sim_opts();
-sim_solver  * {{ocp.model_name}}_acados_get_sim_solver();
+sim_config  * {{ocp.model.name}}_acados_get_sim_config();
+sim_in      * {{ocp.model.name}}_acados_get_sim_in();
+sim_out     * {{ocp.model.name}}_acados_get_sim_out();
+void        * {{ocp.model.name}}_acados_get_sim_dims();
+sim_opts    * {{ocp.model.name}}_acados_get_sim_opts();
+sim_solver  * {{ocp.model.name}}_acados_get_sim_solver();
 
 // ** global data **
-extern sim_config  * {{ocp.model_name}}_sim_config;
-extern sim_in      * {{ocp.model_name}}_sim_in;
-extern sim_out     * {{ocp.model_name}}_sim_out; 
-extern void        * {{ocp.model_name}}_sim_dims;
-extern sim_opts    * {{ocp.model_name}}_sim_opts;
-extern sim_solver  * {{ocp.model_name}}_sim_solver; 
+extern sim_config  * {{ocp.model.name}}_sim_config;
+extern sim_in      * {{ocp.model.name}}_sim_in;
+extern sim_out     * {{ocp.model.name}}_sim_out; 
+extern void        * {{ocp.model.name}}_sim_dims;
+extern sim_opts    * {{ocp.model.name}}_sim_opts;
+extern sim_solver  * {{ocp.model.name}}_sim_solver; 
 
 #ifdef __cplusplus
 }
@@ -60,4 +60,4 @@ extern external_function_param_casadi * sim_impl_dae_jac_x_xdot_u_z;
 {% endif %}
 {% endif %}
 
-#endif  // ACADOS_SIM_{{ocp.model_name}}_H_
+#endif  // ACADOS_SIM_{{ocp.model.name}}_H_

--- a/interfaces/acados_template/acados_template/c_templates/main.in.c
+++ b/interfaces/acados_template/acados_template/c_templates/main.in.c
@@ -52,12 +52,12 @@ ocp_nlp_plan * nlp_solver_plan;
 ocp_nlp_config * nlp_config;
 ocp_nlp_dims * nlp_dims;
 
-sim_config  * {{ocp.model_name}}_sim_config;
-sim_in      * {{ocp.model_name}}_sim_in;
-sim_out     * {{ocp.model_name}}_sim_out; 
-void        * {{ocp.model_name}}_sim_dims;
-sim_opts    * {{ocp.model_name}}_sim_opts;
-sim_solver  * {{ocp.model_name}}_sim_solver; 
+sim_config  * {{ocp.model.name}}_sim_config;
+sim_in      * {{ocp.model.name}}_sim_in;
+sim_out     * {{ocp.model.name}}_sim_out; 
+void        * {{ocp.model.name}}_sim_dims;
+sim_opts    * {{ocp.model.name}}_sim_opts;
+sim_solver  * {{ocp.model.name}}_sim_solver; 
 
 {% if ocp.solver_config.integrator_type == "ERK" %}
 {% if ocp.dims.np < 1 %}
@@ -112,7 +112,7 @@ int main() {
 
     // test integrator first
     int sim_status = 0;
-    sim_status = {{ ocp.model_name }}_acados_sim_create();
+    sim_status = {{ ocp.model.name }}_acados_sim_create();
 
     // set sim input
     double x_sim[{{ocp.dims.nx}}];
@@ -128,26 +128,26 @@ int main() {
     
     // seeds forw
     for (int ii = 0; ii < {{ocp.dims.nx}} * ({{ocp.dims.nx}} + {{ocp.dims.nu}}); ii++)
-        {{ ocp.model_name }}_sim_in->S_forw[ii] = 0.0;
+        {{ ocp.model.name }}_sim_in->S_forw[ii] = 0.0;
     for (int ii = 0; ii < {{ocp.dims.nx}}; ii++)
-        {{ ocp.model_name }}_sim_in->S_forw[ii * ({{ocp.dims.nx}} + 1)] = 1.0;
+        {{ ocp.model.name }}_sim_in->S_forw[ii * ({{ocp.dims.nx}} + 1)] = 1.0;
 
     double Td = {{ ocp.solver_config.tf }}/ {{ ocp.dims.N }};
-    sim_in_set({{ ocp.model_name }}_sim_config, {{ ocp.model_name }}_sim_dims, {{ ocp.model_name }}_sim_in, "T", &Td);
-    sim_in_set({{ ocp.model_name }}_sim_config, {{ ocp.model_name }}_sim_dims, {{ ocp.model_name }}_sim_in, "x", x_sim);
-    sim_in_set({{ ocp.model_name }}_sim_config, {{ ocp.model_name }}_sim_dims, {{ ocp.model_name }}_sim_in, "u", u_sim);
+    sim_in_set({{ ocp.model.name }}_sim_config, {{ ocp.model.name }}_sim_dims, {{ ocp.model.name }}_sim_in, "T", &Td);
+    sim_in_set({{ ocp.model.name }}_sim_config, {{ ocp.model.name }}_sim_dims, {{ ocp.model.name }}_sim_in, "x", x_sim);
+    sim_in_set({{ ocp.model.name }}_sim_config, {{ ocp.model.name }}_sim_dims, {{ ocp.model.name }}_sim_in, "u", u_sim);
 
 
-    sim_status = {{ ocp.model_name }}_acados_sim_solve();
+    sim_status = {{ ocp.model.name }}_acados_sim_solve();
     // get and print output
     double *xn_out = calloc( {{ ocp.dims.nx }}, sizeof(double));
-    sim_out_get({{ ocp.model_name }}_sim_config, {{ ocp.model_name }}_sim_dims, {{ ocp.model_name }}_sim_out, "xn", xn_out);
+    sim_out_get({{ ocp.model.name }}_sim_config, {{ ocp.model.name }}_sim_dims, {{ ocp.model.name }}_sim_out, "xn", xn_out);
     printf("\nxn: \n");
     d_print_exp_mat(1, {{ ocp.dims.nx }}, xn_out, 1);
 
     double *S_forw_out = calloc({{ ocp.dims.nx }}*({{ ocp.dims.nx }}+{{ ocp.dims.nu }}), sizeof(double));
-    if ({{ ocp.model_name }}_sim_opts->sens_forw){
-        sim_out_get({{ ocp.model_name }}_sim_config, {{ ocp.model_name }}_sim_dims, {{ ocp.model_name }}_sim_out, "S_forw", S_forw_out);
+    if ({{ ocp.model.name }}_sim_opts->sens_forw){
+        sim_out_get({{ ocp.model.name }}_sim_config, {{ ocp.model.name }}_sim_dims, {{ ocp.model.name }}_sim_out, "S_forw", S_forw_out);
         printf("\nS_forw_out: \n");
         d_print_exp_mat({{ ocp.dims.nx }}, {{ ocp.dims.nx }} + {{ ocp.dims.nu }}, S_forw_out, {{ ocp.dims.nx }});
     }

--- a/interfaces/acados_template/acados_template/generate_solver.py
+++ b/interfaces/acados_template/acados_template/generate_solver.py
@@ -37,6 +37,7 @@ from .generate_c_code_implicit_ode import *
 from .generate_c_code_constraint import *
 from .acados_ocp_nlp import *
 from ctypes import *
+from copy import deepcopy
 
 def generate_solver(acados_ocp, json_file='acados_ocp_nlp.json'):
     USE_TERA = 0 # EXPERIMENTAL: use Tera standalone parser instead of Jinja2
@@ -65,7 +66,7 @@ def generate_solver(acados_ocp, json_file='acados_ocp_nlp.json'):
         # convex part of nonlinear constraints 
         generate_c_code_constraint(acados_ocp.con_p, '_p_constraint')
 
-    ocp_nlp = acados_ocp
+    ocp_nlp = deepcopy(acados_ocp)
     ocp_nlp.cost = acados_ocp.cost.__dict__
     ocp_nlp.constraints = acados_ocp.constraints.__dict__
     ocp_nlp.solver_config = acados_ocp.solver_config.__dict__

--- a/interfaces/acados_template/acados_template/generate_solver.py
+++ b/interfaces/acados_template/acados_template/generate_solver.py
@@ -39,7 +39,7 @@ from .acados_ocp_nlp import *
 from ctypes import *
 
 def generate_solver(acados_ocp, json_file='acados_ocp_nlp.json'):
-    USE_TERA = 1 # EXPERIMENTAL: use Tera standalone parser instead of Jinja2
+    USE_TERA = 0 # EXPERIMENTAL: use Tera standalone parser instead of Jinja2
     
     model = acados_ocp.model
     if acados_ocp.solver_config.integrator_type == 'ERK':


### PR DESCRIPTION
Fixing issue with shallow copy in generate_solver.py. @FreyJo @giaf I have tried to fix the same issue in MATLAB, without success :P If you figure out how to to deep copies of objects in MATLAB, we can do the same for the MEX interface too ;) 

PS: I have also fixed an inconsistency in the Jinja templates (some people still use them).