### PR TITLE
fix bug in acados_sover.in.c - wrong dimension for lphi_e uphi_e

### DIFF
--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -1081,8 +1081,8 @@ int acados_create()
 
 {% if dims.nphi_e > 0 and constraints.constr_type_e == "BGP" %}
     // set up convex-over-nonlinear constraints for last stage 
-    double lphi_e[NHN];
-    double uphi_e[NHN];
+    double lphi_e[NPHIN];
+    double uphi_e[NPHIN];
 
     {% for i in range(end=dims.nphi_e) %}
     lphi_e[{{ i }}] = {{ constraints.lphi_e[i] }};

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.h
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.h
@@ -42,7 +42,7 @@ extern "C" {
 #endif
 
 int acados_create();
-int acados_update_param(int stage, double *value, int np);
+int acados_update_params(int stage, double *value, int np);
 int acados_solve();
 int acados_free();
 


### PR DESCRIPTION
1. fix bug in acados_sover.in.c - wrong dimension for lphi_e uphi_e
2. header fix: acados_update_param -> acados_update_params