### PR TITLE
Use setuptools-scm to simplify package building of Python acados_template

### DIFF
--- a/interfaces/acados_template/setup.py
+++ b/interfaces/acados_template/setup.py
@@ -48,6 +48,12 @@ setup(name='acados_template',
    license='BSD',
    packages = find_packages(),
    include_package_data = True,
+   setup_requires=['setuptools_scm'],
+   use_scm_version={
+     "fallback_version": "0.1-local",
+     "root": "../..",
+     "relative_to": __file__
+   },
    install_requires=[
       'numpy',
       'scipy',


### PR DESCRIPTION
When using tools like `python setup.py bdist_wheel` a python package can be produced and shared with other developers.
Because of frequent changes, it is not convenient to update version in setup.py on each change. The scm module will update change accordingly to git version (using annotated tags).