### PR TITLE
s-fun templates: fix pointer. avoids segfault and matlab crash

### DIFF
--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver_sfun.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver_sfun.in.c
@@ -346,7 +346,7 @@ static void mdlOutputs(SimStruct *S, int_T tid)
 
     /* call solver */
     int rti_phase = 0;
-    ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "rti_phase", rti_phase);
+    ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "rti_phase", &rti_phase);
     int acados_status = acados_solve();
 
 


### PR DESCRIPTION
Matlab crashes when using the generated s-function with a segfault (including when using the example getting_started - simulink_model_closed_loop). 