### PR TITLE
Python: Detect x0 equality for great speedups

### DIFF
--- a/interfaces/acados_matlab_octave/acados_template_mex/+acados_template_mex/ocp_nlp_constraints_json.m
+++ b/interfaces/acados_matlab_octave/acados_template_mex/+acados_template_mex/ocp_nlp_constraints_json.m
@@ -92,6 +92,7 @@ classdef ocp_nlp_constraints_json < handle
         lbx_0    % lower bound on initial state
         ubx_0    % upper bound on initial state
         idxbx_0  % bound indices of initial state
+        idxbxe_0 %
         % convex over nonlinear constraint (BGP) to work with json
         % TODO: implement in MEX..
         lphi   % lower bound on convex over nonlinear constraint

--- a/interfaces/acados_matlab_octave/acados_template_mex/+acados_template_mex/ocp_nlp_dims_json.m
+++ b/interfaces/acados_matlab_octave/acados_template_mex/+acados_template_mex/ocp_nlp_dims_json.m
@@ -67,6 +67,7 @@ classdef ocp_nlp_dims_json < handle
         nsphi_e % number of softend convex over nonlinear constraints (BGP) at t=T
         nr %
         nr_e %
+        nbxe_0
 
     end
     methods
@@ -102,6 +103,7 @@ classdef ocp_nlp_dims_json < handle
             obj.nr = 0;
             obj.nr_e = 0;
             obj.N     = [];
+            obj.nbxe_0 = 0;
         end
     end
 end

--- a/interfaces/acados_matlab_octave/detect_dims_ocp.m
+++ b/interfaces/acados_matlab_octave/detect_dims_ocp.m
@@ -114,9 +114,10 @@ function [model, opts] = detect_dims_ocp(model, opts)
     else
         nbx_0 = 0;
     end
-
     model.dim_nbx_0 = nbx_0;
-    model.dim_nbxe_0 = nbx_0;
+
+    if isfield(model, 'constr_idxbxe_0')
+        model.dim_nbxe_0 = length(model.constr_idxbxe_0);
 
     % path
     if isfield(model, 'constr_Jbx') && isfield(model, 'constr_lbx') && isfield(model, 'constr_ubx')

--- a/interfaces/acados_matlab_octave/set_up_acados_ocp_nlp_json.m
+++ b/interfaces/acados_matlab_octave/set_up_acados_ocp_nlp_json.m
@@ -59,7 +59,7 @@ function ocp_json = set_up_acados_ocp_nlp_json(obj)
     ocp_json.solver_options.qp_solver_cond_N = obj.opts_struct.qp_solver_cond_N;
     ocp_json.solver_options.qp_solver_iter_max = obj.opts_struct.qp_solver_iter_max;
 
-    ocp_json.solver_options.time_steps = obj.opts_struct.time_steps
+    ocp_json.solver_options.time_steps = obj.opts_struct.time_steps;
 
     %% dims
     % path
@@ -73,6 +73,8 @@ function ocp_json = set_up_acados_ocp_nlp_json(obj)
     ocp_json.dims.nbu = model.dim_nbu;
     ocp_json.dims.ng = model.dim_ng;
     ocp_json.dims.nh = model.dim_nh;
+    ocp_json.dims.nbxe_0 = model.dim_nbxe_0;
+
     if isfield(model, 'dim_ns')
         ocp_json.dims.ns = model.dim_ns;
     end
@@ -87,8 +89,8 @@ function ocp_json = set_up_acados_ocp_nlp_json(obj)
         ocp_json.dims.nsg = model.nsg;
     end
     % missing in MEX
-    % ocp_json.dims.npd = model.npd;
-    % ocp_json.dims.npd_e = model.npd_e;
+    % ocp_json.dims.nphi;
+    % ocp_json.dims.nphi_e;
 
     if isfield(model, 'dim_nsh')
         ocp_json.dims.nsh = model.dim_nsh;
@@ -151,6 +153,8 @@ function ocp_json = set_up_acados_ocp_nlp_json(obj)
     if isfield(model, 'constr_Jbx_0')
         ocp_json.constraints.idxbx_0 = J_to_idx( model.constr_Jbx_0 );
     end
+    ocp_json.constraints.idxbxe_0 = model.constr_idxbxe_0;
+
 
     % path
     if ocp_json.dims.nbx > 0

--- a/interfaces/acados_template/acados_template/acados_layout.json
+++ b/interfaces/acados_template/acados_template/acados_layout.json
@@ -95,6 +95,12 @@
                 "nbx_0"
             ]
         ],
+        "idxbxe_0": [
+            "ndarray",
+            [
+                "nbxe_0"
+            ]
+        ],
         "lg": [
             "ndarray",
             [
@@ -484,6 +490,9 @@
             "int"
         ],
         "nbx_e": [
+            "int"
+        ],
+        "nbxe_0": [
             "int"
         ],
         "nsg": [

--- a/interfaces/acados_template/acados_template/acados_ocp.py
+++ b/interfaces/acados_template/acados_template/acados_ocp.py
@@ -71,6 +71,7 @@ class AcadosOcpDims:
         self.__ng_e    = 0
         self.__nsg     = 0
         self.__nsg_e   = 0
+        self.__nbxe_0  = 0
         self.__N       = None
 
 
@@ -138,6 +139,11 @@ class AcadosOcpDims:
     def nbx(self):
         """:math:`n_{b_x}` - number of state bounds"""
         return self.__nbx
+
+    @property
+    def nbxe_0(self):
+        """:math:`n_{be_{x0}}` - number of state bounds at initial shooting node that are equalities"""
+        return self.__nbxe_0
 
     @property
     def nbx_0(self):
@@ -310,10 +316,17 @@ class AcadosOcpDims:
 
     @nbx.setter
     def nbx(self, nbx):
-        if type(nbx) == int and nbx > -1:
+        if isinstance(nbx, int) and nbx > -1:
             self.__nbx = nbx
         else:
             raise Exception('Invalid nbx value, expected nonnegative integer. Exiting.')
+
+    @nbxe_0.setter
+    def nbxe_0(self, nbxe_0):
+        if isinstance(nbxe_0, int) and nbxe_0 > -1:
+            self.__nbxe_0 = nbxe_0
+        else:
+            raise Exception('Invalid nbxe_0 value, expected nonnegative integer. Exiting.')
 
     @nbx_0.setter
     def nbx_0(self, nbx_0):
@@ -718,6 +731,7 @@ class AcadosOcpConstraints:
         self.__lbx_0   = np.array([])
         self.__ubx_0   = np.array([])
         self.__idxbx_0 = np.array([])
+        self.__idxbxe_0 = np.array([])
         # state bounds
         self.__lbx     = np.array([])
         self.__ubx     = np.array([])
@@ -816,6 +830,11 @@ class AcadosOcpConstraints:
     def idxbx_0(self):
         """indexes of bounds on x0"""
         return self.__idxbx_0
+
+    @property
+    def idxbxe_0(self):
+        """indexes of bounds on x0 that are equalities (set automatically)"""
+        return self.__idxbxe_0
 
     # bounds on x
     @property
@@ -1174,6 +1193,7 @@ class AcadosOcpConstraints:
         print("idxbx_0: ", self.__idxbx_0)
         print("lbx_0: ", self.__lbx_0)
         print("ubx_0: ", self.__ubx_0)
+        print("idxbxe_0: ", self.__idxbxe_0)
         return None
 
     # SETTERS
@@ -1214,10 +1234,18 @@ class AcadosOcpConstraints:
 
     @idxbx_0.setter
     def idxbx_0(self, idxbx_0):
-        if type(idxbx_0) == np.ndarray:
+        if isinstance(idxbx_0, np.ndarray):
             self.__idxbx_0 = idxbx_0
         else:
             raise Exception('Invalid idxbx_0 value. Exiting.')
+
+    @idxbxe_0.setter
+    def idxbxe_0(self, idxbxe_0):
+        if isinstance(idxbxe_0, np.ndarray):
+            self.__idxbxe_0 = idxbxe_0
+        else:
+            raise Exception('Invalid idxbxe_0 value. Exiting.')
+
 
     @x0.setter
     def x0(self, x0):
@@ -1225,6 +1253,7 @@ class AcadosOcpConstraints:
             self.__lbx_0 = x0
             self.__ubx_0 = x0
             self.__idxbx_0 = np.arange(x0.size)
+            self.__idxbxe_0 = np.arange(x0.size)
         else:
             raise Exception('Invalid x0 value. Exiting.')
 

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -142,15 +142,17 @@ def make_ocp_dims_consistent(acados_ocp):
     # initial
     if (constraints.lbx_0 == [] and constraints.ubx_0 == []):
         dims.nbx_0 = 0
-    elif not (constraints.lbx_0 == [] and constraints.ubx_0 == []):
+    else:
         this_shape = constraints.lbx_0.shape
         other_shape = constraints.ubx_0.shape
         if not this_shape == other_shape:
             raise Exception('lbx_0, ubx_0 have different shapes!')
         if not is_column(constraints.lbx_0):
             raise Exception('lbx_0, ubx_0 must be column vectors!')
-
         dims.nbx_0 = constraints.lbx_0.size
+
+    if all(constraints.lbx_0 == constraints.ubx_0):
+        dims.nbxe_0 = dims.nbx_0
 
     # path
     nbx = constraints.idxbx.shape[0]

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -236,8 +236,7 @@ int acados_create()
     int nz[N+1];
     int ny[N+1];
     int nr[N+1];
-    int nr_e[N+1];
-
+    int nbxe[N+1];
 
     for (int i = 0; i < N+1; i++)
     {
@@ -260,12 +259,14 @@ int acados_create()
         nh[i]     = NH;
         nphi[i]   = NPHI;
         nr[i]     = NR;
+        nbxe[i]   = 0;
     }
 
     // for initial state
     nbx[0]  = NBX0;
     nsbx[0] = 0;
     ns[0] = NS - NSBX;
+    nbxe[0] = {{ dims.nbxe_0 }};
 
     // terminal - common
     nu[N]   = 0;
@@ -303,6 +304,7 @@ int acados_create()
         ocp_nlp_dims_set_constraints(nlp_config, nlp_dims, i, "nsbu", &nsbu[i]);
         ocp_nlp_dims_set_constraints(nlp_config, nlp_dims, i, "ng", &ng[i]);
         ocp_nlp_dims_set_constraints(nlp_config, nlp_dims, i, "nsg", &nsg[i]);
+        ocp_nlp_dims_set_constraints(nlp_config, nlp_dims, i, "nbxe", &nbxe[i]);
     }
 
     for (int i = 0; i < N; i++)
@@ -925,7 +927,14 @@ int acados_create()
     ocp_nlp_constraints_model_set(nlp_config, nlp_dims, nlp_in, 0, "lbx", lbx0);
     ocp_nlp_constraints_model_set(nlp_config, nlp_dims, nlp_in, 0, "ubx", ubx0);
 {% endif %}
-
+{% if dims.nbxe_0 > 0 %}
+    // idxbxe_0
+    int idxbxe_0[{{ dims.nbxe_0 }}];
+    {% for i in range(end=dims.nbxe_0) %}
+    idxbxe_0[{{ i }}] = {{ constraints.idxbxe_0[i] }};
+    {%- endfor %}
+    ocp_nlp_constraints_model_set(nlp_config, nlp_dims, nlp_in, 0, "idxbxe", idxbxe_0);
+{% endif %}
 
     /* constraints that are the same for initial and intermediate */
 {%- if dims.nsbx > 0 %}

--- a/interfaces/acados_template/acados_template/c_templates_tera/main.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/main.in.c
@@ -125,7 +125,7 @@ int main()
   {% endif %}{# if np > 0 #}
 
     // prepare evaluation
-    int NTIMINGS = 1;
+    int NTIMINGS = 20;
     double min_time = 1e12;
     double kkt_norm_inf;
     double elapsed_time;
@@ -182,8 +182,8 @@ int main()
     acados_print_stats();
 
     printf("\nSolver info:\n");
-    printf(" SQP iterations %2d\n minimum time for 1 solve %f [ms]\n KKT %e\n",
-           sqp_iter, min_time*1000, kkt_norm_inf);
+    printf(" SQP iterations %2d\n minimum time for %d solve %f [ms]\n KKT %e\n",
+           sqp_iter, NTIMINGS, min_time*1000, kkt_norm_inf);
 
     // free solver
     status = acados_free();

--- a/interfaces/acados_template/acados_template/c_templates_tera/mex_solver.in.m
+++ b/interfaces/acados_template/acados_template/c_templates_tera/mex_solver.in.m
@@ -49,7 +49,7 @@ classdef {{ model.name }}_mex_solver < handle
             [obj.C_ocp, obj.C_ocp_ext_fun] = acados_mex_create_{{ model.name }}();
             % to have path to destructor when changing directory
             addpath('.')
-            obj.ext_fun_type = "casadi";
+            obj.ext_fun_type = 'casadi';
         end
 
         % destructor


### PR DESCRIPTION
Closely connected to #572 
I made the x0 equality detection for Python and MEX templating.
For the [minimal_example_ocp.py](https://github.com/acados/acados/blob/master/examples/acados_python/getting_started/ocp/minimal_example_ocp.py) or better the generated Code, I get ~30% speedup on my machine just telling HPIPM about the equality! :rocket::zap: