### PR TITLE
Memory management - some fixes wrt 32 Bit architectures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,7 @@ endif()
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99 -Wall -fdiagnostics-show-option")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -fdiagnostics-show-option")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x -Wall -fdiagnostics-show-option")
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
     set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} /MT")
     set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MT")

--- a/acados/ocp_nlp/ocp_nlp_common.c
+++ b/acados/ocp_nlp/ocp_nlp_common.c
@@ -265,26 +265,26 @@ static ocp_nlp_dims *ocp_nlp_dims_assign_self(int N, void *raw_memory)
     // N
     dims->N = N;
 
-	// initialize dimensions to zero by default
-	// nv
-	for(ii=0; ii<=N; ii++)
-		dims->nv[ii] = 0;
-	// nx
-	for(ii=0; ii<=N; ii++)
-		dims->nx[ii] = 0;
-	// nu
-	for(ii=0; ii<=N; ii++)
-		dims->nu[ii] = 0;
-	// ni
-	for(ii=0; ii<=N; ii++)
-		dims->ni[ii] = 0;
-	// nz
-	for(ii=0; ii<=N; ii++)
-		dims->nz[ii] = 0;
-	// ns
-	for(ii=0; ii<=N; ii++)
-		dims->ns[ii] = 0;
-	// TODO initialize dims to zero by default also in modules !!!!!!!
+    // initialize dimensions to zero by default
+    // nv
+    for(ii=0; ii<=N; ii++)
+        dims->nv[ii] = 0;
+    // nx
+    for(ii=0; ii<=N; ii++)
+        dims->nx[ii] = 0;
+    // nu
+    for(ii=0; ii<=N; ii++)
+        dims->nu[ii] = 0;
+    // ni
+    for(ii=0; ii<=N; ii++)
+        dims->ni[ii] = 0;
+    // nz
+    for(ii=0; ii<=N; ii++)
+        dims->nz[ii] = 0;
+    // ns
+    for(ii=0; ii<=N; ii++)
+        dims->ns[ii] = 0;
+    // TODO initialize dims to zero by default also in modules !!!!!!!
 
     // assert
     assert((char *) raw_memory + ocp_nlp_dims_calculate_size_self(N) >= c_ptr);
@@ -576,15 +576,15 @@ void ocp_nlp_dims_set_constraints(void *config_, void *dims_, int stage, const c
     // update qp_solver dims
     if ( (!strcmp(field, "nbx")) || (!strcmp(field, "nbu")) )
     {
-		// qp solver
+        // qp solver
         config->qp_solver->dims_set(config->qp_solver, dims->qp_solver, i, field, int_value);
 
-		// regularization
+        // regularization
         config->regularize->dims_set(config->regularize, dims->regularize, i, (char *) field, int_value);
     }
     else if ( (!strcmp(field, "nsbx")) || (!strcmp(field, "nsbu")) )
     {
-		// qp solver
+        // qp solver
         config->qp_solver->dims_set(config->qp_solver, dims->qp_solver, i, field, int_value);
     }
     else if ( (!strcmp(field, "ng")) || (!strcmp(field, "nh")) || (!strcmp(field, "nphi")))
@@ -594,10 +594,10 @@ void ocp_nlp_dims_set_constraints(void *config_, void *dims_, int stage, const c
         config->constraints[i]->dims_get(config->constraints[i], dims->constraints[i],
                                          "ng_qp_solver", &ng_qp_solver);
 
-		// qp solver
+        // qp solver
         config->qp_solver->dims_set(config->qp_solver, dims->qp_solver, i, "ng", &ng_qp_solver);
 
-		// regularization
+        // regularization
         config->regularize->dims_set(config->regularize, dims->regularize, i, "ng", &ng_qp_solver);
     }
     else if ( (!strcmp(field, "nsg")) || (!strcmp(field, "nsh")) || (!strcmp(field, "nsphi")))
@@ -606,12 +606,12 @@ void ocp_nlp_dims_set_constraints(void *config_, void *dims_, int stage, const c
         int nsg_qp_solver;
         config->constraints[i]->dims_get(config->constraints[i], dims->constraints[i], "nsg_qp_solver", &nsg_qp_solver);
 
-		// qp solver
+        // qp solver
         config->qp_solver->dims_set(config->qp_solver, dims->qp_solver, i, "nsg", &nsg_qp_solver);
     }
     else if ( (!strcmp(field, "nbxe")) || (!strcmp(field, "nbue")) )
     {
-		// qp solver
+        // qp solver
         config->qp_solver->dims_set(config->qp_solver, dims->qp_solver, i, field, int_value);
     }
     else if ( (!strcmp(field, "nge")) || (!strcmp(field, "nhe")) || (!strcmp(field, "nphie")))
@@ -621,11 +621,11 @@ void ocp_nlp_dims_set_constraints(void *config_, void *dims_, int stage, const c
         config->constraints[i]->dims_get(config->constraints[i], dims->constraints[i],
                                          "nge_qp_solver", &ng_qp_solver);
 
-		// qp solver
+        // qp solver
         config->qp_solver->dims_set(config->qp_solver, dims->qp_solver, i, "nge", &ng_qp_solver);
     }
 
-	return;
+    return;
 }
 
 
@@ -836,8 +836,8 @@ int ocp_nlp_out_calculate_size(ocp_nlp_config *config, ocp_nlp_dims *dims)
 
 ocp_nlp_out *ocp_nlp_out_assign(ocp_nlp_config *config, ocp_nlp_dims *dims, void *raw_memory)
 {
-	// loop index
-	int ii;
+    // loop index
+    int ii;
 
     // extract sizes
     int N = dims->N;
@@ -900,20 +900,20 @@ ocp_nlp_out *ocp_nlp_out_assign(ocp_nlp_config *config, ocp_nlp_dims *dims, void
         assign_and_advance_blasfeo_dvec_mem(2 * ni[ii], out->t + ii, &c_ptr);
     }
 
-	// zero solution
-	for(ii=0; ii<N; ii++)
-	{
-		blasfeo_dvecse(nv[ii], 0.0, out->ux+ii, 0);
-		blasfeo_dvecse(nz[ii], 0.0, out->z+ii, 0);
-		blasfeo_dvecse(nx[ii+1], 0.0, out->pi+ii, 0);
-		blasfeo_dvecse(2*ni[ii], 0.0, out->lam+ii, 0);
-		blasfeo_dvecse(2*ni[ii], 0.0, out->t+ii, 0);
-	}
-	ii = N;
-	blasfeo_dvecse(nv[ii], 0.0, out->ux+ii, 0);
-	blasfeo_dvecse(nz[ii], 0.0, out->z+ii, 0);
-	blasfeo_dvecse(2*ni[ii], 0.0, out->lam+ii, 0);
-	blasfeo_dvecse(2*ni[ii], 0.0, out->t+ii, 0);
+    // zero solution
+    for(ii=0; ii<N; ii++)
+    {
+        blasfeo_dvecse(nv[ii], 0.0, out->ux+ii, 0);
+        blasfeo_dvecse(nz[ii], 0.0, out->z+ii, 0);
+        blasfeo_dvecse(nx[ii+1], 0.0, out->pi+ii, 0);
+        blasfeo_dvecse(2*ni[ii], 0.0, out->lam+ii, 0);
+        blasfeo_dvecse(2*ni[ii], 0.0, out->t+ii, 0);
+    }
+    ii = N;
+    blasfeo_dvecse(nv[ii], 0.0, out->ux+ii, 0);
+    blasfeo_dvecse(nz[ii], 0.0, out->z+ii, 0);
+    blasfeo_dvecse(2*ni[ii], 0.0, out->lam+ii, 0);
+    blasfeo_dvecse(2*ni[ii], 0.0, out->t+ii, 0);
 
     assert((char *) raw_memory + ocp_nlp_out_calculate_size(config, dims) >= c_ptr);
 
@@ -1236,10 +1236,10 @@ void ocp_nlp_opts_set_at_stage(void *config_, void *opts_, int stage, const char
         config->constraints[stage]->opts_set( config->constraints[stage], opts->constraints[stage],
                                               (char *) field+module_length+1, value);
     }
-	else
-	{
-		printf("\nerror: ocp_nlp_opts_set_at_stage: wrong field: %s\n", field);
-		exit(1);
+    else
+    {
+        printf("\nerror: ocp_nlp_opts_set_at_stage: wrong field: %s\n", field);
+        exit(1);
     }
 
     return;
@@ -1310,16 +1310,16 @@ int ocp_nlp_memory_calculate_size(ocp_nlp_config *config, ocp_nlp_dims *dims, oc
 
     for (int ii = 0; ii < N; ii++)
     {
-		size += 1*blasfeo_memsize_dmat(nu[ii]+nx[ii], nz[ii]); // dzduxt
-		size += 1*blasfeo_memsize_dvec(nz[ii]); // z_alg
+        size += 1*blasfeo_memsize_dmat(nu[ii]+nx[ii], nz[ii]); // dzduxt
+        size += 1*blasfeo_memsize_dvec(nz[ii]); // z_alg
         size += 2*blasfeo_memsize_dvec(nv[ii]);           // cost_grad ineq_adj
         size += 1*blasfeo_memsize_dvec(nu[ii] + nx[ii]);  // dyn_adj
         size += 1*blasfeo_memsize_dvec(nx[ii + 1]);       // dyn_fun
         size += 1*blasfeo_memsize_dvec(2 * ni[ii]);       // ineq_fun
         size += 1*blasfeo_memsize_dvec(nx[ii] + nz[ii]); // sim_guess
     }
-	size += 1*blasfeo_memsize_dmat(nu[N]+nx[N], nz[N]); // dzduxt
-	size += 1*blasfeo_memsize_dvec(nz[N]); // z_alg
+    size += 1*blasfeo_memsize_dmat(nu[N]+nx[N], nz[N]); // dzduxt
+    size += 1*blasfeo_memsize_dvec(nz[N]); // z_alg
     size += 2*blasfeo_memsize_dvec(nv[N]);          // cost_grad ineq_adj
     size += 1*blasfeo_memsize_dvec(nu[N] + nx[N]);  // dyn_adj
     size += 1*blasfeo_memsize_dvec(2 * ni[N]);      // ineq_fun
@@ -1493,7 +1493,7 @@ ocp_nlp_memory *ocp_nlp_memory_assign(ocp_nlp_config *config, ocp_nlp_dims *dims
     {
         assign_and_advance_blasfeo_dvec_mem(nx[ii] + nz[ii], mem->sim_guess + ii, &c_ptr);
         // set to 0;
-		blasfeo_dvecse(nx[ii] + nz[ii], 0.0, mem->sim_guess+ii, 0);
+        blasfeo_dvecse(nx[ii] + nz[ii], 0.0, mem->sim_guess+ii, 0);
         // printf("sim_guess ii %d: %p\n", ii, mem->sim_guess+ii);
     }
     // printf("created memory %p\n", mem);
@@ -1528,11 +1528,11 @@ int ocp_nlp_workspace_calculate_size(ocp_nlp_config *config, ocp_nlp_dims *dims,
     // nlp
     size += sizeof(ocp_nlp_workspace);
 
-	// tmp_nlp_out
-	size += ocp_nlp_out_calculate_size(config, dims);
+    // tmp_nlp_out
+    size += ocp_nlp_out_calculate_size(config, dims);
 
-	// weights_nlp_out
-	size += ocp_nlp_out_calculate_size(config, dims);
+    // weights_nlp_out
+    size += ocp_nlp_out_calculate_size(config, dims);
 
     // array of pointers
     // cost
@@ -1542,7 +1542,7 @@ int ocp_nlp_workspace_calculate_size(ocp_nlp_config *config, ocp_nlp_dims *dims,
     // constraints
     size += (N+1)*sizeof(void *);
 
-	// module workspace
+    // module workspace
     if (opts->reuse_workspace)
     {
 
@@ -1648,16 +1648,16 @@ ocp_nlp_workspace *ocp_nlp_workspace_assign(ocp_nlp_config *config, ocp_nlp_dims
 
     char *c_ptr = (char *) raw_memory;
 
-	ocp_nlp_workspace *work = (ocp_nlp_workspace *) c_ptr;
+    ocp_nlp_workspace *work = (ocp_nlp_workspace *) c_ptr;
     c_ptr += sizeof(ocp_nlp_workspace);
 
-	// tmp_nlp_out
-	work->tmp_nlp_out = ocp_nlp_out_assign(config, dims, c_ptr);
-	c_ptr += ocp_nlp_out_calculate_size(config, dims);
+    // tmp_nlp_out
+    work->tmp_nlp_out = ocp_nlp_out_assign(config, dims, c_ptr);
+    c_ptr += ocp_nlp_out_calculate_size(config, dims);
 
-	// weights_nlp_out
-	work->weights_nlp_out = ocp_nlp_out_assign(config, dims, c_ptr);
-	c_ptr += ocp_nlp_out_calculate_size(config, dims);
+    // weights_nlp_out
+    work->weights_nlp_out = ocp_nlp_out_assign(config, dims, c_ptr);
+    c_ptr += ocp_nlp_out_calculate_size(config, dims);
 
     // array of pointers
     //
@@ -1796,14 +1796,14 @@ void ocp_nlp_initialize_qp(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_i
     {
         // cost
         config->cost[ii]->initialize(config->cost[ii], dims->cost[ii], in->cost[ii],
-        		opts->cost[ii], mem->cost[ii], work->cost[ii]);
+                opts->cost[ii], mem->cost[ii], work->cost[ii]);
         // dynamics
         if (ii < N)
             config->dynamics[ii]->initialize(config->dynamics[ii], dims->dynamics[ii],
-            		in->dynamics[ii], opts->dynamics[ii], mem->dynamics[ii], work->dynamics[ii]);
+                    in->dynamics[ii], opts->dynamics[ii], mem->dynamics[ii], work->dynamics[ii]);
         // constraints
         config->constraints[ii]->initialize(config->constraints[ii], dims->constraints[ii],
-        		in->constraints[ii], opts->constraints[ii], mem->constraints[ii], work->constraints[ii]);
+                in->constraints[ii], opts->constraints[ii], mem->constraints[ii], work->constraints[ii]);
     }
 
     return;
@@ -1986,15 +1986,15 @@ double ocp_nlp_evaluate_merit_fun(ocp_nlp_config *config, ocp_nlp_dims *dims,
                                   ocp_nlp_memory *mem, ocp_nlp_workspace *work)
 {
 
-	int i, j;
+    int i, j;
 
-	int N = dims->N;
-	int *nx = dims->nx;
-	int *ni = dims->ni;
+    int N = dims->N;
+    int *nx = dims->nx;
+    int *ni = dims->ni;
 
-	double merit_fun = 0.0;
+    double merit_fun = 0.0;
 
-	// compute fun value
+    // compute fun value
 #if defined(ACADOS_WITH_OPENMP)
     #pragma omp parallel for
 #endif
@@ -2022,52 +2022,52 @@ double ocp_nlp_evaluate_merit_fun(ocp_nlp_config *config, ocp_nlp_dims *dims,
                                             mem->constraints[i], work->constraints[i]);
     }
 
-	double *tmp_fun;
-	double tmp;
-	struct blasfeo_dvec *tmp_fun_vec;
+    double *tmp_fun;
+    double tmp;
+    struct blasfeo_dvec *tmp_fun_vec;
 
-	double cost_fun = 0.0;
-	for(i=0; i<=N; i++)
-	{
-		tmp_fun = config->cost[i]->memory_get_fun_ptr(mem->cost[i]);
-		cost_fun += *tmp_fun;
-	}
+    double cost_fun = 0.0;
+    for(i=0; i<=N; i++)
+    {
+        tmp_fun = config->cost[i]->memory_get_fun_ptr(mem->cost[i]);
+        cost_fun += *tmp_fun;
+    }
 
-	double dyn_fun = 0.0;
-	for(i=0; i<N; i++)
-	{
-//		printf("\ni %d\n", i);
-		tmp_fun_vec = config->dynamics[i]->memory_get_fun_ptr(mem->dynamics[i]);
-//		blasfeo_print_exp_tran_dvec(nx[i+1], tmp_fun_vec, 0);
-//		blasfeo_print_exp_tran_dvec(nx[i+1], work->weights_nlp_out->pi+i, 0);
-		for(j=0; j<nx[i+1]; j++)
-		{
-//			printf("\n%e %e\n", fabs(BLASFEO_DVECEL(work->weights_nlp_out->pi+i, j)), fabs(BLASFEO_DVECEL(tmp_fun_vec, j)));
-			dyn_fun += fabs(BLASFEO_DVECEL(work->weights_nlp_out->pi+i, j)) * fabs(BLASFEO_DVECEL(tmp_fun_vec, j));
-		}
-	}
+    double dyn_fun = 0.0;
+    for(i=0; i<N; i++)
+    {
+//        printf("\ni %d\n", i);
+        tmp_fun_vec = config->dynamics[i]->memory_get_fun_ptr(mem->dynamics[i]);
+//        blasfeo_print_exp_tran_dvec(nx[i+1], tmp_fun_vec, 0);
+//        blasfeo_print_exp_tran_dvec(nx[i+1], work->weights_nlp_out->pi+i, 0);
+        for(j=0; j<nx[i+1]; j++)
+        {
+//            printf("\n%e %e\n", fabs(BLASFEO_DVECEL(work->weights_nlp_out->pi+i, j)), fabs(BLASFEO_DVECEL(tmp_fun_vec, j)));
+            dyn_fun += fabs(BLASFEO_DVECEL(work->weights_nlp_out->pi+i, j)) * fabs(BLASFEO_DVECEL(tmp_fun_vec, j));
+        }
+    }
 
-	double constr_fun = 0.0;
-	for(i=0; i<=N; i++)
-	{
-//		printf("\ni %d\n", i);
-		tmp_fun_vec = config->constraints[i]->memory_get_fun_ptr(mem->constraints[i]);
-//		blasfeo_print_exp_tran_dvec(2*ni[i], tmp_fun_vec, 0);
-//		blasfeo_print_exp_tran_dvec(2*ni[i], work->weights_nlp_out->lam+i, 0);
-		for(j=0; j<2*ni[i]; j++)
-		{
-			tmp = BLASFEO_DVECEL(tmp_fun_vec, j);
-			tmp = tmp>0.0 ? tmp : 0.0;
-//			printf("\n%e %e\n", fabs(BLASFEO_DVECEL(work->weights_nlp_out->pi+i, j)), fabs(BLASFEO_DVECEL(tmp_fun_vec, j)));
-			constr_fun += fabs(BLASFEO_DVECEL(work->weights_nlp_out->lam+i, j)) * tmp;
-		}
-	}
+    double constr_fun = 0.0;
+    for(i=0; i<=N; i++)
+    {
+//        printf("\ni %d\n", i);
+        tmp_fun_vec = config->constraints[i]->memory_get_fun_ptr(mem->constraints[i]);
+//        blasfeo_print_exp_tran_dvec(2*ni[i], tmp_fun_vec, 0);
+//        blasfeo_print_exp_tran_dvec(2*ni[i], work->weights_nlp_out->lam+i, 0);
+        for(j=0; j<2*ni[i]; j++)
+        {
+            tmp = BLASFEO_DVECEL(tmp_fun_vec, j);
+            tmp = tmp>0.0 ? tmp : 0.0;
+//            printf("\n%e %e\n", fabs(BLASFEO_DVECEL(work->weights_nlp_out->pi+i, j)), fabs(BLASFEO_DVECEL(tmp_fun_vec, j)));
+            constr_fun += fabs(BLASFEO_DVECEL(work->weights_nlp_out->lam+i, j)) * tmp;
+        }
+    }
 
-	merit_fun = cost_fun + dyn_fun + constr_fun;
+    merit_fun = cost_fun + dyn_fun + constr_fun;
 
-	printf("\n%e %e %e %e\n", merit_fun, cost_fun, dyn_fun, constr_fun);
+    printf("\n%e %e %e %e\n", merit_fun, cost_fun, dyn_fun, constr_fun);
 
-	return merit_fun;
+    return merit_fun;
 }
 
 
@@ -2086,21 +2086,21 @@ void ocp_nlp_update_variables_sqp(ocp_nlp_config *config, ocp_nlp_dims *dims, oc
 
     // ocp_nlp_config *config = (ocp_nlp_config *) config_;
 
-	// (fixed) step length
+    // (fixed) step length
     double alpha = opts->step_length;
 
 #if 0 // XXX test piece of code
-	double tmp0, tmp1;
+    double tmp0, tmp1;
 
-	// current point
+    // current point
     for (i = 0; i <= N; i++)
         blasfeo_dveccp(nv[i], out->ux+i, 0, work->tmp_nlp_out->ux+i, 0);
     
-	for (i = 0; i < N; i++)
-		blasfeo_dveccp(nx[i+1], out->pi+i, 0, work->tmp_nlp_out->pi+i, 0);
+    for (i = 0; i < N; i++)
+        blasfeo_dveccp(nx[i+1], out->pi+i, 0, work->tmp_nlp_out->pi+i, 0);
 
-	for (i = 0; i <= N; i++)
-		blasfeo_dveccp(2*ni[i], out->lam+i, 0, work->tmp_nlp_out->lam+i, 0);
+    for (i = 0; i <= N; i++)
+        blasfeo_dveccp(2*ni[i], out->lam+i, 0, work->tmp_nlp_out->lam+i, 0);
 
         // linear update of algebraic variables using state and input sensitivity
 //        if (i < N)
@@ -2108,62 +2108,61 @@ void ocp_nlp_update_variables_sqp(ocp_nlp_config *config, ocp_nlp_dims *dims, oc
 //            blasfeo_dgemv_t(nu[i]+nx[i], nz[i], alpha, mem->dzduxt+i, 0, 0, mem->qp_out->ux+i, 0, 1.0, mem->z_alg+i, 0, out->z+i, 0); 
 //        }
 
-	// initialize weights
-	if(mem->sqp_iter[0]==0)
-	{
-		for (i = 0; i < N; i++)
-			blasfeo_dveccp(nx[i+1], out->pi+i, 0, work->weights_nlp_out->pi+i, 0);
+    // initialize weights
+    if(mem->sqp_iter[0]==0)
+    {
+        for (i = 0; i < N; i++)
+            blasfeo_dveccp(nx[i+1], out->pi+i, 0, work->weights_nlp_out->pi+i, 0);
 
-		for (i = 0; i <= N; i++)
-			blasfeo_dveccp(2*ni[i], out->lam+i, 0, work->weights_nlp_out->lam+i, 0);
-	}
+        for (i = 0; i <= N; i++)
+            blasfeo_dveccp(2*ni[i], out->lam+i, 0, work->weights_nlp_out->lam+i, 0);
+    }
 
-	// update weigths
-	for (i = 0; i < N; i++)
-	{
-		for(j=0; j<nx[i+1]; j++)
-		{
-			tmp0 = fabs(BLASFEO_DVECEL(work->weights_nlp_out->pi+i, j));
-			tmp1 = 0.5 * (tmp0 + fabs(BLASFEO_DVECEL(mem->qp_out->pi+i, j)));
-			BLASFEO_DVECEL(work->weights_nlp_out->pi+i, j) = tmp0>tmp1 ? tmp0 : tmp1;
-		}
-	}
-	for (i = 0; i <= N; i++)
-	{
-		for(j=0; j<2*ni[i]; j++)
-		{
-			tmp0 = fabs(BLASFEO_DVECEL(work->weights_nlp_out->lam+i, j));
-			tmp1 = 0.5 * (tmp0 + fabs(BLASFEO_DVECEL(mem->qp_out->lam+i, j)));
-			BLASFEO_DVECEL(work->weights_nlp_out->lam+i, j) = tmp0>tmp1 ? tmp0 : tmp1;
-		}
-	}
+    // update weigths
+    for (i = 0; i < N; i++)
+    {
+        for(j=0; j<nx[i+1]; j++)
+        {
+            tmp0 = fabs(BLASFEO_DVECEL(work->weights_nlp_out->pi+i, j));
+            tmp1 = 0.5 * (tmp0 + fabs(BLASFEO_DVECEL(mem->qp_out->pi+i, j)));
+            BLASFEO_DVECEL(work->weights_nlp_out->pi+i, j) = tmp0>tmp1 ? tmp0 : tmp1;
+        }
+    }
+    for (i = 0; i <= N; i++)
+    {
+        for(j=0; j<2*ni[i]; j++)
+        {
+            tmp0 = fabs(BLASFEO_DVECEL(work->weights_nlp_out->lam+i, j));
+            tmp1 = 0.5 * (tmp0 + fabs(BLASFEO_DVECEL(mem->qp_out->lam+i, j)));
+            BLASFEO_DVECEL(work->weights_nlp_out->lam+i, j) = tmp0>tmp1 ? tmp0 : tmp1;
+        }
+    }
 
-	printf("\n\nmerit fun value\n");
-	double merit_fun0 = ocp_nlp_evaluate_merit_fun(config, dims, in, out, opts, mem, work);
+    printf("\n\nmerit fun value\n");
+    double merit_fun0 = ocp_nlp_evaluate_merit_fun(config, dims, in, out, opts, mem, work);
 
-	double alpha_min = 0.2;
+    double alpha_min = 0.2;
 
-	for (j=0; j<10 & alpha>alpha_min; j++)
-	{
+    for (j=0; j<10 & alpha>alpha_min; j++)
+    {
 
-		for (i = 0; i <= N; i++)
-			blasfeo_daxpy(nv[i], alpha, mem->qp_out->ux+i, 0, out->ux+i, 0, work->tmp_nlp_out->ux+i, 0);
+        for (i = 0; i <= N; i++)
+            blasfeo_daxpy(nv[i], alpha, mem->qp_out->ux+i, 0, out->ux+i, 0, work->tmp_nlp_out->ux+i, 0);
 
-		printf("\n%d tmp merit fun value\n", j);
-		double merit_fun1 = ocp_nlp_evaluate_merit_fun(config, dims, in, out, opts, mem, work);
+        printf("\n%d tmp merit fun value\n", j);
+        double merit_fun1 = ocp_nlp_evaluate_merit_fun(config, dims, in, out, opts, mem, work);
 
-		if(merit_fun1 < merit_fun0)
-		{
-			break;
-		}
-		else
-		{
-			alpha *= 0.7;
-		}
-	
-	}
+        if(merit_fun1 < merit_fun0)
+        {
+            break;
+        }
+        else
+        {
+            alpha *= 0.7;
+        }
+    }
 
-	printf("\nalpha %f\n", alpha);
+    printf("\nalpha %f\n", alpha);
 
 #endif
 

--- a/acados/ocp_nlp/ocp_nlp_common.c
+++ b/acados/ocp_nlp/ocp_nlp_common.c
@@ -2116,7 +2116,7 @@ double ocp_nlp_evaluate_merit_fun(ocp_nlp_config *config, ocp_nlp_dims *dims,
 
     merit_fun = cost_fun + dyn_fun + constr_fun;
 
-	printf("\nMerit fun: %e cost: %e dyn: %e constr: %e\n", merit_fun, cost_fun, dyn_fun, constr_fun);
+	// printf("\nMerit fun: %e cost: %e dyn: %e constr: %e\n", merit_fun, cost_fun, dyn_fun, constr_fun);
 
     return merit_fun;
 }
@@ -2238,14 +2238,14 @@ static double ocp_nlp_line_search(ocp_nlp_config *config, ocp_nlp_dims *dims, oc
         {
             // TODO: take abs() as in Leineweber
             // initialize weights
-            printf("merit fun: initialize weights pi\n");
+            // printf("merit fun: initialize weights pi\n");
             for (i = 0; i < N; i++)
             {
                 blasfeo_dveccp(nx[i+1], out->pi+i, 0, work->weight_merit_fun->pi+i, 0);
                 // blasfeo_print_dvec(nx[i+1], work->weight_merit_fun->pi+i, 0);
             }
 
-            printf("merit fun: initialize weights lam\n");
+            // printf("merit fun: initialize weights lam\n");
             for (i = 0; i <= N; i++)
             {
                 blasfeo_dveccp(2*ni[i], out->lam+i, 0, work->weight_merit_fun->lam+i, 0);
@@ -2295,7 +2295,7 @@ static double ocp_nlp_line_search(ocp_nlp_config *config, ocp_nlp_dims *dims, oc
                 for (i = 0; i <= N; i++)
                     blasfeo_daxpy(nv[i], alpha, mem->qp_out->ux+i, 0, out->ux+i, 0, work->tmp_nlp_out->ux+i, 0);
 
-                printf("\ntmp merit fun value step search iter: %d", j);
+                // printf("\ntmp merit fun value step search iter: %d", j);
                 double merit_fun1 = ocp_nlp_evaluate_merit_fun(config, dims, in, out, opts, mem, work);
 
                 if(merit_fun1 < merit_fun0)

--- a/acados/ocp_nlp/ocp_nlp_common.c
+++ b/acados/ocp_nlp/ocp_nlp_common.c
@@ -1154,7 +1154,6 @@ void ocp_nlp_opts_set(void *config_, void *opts_, const char *field, void* value
         config->qp_solver->opts_set(config->qp_solver, opts->qp_solver_opts,
                                     field+module_length+1, value);
     }
-    // pass options to dynamics module
     else // nlp opts
     {
         if (!strcmp(field, "reuse_workspace"))
@@ -1203,10 +1202,33 @@ void ocp_nlp_opts_set(void *config_, void *opts_, const char *field, void* value
                 config->cost[ii]->opts_set(config->cost[ii], opts->cost[ii], "exact_hess", value);
             // dynamics
             for (ii=0; ii<N; ii++)
-                config->dynamics[ii]->opts_set(config->dynamics[ii], opts->dynamics[ii], "compute_hess", value);
+                config->dynamics[ii]->opts_set(config->dynamics[ii], opts->dynamics[ii],
+                                               "compute_hess", value);
             // constraints
             for (ii=0; ii<=N; ii++)
-                config->constraints[ii]->opts_set(config->constraints[ii], opts->constraints[ii], "compute_hess", value);
+                config->constraints[ii]->opts_set(config->constraints[ii], opts->constraints[ii],
+                                                  "compute_hess", value);
+        }
+        // selectively turn on exact hessian contributions
+        else if (!strcmp(field, "exact_hess_cost"))
+        {
+            int N = config->N;
+            for (ii=0; ii<=N; ii++)
+                config->cost[ii]->opts_set(config->cost[ii], opts->cost[ii], "exact_hess", value);
+        }
+        else if (!strcmp(field, "exact_hess_dyn"))
+        {
+            int N = config->N;
+            for (ii=0; ii<N; ii++)
+                config->dynamics[ii]->opts_set(config->dynamics[ii], opts->dynamics[ii],
+                                               "compute_hess", value);
+        }
+        else if (!strcmp(field, "exact_hess_constr"))
+        {
+            int N = config->N;
+            for (ii=0; ii<=N; ii++)
+                config->constraints[ii]->opts_set(config->constraints[ii], opts->constraints[ii],
+                                                  "compute_hess", value);
         }
         else
         {

--- a/acados/ocp_nlp/ocp_nlp_common.h
+++ b/acados/ocp_nlp/ocp_nlp_common.h
@@ -246,14 +246,22 @@ ocp_nlp_out *ocp_nlp_out_assign(ocp_nlp_config *config, ocp_nlp_dims *dims,
  * options
  ************************************************/
 
+/// Globalization types
+typedef enum
+{
+    FIXED_STEP,
+    MERIT_BACKTRACKING,
+} ocp_nlp_globalization_t;
+
 typedef struct
 {
+    ocp_nlp_globalization_t globalization;
     ocp_qp_xcond_solver_opts *qp_solver_opts; // xcond solver opts instead ???
     void *regularize;
     void **dynamics;     // dynamics_opts
     void **cost;         // cost_opts
     void **constraints;  // constraints_opts
-    double step_length;  // (fixed) step length in SQP loop
+    double step_length;  // step length in case of FIXED_STEP
     int reuse_workspace;
     int num_threads;
 

--- a/acados/ocp_nlp/ocp_nlp_common.h
+++ b/acados/ocp_nlp/ocp_nlp_common.h
@@ -329,7 +329,7 @@ typedef struct
     void **constraints;  // constraints_workspace
 
 	ocp_nlp_out *tmp_nlp_out;
-	ocp_nlp_out *weights_nlp_out;
+	ocp_nlp_out *weight_merit_fun;
 
 } ocp_nlp_workspace;
 

--- a/acados/ocp_nlp/ocp_nlp_constraints_bgh.c
+++ b/acados/ocp_nlp/ocp_nlp_constraints_bgh.c
@@ -1453,7 +1453,7 @@ void ocp_nlp_constraints_bgh_compute_fun(void *config_, void *dims_, void *model
 
         if (model->nl_constr_h_fun == 0)
         {
-            printf("constraints BGH: nl_constr_h_fun is not provided. Exiting.");
+            printf("ocp_nlp_constraints_bgh_compute_fun: nl_constr_h_fun is not provided. Exiting.\n");
             exit(1);
         }
         model->nl_constr_h_fun->evaluate(model->nl_constr_h_fun, ext_fun_type_in, ext_fun_in, ext_fun_type_out, ext_fun_out);

--- a/acados/ocp_nlp/ocp_nlp_constraints_bgp.c
+++ b/acados/ocp_nlp/ocp_nlp_constraints_bgp.c
@@ -1436,6 +1436,11 @@ void ocp_nlp_constraints_bgp_compute_fun(void *config_, void *dims_, void *model
 		ext_fun_type_out[0] = BLASFEO_DVEC_ARGS;
 		ext_fun_out[0] = &fun_out;  // fun: nphi
 
+        if (model->nl_constr_phi_o_r_fun == 0)
+        {
+            printf("ocp_nlp_constraints_bgp_compute_fun: nl_constr_phi_o_r_fun is not provided. Exiting.\n");
+            exit(1);
+        }
 		model->nl_constr_phi_o_r_fun->evaluate(model->nl_constr_phi_o_r_fun, ext_fun_type_in, ext_fun_in, ext_fun_type_out, ext_fun_out);
 	}
 

--- a/acados/ocp_nlp/ocp_nlp_cost_external.c
+++ b/acados/ocp_nlp/ocp_nlp_cost_external.c
@@ -683,6 +683,11 @@ void ocp_nlp_cost_external_compute_fun(void *config_, void *dims_, void *model_,
     ext_fun_out[0] = &memory->fun;  // function: scalar
 
     // evaluate external function
+    if (model->ext_cost_fun == 0)
+    {
+        printf("ocp_nlp_cost_external_compute_fun: ext_cost_fun is not provided. Exiting.\n");
+        exit(1);
+    }
     model->ext_cost_fun->evaluate(model->ext_cost_fun, ext_fun_type_in, ext_fun_in,
                                   ext_fun_type_out, ext_fun_out);
 

--- a/acados/ocp_nlp/ocp_nlp_cost_ls.c
+++ b/acados/ocp_nlp/ocp_nlp_cost_ls.c
@@ -239,6 +239,7 @@ int ocp_nlp_cost_ls_model_calculate_size(void *config_, void *dims_)
     size += 1 * blasfeo_memsize_dmat(nz, ny);           // Vz
     size += 1 * blasfeo_memsize_dvec(ny);               // y_ref
     size += 2 * blasfeo_memsize_dvec(2 * ns);           // Z, z
+    make_int_multiple_of(8, &size);
 
     return size;
 }

--- a/acados/ocp_nlp/ocp_nlp_cost_nls.c
+++ b/acados/ocp_nlp/ocp_nlp_cost_nls.c
@@ -859,6 +859,11 @@ void ocp_nlp_cost_nls_compute_fun(void *config_, void *dims_, void *model_,
     ext_fun_type_out[0] = BLASFEO_DVEC;
     ext_fun_out[0] = &memory->res;  // fun: ny
 
+    if (model->nls_y_fun == 0)
+    {
+        printf("ocp_nlp_cost_nls_compute_fun: nls_y_fun is not provided. Exiting.\n");
+        exit(1);
+    }
     // evaluate external function
     model->nls_y_fun->evaluate(model->nls_y_fun, ext_fun_type_in, ext_fun_in,
                              ext_fun_type_out, ext_fun_out);

--- a/acados/ocp_nlp/ocp_nlp_dynamics_cont.c
+++ b/acados/ocp_nlp/ocp_nlp_dynamics_cont.c
@@ -904,8 +904,6 @@ void ocp_nlp_dynamics_cont_compute_fun(void *config_, void *dims_, void *model_,
     config->sim_solver->opts_set(config->sim_solver, opts->sim_solver, "sens_adj", &sens_adj_bkp);
     config->sim_solver->opts_set(config->sim_solver, opts->sim_solver, "sens_hess", &sens_hess_bkp);
 
-    // TODO transition functions for changing dimensions not yet implemented!
-
     // function
     blasfeo_pack_dvec(nx1, work->sim_out->xn, &mem->fun, 0);
     blasfeo_daxpy(nx1, -1.0, mem->tmp_ux1, nu1, &mem->fun, 0, &mem->fun, 0);

--- a/acados/ocp_nlp/ocp_nlp_dynamics_cont.c
+++ b/acados/ocp_nlp/ocp_nlp_dynamics_cont.c
@@ -876,14 +876,13 @@ void ocp_nlp_dynamics_cont_compute_fun(void *config_, void *dims_, void *model_,
 
     if (mem->set_sim_guess!=NULL && mem->set_sim_guess[0])
     {
-        config->sim_solver->memory_set(config->sim_solver, work->sim_in->dims, mem->sim_solver, "guesses_blasfeo", mem->sim_guess);
+        config->sim_solver->memory_set(config->sim_solver, work->sim_in->dims, mem->sim_solver,
+                                       "guesses_blasfeo", mem->sim_guess);
         // only use/pass the initial guess once
         mem->set_sim_guess[0] = false;
     }
 
-	// TODO get opts for sens as backup, and set them to false
-
-	// backup sens
+	// backup sens options
 	bool sens_forw_bkp, sens_adj_bkp, sens_hess_bkp;
     config->sim_solver->opts_get(config->sim_solver, opts->sim_solver, "sens_forw", &sens_forw_bkp);
     config->sim_solver->opts_get(config->sim_solver, opts->sim_solver, "sens_adj", &sens_adj_bkp);
@@ -899,13 +898,14 @@ void ocp_nlp_dynamics_cont_compute_fun(void *config_, void *dims_, void *model_,
     config->sim_solver->evaluate(config->sim_solver, work->sim_in, work->sim_out, opts->sim_solver,
             mem->sim_solver, work->sim_solver);
 
-	// restore sens
+	// restore sens options
     config->sim_solver->opts_set(config->sim_solver, opts->sim_solver, "sens_forw", &sens_forw_bkp);
     config->sim_solver->opts_set(config->sim_solver, opts->sim_solver, "sens_adj", &sens_adj_bkp);
     config->sim_solver->opts_set(config->sim_solver, opts->sim_solver, "sens_hess", &sens_hess_bkp);
 
     // function
     blasfeo_pack_dvec(nx1, work->sim_out->xn, &mem->fun, 0);
+    // fun -= x[next_stage]
     blasfeo_daxpy(nx1, -1.0, mem->tmp_ux1, nu1, &mem->fun, 0, &mem->fun, 0);
 //    blasfeo_pack_dvec(nz, work->sim_out->zn, mem->z_alg, 0);
 

--- a/acados/ocp_nlp/ocp_nlp_dynamics_cont.c
+++ b/acados/ocp_nlp/ocp_nlp_dynamics_cont.c
@@ -365,6 +365,8 @@ int ocp_nlp_dynamics_cont_memory_calculate_size(void *config_, void *dims_, void
 
     size += 1*64;  // blasfeo_mem align
 
+    make_int_multiple_of(8, &size);
+
     return size;
 }
 
@@ -599,6 +601,7 @@ int ocp_nlp_dynamics_cont_workspace_calculate_size(void *config_, void *dims_, v
     size += 1 * blasfeo_memsize_dmat(nu+nx, nu+nx);   // hess
 
     size += 1*64;  // blasfeo_mem align
+    make_int_multiple_of(8, &size);
 
     return size;
 }
@@ -661,6 +664,8 @@ int ocp_nlp_dynamics_cont_model_calculate_size(void *config_, void *dims_)
     size += sizeof(ocp_nlp_dynamics_cont_model);
 
     size += config->sim_solver->model_calculate_size(config->sim_solver, dims->sim);
+    size += 1*8;
+    make_int_multiple_of(8, &size);
 
     return size;
 }
@@ -681,6 +686,7 @@ void *ocp_nlp_dynamics_cont_model_assign(void *config_, void *dims_, void *raw_m
     // struct
     ocp_nlp_dynamics_cont_model *model = (ocp_nlp_dynamics_cont_model *) c_ptr;
     c_ptr += sizeof(ocp_nlp_dynamics_cont_model);
+    align_char_to(8, &c_ptr);
 
     model->sim_model = config->sim_solver->model_assign(config->sim_solver, dims->sim, c_ptr);
     c_ptr += config->sim_solver->model_calculate_size(config->sim_solver, dims->sim);

--- a/acados/ocp_nlp/ocp_nlp_sqp.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp.c
@@ -326,7 +326,7 @@ int ocp_nlp_sqp_memory_calculate_size(void *config_, void *dims_, void *opts_)
         stat_n += 4;
     size += stat_n*stat_m*sizeof(double);
 
-    size += 8;  // initial align
+    size += 3*8;  // align
 
     make_int_multiple_of(8, &size);
 
@@ -360,6 +360,8 @@ void *ocp_nlp_sqp_memory_assign(void *config_, void *dims_, void *opts_, void *r
     ocp_nlp_sqp_memory *mem = (ocp_nlp_sqp_memory *) c_ptr;
     c_ptr += sizeof(ocp_nlp_sqp_memory);
 
+    align_char_to(8, &c_ptr);
+
     // nlp res
     mem->nlp_res = ocp_nlp_res_assign(dims, c_ptr);
     c_ptr += mem->nlp_res->memsize;
@@ -377,6 +379,8 @@ void *ocp_nlp_sqp_memory_assign(void *config_, void *dims_, void *opts_, void *r
     c_ptr += mem->stat_m*mem->stat_n*sizeof(double);
 
     mem->status = ACADOS_READY;
+
+    align_char_to(8, &c_ptr);
 
     assert((char *) raw_memory + ocp_nlp_sqp_memory_calculate_size(config, dims, opts) >= c_ptr);
 

--- a/acados/ocp_qp/ocp_qp_hpipm.c
+++ b/acados/ocp_qp/ocp_qp_hpipm.c
@@ -64,6 +64,8 @@ int ocp_qp_hpipm_opts_calculate_size(void *config_, void *dims_)
     size += d_ocp_qp_ipm_arg_memsize(dims);
 
     size += 1 * 8;
+    make_int_multiple_of(8, &size);
+
     return size;
 }
 
@@ -155,6 +157,8 @@ int ocp_qp_hpipm_memory_calculate_size(void *config_, void *dims_, void *opts_)
     size += d_ocp_qp_ipm_ws_memsize(dims, opts->hpipm_opts);
 
     size += 1 * 8;
+    make_int_multiple_of(8, &size);
+
     return size;
 }
 

--- a/acados/ocp_qp/ocp_qp_partial_condensing.c
+++ b/acados/ocp_qp/ocp_qp_partial_condensing.c
@@ -361,6 +361,7 @@ int ocp_qp_partial_condensing_memory_calculate_size(void *dims_, void *opts_)
     size += d_ocp_qp_reduce_eq_dof_work_memsize(dims->orig_dims);
 
     size += 2*8;
+    make_int_multiple_of(8, &size);
 
     return size;
 }

--- a/acados/sim/sim_erk_integrator.c
+++ b/acados/sim/sim_erk_integrator.c
@@ -823,6 +823,11 @@ int sim_erk(void *config_, sim_in *in, sim_out *out, void *opts_, void *mem_, vo
                 ext_fun_type_out[0] = COLMAJ;
                 ext_fun_out[0] = K_traj + s * nX + 0;  // fun: nx
 
+                if (model->expl_ode_fun == 0)
+                {
+                    printf("sim ERK: expl_ode_fun is not provided. Exiting.\n");
+                    exit(1);
+                }
                 model->expl_ode_fun->evaluate(model->expl_ode_fun, ext_fun_type_in, ext_fun_in,
                                               ext_fun_type_out, ext_fun_out);  // ODE evaluation
             }
@@ -935,6 +940,11 @@ int sim_erk(void *config_, sim_in *in, sim_out *out, void *opts_, void *mem_, vo
 //                    ext_fun_type_out[1] = COLMAJ;
 //                    ext_fun_out[1] = adj_traj + s * nAdj + nx + nu;  // hess: (nx+nu)*(nx+nu)
 
+                    if (model->expl_vde_adj == 0)
+                    {
+                        printf("sim ERK: expl_vde_adj is not provided. Exiting.\n");
+                        exit(1);
+                    }
                     // adjoint VDE evaluation
                     model->expl_vde_adj->evaluate(model->expl_vde_adj, ext_fun_type_in, ext_fun_in,
                             ext_fun_type_out, ext_fun_out);

--- a/acados/sim/sim_erk_integrator.c
+++ b/acados/sim/sim_erk_integrator.c
@@ -157,12 +157,10 @@ void *sim_erk_model_assign(void *config, void *dims, void *raw_memory)
 
 int sim_erk_model_set(void *model_, const char *field, void *value)
 {
-//    printf("\nsim_erk_model_set\n");
     erk_model *model = model_;
 
     if (!strcmp(field, "expl_ode_fun"))
     {
-//    printf("\nsim_erk_model_set expl_ode_fun\n");
         model->expl_ode_fun = value;
     }
     else if (!strcmp(field, "expl_vde_for") || !strcmp(field, "expl_vde_forw"))

--- a/acados/sim/sim_irk_integrator.c
+++ b/acados/sim/sim_irk_integrator.c
@@ -1030,6 +1030,11 @@ int sim_irk(void *config_, sim_in *in, sim_out *out, void *opts_, void *mem_, vo
                 }
                 else // only eval function (without jacobian)
                 {
+                    if (model->impl_ode_fun == 0)
+                    {
+                        printf("sim IRK: impl_ode_fun is not provided. Exiting.\n");
+                        exit(1);
+                    }
                     acados_tic(&timer_ad);
                     model->impl_ode_fun->evaluate(model->impl_ode_fun, impl_ode_type_in,
                                                   impl_ode_in, impl_ode_fun_type_out,

--- a/docs/memory_management.md
+++ b/docs/memory_management.md
@@ -1,0 +1,73 @@
+# Memory management in acados:
+Guidelines on how memory should be assigned for an `acados` structure `astruct`.
+
+There are two functions: `astruct_calculate_size()`, `astruct_assign()`.
+
+## `astruct_calculate_size()`
+Must return a multiple of 8 to keep the pointer aligned to 8 when allocating substructures.
+Thus, it should end with:
+```
+make_int_multiple_of(8, &size);
+```
+
+
+## `astruct_assign()`
+Should assign its members in the following order:
+
+- Align to 8 bytes
+- structure itself, i.e.:
+```
+    astruct *as_instance = (astruct *) c_ptr;
+    c_ptr += sizeof(astruct);
+```
+- pointers to substructures, if `astruct` contains an array of `bstruct`s, e.g.
+```
+    mem->bstructs = (void **) c_ptr;
+    c_ptr += N*sizeof(void *);
+```
+- Note: It should be aligned to 8 here after, since `astruct` might contain an `int`, and the pointers were assigned.
+
+
+- Assign "substructures", i.e. structures that `astruct` has pointers to:
+```
+    // assume astruct contains an instance of bstruct
+    as_instance->bstruct = bstruct_assign(c_ptr,...);
+    c_ptr += bstruct_calculate_size(astruct);
+```
+- Note:
+    - since calculate_size returns multiple of 8, c_ptr is still aligned to 8 bytes.
+    - blasfeo_dmat_structs, blasfeo_dvec_structs can be seehn as "substructures" here.
+
+
+- Assign doubles (are 8 bytes anyway)
+```
+    assign_and_advance_double(n_doubles, &as_instance->doubles, &c_ptr);
+```
+
+- Assign pointers (4 bytes on 32 Bit)
+```
+    assign_and_advance_double_ptrs(n_pointers, &as_instance->double_pointer, &c_ptr);
+```
+
+- Align to 8 bytes, can be skipped if no pointers are allcoted
+
+
+- Assign integers
+```
+    assign_and_advance_int(n_integers, &as_instance->ints, &c_ptr);
+```
+
+- Align to 64 bytes
+
+- Assign blasfeo_dmat_mems (are multiple of 64 Bytes)
+```
+    assign_and_advance_blasfeo_dmat_mem(nrow, ncol, &as_instance->blasfeo_mat, &c_ptr);
+```
+
+- blasfeo_vec_mem (are multiple of 32 Bytes)
+```
+    assign_and_advance_blasfeo_dvec_mem(n, &as_instance->blasfeo_vec, &c_ptr);
+```
+
+- Align c_ptr to 8 byte here for nested assigns, see "substructures"
+   - relevant if no blasfeo_mems are in `astruct`

--- a/examples/acados_matlab_octave/test/test_ocp_linear_mass_spring.m
+++ b/examples/acados_matlab_octave/test/test_ocp_linear_mass_spring.m
@@ -37,7 +37,6 @@ clear all
 
 addpath('../linear_mass_spring_model/');
 
-
 %% arguments
 compile_interface = 'auto';
 codgen_model = 'true';
@@ -59,10 +58,9 @@ nlp_solver_ext_qp_res = 1;
 qp_solver = 'partial_condensing_hpipm';
 %qp_solver = 'full_condensing_hpipm';
 qp_solver_cond_N = 5;
-%dyn_type = 'discrete';
-sim_method = 'erk';
 % sim_method = 'irk';
 %sim_method = 'irk_gnsf';
+sim_method = 'discrete'
 sim_method_num_stages = 4;
 sim_method_num_steps = 3;
 %cost_type = 'linear_ls';
@@ -71,9 +69,12 @@ cost_type = 'ext_cost';
 
 if strcmp(sim_method, 'erk')
     dyn_type = 'explicit';
-else % irk, irk_gnsf
-    dyn_type = 'implicit';
+elseif any(strcmp(sim_method, {'irk','irk_gnsf'}))
+	dyn_type = 'implicit';
+else
+	dyn_type = 'discrete';
 end
+
 
 %% create model entries
 model = linear_mass_spring_model;
@@ -279,7 +280,8 @@ if status~=0
 elseif sqp_iter > 2
     error('ocp can be solved in 2 iterations!');
 else
-	fprintf('\ntest_ocp_linear_mass_spring: success!\n');
+	fprintf(['\ntest_ocp_linear_mass_spring: success with sim method ', ...
+        sim_method, ' !\n']);
 end
 
 % plot result

--- a/examples/acados_matlab_octave/test/test_ocp_wtnx6.m
+++ b/examples/acados_matlab_octave/test/test_ocp_wtnx6.m
@@ -477,6 +477,11 @@ for ii=1:n_sim
 
 end
 
+% test setter
+ocp.set('cost_z', ones(2,1), 1)
+ocp.set('cost_Z', ones(2,1), 1)
+ocp.set('cost_zl', ones(2,1), N-1)
+
 electrical_power = 0.944*97/100*x_sim(1,:).*x_sim(6,:);
 
 x_sim_ref = [   1.263425730522397

--- a/examples/acados_python/getting_started/ocp/nonuniform_discretization_example.py
+++ b/examples/acados_python/getting_started/ocp/nonuniform_discretization_example.py
@@ -114,6 +114,8 @@ ocp_solver = AcadosOcpSolver(ocp, json_file = 'acados_ocp.json')
 simX = np.ndarray((N+1, nx))
 simU = np.ndarray((N, nu))
 
+ocp_solver.options_set("step_length", 0.99999)
+
 status = ocp_solver.solve()
 
 if status != 0:

--- a/examples/acados_python/getting_started/ocp/nonuniform_discretization_example.py
+++ b/examples/acados_python/getting_started/ocp/nonuniform_discretization_example.py
@@ -118,13 +118,14 @@ simX = np.ndarray((N+1, nx))
 simU = np.ndarray((N, nu))
 
 ocp_solver.options_set("step_length", 0.99999)
+ocp_solver.options_set("globalization", "fixed_step") # fixed_step, merit_backtracking
 
 # initialize solver
 for i in range(N):
     ocp_solver.set(i, "x", x0)
 status = ocp_solver.solve()
 
-if status != 0:
+if status not in [0, 2]:
     raise Exception('acados returned status {}. Exiting.'.format(status))
 
 # get primal solution

--- a/examples/acados_python/tests/test_ocp_setting.py
+++ b/examples/acados_python/tests/test_ocp_setting.py
@@ -228,6 +228,9 @@ ocp.constraints.idxbu = np.array([0])
 # set options
 ocp.solver_options.qp_solver = QP_SOLVER
 ocp.solver_options.hessian_approx = HESS_APPROX
+ocp.solver_options.exact_hess_constr = 1
+ocp.solver_options.exact_hess_cost = 1
+ocp.solver_options.exact_hess_dyn = 1
 ocp.solver_options.regularize_method = REGULARIZATION
 
 ocp.solver_options.integrator_type = INTEGRATOR_TYPE

--- a/interfaces/acados_c/ocp_nlp_interface.c
+++ b/interfaces/acados_c/ocp_nlp_interface.c
@@ -190,10 +190,8 @@ ocp_nlp_config *ocp_nlp_config_create(ocp_nlp_plan plan)
             ocp_nlp_sqp_rti_config_initialize_default(config);
             break;
         case INVALID_NLP_SOLVER:
-            break;
             printf("\nerror: ocp_nlp_config_create: forgot to initialize plan->nlp_solver\n");
             exit(1);
-            break;
         default:
             printf("\nerror: ocp_nlp_config_create: unsupported plan->nlp_solver\n");
             exit(1);
@@ -242,7 +240,6 @@ ocp_nlp_config *ocp_nlp_config_create(ocp_nlp_plan plan)
             case INVALID_COST:
                 printf("\nerror: ocp_nlp_config_create: forgot to initialize plan->nlp_cost\n");
                 exit(1);
-                break;
             default:
                 printf("\nerror: ocp_nlp_config_create: unsupported plan->nlp_cost\n");
                 exit(1);
@@ -285,7 +282,6 @@ ocp_nlp_config *ocp_nlp_config_create(ocp_nlp_plan plan)
             case INVALID_DYNAMICS:
                 printf("\nerror: ocp_nlp_config_create: forgot to initialize plan->nlp_dynamics\n");
                 exit(1);
-                break;
             default:
                 printf("\nerror: ocp_nlp_config_create: unsupported plan->nlp_dynamics\n");
                 exit(1);
@@ -306,7 +302,6 @@ ocp_nlp_config *ocp_nlp_config_create(ocp_nlp_plan plan)
             case INVALID_CONSTRAINT:
                 printf("\nerror: ocp_nlp_config_create: forgot to initialize plan->nlp_constraints\n");
                 exit(1);
-                break;
             default:
                 printf("\nerror: ocp_nlp_config_create: unsupported plan->nlp_constraints\n");
                 exit(1);

--- a/interfaces/acados_c/ocp_nlp_interface.c
+++ b/interfaces/acados_c/ocp_nlp_interface.c
@@ -540,7 +540,9 @@ int ocp_nlp_dims_get_from_attr(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_n
     {
         return dims->nz[stage];
     }
-    else if (!strcmp(field, "sl") || !strcmp(field, "su"))
+    else if (!strcmp(field, "sl") || !strcmp(field, "su") || !strcmp(field, "s") ||
+             !strcmp(field, "zl") || !strcmp(field, "zu") || !strcmp(field, "cost_z") ||
+             !strcmp(field, "Zl") || !strcmp(field, "Zu") || !strcmp(field, "cost_Z"))
     {
         return dims->ns[stage];
     }
@@ -568,12 +570,6 @@ int ocp_nlp_dims_get_from_attr(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_n
     {
         config->constraints[stage]->dims_get(config->constraints[stage], dims->constraints[stage],
                                             "ng", &dims_value);
-        return dims_value;
-    }
-    else if (!strcmp(field, "s"))
-    {
-        config->constraints[stage]->dims_get(config->constraints[stage], dims->constraints[stage],
-                                            "ns", &dims_value);
         return dims_value;
     }
     // ocp_nlp_cost_dims

--- a/interfaces/acados_matlab_octave/detect_dims_ocp.m
+++ b/interfaces/acados_matlab_octave/detect_dims_ocp.m
@@ -118,6 +118,7 @@ function [model, opts] = detect_dims_ocp(model, opts)
 
     if isfield(model, 'constr_idxbxe_0')
         model.dim_nbxe_0 = length(model.constr_idxbxe_0);
+    end
 
     % path
     if isfield(model, 'constr_Jbx') && isfield(model, 'constr_lbx') && isfield(model, 'constr_ubx')

--- a/interfaces/acados_matlab_octave/ocp_create.c
+++ b/interfaces/acados_matlab_octave/ocp_create.c
@@ -860,144 +860,146 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         ocp_nlp_solver_opts_set(config, opts, "print_level", &print_level);
     }
 
-    // sim_method_num_stages
-    sprintf(matlab_field_name, "sim_method_num_stages");
-    const mxArray *matlab_array;
-    matlab_array = mxGetField( matlab_opts, 0, matlab_field_name );
-    if (matlab_array!=NULL)
+    if (strcmp(dyn_type, "discrete"))
     {
-        int matlab_size = (int) mxGetNumberOfElements( matlab_array );
-        MEX_DIM_CHECK_VEC_TWO(fun_name, matlab_field_name, matlab_size, 1, N);
-
-        if (matlab_size == 1)
+        // sim_method_num_stages
+        sprintf(matlab_field_name, "sim_method_num_stages");
+        const mxArray *matlab_array;
+        matlab_array = mxGetField( matlab_opts, 0, matlab_field_name );
+        if (matlab_array!=NULL)
         {
-            int sim_method_num_stages = mxGetScalar( matlab_array );
-            for (int ii=0; ii<N; ii++)
+            int matlab_size = (int) mxGetNumberOfElements( matlab_array );
+            MEX_DIM_CHECK_VEC_TWO(fun_name, matlab_field_name, matlab_size, 1, N);
+
+            if (matlab_size == 1)
             {
-                ocp_nlp_solver_opts_set_at_stage(config, opts, ii, "dynamics_num_stages", &sim_method_num_stages);
+                int sim_method_num_stages = mxGetScalar( matlab_array );
+                for (int ii=0; ii<N; ii++)
+                {
+                    ocp_nlp_solver_opts_set_at_stage(config, opts, ii, "dynamics_num_stages", &sim_method_num_stages);
+                }
+            }
+            else
+            {
+                double *values = mxGetPr(matlab_array);
+                for (int ii=0; ii<N; ii++)
+                {
+                    int sim_method_num_stages = (int) values[ii];
+                    // mexPrintf("\nsim_method_num_stages[%d] = %d", ii, sim_method_num_stages);
+                    ocp_nlp_solver_opts_set_at_stage(config, opts, ii, "dynamics_num_stages", &sim_method_num_stages);
+                }
             }
         }
-        else
+        // sim_method_num_steps
+        sprintf(matlab_field_name, "sim_method_num_steps");
+        matlab_array = mxGetField( matlab_opts, 0, matlab_field_name );
+        if (matlab_array!=NULL)
         {
-            double *values = mxGetPr(matlab_array);
-            for (int ii=0; ii<N; ii++)
+            int matlab_size = (int) mxGetNumberOfElements( matlab_array );
+            MEX_DIM_CHECK_VEC_TWO(fun_name, matlab_field_name, matlab_size, 1, N);
+
+            if (matlab_size == 1)
             {
-                int sim_method_num_stages = (int) values[ii];
-                // mexPrintf("\nsim_method_num_stages[%d] = %d", ii, sim_method_num_stages);
-                ocp_nlp_solver_opts_set_at_stage(config, opts, ii, "dynamics_num_stages", &sim_method_num_stages);
+                int sim_method_num_steps = mxGetScalar( matlab_array );
+                for (int ii=0; ii<N; ii++)
+                {
+                    ocp_nlp_solver_opts_set_at_stage(config, opts, ii, "dynamics_num_steps", &sim_method_num_steps);
+                }
+            }
+            else
+            {
+                double *values = mxGetPr(matlab_array);
+                for (int ii=0; ii<N; ii++)
+                {
+                    int sim_method_num_steps = (int) values[ii];
+                    // mexPrintf("\nsim_method_num_steps[%d] = %d", ii, sim_method_num_steps);
+                    ocp_nlp_solver_opts_set_at_stage(config, opts, ii, "dynamics_num_steps", &sim_method_num_steps);
+                }
+            }
+        }
+        // sim_method_newton_iter
+        sprintf(matlab_field_name, "sim_method_newton_iter");
+        matlab_array = mxGetField( matlab_opts, 0, matlab_field_name );
+        if (matlab_array!=NULL)
+        {
+            int matlab_size = (int) mxGetNumberOfElements( matlab_array );
+            MEX_DIM_CHECK_VEC_TWO(fun_name, matlab_field_name, matlab_size, 1, N);
+
+            if (matlab_size == 1)
+            {
+                int sim_method_newton_iter = mxGetScalar( matlab_array );
+                for (int ii=0; ii<N; ii++)
+                {
+                    ocp_nlp_solver_opts_set_at_stage(config, opts, ii, "dynamics_newton_iter", &sim_method_newton_iter);
+                }
+            }
+            else
+            {
+                double *values = mxGetPr(matlab_array);
+                for (int ii=0; ii<N; ii++)
+                {
+                    int sim_method_newton_iter = (int) values[ii];
+                    // mexPrintf("\nsim_method_newton_iter[%d] = %d", ii, sim_method_newton_iter);
+                    ocp_nlp_solver_opts_set_at_stage(config, opts, ii, "dynamics_newton_iter", &sim_method_newton_iter);
+                }
+            }
+        }
+        // sim_method_jac_reuse
+        sprintf(matlab_field_name, "sim_method_jac_reuse");
+        matlab_array = mxGetField( matlab_opts, 0, matlab_field_name );
+        if (matlab_array!=NULL)
+        {
+            int matlab_size = (int) mxGetNumberOfElements( matlab_array );
+            MEX_DIM_CHECK_VEC_TWO(fun_name, matlab_field_name, matlab_size, 1, N);
+
+            if (matlab_size == 1)
+            {
+                bool sim_method_jac_reuse = mxGetScalar( matlab_array );
+                for (int ii=0; ii<N; ii++)
+                {
+                    ocp_nlp_solver_opts_set_at_stage(config, opts, ii, "dynamics_jac_reuse", &sim_method_jac_reuse);
+                }
+            }
+            else
+            {
+                double *values = mxGetPr(matlab_array);
+                for (int ii=0; ii<N; ii++)
+                {
+                    bool sim_method_jac_reuse = (int) values[ii];
+                    // mexPrintf("\nsim_method_jac_reuse[%d] = %d", ii, sim_method_jac_reuse);
+                    ocp_nlp_solver_opts_set_at_stage(config, opts, ii, "dynamics_jac_reuse", &sim_method_jac_reuse);
+                }
+            }
+        }
+        // sim_method_exact_z_output
+        sprintf(matlab_field_name, "sim_method_exact_z_output");
+        matlab_array = mxGetField( matlab_opts, 0, matlab_field_name );
+        if (matlab_array!=NULL)
+        {
+            int matlab_size = (int) mxGetNumberOfElements( matlab_array );
+            MEX_DIM_CHECK_VEC_TWO(fun_name, matlab_field_name, matlab_size, 1, N);
+
+            if (matlab_size == 1)
+            {
+                bool sim_method_exact_z_output = mxGetScalar( matlab_array );
+                for (int ii=0; ii<N; ii++)
+                {
+                    ocp_nlp_solver_opts_set_at_stage(config, opts, ii, "dynamics_exact_z_output", &sim_method_exact_z_output);
+                }
+            }
+            else
+            {
+                double *values = mxGetPr(matlab_array);
+                for (int ii=0; ii<N; ii++)
+                {
+                    bool sim_method_exact_z_output = (int) values[ii];
+                    // mexPrintf("\nsim_method_exact_z_output[%d] = %d", ii, sim_method_exact_z_output);
+                    ocp_nlp_solver_opts_set_at_stage(config, opts, ii, "dynamics_exact_z_output", &sim_method_exact_z_output);
+                }
             }
         }
     }
-    // sim_method_num_steps
-    sprintf(matlab_field_name, "sim_method_num_steps");
-    matlab_array = mxGetField( matlab_opts, 0, matlab_field_name );
-    if (matlab_array!=NULL)
-    {
-        int matlab_size = (int) mxGetNumberOfElements( matlab_array );
-        MEX_DIM_CHECK_VEC_TWO(fun_name, matlab_field_name, matlab_size, 1, N);
 
-        if (matlab_size == 1)
-        {
-            int sim_method_num_steps = mxGetScalar( matlab_array );
-            for (int ii=0; ii<N; ii++)
-            {
-                ocp_nlp_solver_opts_set_at_stage(config, opts, ii, "dynamics_num_steps", &sim_method_num_steps);
-            }
-        }
-        else
-        {
-            double *values = mxGetPr(matlab_array);
-            for (int ii=0; ii<N; ii++)
-            {
-                int sim_method_num_steps = (int) values[ii];
-                // mexPrintf("\nsim_method_num_steps[%d] = %d", ii, sim_method_num_steps);
-                ocp_nlp_solver_opts_set_at_stage(config, opts, ii, "dynamics_num_steps", &sim_method_num_steps);
-            }
-        }
-    }
-    // sim_method_newton_iter
-    sprintf(matlab_field_name, "sim_method_newton_iter");
-    matlab_array = mxGetField( matlab_opts, 0, matlab_field_name );
-    if (matlab_array!=NULL)
-    {
-        int matlab_size = (int) mxGetNumberOfElements( matlab_array );
-        MEX_DIM_CHECK_VEC_TWO(fun_name, matlab_field_name, matlab_size, 1, N);
-
-        if (matlab_size == 1)
-        {
-            int sim_method_newton_iter = mxGetScalar( matlab_array );
-            for (int ii=0; ii<N; ii++)
-            {
-                ocp_nlp_solver_opts_set_at_stage(config, opts, ii, "dynamics_newton_iter", &sim_method_newton_iter);
-            }
-        }
-        else
-        {
-            double *values = mxGetPr(matlab_array);
-            for (int ii=0; ii<N; ii++)
-            {
-                int sim_method_newton_iter = (int) values[ii];
-                // mexPrintf("\nsim_method_newton_iter[%d] = %d", ii, sim_method_newton_iter);
-                ocp_nlp_solver_opts_set_at_stage(config, opts, ii, "dynamics_newton_iter", &sim_method_newton_iter);
-            }
-        }
-    }
-
-    // sim_method_jac_reuse
-    sprintf(matlab_field_name, "sim_method_jac_reuse");
-    matlab_array = mxGetField( matlab_opts, 0, matlab_field_name );
-    if (matlab_array!=NULL)
-    {
-        int matlab_size = (int) mxGetNumberOfElements( matlab_array );
-        MEX_DIM_CHECK_VEC_TWO(fun_name, matlab_field_name, matlab_size, 1, N);
-
-        if (matlab_size == 1)
-        {
-            bool sim_method_jac_reuse = mxGetScalar( matlab_array );
-            for (int ii=0; ii<N; ii++)
-            {
-                ocp_nlp_solver_opts_set_at_stage(config, opts, ii, "dynamics_jac_reuse", &sim_method_jac_reuse);
-            }
-        }
-        else
-        {
-            double *values = mxGetPr(matlab_array);
-            for (int ii=0; ii<N; ii++)
-            {
-                bool sim_method_jac_reuse = (int) values[ii];
-                // mexPrintf("\nsim_method_jac_reuse[%d] = %d", ii, sim_method_jac_reuse);
-                ocp_nlp_solver_opts_set_at_stage(config, opts, ii, "dynamics_jac_reuse", &sim_method_jac_reuse);
-            }
-        }
-    }
-
-    // sim_method_exact_z_output
-    sprintf(matlab_field_name, "sim_method_exact_z_output");
-    matlab_array = mxGetField( matlab_opts, 0, matlab_field_name );
-    if (matlab_array!=NULL)
-    {
-        int matlab_size = (int) mxGetNumberOfElements( matlab_array );
-        MEX_DIM_CHECK_VEC_TWO(fun_name, matlab_field_name, matlab_size, 1, N);
-
-        if (matlab_size == 1)
-        {
-            bool sim_method_exact_z_output = mxGetScalar( matlab_array );
-            for (int ii=0; ii<N; ii++)
-            {
-                ocp_nlp_solver_opts_set_at_stage(config, opts, ii, "dynamics_exact_z_output", &sim_method_exact_z_output);
-            }
-        }
-        else
-        {
-            double *values = mxGetPr(matlab_array);
-            for (int ii=0; ii<N; ii++)
-            {
-                bool sim_method_exact_z_output = (int) values[ii];
-                // mexPrintf("\nsim_method_exact_z_output[%d] = %d", ii, sim_method_exact_z_output);
-                ocp_nlp_solver_opts_set_at_stage(config, opts, ii, "dynamics_exact_z_output", &sim_method_exact_z_output);
-            }
-        }
-    }
 
     /* in */
     ocp_nlp_in *in = ocp_nlp_in_create(config, dims);

--- a/interfaces/acados_matlab_octave/ocp_set.c
+++ b/interfaces/acados_matlab_octave/ocp_set.c
@@ -287,10 +287,9 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
             }
         }
     }
-    // slacks, TODO(oj): _e stuff, but maybe this can be avoided!!
     else if (!strcmp(field, "cost_Z"))
     {
-        acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, s0, "ns");
+        acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, s0, "cost_Z");
         MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
         for (int ii=s0; ii<se; ii++)
         {
@@ -299,7 +298,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     }
     else if (!strcmp(field, "cost_Zl"))
     {
-        acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, s0, "ns");
+        acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, s0, "Zl");
         MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
         for (int ii=s0; ii<se; ii++)
         {
@@ -308,7 +307,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     }
     else if (!strcmp(field, "cost_Zu"))
     {
-        acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, s0, "ns");
+        acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, s0, "Zu");
         MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
         for (int ii=s0; ii<se; ii++)
         {
@@ -317,7 +316,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     }
     else if (!strcmp(field, "cost_z"))
     {
-        acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, s0, "ns");
+        acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, s0, "cost_z");
         MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
         for (int ii=s0; ii<se; ii++)
         {
@@ -326,7 +325,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     }
     else if (!strcmp(field, "cost_zl"))
     {
-        acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, s0, "ns");
+        acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, s0, "zl");
         MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
         for (int ii=s0; ii<se; ii++)
         {
@@ -335,7 +334,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     }
     else if (!strcmp(field, "cost_zu"))
     {
-        acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, s0, "ns");
+        acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, s0, "zu");
         MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
         for (int ii=s0; ii<se; ii++)
         {

--- a/interfaces/acados_template/acados_template/acados_layout.json
+++ b/interfaces/acados_template/acados_template/acados_layout.json
@@ -659,6 +659,15 @@
         "initialize_t_slacks": [
             "int"
         ],
+        "exact_hess_cost": [
+            "int"
+        ],
+        "exact_hess_constr": [
+            "int"
+        ],
+        "exact_hess_dyn": [
+            "int"
+        ],
         "model_external_shared_lib_dir": [
             "str"
         ],

--- a/interfaces/acados_template/acados_template/acados_ocp.py
+++ b/interfaces/acados_template/acados_template/acados_ocp.py
@@ -1454,10 +1454,10 @@ class AcadosOcpConstraints:
 
     @Jsbx.setter
     def Jsbx(self, Jsbx):
-        if type(Jsbx) == np.ndarray:
+        if isinstance(Jsbx, np.ndarray):
             self.__idxsbx = J_to_idx_slack(Jsbx)
         else:
-            raise Exception('Invalid Jsbx value. Exiting.')
+            raise Exception('Invalid Jsbx value, expected numpy array. Exiting.')
 
     # soft bounds on u
     @lsbu.setter
@@ -1543,10 +1543,9 @@ class AcadosOcpConstraints:
     @Jsg.setter
     def Jsg(self, Jsg):
         if isinstance(Jsg, np.ndarray):
-            self.__Jsg = Jsg
             self.__idxsg = J_to_idx_slack(Jsg)
         else:
-            raise Exception('Invalid Jsg value. Exiting.')
+            raise Exception('Invalid Jsg value, expected numpy array. Exiting.')
 
 
     # soft bounds on nonlinear constraints
@@ -1595,11 +1594,10 @@ class AcadosOcpConstraints:
 
     @Jsphi.setter
     def Jsphi(self, Jsphi):
-        if type(Jsphi) == np.ndarray:
-            self.__Jsphi = Jsphi
+        if isinstance(Jsphi, np.ndarray):
             self.__idxsphi = J_to_idx_slack(Jsphi)
         else:
-            raise Exception('Invalid Jsphi value. Exiting.')
+            raise Exception('Invalid Jsphi value, expected numpy array. Exiting.')
 
     # soft bounds on general linear constraints at t=T
     @lsg_e.setter
@@ -1626,10 +1624,9 @@ class AcadosOcpConstraints:
     @Jsg_e.setter
     def Jsg_e(self, Jsg_e):
         if isinstance(Jsg_e, np.ndarray):
-            self.__Jsg_e = Jsg_e
             self.__idxsg_e = J_to_idx_slack(Jsg_e)
         else:
-            raise Exception('Invalid Jsg_e value. Exiting.')
+            raise Exception('Invalid Jsg_e value, expected numpy array. Exiting.')
 
     # soft bounds on nonlinear constraints at t=T
     @lsh_e.setter
@@ -1678,7 +1675,6 @@ class AcadosOcpConstraints:
     @Jsphi_e.setter
     def Jsphi_e(self, Jsphi_e):
         if isinstance(Jsphi_e, np.ndarray):
-            self.__Jsphi_e = Jsphi_e
             self.__idxsphi_e = J_to_idx_slack(Jsphi_e)
         else:
             raise Exception('Invalid Jsphi_e value. Exiting.')

--- a/interfaces/acados_template/acados_template/acados_ocp.py
+++ b/interfaces/acados_template/acados_template/acados_ocp.py
@@ -1746,6 +1746,9 @@ class AcadosOcpOptions:
         self.__regularize_method = None
         self.__time_steps = None
         self.__shooting_nodes = None
+        self.__exact_hess_cost = 1
+        self.__exact_hess_dyn = 1
+        self.__exact_hess_constr = 1
 
 
 
@@ -1894,6 +1897,24 @@ class AcadosOcpOptions:
     def model_external_shared_lib_name(self):
         """Name of the .so lib"""
         return self.__model_external_shared_lib_name
+
+    @property
+    def exact_hess_constr(self):
+        """Used in case of hessian_approx == 'EXACT'.\n
+           Can be used to turn off exact hessian contributions from the constraints module"""
+        return self.__exact_hess_constr
+
+    @property
+    def exact_hess_cost(self):
+        """Used in case of hessian_approx == 'EXACT'.\n
+           Can be used to turn off exact hessian contributions from the cost module"""
+        return self.__exact_hess_cost
+
+    @property
+    def exact_hess_dyn(self):
+        """Used in case of hessian_approx == 'EXACT'.\n
+           Can be used to turn off exact hessian contributions from the dynamics module"""
+        return self.__exact_hess_dyn
 
     @qp_solver.setter
     def qp_solver(self, qp_solver):
@@ -2129,6 +2150,27 @@ class AcadosOcpOptions:
         else:
             raise Exception('Invalid model_external_shared_lib_name value. Str expected.' \
             + '.\n\nYou have: ' + type(model_external_shared_lib_name) + '.\n\nExiting.')
+
+    @exact_hess_constr.setter
+    def exact_hess_constr(self, exact_hess_constr):
+        if exact_hess_constr in [0, 1]:
+            self.__exact_hess_constr = exact_hess_constr
+        else:
+            raise Exception('Invalid exact_hess_constr value. exact_hess_constr takes one of the values 0, 1. Exiting')
+
+    @exact_hess_cost.setter
+    def exact_hess_cost(self, exact_hess_cost):
+        if exact_hess_cost in [0, 1]:
+            self.__exact_hess_cost = exact_hess_cost
+        else:
+            raise Exception('Invalid exact_hess_cost value. exact_hess_cost takes one of the values 0, 1. Exiting')
+
+    @exact_hess_dyn.setter
+    def exact_hess_dyn(self, exact_hess_dyn):
+        if exact_hess_dyn in [0, 1]:
+            self.__exact_hess_dyn = exact_hess_dyn
+        else:
+            raise Exception('Invalid exact_hess_dyn value. exact_hess_dyn takes one of the values 0, 1. Exiting')
 
     def set(self, attr, value):
         setattr(self, attr, value)

--- a/interfaces/acados_template/acados_template/acados_ocp.py
+++ b/interfaces/acados_template/acados_template/acados_ocp.py
@@ -935,12 +935,12 @@ class AcadosOcpConstraints:
     # nonlinear constraints at t=T
     @property
     def lh_e(self):
-        """:math:`\\bar{h}^e` - upper bound on nonlinear inequalities at t=T"""
+        """:math:`\\underline{h}^e` - lower bound on nonlinear inequalities at t=T"""
         return self.__lh_e
 
     @property
     def uh_e(self):
-        """:math:`\\underline{h}^e` - lower bound on nonlinear inequalities at t=T"""
+        """:math:`\\bar{h}^e` - upper bound on nonlinear inequalities at t=T"""
         return self.__uh_e
 
     # convex-over-nonlinear constraints

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -1023,12 +1023,23 @@ class AcadosOcpSolver:
         """
         set options of the solver:
         Parameters:
-            :param field_: string, e.g. 'print_level', 'rti_phase'
-            :param value_: of type int
+            :param field_: string, e.g. 'print_level', 'rti_phase', 'step_length'
+            :param value_: of type int, float
         """
-        # cast value_ to avoid conversion issues
-        if not isinstance(value_, int):
-            raise Exception('solver options must be of type int. You have {}.'.format(type(value_)))
+        int_fields = ['print_level', 'rti_phase', 'initialize_t_slacks']
+        double_fields = ['step_length']
+
+        if field_ in int_fields:
+            if not isinstance(value_, int):
+                raise Exception('solver option {} must be of type int. You have {}.'.format(field_, type(value_)))
+            else:
+                value_ctypes = c_int(value_)
+
+        elif field_ in double_fields:
+            if not isinstance(value_, float):
+                raise Exception('solver option {} must be of type float. You have {}.'.format(field_, type(value_)))
+            else:
+                value_ctypes = c_double(value_)
 
         if field_ == 'rti_phase':
             if value_ < 0 or value_ > 2:
@@ -1040,8 +1051,6 @@ class AcadosOcpSolver:
 
         field = field_
         field = field.encode('utf-8')
-
-        value_ctypes = c_int(value_)
 
         self.shared_lib.ocp_nlp_solver_opts_set.argtypes = \
             [c_void_p, c_void_p, c_char_p, c_void_p]

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -1028,6 +1028,7 @@ class AcadosOcpSolver:
         """
         int_fields = ['print_level', 'rti_phase', 'initialize_t_slacks']
         double_fields = ['step_length']
+        string_fields = ['globalization']
 
         if field_ in int_fields:
             if not isinstance(value_, int):
@@ -1041,6 +1042,12 @@ class AcadosOcpSolver:
             else:
                 value_ctypes = c_double(value_)
 
+        elif field_ in string_fields:
+            if not isinstance(value_, str):
+                raise Exception('solver option {} must be of type str. You have {}.'.format(field_, type(value_)))
+            else:
+                value_ctypes = value_.encode('utf-8')
+
         if field_ == 'rti_phase':
             if value_ < 0 or value_ > 2:
                 raise Exception('AcadosOcpSolver.solve(): argument \'rti_phase\' can '
@@ -1052,10 +1059,16 @@ class AcadosOcpSolver:
         field = field_
         field = field.encode('utf-8')
 
-        self.shared_lib.ocp_nlp_solver_opts_set.argtypes = \
-            [c_void_p, c_void_p, c_char_p, c_void_p]
-        self.shared_lib.ocp_nlp_solver_opts_set(self.nlp_config, \
-            self.nlp_opts, field, byref(value_ctypes))
+        if field_ in string_fields:
+            self.shared_lib.ocp_nlp_solver_opts_set.argtypes = \
+                [c_void_p, c_void_p, c_char_p, c_char_p]
+            self.shared_lib.ocp_nlp_solver_opts_set(self.nlp_config, \
+                self.nlp_opts, field, value_ctypes)
+        else:
+            self.shared_lib.ocp_nlp_solver_opts_set.argtypes = \
+                [c_void_p, c_void_p, c_char_p, c_void_p]
+            self.shared_lib.ocp_nlp_solver_opts_set(self.nlp_config, \
+                self.nlp_opts, field, byref(value_ctypes))
 
         return
 

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_mex_create.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_mex_create.in.c
@@ -73,7 +73,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 
     // field names of output struct
     #define FIELDS_OCP 8
-    #define FIELDS_EXT_FUN 8
+    #define FIELDS_EXT_FUN 9
     #define MAX_FIELDS 8
     char *fieldnames[MAX_FIELDS];
 
@@ -145,15 +145,16 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     mxSetField(plhs[0], 0, "sens_out", sens_out_mat);
 
     /* store external function pointers */
-    memcpy(fieldnames[0],"forw_vde",sizeof("forw_vde"));
-    memcpy(fieldnames[1],"hess_vde",sizeof("hess_vde"));
-    memcpy(fieldnames[2],"impl_dae_fun",sizeof("impl_dae_fun"));
-    memcpy(fieldnames[3],"impl_dae_fun_jac_x_xdot_z",sizeof("impl_dae_fun_jac_x_xdot_z"));
-    memcpy(fieldnames[4],"impl_dae_jac_x_xdot_u_z",sizeof("impl_dae_jac_x_xdot_u_z"));
+    memcpy(fieldnames[0],"expl_ode_fun",sizeof("expl_ode_fun"));
+    memcpy(fieldnames[1],"forw_vde",sizeof("forw_vde"));
+    memcpy(fieldnames[2],"hess_vde",sizeof("hess_vde"));
+    memcpy(fieldnames[3],"impl_dae_fun",sizeof("impl_dae_fun"));
+    memcpy(fieldnames[4],"impl_dae_fun_jac_x_xdot_z",sizeof("impl_dae_fun_jac_x_xdot_z"));
+    memcpy(fieldnames[5],"impl_dae_jac_x_xdot_u_z",sizeof("impl_dae_jac_x_xdot_u_z"));
     // constraints
-    memcpy(fieldnames[5],"phi_constraint",sizeof("phi_constraint"));
-    memcpy(fieldnames[6],"nl_constr_h_fun_jac",sizeof("nl_constr_h_fun_jac"));
-    memcpy(fieldnames[7],"nl_constr_h_fun",sizeof("nl_constr_h_fun"));
+    memcpy(fieldnames[6],"phi_constraint",sizeof("phi_constraint"));
+    memcpy(fieldnames[7],"nl_constr_h_fun_jac",sizeof("nl_constr_h_fun_jac"));
+    memcpy(fieldnames[8],"nl_constr_h_fun",sizeof("nl_constr_h_fun"));
 
     // create output struct - C_ocp_ext_fun
     plhs[1] = mxCreateStructMatrix(1, 1, FIELDS_EXT_FUN, (const char **) fieldnames);
@@ -165,6 +166,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     }
 
 // dynamics
+    mxArray *expl_ode_fun_mat = mxCreateNumericMatrix(1, 1, mxINT64_CLASS, mxREAL);
     mxArray *forw_vde_mat = mxCreateNumericMatrix(1, 1, mxINT64_CLASS, mxREAL);
     mxArray *hess_vde_mat = mxCreateNumericMatrix(1, 1, mxINT64_CLASS, mxREAL);
     mxArray *impl_dae_fun_mat = mxCreateNumericMatrix(1, 1, mxINT64_CLASS, mxREAL);
@@ -175,7 +177,9 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     {# TODO: remove _casadi from these names.. #}
     l_ptr = mxGetData(forw_vde_mat);
     l_ptr[0] = (long long) forw_vde_casadi;
-    // mexPrintf("\nforw vde %p\n", forw_vde_casadi);
+    //
+    l_ptr = mxGetData(expl_ode_fun_mat);
+    l_ptr[0] = (long long) expl_ode_fun;
 {% if solver_options.hessian_approx == "EXACT" %}
     l_ptr = mxGetData(hess_vde_mat);
     l_ptr[0] = (long long) hess_vde_casadi;
@@ -191,6 +195,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     l_ptr = mxGetData(impl_dae_jac_x_xdot_u_z_mat);
     l_ptr[0] = (long long) impl_dae_jac_x_xdot_u_z;
 {%- endif %}
+    mxSetField(plhs[1], 0, "expl_ode_fun", expl_ode_fun_mat);
     mxSetField(plhs[1], 0, "forw_vde", forw_vde_mat);
     mxSetField(plhs[1], 0, "hess_vde", hess_vde_mat);
 

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_mex_create.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_mex_create.in.c
@@ -74,7 +74,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     // field names of output struct
     #define FIELDS_OCP 8
     #define FIELDS_EXT_FUN 9
-    #define MAX_FIELDS 8
+    #define MAX_FIELDS 9
     char *fieldnames[MAX_FIELDS];
 
     for (int i = 0; i < MAX_FIELDS; i++)

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -1405,6 +1405,14 @@ int acados_create()
     {
         ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "exact_hess", &nlp_solver_exact_hessian);
     }
+    int exact_hess_dyn = {{ solver_options.exact_hess_dyn }};
+    ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "exact_hess_dyn", &exact_hess_dyn);
+
+    int exact_hess_cost = {{ solver_options.exact_hess_cost }};
+    ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "exact_hess_cost", &exact_hess_cost);
+
+    int exact_hess_constr = {{ solver_options.exact_hess_constr }};
+    ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "exact_hess_constr", &exact_hess_constr);
 {%- endif -%}
 
 {%- if dims.nz > 0 %}

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.h
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.h
@@ -69,7 +69,8 @@ extern ocp_nlp_plan * nlp_solver_plan;
 extern ocp_nlp_config * nlp_config;
 extern ocp_nlp_dims * nlp_dims;
 
-// external functions
+/* external functions */
+// dynamics
 {% if solver_options.integrator_type == "ERK" %}
 extern external_function_param_casadi * forw_vde_casadi;
 {% if solver_options.hessian_approx == "EXACT" %}
@@ -79,8 +80,32 @@ extern external_function_param_casadi * hess_vde_casadi;
 extern external_function_param_casadi * impl_dae_fun;
 extern external_function_param_casadi * impl_dae_fun_jac_x_xdot_z;
 extern external_function_param_casadi * impl_dae_jac_x_xdot_u_z;
+{%- if solver_options.hessian_approx == "EXACT" %}
+extern external_function_param_casadi * impl_dae_hess;
+{%- endif %}
+{% elif solver_options.integrator_type == "GNSF" %}
+extern external_function_param_casadi * gnsf_phi_fun;
+extern external_function_param_casadi * gnsf_phi_fun_jac_y;
+extern external_function_param_casadi * gnsf_phi_jac_y_uhat;
+extern external_function_param_casadi * gnsf_f_lo_jac_x1_x1dot_u_z;
+extern external_function_param_casadi * gnsf_get_matrices_fun;
 {%- endif %}
 
+// cost
+{% if cost.cost_type == "NONLINEAR_LS" %}
+extern external_function_param_casadi * cost_y_fun;
+{%- elif cost.cost_type == "EXTERNAL" %}
+extern external_function_param_casadi * ext_cost_fun;
+extern external_function_param_casadi * ext_cost_fun_jac_hess;
+{% endif %}
+{% if cost.cost_type_e == "NONLINEAR_LS" %}
+extern external_function_param_casadi cost_y_e_fun;
+{% elif cost.cost_type_e == "EXTERNAL" %}
+extern external_function_param_casadi ext_cost_e_fun;
+extern external_function_param_casadi ext_cost_e_fun_jac_hess;
+{%- endif %}
+
+// constraints
 {%- if constraints.constr_type == "BGP" %}
 extern external_function_param_casadi * phi_constraint;
 // extern external_function_param_casadi * r_constraint;
@@ -93,13 +118,6 @@ extern external_function_param_casadi phi_e_constraint;
 // extern external_function_param_casadi r_e_constraint;
 {% elif constraints.constr_type_e == "BGH" and dims.nh_e > 0 %}
 extern external_function_param_casadi h_e_constraint;
-{%- endif %}
-
-{% if cost.cost_type == "NONLINEAR_LS" %}
-extern external_function_param_casadi * cost_y_fun;
-{% endif %}
-{% if cost.cost_type_e == "NONLINEAR_LS" %}
-extern external_function_param_casadi cost_y_e_fun;
 {%- endif %}
 
 

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.h
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.h
@@ -73,6 +73,7 @@ extern ocp_nlp_dims * nlp_dims;
 // dynamics
 {% if solver_options.integrator_type == "ERK" %}
 extern external_function_param_casadi * forw_vde_casadi;
+extern external_function_param_casadi * expl_ode_fun;
 {% if solver_options.hessian_approx == "EXACT" %}
 extern external_function_param_casadi * hess_vde_casadi;
 {%- endif %}

--- a/interfaces/acados_template/acados_template/c_templates_tera/main.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/main.in.c
@@ -103,6 +103,7 @@ int main()
     {% elif solver_options.integrator_type == "ERK" %}
     for (int ii = 0; ii < {{ dims.N }}; ii++)
     {
+        expl_ode_fun[ii].set_param(expl_ode_fun+ii, p);
         forw_vde_casadi[ii].set_param(forw_vde_casadi+ii, p);
     }
     {%- endif %}

--- a/interfaces/acados_template/acados_template/generate_c_code_explicit_ode.py
+++ b/interfaces/acados_template/acados_template/generate_c_code_explicit_ode.py
@@ -92,11 +92,6 @@ def generate_c_code_explicit_ode( model ):
 
     expl_vde_forw = Function(fun_name, [x, Sx, Sp, u, p], [f_expl,vdeX,vdeP])
 
-    if isinstance(f_expl, casadi.SX):
-        jacX = SX.zeros(nx,nx) + jacobian(f_expl,x)
-    else:
-        jacX = MX.zeros(nx,nx) + jacobian(f_expl,x)
-
     adj = jtimes(f_expl, vertcat(x, u), lambdaX, True)
 
     fun_name = model_name + '_expl_vde_adj'


### PR DESCRIPTION
Hi,

this is on top, but contentwise independent from
https://github.com/acados/acados/pull/590
For compact diff, check:
https://github.com/FreyJo/acados/pull/45

I added the file:
`docs/memory_management.md`, which is intended for developers and documents how the `*_calculate_size`, `*_assign` functions should look like.

I made the `minimal_ocp_example` work on the Raspberry Pi 2 instance in the office, by adapting some of the core functions wrt the guidline file.
https://discourse.acados.org/t/convergence-failure-on-embedded-platform/122/6

Note: that for now, this does not mean that there is full acados support on 32 Bit architectures.
The next steps to do on a 32 Bit machine would be
- [ ] make C tests / examples work
- [ ] make the Python tests work
- [ ] ideally have some CI to check some form of 32 Bit compatibility.

I suggest to copy these points (and further ones from discussion) to a new issue and close related outdated issues.

For now the official statement should still be that acados does not support 32 Bit architectures.

Feedback very welcome!
