### PR TITLE
 Memory management - some fixes wrt 32 Bit architectures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,7 @@ endif()
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99 -Wall -fdiagnostics-show-option")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -fdiagnostics-show-option")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x -Wall -fdiagnostics-show-option")
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
     set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} /MT")
     set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MT")

--- a/acados/dense_qp/dense_qp_common.c
+++ b/acados/dense_qp/dense_qp_common.c
@@ -54,6 +54,8 @@
 // acados
 #include "acados/dense_qp/dense_qp_common.h"
 #include "acados/utils/types.h"
+#include "acados/utils/mem.h"
+
 
 
 
@@ -182,6 +184,9 @@ int dense_qp_out_calculate_size(dense_qp_dims *dims)
     int size = sizeof(dense_qp_out);
     size += d_dense_qp_sol_memsize(dims);
     size += sizeof(qp_info);
+    size += 8;
+    make_int_multiple_of(8, &size);
+
     return size;
 }
 
@@ -193,8 +198,7 @@ dense_qp_out *dense_qp_out_assign(dense_qp_dims *dims, void *raw_memory)
 
     dense_qp_out *qp_out = (dense_qp_out *) c_ptr;
     c_ptr += sizeof(dense_qp_out);
-
-    assert((size_t) c_ptr % 8 == 0 && "memory not 8-byte aligned!");
+    align_char_to(8, &c_ptr);
 
     d_dense_qp_sol_create(dims, qp_out, c_ptr);
     c_ptr += d_dense_qp_sol_memsize(dims);
@@ -202,7 +206,7 @@ dense_qp_out *dense_qp_out_assign(dense_qp_dims *dims, void *raw_memory)
     qp_out->misc = (void *) c_ptr;
     c_ptr += sizeof(qp_info);
 
-    assert((char *) raw_memory + dense_qp_out_calculate_size(dims) == c_ptr);
+    assert((char *) raw_memory + dense_qp_out_calculate_size(dims) >= c_ptr);
 
     return qp_out;
 }
@@ -235,6 +239,8 @@ int dense_qp_res_calculate_size(dense_qp_dims *dims)
 {
     int size = sizeof(dense_qp_res);
     size += d_dense_qp_res_memsize(dims);
+
+    make_int_multiple_of(8, &size);
     return size;
 }
 
@@ -247,10 +253,10 @@ dense_qp_res *dense_qp_res_assign(dense_qp_dims *dims, void *raw_memory)
     dense_qp_res *qp_res = (dense_qp_res *) c_ptr;
     c_ptr += sizeof(dense_qp_res);
 
+    align_char_to(8, &c_ptr);
     d_dense_qp_res_create(dims, qp_res, c_ptr);
     c_ptr += d_dense_qp_res_memsize(dims);
-
-    assert((char *) raw_memory + dense_qp_res_calculate_size(dims) == c_ptr);
+    assert((char *) raw_memory + dense_qp_res_calculate_size(dims) >= c_ptr);
 
     return qp_res;
 }
@@ -260,7 +266,10 @@ dense_qp_res *dense_qp_res_assign(dense_qp_dims *dims, void *raw_memory)
 int dense_qp_res_workspace_calculate_size(dense_qp_dims *dims)
 {
     int size = sizeof(dense_qp_res_ws);
+
     size += d_dense_qp_res_ws_memsize(dims);
+    make_int_multiple_of(8, &size);
+
     return size;
 }
 
@@ -273,10 +282,12 @@ dense_qp_res_ws *dense_qp_res_workspace_assign(dense_qp_dims *dims, void *raw_me
     dense_qp_res_ws *res_ws = (dense_qp_res_ws *) c_ptr;
     c_ptr += sizeof(dense_qp_res_ws);
 
+    align_char_to(8, &c_ptr);
+
     d_dense_qp_res_ws_create(dims, res_ws, c_ptr);
     c_ptr += d_dense_qp_res_ws_memsize(dims);
 
-    assert((char *) raw_memory + dense_qp_res_workspace_calculate_size(dims) == c_ptr);
+    assert((char *) raw_memory + dense_qp_res_workspace_calculate_size(dims) >= c_ptr);
 
     return res_ws;
 }

--- a/acados/ocp_nlp/ocp_nlp_cost_ls.c
+++ b/acados/ocp_nlp/ocp_nlp_cost_ls.c
@@ -239,6 +239,7 @@ int ocp_nlp_cost_ls_model_calculate_size(void *config_, void *dims_)
     size += 1 * blasfeo_memsize_dmat(nz, ny);           // Vz
     size += 1 * blasfeo_memsize_dvec(ny);               // y_ref
     size += 2 * blasfeo_memsize_dvec(2 * ns);           // Z, z
+    make_int_multiple_of(8, &size);
 
     return size;
 }

--- a/acados/ocp_nlp/ocp_nlp_dynamics_cont.c
+++ b/acados/ocp_nlp/ocp_nlp_dynamics_cont.c
@@ -365,6 +365,8 @@ int ocp_nlp_dynamics_cont_memory_calculate_size(void *config_, void *dims_, void
 
     size += 1*64;  // blasfeo_mem align
 
+    make_int_multiple_of(8, &size);
+
     return size;
 }
 
@@ -599,6 +601,7 @@ int ocp_nlp_dynamics_cont_workspace_calculate_size(void *config_, void *dims_, v
     size += 1 * blasfeo_memsize_dmat(nu+nx, nu+nx);   // hess
 
     size += 1*64;  // blasfeo_mem align
+    make_int_multiple_of(8, &size);
 
     return size;
 }
@@ -661,6 +664,8 @@ int ocp_nlp_dynamics_cont_model_calculate_size(void *config_, void *dims_)
     size += sizeof(ocp_nlp_dynamics_cont_model);
 
     size += config->sim_solver->model_calculate_size(config->sim_solver, dims->sim);
+    size += 1*8;
+    make_int_multiple_of(8, &size);
 
     return size;
 }
@@ -681,6 +686,7 @@ void *ocp_nlp_dynamics_cont_model_assign(void *config_, void *dims_, void *raw_m
     // struct
     ocp_nlp_dynamics_cont_model *model = (ocp_nlp_dynamics_cont_model *) c_ptr;
     c_ptr += sizeof(ocp_nlp_dynamics_cont_model);
+    align_char_to(8, &c_ptr);
 
     model->sim_model = config->sim_solver->model_assign(config->sim_solver, dims->sim, c_ptr);
     c_ptr += config->sim_solver->model_calculate_size(config->sim_solver, dims->sim);

--- a/acados/ocp_nlp/ocp_nlp_sqp.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp.c
@@ -326,7 +326,7 @@ int ocp_nlp_sqp_memory_calculate_size(void *config_, void *dims_, void *opts_)
         stat_n += 4;
     size += stat_n*stat_m*sizeof(double);
 
-    size += 8;  // initial align
+    size += 3*8;  // align
 
     make_int_multiple_of(8, &size);
 
@@ -360,6 +360,8 @@ void *ocp_nlp_sqp_memory_assign(void *config_, void *dims_, void *opts_, void *r
     ocp_nlp_sqp_memory *mem = (ocp_nlp_sqp_memory *) c_ptr;
     c_ptr += sizeof(ocp_nlp_sqp_memory);
 
+    align_char_to(8, &c_ptr);
+
     // nlp res
     mem->nlp_res = ocp_nlp_res_assign(dims, c_ptr);
     c_ptr += mem->nlp_res->memsize;
@@ -377,6 +379,8 @@ void *ocp_nlp_sqp_memory_assign(void *config_, void *dims_, void *opts_, void *r
     c_ptr += mem->stat_m*mem->stat_n*sizeof(double);
 
     mem->status = ACADOS_READY;
+
+    align_char_to(8, &c_ptr);
 
     assert((char *) raw_memory + ocp_nlp_sqp_memory_calculate_size(config, dims, opts) >= c_ptr);
 

--- a/acados/ocp_qp/ocp_qp_hpipm.c
+++ b/acados/ocp_qp/ocp_qp_hpipm.c
@@ -64,6 +64,8 @@ int ocp_qp_hpipm_opts_calculate_size(void *config_, void *dims_)
     size += d_ocp_qp_ipm_arg_memsize(dims);
 
     size += 1 * 8;
+    make_int_multiple_of(8, &size);
+
     return size;
 }
 
@@ -155,6 +157,8 @@ int ocp_qp_hpipm_memory_calculate_size(void *config_, void *dims_, void *opts_)
     size += d_ocp_qp_ipm_ws_memsize(dims, opts->hpipm_opts);
 
     size += 1 * 8;
+    make_int_multiple_of(8, &size);
+
     return size;
 }
 

--- a/acados/ocp_qp/ocp_qp_partial_condensing.c
+++ b/acados/ocp_qp/ocp_qp_partial_condensing.c
@@ -361,6 +361,7 @@ int ocp_qp_partial_condensing_memory_calculate_size(void *dims_, void *opts_)
     size += d_ocp_qp_reduce_eq_dof_work_memsize(dims->orig_dims);
 
     size += 2*8;
+    make_int_multiple_of(8, &size);
 
     return size;
 }

--- a/docs/memory_management.md
+++ b/docs/memory_management.md
@@ -4,7 +4,7 @@ Guidelines on how memory should be assigned for an `acados` structure `astruct`.
 There are two functions: `astruct_calculate_size()`, `astruct_assign()`.
 
 ## `astruct_calculate_size()`
-Must return a multiple of 8 to keep the pointer aligned to 8 when allocating substructures.
+Must return a multiple of 8 to keep the pointer aligned to 8 bytes when allocating substructures.
 Thus, it should end with:
 ```
 make_int_multiple_of(8, &size);
@@ -18,17 +18,20 @@ Should assign its members in the following order:
 ```
 align_char_to(8, &c_ptr);
 ```
-- structure itself, i.e.:
+
+- Assign structure itself, i.e.:
 ```
     astruct *as_instance = (astruct *) c_ptr;
     c_ptr += sizeof(astruct);
 ```
-- pointers to substructures, if `astruct` contains an array of `bstruct`s, e.g.
+
+- Assign pointers to substructures, if `astruct` contains an array of `bstruct`s, e.g.
 ```
     mem->bstructs = (void **) c_ptr;
     c_ptr += N*sizeof(void *);
 ```
-- Note: It should be aligned to 8 here after, since `astruct` might contain an `int`, and the pointers were assigned.
+
+- Align to 8 bytes, since `astruct` might contain an `int`, and the pointers were assigned.
 
 
 - Assign "substructures", i.e. structures that `astruct` has pointers to:
@@ -37,9 +40,10 @@ align_char_to(8, &c_ptr);
     as_instance->bstruct = bstruct_assign(c_ptr,...);
     c_ptr += bstruct_calculate_size(astruct);
 ```
+
 - Note:
     - since calculate_size returns multiple of 8, c_ptr is still aligned to 8 bytes.
-    - blasfeo_dmat_structs, blasfeo_dvec_structs can be seen as "substructures" here.
+    - `blasfeo_dmat_structs`, `blasfeo_dvec_structs` can be seen as "substructures" here.
 
 
 - Assign doubles (are 8 bytes anyway)
@@ -52,7 +56,7 @@ align_char_to(8, &c_ptr);
     assign_and_advance_double_ptrs(n_pointers, &as_instance->double_pointer, &c_ptr);
 ```
 
-- Align to 8 bytes, can be skipped if no pointers are allcoted
+- Align to 8 bytes, can be skipped if no pointers have been assigned
 
 
 - Assign integers
@@ -60,14 +64,17 @@ align_char_to(8, &c_ptr);
     assign_and_advance_int(n_integers, &as_instance->ints, &c_ptr);
 ```
 
-- Align to 64 bytes
+- Align to 64 bytes, i.e.:
+```
+align_char_to(64, &c_ptr);
+```
 
-- Assign blasfeo_dmat_mems (are multiple of 64 Bytes)
+- Assign `blasfeo_dmat_mem` (are multiple of 64 Bytes)
 ```
     assign_and_advance_blasfeo_dmat_mem(nrow, ncol, &as_instance->blasfeo_mat, &c_ptr);
 ```
 
-- blasfeo_vec_mem (are multiple of 32 Bytes)
+- Assign `blasfeo_vec_mem` (are multiple of 32 Bytes)
 ```
     assign_and_advance_blasfeo_dvec_mem(n, &as_instance->blasfeo_vec, &c_ptr);
 ```

--- a/docs/memory_management.md
+++ b/docs/memory_management.md
@@ -14,7 +14,10 @@ make_int_multiple_of(8, &size);
 ## `astruct_assign()`
 Should assign its members in the following order:
 
-- Align to 8 bytes
+- Align to 8 bytes, i.e.:
+```
+align_char_to(8, &c_ptr);
+```
 - structure itself, i.e.:
 ```
     astruct *as_instance = (astruct *) c_ptr;
@@ -36,7 +39,7 @@ Should assign its members in the following order:
 ```
 - Note:
     - since calculate_size returns multiple of 8, c_ptr is still aligned to 8 bytes.
-    - blasfeo_dmat_structs, blasfeo_dvec_structs can be seehn as "substructures" here.
+    - blasfeo_dmat_structs, blasfeo_dvec_structs can be seen as "substructures" here.
 
 
 - Assign doubles (are 8 bytes anyway)

--- a/docs/memory_management.md
+++ b/docs/memory_management.md
@@ -1,0 +1,73 @@
+# Memory management in acados:
+Guidelines on how memory should be assigned for an `acados` structure `astruct`.
+
+There are two functions: `astruct_calculate_size()`, `astruct_assign()`.
+
+## `astruct_calculate_size()`
+Must return a multiple of 8 to keep the pointer aligned to 8 when allocating substructures.
+Thus, it should end with:
+```
+make_int_multiple_of(8, &size);
+```
+
+
+## `astruct_assign()`
+Should assign its members in the following order:
+
+- Align to 8 bytes
+- structure itself, i.e.:
+```
+    astruct *as_instance = (astruct *) c_ptr;
+    c_ptr += sizeof(astruct);
+```
+- pointers to substructures, if `astruct` contains an array of `bstruct`s, e.g.
+```
+    mem->bstructs = (void **) c_ptr;
+    c_ptr += N*sizeof(void *);
+```
+- Note: It should be aligned to 8 here after, since `astruct` might contain an `int`, and the pointers were assigned.
+
+
+- Assign "substructures", i.e. structures that `astruct` has pointers to:
+```
+    // assume astruct contains an instance of bstruct
+    as_instance->bstruct = bstruct_assign(c_ptr,...);
+    c_ptr += bstruct_calculate_size(astruct);
+```
+- Note:
+    - since calculate_size returns multiple of 8, c_ptr is still aligned to 8 bytes.
+    - blasfeo_dmat_structs, blasfeo_dvec_structs can be seehn as "substructures" here.
+
+
+- Assign doubles (are 8 bytes anyway)
+```
+    assign_and_advance_double(n_doubles, &as_instance->doubles, &c_ptr);
+```
+
+- Assign pointers (4 bytes on 32 Bit)
+```
+    assign_and_advance_double_ptrs(n_pointers, &as_instance->double_pointer, &c_ptr);
+```
+
+- Align to 8 bytes, can be skipped if no pointers are allcoted
+
+
+- Assign integers
+```
+    assign_and_advance_int(n_integers, &as_instance->ints, &c_ptr);
+```
+
+- Align to 64 bytes
+
+- Assign blasfeo_dmat_mems (are multiple of 64 Bytes)
+```
+    assign_and_advance_blasfeo_dmat_mem(nrow, ncol, &as_instance->blasfeo_mat, &c_ptr);
+```
+
+- blasfeo_vec_mem (are multiple of 32 Bytes)
+```
+    assign_and_advance_blasfeo_dvec_mem(n, &as_instance->blasfeo_vec, &c_ptr);
+```
+
+- Align c_ptr to 8 byte here for nested assigns, see "substructures"
+   - relevant if no blasfeo_mems are in `astruct`


### PR DESCRIPTION
Replacing #593:

I added the file:
`docs/memory_management.md`, which is intended for developers and documents how the `*_calculate_size`, `*_assign` functions should look like.

I made the `minimal_ocp_example` work on the Raspberry Pi 2 instance in the office, by adapting some of the core functions wrt the guidline file.
https://discourse.acados.org/t/convergence-failure-on-embedded-platform/122/6

Note: that for now, this does not mean that there is full acados support on 32 Bit architectures.
The next steps to do on a 32 Bit machine would be
- [ ] make C tests / examples work
- [ ] make the Python tests work
- [ ] ideally have some CI to check some form of 32 Bit compatibility.

I suggest to copy these points (and further ones from discussion) to a new issue and close related outdated issues.

For now the official statement should still be that acados does not support 32 Bit architectures.

Feedback very welcome!