### PR TITLE
github actions: use ubuntu20.04, Octave 5.2.0, CasADi 3.5.5

### DIFF
--- a/.github/linux/install_casadi_octave.sh
+++ b/.github/linux/install_casadi_octave.sh
@@ -32,8 +32,9 @@
 # POSSIBILITY OF SUCH DAMAGE.;
 #
 
-CASADI_VERSION='3.5.3'; # Latest version with Octave 4.2.2 binaries
-OCTAVE_VERSION='4.2.2';
+# CASADI_VERSION='3.5.3'; # Latest version with Octave 4.2.2 binaries
+CASADI_VERSION='3.5.5';
+OCTAVE_VERSION='5.2.0';
 
 _CASADI_GITHUB_RELEASES="https://github.com/casadi/casadi/releases/download/${CASADI_VERSION}";
 

--- a/.github/workflows/full_build.yml
+++ b/.github/workflows/full_build.yml
@@ -21,7 +21,7 @@ jobs:
     # well on Windows or Mac.  You can convert this to a matrix build if you need
     # cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Octave template tests were failing irregularly without proper error on old Octave.