### PR TITLE
parametric functions & globalization options

### DIFF
--- a/acados/ocp_nlp/ocp_nlp_common.c
+++ b/acados/ocp_nlp/ocp_nlp_common.c
@@ -2200,7 +2200,7 @@ double ocp_nlp_evaluate_merit_fun(ocp_nlp_config *config, ocp_nlp_dims *dims,
 
 
 
-static double ocp_nlp_line_search(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in,
+double ocp_nlp_line_search(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in,
             ocp_nlp_out *out, ocp_nlp_opts *opts, ocp_nlp_memory *mem, ocp_nlp_workspace *work)
 {
     int i;
@@ -2399,7 +2399,7 @@ static double ocp_nlp_line_search(ocp_nlp_config *config, ocp_nlp_dims *dims, oc
 
 
 void ocp_nlp_update_variables_sqp(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in,
-            ocp_nlp_out *out, ocp_nlp_opts *opts, ocp_nlp_memory *mem, ocp_nlp_workspace *work)
+            ocp_nlp_out *out, ocp_nlp_opts *opts, ocp_nlp_memory *mem, ocp_nlp_workspace *work, double alpha)
 {
     int i;
 
@@ -2409,9 +2409,6 @@ void ocp_nlp_update_variables_sqp(ocp_nlp_config *config, ocp_nlp_dims *dims, oc
     int *nu = dims->nu;
     int *ni = dims->ni;
     int *nz = dims->nz;
-
-    // step length
-    double alpha = ocp_nlp_line_search(config, dims, in, out, opts, mem, work);
 
 
 #if defined(ACADOS_WITH_OPENMP)

--- a/acados/ocp_nlp/ocp_nlp_common.h
+++ b/acados/ocp_nlp/ocp_nlp_common.h
@@ -396,7 +396,10 @@ void ocp_nlp_embed_initial_value(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp
                  ocp_nlp_out *out, ocp_nlp_opts *opts, ocp_nlp_memory *mem, ocp_nlp_workspace *work);
 //
 void ocp_nlp_update_variables_sqp(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in,
-           ocp_nlp_out *out, ocp_nlp_opts *opts, ocp_nlp_memory *mem, ocp_nlp_workspace *work);
+           ocp_nlp_out *out, ocp_nlp_opts *opts, ocp_nlp_memory *mem, ocp_nlp_workspace *work, double alpha);
+//
+double ocp_nlp_line_search(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in,
+            ocp_nlp_out *out, ocp_nlp_opts *opts, ocp_nlp_memory *mem, ocp_nlp_workspace *work);
 //
 double ocp_nlp_evaluate_merit_fun(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in,
           ocp_nlp_out *out, ocp_nlp_opts *opts, ocp_nlp_memory *mem, ocp_nlp_workspace *work);

--- a/acados/ocp_nlp/ocp_nlp_common.h
+++ b/acados/ocp_nlp/ocp_nlp_common.h
@@ -258,7 +258,6 @@ typedef enum
 
 typedef struct ocp_nlp_opts
 {
-    ocp_nlp_globalization_t globalization;
     ocp_qp_xcond_solver_opts *qp_solver_opts; // xcond solver opts instead ???
     void *regularize;
     void **dynamics;     // dynamics_opts
@@ -269,6 +268,10 @@ typedef struct ocp_nlp_opts
     int reuse_workspace;
     int num_threads;
 
+    // TODO: move to separate struct?
+    ocp_nlp_globalization_t globalization;
+    double alpha_min;
+    double alpha_reduction;
 } ocp_nlp_opts;
 
 //

--- a/acados/ocp_nlp/ocp_nlp_sqp.h
+++ b/acados/ocp_nlp/ocp_nlp_sqp.h
@@ -103,6 +103,7 @@ typedef struct
     double time_lin;
     double time_reg;
     double time_tot;
+    double time_glob;
 
     // statistics
     double *stat;

--- a/acados/ocp_nlp/ocp_nlp_sqp_rti.h
+++ b/acados/ocp_nlp/ocp_nlp_sqp_rti.h
@@ -99,6 +99,7 @@ typedef struct
     double time_lin;
     double time_reg;
     double time_tot;
+    double time_glob;
 
     // statistics
     double *stat;

--- a/acados/utils/external_function_generic.c
+++ b/acados/utils/external_function_generic.c
@@ -991,6 +991,18 @@ void external_function_param_casadi_set_n_out(external_function_param_casadi *fu
 }
 
 
+static void external_function_param_casadi_set_param(void *self, double *p)
+{
+    external_function_param_casadi *fun = self;
+
+    // set value for all parameters
+    for (int ii = 0; ii < fun->np; ii++)
+    {
+        fun->args[fun->in_num-1][ii] = p[ii];
+    }
+    return;
+}
+
 
 static void external_function_param_casadi_set_param_sparse(void *self, int n_update,
                                                             int *idx, double *p)
@@ -999,7 +1011,7 @@ static void external_function_param_casadi_set_param_sparse(void *self, int n_up
 
     for (int ii = 0; ii < n_update; ii++)
     {
-        fun->p[idx[ii]] = p[ii];
+        fun->args[fun->in_num-1][idx[ii]] = p[ii];
     }
 
     return;
@@ -1107,8 +1119,6 @@ void external_function_param_casadi_assign(external_function_param_casadi *fun, 
         assign_and_advance_double(fun->res_size[ii], &fun->res[ii], &c_ptr);
     // w
     assign_and_advance_double(fun->w_size, &fun->w, &c_ptr);
-    // p
-    assign_and_advance_double(fun->np, &fun->p, &c_ptr);
 
     assert((char *) raw_memory + external_function_param_casadi_calculate_size(fun, fun->np) >=
            c_ptr);
@@ -1172,9 +1182,7 @@ void external_function_param_casadi_wrapper(void *self, ext_fun_arg_t *type_in, 
                 exit(1);
         }
     }
-    // copy parametrs vector as last arg
-    ii = fun->in_num - 1;
-    for (jj = 0; jj < fun->np; jj++) fun->args[ii][jj] = fun->p[jj];
+    // parameters are last argument and set via external_function_param_casadi_set_param
 
     // call casadi function
     fun->casadi_fun((const double **) fun->args, fun->res, fun->iw, fun->w, NULL);
@@ -1239,16 +1247,3 @@ void external_function_param_casadi_get_nparam(void *self, int *np)
 }
 
 
-void external_function_param_casadi_set_param(void *self, double *p)
-{
-    // cast into external casadi function
-    external_function_param_casadi *fun = self;
-
-    // set value for all parameters
-    for (int ii = 0; ii < fun->np; ii++)
-    {
-        fun->p[ii] = p[ii];
-    }
-
-    return;
-}

--- a/acados/utils/external_function_generic.h
+++ b/acados/utils/external_function_generic.h
@@ -200,7 +200,6 @@ typedef struct
     double **args;
     double **res;
     double *w;
-    double *p;  // parameters
     int *iw;
     int *args_size;     // size of args[i]
     int *res_size;      // size of res[i]
@@ -238,8 +237,6 @@ void external_function_param_casadi_wrapper(void *self, ext_fun_arg_t *type_in, 
                                             ext_fun_arg_t *type_out, void **out);
 //
 void external_function_param_casadi_get_nparam(void *self, int *np);
-//
-void external_function_param_casadi_set_param(void *self, double *p);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/interfaces/acados_matlab_octave/acados_ocp_opts.m
+++ b/interfaces/acados_matlab_octave/acados_ocp_opts.m
@@ -67,6 +67,11 @@ classdef acados_ocp_opts < handle
             obj.opts_struct.nlp_solver_step_length = 1.0; % fixed step length in SQP algorithm
             obj.opts_struct.rti_phase = 0; % RTI phase: (1) preparation, (2) feedback, (0) both
             obj.opts_struct.qp_solver = 'partial_condensing_hpipm';
+            % globalization
+            obj.opts_struct.globalization = 'fixed_step';
+            obj.opts_struct.alpha_min = 0.05;
+            obj.opts_struct.alpha_reduction = 0.7;
+
             obj.opts_struct.qp_solver_iter_max = 50;
             % obj.opts_struct.qp_solver_cond_N = 5; % New horizon after partial condensing
             obj.opts_struct.qp_solver_cond_ric_alg = 0; % 0: dont factorize hessian in the condensing; 1: factorize
@@ -184,6 +189,12 @@ classdef acados_ocp_opts < handle
                 obj.opts_struct.print_level = value;
             elseif (strcmp(field, 'levenberg_marquardt'))
                 obj.opts_struct.levenberg_marquardt = value;
+            elseif (strcmp(field, 'alpha_min'))
+                obj.opts_struct.alpha_min = value;
+            elseif (strcmp(field, 'alpha_reduction'))
+                obj.opts_struct.alpha_reduction = value;
+            elseif (strcmp(field, 'globalization'))
+                obj.opts_struct.globalization = value;
             elseif (strcmp(field, 'compile_mex'))
                 disp(['Option compile_mex is not supported anymore,'...
                     'please use compile_interface instead or dont set the option.', ...

--- a/interfaces/acados_matlab_octave/acados_template_mex/+acados_template_mex/ocp_nlp_solver_options_json.m
+++ b/interfaces/acados_matlab_octave/acados_template_mex/+acados_template_mex/ocp_nlp_solver_options_json.m
@@ -67,6 +67,9 @@ classdef ocp_nlp_solver_options_json < handle
         exact_hess_constr
         exact_hess_dyn
         ext_cost_num_hess
+        alpha_min
+        alpha_reduction
+        globalization
 
     end
     methods
@@ -95,6 +98,9 @@ classdef ocp_nlp_solver_options_json < handle
             obj.exact_hess_constr = 1;
             obj.exact_hess_dyn = 1;
             obj.ext_cost_num_hess = 0;
+            obj.alpha_min = 0.05;
+            obj.alpha_reduction = 0.7;
+            obj.globalization = 'FIXED_STEP';
 
         end
     end

--- a/interfaces/acados_matlab_octave/ocp_create.c
+++ b/interfaces/acados_matlab_octave/ocp_create.c
@@ -893,6 +893,28 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         ocp_nlp_solver_opts_set(config, opts, "print_level", &print_level);
     }
 
+
+    // globalization
+    char *globalization;
+    if (mxGetField( matlab_opts, 0, "globalization" )!=NULL)
+    {
+        globalization = mxArrayToString( mxGetField( matlab_opts, 0, "globalization" ) );
+        ocp_nlp_solver_opts_set(config, opts, "globalization", globalization);
+
+        if (strcmp(globalization, "fixed_step"))
+        {
+            double alpha_min = mxGetScalar( mxGetField( matlab_opts, 0, "alpha_min" ) );
+            ocp_nlp_solver_opts_set(config, opts, "alpha_min", &alpha_min);
+            double alpha_reduction = mxGetScalar( mxGetField( matlab_opts, 0, "alpha_reduction" ) );
+            ocp_nlp_solver_opts_set(config, opts, "alpha_reduction", &alpha_reduction);
+        }
+    }
+    else
+    {
+        MEX_MISSING_ARGUMENT(fun_name, "globalization");
+    }
+
+
     if (strcmp(dyn_type, "discrete"))
     {
         // sim_method_num_stages

--- a/interfaces/acados_matlab_octave/ocp_get.c
+++ b/interfaces/acados_matlab_octave/ocp_get.c
@@ -319,7 +319,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         ocp_nlp_get(config, solver, "sqp_iter", &sqp_iter);
         *mat_ptr = (double) sqp_iter;
     }
-    else if (!strcmp(field, "time_tot") || !strcmp(field, "time_lin") || !strcmp(field, "time_reg") || !strcmp(field, "time_qp_sol") || !strcmp(field, "time_qp_solver_call") || !strcmp(field, "time_qp_solver") || !strcmp(field, "time_qp_xcond") || !strcmp(field, "time_sim") || !strcmp(field, "time_sim_la") || !strcmp(field, "time_sim_ad"))
+    else if (!strcmp(field, "time_tot") || !strcmp(field, "time_lin") || !strcmp(field, "time_glob") || !strcmp(field, "time_reg") || !strcmp(field, "time_qp_sol") || !strcmp(field, "time_qp_solver_call") || !strcmp(field, "time_qp_solver") || !strcmp(field, "time_qp_xcond") || !strcmp(field, "time_sim") || !strcmp(field, "time_sim_la") || !strcmp(field, "time_sim_ad"))
     {
         plhs[0] = mxCreateNumericMatrix(1, 1, mxDOUBLE_CLASS, mxREAL);
         double *mat_ptr = mxGetPr( plhs[0] );

--- a/interfaces/acados_template/acados_template/acados_layout.json
+++ b/interfaces/acados_template/acados_template/acados_layout.json
@@ -599,6 +599,9 @@
         "nlp_solver_type": [
             "str"
         ],
+        "globalization": [
+            "str"
+        ],
         "nlp_solver_step_length": [
             "float"
         ],
@@ -612,6 +615,12 @@
             "float"
         ],
         "Tsim": [
+            "float"
+        ],
+        "alpha_min": [
+            "float"
+        ],
+        "alpha_reduction": [
             "float"
         ],
         "sim_method_num_stages": [

--- a/interfaces/acados_template/acados_template/acados_ocp.py
+++ b/interfaces/acados_template/acados_template/acados_ocp.py
@@ -1749,6 +1749,7 @@ class AcadosOcpOptions:
         self.__integrator_type  = 'ERK'                       # integrator type
         self.__tf               = None                        # prediction horizon
         self.__nlp_solver_type  = 'SQP_RTI'                   # NLP solver
+        self.__globalization = 'FIXED_STEP'
         self.__nlp_solver_step_length = 1.0                   # fixed Newton step length
         self.__levenberg_marquardt = 0.0
         self.__sim_method_num_stages  = 4                     # number of stages in the integrator
@@ -1799,6 +1800,11 @@ class AcadosOcpOptions:
     def nlp_solver_type(self):
         """NLP solver"""
         return self.__nlp_solver_type
+
+    @property
+    def globalization(self):
+        """Globalization type"""
+        return self.__globalization
 
     @property
     def regularize_method(self):
@@ -1886,6 +1892,16 @@ class AcadosOcpOptions:
     def nlp_solver_tol_eq(self):
         """NLP solver equality tolerance"""
         return self.__nlp_solver_tol_eq
+
+    @property
+    def alpha_min(self):
+        """Minimal step size for globalization"""
+        return self.__alpha_min
+
+    @property
+    def alpha_reduction(self):
+        """Step size reduction factor for globalization"""
+        return self.__alpha_reduction
 
     @property
     def nlp_solver_tol_ineq(self):
@@ -2016,6 +2032,18 @@ class AcadosOcpOptions:
     @Tsim.setter
     def Tsim(self, Tsim):
         self.__Tsim = Tsim
+
+    @globalization.setter
+    def globalization(self, globalization):
+        self.__globalization = globalization
+
+    @alpha_min.setter
+    def alpha_min(self, alpha_min):
+        self.__alpha_min = alpha_min
+
+    @alpha_reduction.setter
+    def alpha_reduction(self, alpha_reduction):
+        self.__alpha_reduction = alpha_reduction
 
     @sim_method_num_stages.setter
     def sim_method_num_stages(self, sim_method_num_stages):

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -1192,11 +1192,11 @@ class AcadosOcpSolver:
     def options_set(self, field_, value_):
         """
         set options of the solver:
-            :param field_: string, e.g. 'print_level', 'rti_phase', 'initialize_t_slacks', 'step_length'
+            :param field_: string, e.g. 'print_level', 'rti_phase', 'initialize_t_slacks', 'step_length', 'alpha_min', 'alpha_reduction'
             :param value_: of type int, float
         """
         int_fields = ['print_level', 'rti_phase', 'initialize_t_slacks']
-        double_fields = ['step_length', 'tol_eq', 'tol_stat', 'tol_ineq', 'tol_comp']
+        double_fields = ['step_length', 'tol_eq', 'tol_stat', 'tol_ineq', 'tol_comp', 'alpha_min', 'alpha_reduction']
         string_fields = ['globalization']
 
         # check field availability and type

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -846,6 +846,7 @@ class AcadosOcpSolver:
                   'time_qp',   # cpu time qp solution
                   'time_qp_solver_call',  # cpu time inside qp solver (without converting the QP)
                   'time_qp_xcond',
+                  'time_glob',  # cpu time globalization
                   'time_reg',  # cpu time regularization
                   'sqp_iter',  # number of SQP iterations
                   'statistics',  # table with info about last iteration

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -1422,6 +1422,18 @@ int {{ model.name }}_acados_create(nlp_solver_capsule * capsule)
     ocp_nlp_solver_opts_set(nlp_config, capsule->nlp_opts, "exact_hess_constr", &exact_hess_constr);
 {%- endif -%}
 
+{%- if solver_options.globalization == "FIXED_STEP" %}
+    ocp_nlp_solver_opts_set(nlp_config, capsule->nlp_opts, "globalization", "fixed_step");
+{%- elif solver_options.globalization == "MERIT_BACKTRACKING" %}
+    ocp_nlp_solver_opts_set(nlp_config, capsule->nlp_opts, "globalization", "merit_backtracking");
+
+    double alpha_min = {{ solver_options.alpha_min }};
+    ocp_nlp_solver_opts_set(nlp_config, capsule->nlp_opts, "alpha_min", &alpha_min);
+
+    double alpha_reduction = {{ solver_options.alpha_reduction }};
+    ocp_nlp_solver_opts_set(nlp_config, capsule->nlp_opts, "alpha_reduction", &alpha_reduction);
+{%- endif -%}
+
 {%- if dims.nz > 0 %}
     // TODO: these options are lower level -> should be encapsulated! maybe through hessian approx option.
     bool output_z_val = true;


### PR DESCRIPTION
- parametric CasADi functions: Removed memory & avoid copying, see https://discourse.acados.org/t/solver-getting-slow-with-a-large-number-of-parameters/290/5
- globalization: add options `alpha_min, alpha_reduction`