### PR TITLE
[bugfix!] adding missing arguments to param update function

### DIFF
--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_sim_solver.in.h
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_sim_solver.in.h
@@ -44,7 +44,7 @@ extern "C" {
 int {{ model.name }}_acados_sim_create();
 int {{ model.name }}_acados_sim_solve();
 int {{ model.name }}_acados_sim_free();
-int {{ model.name }}_acados_sim_update_params();
+int {{ model.name }}_acados_sim_update_params(double *value, int np);
 
 sim_config  * {{ model.name }}_acados_get_sim_config();
 sim_in      * {{ model.name }}_acados_get_sim_in();


### PR DESCRIPTION
The declaration of {model.name}_sim_update_param() was missing its arguments so I fixed it on the fly and thought it would be useful to let you know