### PR TITLE
change return-type for all *calculate_size functions to configurable type

### DIFF
--- a/acados/dense_qp/dense_qp_common.c
+++ b/acados/dense_qp/dense_qp_common.c
@@ -63,9 +63,9 @@
  * config
  ************************************************/
 
-int dense_qp_solver_config_calculate_size()
+acados_size_t dense_qp_solver_config_calculate_size()
 {
-    int size = 0;
+    acados_size_t size = 0;
 
     size += sizeof(qp_solver_config);
 
@@ -90,9 +90,9 @@ qp_solver_config *dense_qp_solver_config_assign(void *raw_memory)
  * dims
  ************************************************/
 
-int dense_qp_dims_calculate_size()
+acados_size_t dense_qp_dims_calculate_size()
 {
-    int size = sizeof(dense_qp_dims);
+    acados_size_t size = sizeof(dense_qp_dims);
 
     size += d_dense_qp_dim_memsize();
 
@@ -135,9 +135,9 @@ void dense_qp_dims_set(void *config_, void *dims_, const char *field, const int*
  * in
  ************************************************/
 
-int dense_qp_in_calculate_size(dense_qp_dims *dims)
+acados_size_t dense_qp_in_calculate_size(dense_qp_dims *dims)
 {
-    int size = sizeof(dense_qp_in);
+    acados_size_t size = sizeof(dense_qp_in);
     size += sizeof(dense_qp_dims);
     size += d_dense_qp_memsize(dims);
     return size;
@@ -179,9 +179,9 @@ dense_qp_in *dense_qp_in_assign(dense_qp_dims *dims, void *raw_memory)
  * out
  ************************************************/
 
-int dense_qp_out_calculate_size(dense_qp_dims *dims)
+acados_size_t dense_qp_out_calculate_size(dense_qp_dims *dims)
 {
-    int size = sizeof(dense_qp_out);
+    acados_size_t size = sizeof(dense_qp_out);
     size += d_dense_qp_sol_memsize(dims);
     size += sizeof(qp_info);
     size += 8;
@@ -235,9 +235,9 @@ void dense_qp_out_get(dense_qp_out *out, const char *field, void *value)
  * res
  ************************************************/
 
-int dense_qp_res_calculate_size(dense_qp_dims *dims)
+acados_size_t dense_qp_res_calculate_size(dense_qp_dims *dims)
 {
-    int size = sizeof(dense_qp_res);
+    acados_size_t size = sizeof(dense_qp_res);
     size += d_dense_qp_res_memsize(dims);
 
     make_int_multiple_of(8, &size);
@@ -263,9 +263,9 @@ dense_qp_res *dense_qp_res_assign(dense_qp_dims *dims, void *raw_memory)
 
 
 
-int dense_qp_res_workspace_calculate_size(dense_qp_dims *dims)
+acados_size_t dense_qp_res_workspace_calculate_size(dense_qp_dims *dims)
 {
-    int size = sizeof(dense_qp_res_ws);
+    acados_size_t size = sizeof(dense_qp_res_ws);
 
     size += d_dense_qp_res_ws_memsize(dims);
     make_int_multiple_of(8, &size);

--- a/acados/dense_qp/dense_qp_common.h
+++ b/acados/dense_qp/dense_qp_common.h
@@ -59,15 +59,15 @@ typedef struct d_dense_qp_res_ws dense_qp_res_ws;
 typedef struct
 {
     void (*dims_set)(void *config_, void *dims_, const char *field, const int* value);
-    int (*opts_calculate_size)(void *config, void *dims);
+    acados_size_t (*opts_calculate_size)(void *config, void *dims);
     void *(*opts_assign)(void *config, void *dims, void *raw_memory);
     void (*opts_initialize_default)(void *config, void *dims, void *args);
     void (*opts_update)(void *config, void *dims, void *args);
     void (*opts_set)(void *config_, void *opts_, const char *field, void* value);
-    int (*memory_calculate_size)(void *config, void *dims, void *args);
+    acados_size_t (*memory_calculate_size)(void *config, void *dims, void *args);
     void *(*memory_assign)(void *config, void *dims, void *args, void *raw_memory);
     void (*memory_get)(void *config_, void *mem_, const char *field, void* value);
-    int (*workspace_calculate_size)(void *config, void *dims, void *args);
+    acados_size_t (*workspace_calculate_size)(void *config, void *dims, void *args);
     int (*evaluate)(void *config, void *qp_in, void *qp_out, void *args, void *mem, void *work);
     void (*eval_sens)(void *config, void *qp_in, void *qp_out, void *opts, void *mem, void *work);
 } qp_solver_config;
@@ -92,13 +92,13 @@ typedef struct
 
 /* config */
 //
-int dense_qp_solver_config_calculate_size();
+acados_size_t dense_qp_solver_config_calculate_size();
 //
 qp_solver_config *dense_qp_solver_config_assign(void *raw_memory);
 
 /* dims */
 //
-int dense_qp_dims_calculate_size();
+acados_size_t dense_qp_dims_calculate_size();
 //
 dense_qp_dims *dense_qp_dims_assign(void *raw_memory);
 //
@@ -107,13 +107,13 @@ void dense_qp_dims_set(void *config_, void *dims_, const char *field, const int*
 
 /* in */
 //
-int dense_qp_in_calculate_size(dense_qp_dims *dims);
+acados_size_t dense_qp_in_calculate_size(dense_qp_dims *dims);
 //
 dense_qp_in *dense_qp_in_assign(dense_qp_dims *dims, void *raw_memory);
 
 /* out */
 //
-int dense_qp_out_calculate_size(dense_qp_dims *dims);
+acados_size_t dense_qp_out_calculate_size(dense_qp_dims *dims);
 //
 dense_qp_out *dense_qp_out_assign(dense_qp_dims *dims, void *raw_memory);
 //
@@ -121,11 +121,11 @@ void dense_qp_out_get(dense_qp_out *out, const char *field, void *value);
 
 /* res */
 //
-int dense_qp_res_calculate_size(dense_qp_dims *dims);
+acados_size_t dense_qp_res_calculate_size(dense_qp_dims *dims);
 //
 dense_qp_res *dense_qp_res_assign(dense_qp_dims *dims, void *raw_memory);
 //
-int dense_qp_res_workspace_calculate_size(dense_qp_dims *dims);
+acados_size_t dense_qp_res_workspace_calculate_size(dense_qp_dims *dims);
 //
 dense_qp_res_ws *dense_qp_res_workspace_assign(dense_qp_dims *dims, void *raw_memory);
 //

--- a/acados/dense_qp/dense_qp_hpipm.c
+++ b/acados/dense_qp/dense_qp_hpipm.c
@@ -52,11 +52,11 @@
  * opts
  ************************************************/
 
-int dense_qp_hpipm_opts_calculate_size(void *config_, void *dims_)
+acados_size_t dense_qp_hpipm_opts_calculate_size(void *config_, void *dims_)
 {
     dense_qp_dims *dims = dims_;
 
-    int size = 0;
+    acados_size_t size = 0;
     size += sizeof(dense_qp_hpipm_opts);
     size += sizeof(struct d_dense_qp_ipm_arg);
     size += d_dense_qp_ipm_arg_memsize(dims);
@@ -137,12 +137,12 @@ void dense_qp_hpipm_opts_set(void *config_, void *opts_, const char *field, void
  * memory
  ************************************************/
 
-int dense_qp_hpipm_memory_calculate_size(void *config_, void *dims_, void *opts_)
+acados_size_t dense_qp_hpipm_memory_calculate_size(void *config_, void *dims_, void *opts_)
 {
     dense_qp_dims *dims = dims_;
     dense_qp_hpipm_opts *opts = opts_;
 
-    int size = 0;
+    acados_size_t size = 0;
     size += sizeof(dense_qp_hpipm_memory);
     size += sizeof(struct d_dense_qp_ipm_ws);
 
@@ -213,7 +213,7 @@ void dense_qp_hpipm_memory_get(void *config_, void *mem_, const char *field, voi
  * workspace
  ************************************************/
 
-int dense_qp_hpipm_workspace_calculate_size(void *config_, void *dims_, void *opts_)
+acados_size_t dense_qp_hpipm_workspace_calculate_size(void *config_, void *dims_, void *opts_)
 {
     return 0;
 }

--- a/acados/dense_qp/dense_qp_hpipm.h
+++ b/acados/dense_qp/dense_qp_hpipm.h
@@ -75,11 +75,11 @@ void dense_qp_hpipm_opts_initialize_default(void *config, void *dims, void *opts
 //
 void dense_qp_hpipm_opts_update(void *config, void *dims, void *opts_);
 //
-size_t dense_qp_hpipm_calculate_memory_size(void *dims, void *opts_);
+acados_size_t dense_qp_hpipm_calculate_memory_size(void *dims, void *opts_);
 //
 void *dense_qp_hpipm_assign_memory(void *dims, void *opts_, void *raw_memory);
 //
-size_t dense_qp_hpipm_calculate_workspace_size(void *dims, void *opts_);
+acados_size_t dense_qp_hpipm_calculate_workspace_size(void *dims, void *opts_);
 //
 int dense_qp_hpipm(void *config, void *qp_in, void *qp_out, void *opts_, void *mem_, void *work_);
 //

--- a/acados/dense_qp/dense_qp_hpipm.h
+++ b/acados/dense_qp/dense_qp_hpipm.h
@@ -67,7 +67,7 @@ typedef struct dense_qp_hpipm_memory_
 
 
 //
-int dense_qp_hpipm_opts_calculate_size(void *config, void *dims);
+acados_size_t dense_qp_hpipm_opts_calculate_size(void *config, void *dims);
 //
 void *dense_qp_hpipm_opts_assign(void *config, void *dims, void *raw_memory);
 //
@@ -75,11 +75,11 @@ void dense_qp_hpipm_opts_initialize_default(void *config, void *dims, void *opts
 //
 void dense_qp_hpipm_opts_update(void *config, void *dims, void *opts_);
 //
-int dense_qp_hpipm_calculate_memory_size(void *dims, void *opts_);
+size_t dense_qp_hpipm_calculate_memory_size(void *dims, void *opts_);
 //
 void *dense_qp_hpipm_assign_memory(void *dims, void *opts_, void *raw_memory);
 //
-int dense_qp_hpipm_calculate_workspace_size(void *dims, void *opts_);
+size_t dense_qp_hpipm_calculate_workspace_size(void *dims, void *opts_);
 //
 int dense_qp_hpipm(void *config, void *qp_in, void *qp_out, void *opts_, void *mem_, void *work_);
 //

--- a/acados/dense_qp/dense_qp_ooqp.c
+++ b/acados/dense_qp/dense_qp_ooqp.c
@@ -304,9 +304,9 @@ static void fill_in_qp_out(const dense_qp_in *in, dense_qp_out *out, dense_qp_oo
 
 
 
-int dense_qp_ooqp_opts_calculate_size(void *config_, dense_qp_dims *dims)
+acados_size_t dense_qp_ooqp_opts_calculate_size(void *config_, dense_qp_dims *dims)
 {
-    int size = 0;
+    acados_size_t size = 0;
     size += sizeof(dense_qp_ooqp_opts);
     return size;
 }
@@ -385,7 +385,7 @@ void dense_qp_ooqp_opts_set(void *config_, void *opts_, const char *field, void 
 
 
 
-int dense_qp_ooqp_memory_calculate_size(void *config_, dense_qp_dims *dims, void *opts_)
+acados_size_t dense_qp_ooqp_memory_calculate_size(void *config_, dense_qp_dims *dims, void *opts_)
 {
     int nv = dims->nv;
     int ne = dims->ne;
@@ -395,7 +395,7 @@ int dense_qp_ooqp_memory_calculate_size(void *config_, dense_qp_dims *dims, void
     // int nsb = dims->nsb;
     // int nsg = dims->nsg;
 
-    int size = 0;
+    acados_size_t size = 0;
     size += sizeof(dense_qp_ooqp_memory);
 
     size += 1 * nv * nv * sizeof(double);  // dQ
@@ -498,12 +498,12 @@ void dense_qp_ooqp_memory_get(void *config_, void *mem_, const char *field, void
  * workspace
  ************************************************/
 
-int dense_qp_ooqp_workspace_calculate_size(void *config_, dense_qp_dims *dims, void *opts_)
+acados_size_t dense_qp_ooqp_workspace_calculate_size(void *config_, dense_qp_dims *dims, void *opts_)
 {
     // dense_qp_ooqp_opts *opts = (dense_qp_ooqp_opts *)opts_;
 
-    int size = 0;
-    int nx, my, mz;
+    acados_size_t size = 0;
+    acados_size_t nx, my, mz;
 
     nx = dims->nv;
     my = dims->ne;
@@ -630,19 +630,19 @@ void dense_qp_ooqp_config_initialize_default(void *config_)
 {
     qp_solver_config *config = config_;
 
-    config->opts_calculate_size = (int (*)(void *, void *)) & dense_qp_ooqp_opts_calculate_size;
+    config->opts_calculate_size = (acados_size_t (*)(void *, void *)) & dense_qp_ooqp_opts_calculate_size;
     config->opts_assign = (void *(*) (void *, void *, void *) ) & dense_qp_ooqp_opts_assign;
     config->opts_initialize_default =
         (void (*)(void *, void *, void *)) & dense_qp_ooqp_opts_initialize_default;
     config->opts_update = (void (*)(void *, void *, void *)) & dense_qp_ooqp_opts_update;
     config->opts_set = &dense_qp_ooqp_opts_set;
     config->memory_calculate_size =
-        (int (*)(void *, void *, void *)) & dense_qp_ooqp_memory_calculate_size;
+        (acados_size_t (*)(void *, void *, void *)) & dense_qp_ooqp_memory_calculate_size;
     config->memory_assign =
         (void *(*) (void *, void *, void *, void *) ) & dense_qp_ooqp_memory_assign;
     config->memory_get = &dense_qp_ooqp_memory_get;
     config->workspace_calculate_size =
-        (int (*)(void *, void *, void *)) & dense_qp_ooqp_workspace_calculate_size;
+        (acados_size_t (*)(void *, void *, void *)) & dense_qp_ooqp_workspace_calculate_size;
     config->evaluate = (int (*)(void *, void *, void *, void *, void *, void *)) & dense_qp_ooqp;
     config->eval_sens = &dense_qp_ooqp_eval_sens;
 }

--- a/acados/dense_qp/dense_qp_ooqp.h
+++ b/acados/dense_qp/dense_qp_ooqp.h
@@ -97,7 +97,7 @@ typedef struct dense_qp_ooqp_memory_
 } dense_qp_ooqp_memory;
 
 //
-int dense_qp_ooqp_opts_calculate_size(void *config_, dense_qp_dims *dims);
+acados_size_t dense_qp_ooqp_opts_calculate_size(void *config_, dense_qp_dims *dims);
 //
 void *dense_qp_ooqp_opts_assign(void *config_, dense_qp_dims *dims, void *raw_memory);
 //
@@ -105,12 +105,12 @@ void dense_qp_ooqp_opts_initialize_default(void *config_, dense_qp_dims *dims, v
 //
 void dense_qp_ooqp_opts_update(void *config_, dense_qp_dims *dims, void *opts_);
 //
-int dense_qp_ooqp_memory_calculate_size(void *config_, dense_qp_dims *dims, void *opts_);
+acados_size_t dense_qp_ooqp_memory_calculate_size(void *config_, dense_qp_dims *dims, void *opts_);
 //
 void *dense_qp_ooqp_memory_assign(void *config_, dense_qp_dims *dims, void *opts_,
                                   void *raw_memory);
 //
-int dense_qp_ooqp_workspace_calculate_size(void *config_, dense_qp_dims *dims, void *opts_);
+acados_size_t dense_qp_ooqp_workspace_calculate_size(void *config_, dense_qp_dims *dims, void *opts_);
 //
 int dense_qp_ooqp(void *config_, dense_qp_in *qp_in, dense_qp_out *qp_out, void *opts_,
                   void *memory_, void *work_);

--- a/acados/dense_qp/dense_qp_qore.c
+++ b/acados/dense_qp/dense_qp_qore.c
@@ -51,9 +51,9 @@
  * opts
  ************************************************/
 
-int dense_qp_qore_opts_calculate_size(void *config_, dense_qp_dims *dims)
+acados_size_t dense_qp_qore_opts_calculate_size(void *config_, dense_qp_dims *dims)
 {
-    int size = 0;
+    acados_size_t size = 0;
     size += sizeof(dense_qp_qore_opts);
 
     return size;
@@ -142,7 +142,7 @@ void dense_qp_qore_opts_set(void *config_, void *opts_, const char *field, void 
  * memory
  ************************************************/
 
-int dense_qp_qore_memory_calculate_size(void *config_, dense_qp_dims *dims, void *opts_)
+acados_size_t dense_qp_qore_memory_calculate_size(void *config_, dense_qp_dims *dims, void *opts_)
 {
     dense_qp_qore_opts *opts = (dense_qp_qore_opts *) opts_;
     dense_qp_dims dims_stacked;
@@ -161,7 +161,7 @@ int dense_qp_qore_memory_calculate_size(void *config_, dense_qp_dims *dims, void
     int nb2 = nb - nsb + 2*ns;
 
     // size in bytes
-    int size = sizeof(dense_qp_qore_memory);
+    acados_size_t size = sizeof(dense_qp_qore_memory);
 
     size += 1 * nv * nv * sizeof(double);      // H
     size += 1 * nv2 * nv2 * sizeof(double);    // HH
@@ -312,7 +312,7 @@ void dense_qp_qore_memory_get(void *config_, void *mem_, const char *field, void
  * workspace
  ************************************************/
 
-int dense_qp_qore_workspace_calculate_size(void *config_, dense_qp_dims *dims, void *opts_)
+acados_size_t dense_qp_qore_workspace_calculate_size(void *config_, dense_qp_dims *dims, void *opts_)
 {
     return 0;
 }
@@ -565,19 +565,19 @@ void dense_qp_qore_config_initialize_default(void *config_)
 {
     qp_solver_config *config = config_;
 
-    config->opts_calculate_size = (int (*)(void *, void *)) & dense_qp_qore_opts_calculate_size;
+    config->opts_calculate_size = (acados_size_t (*)(void *, void *)) & dense_qp_qore_opts_calculate_size;
     config->opts_assign = (void *(*) (void *, void *, void *) ) & dense_qp_qore_opts_assign;
     config->opts_initialize_default =
         (void (*)(void *, void *, void *)) & dense_qp_qore_opts_initialize_default;
     config->opts_update = (void (*)(void *, void *, void *)) & dense_qp_qore_opts_update;
     config->opts_set = &dense_qp_qore_opts_set;
     config->memory_calculate_size =
-        (int (*)(void *, void *, void *)) & dense_qp_qore_memory_calculate_size;
+        (acados_size_t (*)(void *, void *, void *)) & dense_qp_qore_memory_calculate_size;
     config->memory_assign =
         (void *(*) (void *, void *, void *, void *) ) & dense_qp_qore_memory_assign;
     config->memory_get = &dense_qp_qore_memory_get;
     config->workspace_calculate_size =
-        (int (*)(void *, void *, void *)) & dense_qp_qore_workspace_calculate_size;
+        (acados_size_t (*)(void *, void *, void *)) & dense_qp_qore_workspace_calculate_size;
     config->evaluate = (int (*)(void *, void *, void *, void *, void *, void *)) & dense_qp_qore;
     config->eval_sens = &dense_qp_qore_eval_sens;
 

--- a/acados/dense_qp/dense_qp_qore.h
+++ b/acados/dense_qp/dense_qp_qore.h
@@ -100,7 +100,7 @@ typedef struct dense_qp_qore_memory_
 
 } dense_qp_qore_memory;
 
-int dense_qp_qore_opts_calculate_size(void *config, dense_qp_dims *dims);
+acados_size_t dense_qp_qore_opts_calculate_size(void *config, dense_qp_dims *dims);
 //
 void *dense_qp_qore_opts_assign(void *config, dense_qp_dims *dims, void *raw_memory);
 //
@@ -108,11 +108,11 @@ void dense_qp_qore_opts_initialize_default(void *config, dense_qp_dims *dims, vo
 //
 void dense_qp_qore_opts_update(void *config, dense_qp_dims *dims, void *opts_);
 //
-int dense_qp_qore_memory_calculate_size(void *config, dense_qp_dims *dims, void *opts_);
+acados_size_t dense_qp_qore_memory_calculate_size(void *config, dense_qp_dims *dims, void *opts_);
 //
 void *dense_qp_qore_memory_assign(void *config, dense_qp_dims *dims, void *opts_, void *raw_memory);
 //
-int dense_qp_qore_workspace_calculate_size(void *config, dense_qp_dims *dims, void *opts_);
+acados_size_t dense_qp_qore_workspace_calculate_size(void *config, dense_qp_dims *dims, void *opts_);
 //
 int dense_qp_qore(void *config, dense_qp_in *qp_in, dense_qp_out *qp_out, void *opts_, void *memory_, void *work_);
 //

--- a/acados/dense_qp/dense_qp_qpoases.c
+++ b/acados/dense_qp/dense_qp_qpoases.c
@@ -84,9 +84,9 @@
  * opts
  ************************************************/
 
-int dense_qp_qpoases_opts_calculate_size(void *config_, dense_qp_dims *dims)
+acados_size_t dense_qp_qpoases_opts_calculate_size(void *config_, dense_qp_dims *dims)
 {
-    int size = 0;
+    acados_size_t size = 0;
     size += sizeof(dense_qp_qpoases_opts);
 
     return size;
@@ -205,7 +205,7 @@ void dense_qp_qpoases_opts_set(void *config_, void *opts_, const char *field, vo
  * memory
  ************************************************/
 
-int dense_qp_qpoases_memory_calculate_size(void *config_, dense_qp_dims *dims, void *opts_)
+acados_size_t dense_qp_qpoases_memory_calculate_size(void *config_, dense_qp_dims *dims, void *opts_)
 {
     dense_qp_dims dims_stacked;
 
@@ -222,7 +222,7 @@ int dense_qp_qpoases_memory_calculate_size(void *config_, dense_qp_dims *dims, v
     int nb2 = nb - nsb + 2 * ns;
 
     // size in bytes
-    int size = sizeof(dense_qp_qpoases_memory);
+    acados_size_t size = sizeof(dense_qp_qpoases_memory);
 
     size += 1 * nv * nv * sizeof(double);      // H
     size += 1 * nv2 * nv2 * sizeof(double);    // HH
@@ -387,7 +387,7 @@ void dense_qp_qpoases_memory_get(void *config_, void *mem_, const char *field, v
  * workspcae
  ************************************************/
 
-int dense_qp_qpoases_workspace_calculate_size(void *config_, dense_qp_dims *dims, void *opts_)
+acados_size_t dense_qp_qpoases_workspace_calculate_size(void *config_, dense_qp_dims *dims, void *opts_)
 {
     return 0;
 }
@@ -770,19 +770,19 @@ void dense_qp_qpoases_config_initialize_default(void *config_)
 {
     qp_solver_config *config = config_;
 
-    config->opts_calculate_size = (int (*)(void *, void *)) & dense_qp_qpoases_opts_calculate_size;
+    config->opts_calculate_size = (acados_size_t (*)(void *, void *)) & dense_qp_qpoases_opts_calculate_size;
     config->opts_assign = (void *(*) (void *, void *, void *) ) & dense_qp_qpoases_opts_assign;
     config->opts_initialize_default =
         (void (*)(void *, void *, void *)) & dense_qp_qpoases_opts_initialize_default;
     config->opts_update = (void (*)(void *, void *, void *)) & dense_qp_qpoases_opts_update;
     config->opts_set = &dense_qp_qpoases_opts_set;
     config->memory_calculate_size =
-        (int (*)(void *, void *, void *)) & dense_qp_qpoases_memory_calculate_size;
+        (acados_size_t (*)(void *, void *, void *)) & dense_qp_qpoases_memory_calculate_size;
     config->memory_assign =
         (void *(*) (void *, void *, void *, void *) ) & dense_qp_qpoases_memory_assign;
     config->memory_get = &dense_qp_qpoases_memory_get;
     config->workspace_calculate_size =
-        (int (*)(void *, void *, void *)) & dense_qp_qpoases_workspace_calculate_size;
+        (acados_size_t (*)(void *, void *, void *)) & dense_qp_qpoases_workspace_calculate_size;
     config->eval_sens = &dense_qp_qpoases_eval_sens;
     config->evaluate = (int (*)(void *, void *, void *, void *, void *, void *)) & dense_qp_qpoases;
 

--- a/acados/dense_qp/dense_qp_qpoases.h
+++ b/acados/dense_qp/dense_qp_qpoases.h
@@ -100,7 +100,7 @@ typedef struct dense_qp_qpoases_memory_
 
 } dense_qp_qpoases_memory;
 
-int dense_qp_qpoases_opts_calculate_size(void *config, dense_qp_dims *dims);
+acados_size_t dense_qp_qpoases_opts_calculate_size(void *config, dense_qp_dims *dims);
 //
 void *dense_qp_qpoases_opts_assign(void *config, dense_qp_dims *dims, void *raw_memory);
 //
@@ -108,11 +108,11 @@ void dense_qp_qpoases_opts_initialize_default(void *config, dense_qp_dims *dims,
 //
 void dense_qp_qpoases_opts_update(void *config, dense_qp_dims *dims, void *opts_);
 //
-int dense_qp_qpoases__memorycalculate_size(void *config, dense_qp_dims *dims, void *opts_);
+acados_size_t dense_qp_qpoases__memorycalculate_size(void *config, dense_qp_dims *dims, void *opts_);
 //
 void *dense_qp_qpoases_memory_assign(void *config, dense_qp_dims *dims, void *opts_, void *raw_memory);
 //
-int dense_qp_qpoases_workspace_calculate_size(void *config, dense_qp_dims *dims, void *opts_);
+acados_size_t dense_qp_qpoases_workspace_calculate_size(void *config, dense_qp_dims *dims, void *opts_);
 //
 int dense_qp_qpoases(void *config, dense_qp_in *qp_in, dense_qp_out *qp_out, void *opts_, void *memory_, void *work_);
 //

--- a/acados/ocp_nlp/ocp_nlp_common.c
+++ b/acados/ocp_nlp/ocp_nlp_common.c
@@ -56,11 +56,11 @@
  * config
  ************************************************/
 
-int ocp_nlp_config_calculate_size(int N)
+acados_size_t ocp_nlp_config_calculate_size(int N)
 {
     int ii;
 
-    int size = 0;
+    acados_size_t size = 0;
 
     // self
     size += sizeof(ocp_nlp_config);
@@ -150,9 +150,9 @@ ocp_nlp_config *ocp_nlp_config_assign(int N, void *raw_memory)
  * dims
  ************************************************/
 
-static int ocp_nlp_dims_calculate_size_self(int N)
+static acados_size_t ocp_nlp_dims_calculate_size_self(int N)
 {
-    int size = 0;
+    acados_size_t size = 0;
 
     size += sizeof(ocp_nlp_dims);
 
@@ -180,7 +180,7 @@ static int ocp_nlp_dims_calculate_size_self(int N)
 
 
 
-int ocp_nlp_dims_calculate_size(void *config_)
+acados_size_t ocp_nlp_dims_calculate_size(void *config_)
 {
     ocp_nlp_config *config = config_;
 
@@ -188,7 +188,7 @@ int ocp_nlp_dims_calculate_size(void *config_)
 
     int ii;
 
-    int size = 0;
+    acados_size_t size = 0;
 
     // self
     size += ocp_nlp_dims_calculate_size_self(N);
@@ -552,9 +552,6 @@ void ocp_nlp_dims_set_opt_vars(void *config_, void *dims_, const char *field,
         }
     }
 #endif
-
-    return;
-
 }
 
 
@@ -627,8 +624,6 @@ void ocp_nlp_dims_set_constraints(void *config_, void *dims_, int stage, const c
         // qp solver
         config->qp_solver->dims_set(config->qp_solver, dims->qp_solver, i, "nge", &ng_qp_solver);
     }
-
-    return;
 }
 
 
@@ -666,9 +661,9 @@ void ocp_nlp_dims_set_dynamics(void *config_, void *dims_, int stage,
  * in
  ************************************************/
 
-int ocp_nlp_in_calculate_size_self(int N)
+acados_size_t ocp_nlp_in_calculate_size_self(int N)
 {
-    int size = sizeof(ocp_nlp_in);
+    acados_size_t size = sizeof(ocp_nlp_in);
 
     size += N * sizeof(double);  // Ts
 
@@ -683,13 +678,13 @@ int ocp_nlp_in_calculate_size_self(int N)
 
 
 
-int ocp_nlp_in_calculate_size(ocp_nlp_config *config, ocp_nlp_dims *dims)
+acados_size_t ocp_nlp_in_calculate_size(ocp_nlp_config *config, ocp_nlp_dims *dims)
 {
     int ii;
 
     int N = dims->N;
 
-    int size = ocp_nlp_in_calculate_size_self(N);
+    acados_size_t size = ocp_nlp_in_calculate_size_self(N);
 
     // dynamics
     for (ii = 0; ii < N; ii++)
@@ -802,7 +797,7 @@ ocp_nlp_in *ocp_nlp_in_assign(ocp_nlp_config *config, ocp_nlp_dims *dims, void *
  * out
  ************************************************/
 
-int ocp_nlp_out_calculate_size(ocp_nlp_config *config, ocp_nlp_dims *dims)
+acados_size_t ocp_nlp_out_calculate_size(ocp_nlp_config *config, ocp_nlp_dims *dims)
 {
     // extract dims
     int N = dims->N;
@@ -812,7 +807,7 @@ int ocp_nlp_out_calculate_size(ocp_nlp_config *config, ocp_nlp_dims *dims)
     int *ni = dims->ni;
     int *nz = dims->nz;
 
-    int size = sizeof(ocp_nlp_out);
+    acados_size_t size = sizeof(ocp_nlp_out);
 
     size += 4 * (N + 1) * sizeof(struct blasfeo_dvec);  // ux, lam, t, z
     size += 1 * N * sizeof(struct blasfeo_dvec);        // pi
@@ -931,7 +926,7 @@ ocp_nlp_out *ocp_nlp_out_assign(ocp_nlp_config *config, ocp_nlp_dims *dims, void
  * options
  ************************************************/
 
-int ocp_nlp_opts_calculate_size(void *config_, void *dims_)
+acados_size_t ocp_nlp_opts_calculate_size(void *config_, void *dims_)
 {
     ocp_nlp_dims *dims = dims_;
     ocp_nlp_config *config = config_;
@@ -943,7 +938,7 @@ int ocp_nlp_opts_calculate_size(void *config_, void *dims_)
 
     int N = dims->N;
 
-    int size = 0;
+    acados_size_t size = 0;
 
     size += sizeof(ocp_nlp_opts);
 
@@ -1335,7 +1330,7 @@ void ocp_nlp_opts_set_at_stage(void *config_, void *opts_, int stage, const char
  * memory
  ************************************************/
 
-int ocp_nlp_memory_calculate_size(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_opts *opts)
+acados_size_t ocp_nlp_memory_calculate_size(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_opts *opts)
 {
     ocp_qp_xcond_solver_config *qp_solver = config->qp_solver;
     ocp_nlp_dynamics_config **dynamics = config->dynamics;
@@ -1350,7 +1345,7 @@ int ocp_nlp_memory_calculate_size(ocp_nlp_config *config, ocp_nlp_dims *dims, oc
     int *nu = dims->nu;
     int *ni = dims->ni;
 
-    int size = sizeof(ocp_nlp_memory);
+    acados_size_t size = sizeof(ocp_nlp_memory);
 
     // qp in
     size += ocp_qp_in_calculate_size(dims->qp_solver->orig_dims);
@@ -1596,7 +1591,7 @@ ocp_nlp_memory *ocp_nlp_memory_assign(ocp_nlp_config *config, ocp_nlp_dims *dims
  * workspace
  ************************************************/
 
-int ocp_nlp_workspace_calculate_size(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_opts *opts)
+acados_size_t ocp_nlp_workspace_calculate_size(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_opts *opts)
 {
     ocp_qp_xcond_solver_config *qp_solver = config->qp_solver;
     ocp_nlp_dynamics_config **dynamics = config->dynamics;
@@ -1610,7 +1605,7 @@ int ocp_nlp_workspace_calculate_size(ocp_nlp_config *config, ocp_nlp_dims *dims,
     // int *nu = dims->nu;
     // int *nz = dims->nz;
 
-    int size = 0;
+    acados_size_t size = 0;
 
     // nlp
     size += sizeof(ocp_nlp_workspace);
@@ -1658,7 +1653,7 @@ int ocp_nlp_workspace_calculate_size(ocp_nlp_config *config, ocp_nlp_dims *dims,
         }
 
 #else
-        int size_tmp = 0;
+        acados_size_t size_tmp = 0;
         int tmp;
 
         // qp solver
@@ -1796,7 +1791,7 @@ ocp_nlp_workspace *ocp_nlp_workspace_assign(ocp_nlp_config *config, ocp_nlp_dims
 
 #else
 
-        int size_tmp = 0;
+        acados_size_t size_tmp = 0;
         int tmp;
 
         // qp solver
@@ -2057,8 +2052,6 @@ void ocp_nlp_approximate_qp_matrices(ocp_nlp_config *config, ocp_nlp_dims *dims,
         //   }
         //  }
     }
-
-    return;
 }
 
 
@@ -2092,8 +2085,6 @@ void ocp_nlp_approximate_qp_vectors_sqp(ocp_nlp_config *config,
         // d
         blasfeo_dveccp(2 * ni[i], mem->ineq_fun + i, 0, mem->qp_in->d + i, 0);
     }
-
-    return;
 }
 
 
@@ -2116,8 +2107,6 @@ void ocp_nlp_embed_initial_value(ocp_nlp_config *config, ocp_nlp_dims *dims,
 
     // d
     blasfeo_dveccp(2 * ni[0], mem->ineq_fun, 0, mem->qp_in->d, 0);
-
-    return;
 }
 
 
@@ -2454,8 +2443,6 @@ void ocp_nlp_update_variables_sqp(ocp_nlp_config *config, ocp_nlp_dims *dims, oc
                     mem->qp_out->ux+i, 0, 1.0, mem->z_alg+i, 0, out->z+i, 0);
         }
     }
-
-    return;
 }
 
 
@@ -2464,7 +2451,7 @@ void ocp_nlp_update_variables_sqp(ocp_nlp_config *config, ocp_nlp_dims *dims, oc
  * residuals
  ************************************************/
 
-int ocp_nlp_res_calculate_size(ocp_nlp_dims *dims)
+acados_size_t ocp_nlp_res_calculate_size(ocp_nlp_dims *dims)
 {
     // extract dims
     int N = dims->N;
@@ -2473,7 +2460,7 @@ int ocp_nlp_res_calculate_size(ocp_nlp_dims *dims)
     // int *nu = dims->nu;
     int *ni = dims->ni;
 
-    int size = sizeof(ocp_nlp_res);
+    acados_size_t size = sizeof(ocp_nlp_res);
 
     size += 3 * (N + 1) * sizeof(struct blasfeo_dvec);  // res_stat res_ineq res_comp
     size += 1 * N * sizeof(struct blasfeo_dvec);        // res_eq
@@ -2610,7 +2597,6 @@ void ocp_nlp_res_compute(ocp_nlp_dims *dims, ocp_nlp_in *in, ocp_nlp_out *out, o
 
     // printf("computed residuals g: %e, b: %e, d: %e, m: %e\n", res->inf_norm_res_stat, res->inf_norm_res_eq,
     //        res->inf_norm_res_ineq, res->inf_norm_res_comp);
-    return;
 }
 
 
@@ -2640,6 +2626,5 @@ void ocp_nlp_cost_compute(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in
     mem->cost_value = total_cost;
 
     // printf("\ncomputed total cost: %e\n", total_cost);
-    return;
 }
 

--- a/acados/ocp_nlp/ocp_nlp_common.h
+++ b/acados/ocp_nlp/ocp_nlp_common.h
@@ -302,7 +302,7 @@ typedef struct ocp_nlp_res
     double inf_norm_res_eq;
     double inf_norm_res_ineq;
     double inf_norm_res_comp;
-    int memsize;
+    acados_size_t memsize;
 } ocp_nlp_res;
 
 //

--- a/acados/ocp_nlp/ocp_nlp_common.h
+++ b/acados/ocp_nlp/ocp_nlp_common.h
@@ -78,15 +78,15 @@ typedef struct ocp_nlp_config
     int N;  // number of stages
 
     // solver-specific implementations of memory management functions
-    int (*opts_calculate_size)(void *config, void *dims);
+    acados_size_t (*opts_calculate_size)(void *config, void *dims);
     void *(*opts_assign)(void *config, void *dims, void *raw_memory);
     void (*opts_initialize_default)(void *config, void *dims, void *opts_);
     void (*opts_update)(void *config, void *dims, void *opts_);
-    int (*memory_calculate_size)(void *config, void *dims, void *opts_);
+    acados_size_t (*memory_calculate_size)(void *config, void *dims, void *opts_);
     void *(*memory_assign)(void *config, void *dims, void *opts_, void *raw_memory);
-    int (*workspace_calculate_size)(void *config, void *dims, void *opts_);
+    acados_size_t (*workspace_calculate_size)(void *config, void *dims, void *opts_);
     void (*opts_set)(void *config_, void *opts_, const char *field, void* value);
-    void (*opts_set_at_stage)(void *config_, void *opts_, int stage, const char *field, void* value);
+    void (*opts_set_at_stage)(void *config_, void *opts_, size_t stage, const char *field, void* value);
     // evaluate solver // TODO rename into solve
     int (*evaluate)(void *config, void *dims, void *nlp_in, void *nlp_out, void *opts_, void *mem, void *work);
     void (*eval_param_sens)(void *config, void *dims, void *opts_, void *mem, void *work,
@@ -109,7 +109,7 @@ typedef struct ocp_nlp_config
 } ocp_nlp_config;
 
 //
-int ocp_nlp_config_calculate_size(int N);
+acados_size_t ocp_nlp_config_calculate_size(int N);
 //
 ocp_nlp_config *ocp_nlp_config_assign(int N, void *raw_memory);
 
@@ -138,7 +138,7 @@ typedef struct ocp_nlp_dims
 } ocp_nlp_dims;
 
 //
-int ocp_nlp_dims_calculate_size(void *config);
+acados_size_t ocp_nlp_dims_calculate_size(void *config);
 //
 ocp_nlp_dims *ocp_nlp_dims_assign(void *config, void *raw_memory);
 
@@ -206,9 +206,9 @@ typedef struct ocp_nlp_in
 } ocp_nlp_in;
 
 //
-int ocp_nlp_in_calculate_size_self(int N);
+acados_size_t ocp_nlp_in_calculate_size_self(int N);
 //
-int ocp_nlp_in_calculate_size(ocp_nlp_config *config, ocp_nlp_dims *dims);
+acados_size_t ocp_nlp_in_calculate_size(ocp_nlp_config *config, ocp_nlp_dims *dims);
 //
 ocp_nlp_in *ocp_nlp_in_assign_self(int N, void *raw_memory);
 //
@@ -238,7 +238,7 @@ typedef struct ocp_nlp_out
 } ocp_nlp_out;
 
 //
-int ocp_nlp_out_calculate_size(ocp_nlp_config *config, ocp_nlp_dims *dims);
+acados_size_t ocp_nlp_out_calculate_size(ocp_nlp_config *config, ocp_nlp_dims *dims);
 //
 ocp_nlp_out *ocp_nlp_out_assign(ocp_nlp_config *config, ocp_nlp_dims *dims,
                                 void *raw_memory);
@@ -275,7 +275,7 @@ typedef struct ocp_nlp_opts
 } ocp_nlp_opts;
 
 //
-int ocp_nlp_opts_calculate_size(void *config, void *dims);
+acados_size_t ocp_nlp_opts_calculate_size(void *config, void *dims);
 //
 void *ocp_nlp_opts_assign(void *config, void *dims, void *raw_memory);
 //
@@ -306,7 +306,7 @@ typedef struct ocp_nlp_res
 } ocp_nlp_res;
 
 //
-int ocp_nlp_res_calculate_size(ocp_nlp_dims *dims);
+acados_size_t ocp_nlp_res_calculate_size(ocp_nlp_dims *dims);
 //
 ocp_nlp_res *ocp_nlp_res_assign(ocp_nlp_dims *dims, void *raw_memory);
 
@@ -349,7 +349,7 @@ typedef struct ocp_nlp_memory
 } ocp_nlp_memory;
 
 //
-int ocp_nlp_memory_calculate_size(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_opts *opts);
+acados_size_t ocp_nlp_memory_calculate_size(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_opts *opts);
 //
 ocp_nlp_memory *ocp_nlp_memory_assign(ocp_nlp_config *config, ocp_nlp_dims *dims,
                                       ocp_nlp_opts *opts, void *raw_memory);
@@ -374,7 +374,7 @@ typedef struct ocp_nlp_workspace
 } ocp_nlp_workspace;
 
 //
-int ocp_nlp_workspace_calculate_size(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_opts *opts);
+acados_size_t ocp_nlp_workspace_calculate_size(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_opts *opts);
 //
 ocp_nlp_workspace *ocp_nlp_workspace_assign(ocp_nlp_config *config, ocp_nlp_dims *dims,
                                 ocp_nlp_opts *opts, ocp_nlp_memory *mem, void *raw_memory);

--- a/acados/ocp_nlp/ocp_nlp_constraints_bgh.c
+++ b/acados/ocp_nlp/ocp_nlp_constraints_bgh.c
@@ -51,9 +51,9 @@
  * dims
  ************************************************/
 
-int ocp_nlp_constraints_bgh_dims_calculate_size(void *config_)
+acados_size_t ocp_nlp_constraints_bgh_dims_calculate_size(void *config_)
 {
-    int size = sizeof(ocp_nlp_constraints_bgh_dims);
+    acados_size_t size = sizeof(ocp_nlp_constraints_bgh_dims);
 
     return size;
 }
@@ -529,7 +529,7 @@ void ocp_nlp_constraints_bgh_dims_get(void *config_, void *dims_, const char *fi
  * model
  ************************************************/
 
-int ocp_nlp_constraints_bgh_model_calculate_size(void *config, void *dims_)
+acados_size_t ocp_nlp_constraints_bgh_model_calculate_size(void *config, void *dims_)
 {
     ocp_nlp_constraints_bgh_dims *dims = dims_;
 
@@ -545,7 +545,7 @@ int ocp_nlp_constraints_bgh_model_calculate_size(void *config, void *dims_)
     int nge = dims->nge;
     int nhe = dims->nhe;
 
-    int size = 0;
+    acados_size_t size = 0;
 
     size += sizeof(ocp_nlp_constraints_bgh_model);
 
@@ -826,9 +826,9 @@ int ocp_nlp_constraints_bgh_model_set(void *config_, void *dims_,
  * options
  ************************************************/
 
-int ocp_nlp_constraints_bgh_opts_calculate_size(void *config_, void *dims_)
+acados_size_t ocp_nlp_constraints_bgh_opts_calculate_size(void *config_, void *dims_)
 {
-    int size = 0;
+    acados_size_t size = 0;
 
     size += sizeof(ocp_nlp_constraints_bgh_opts);
 
@@ -904,7 +904,7 @@ void ocp_nlp_constraints_bgh_opts_set(void *config_, void *opts_, char *field, v
  * memory
  ************************************************/
 
-int ocp_nlp_constraints_bgh_memory_calculate_size(void *config_, void *dims_, void *opts_)
+acados_size_t ocp_nlp_constraints_bgh_memory_calculate_size(void *config_, void *dims_, void *opts_)
 {
     ocp_nlp_constraints_bgh_dims *dims = dims_;
 
@@ -916,7 +916,7 @@ int ocp_nlp_constraints_bgh_memory_calculate_size(void *config_, void *dims_, vo
     int nh = dims->nh;
     int ns = dims->ns;
 
-    int size = 0;
+    acados_size_t size = 0;
 
     size += sizeof(ocp_nlp_constraints_bgh_memory);
 
@@ -1093,7 +1093,7 @@ void ocp_nlp_constraints_bgh_memory_set_idxe_ptr(int *idxe, void *memory_)
  * workspace
  ************************************************/
 
-int ocp_nlp_constraints_bgh_workspace_calculate_size(void *config_, void *dims_, void *opts_)
+acados_size_t ocp_nlp_constraints_bgh_workspace_calculate_size(void *config_, void *dims_, void *opts_)
 {
     ocp_nlp_constraints_bgh_dims *dims = dims_;
 
@@ -1106,7 +1106,7 @@ int ocp_nlp_constraints_bgh_workspace_calculate_size(void *config_, void *dims_,
     int nh = dims->nh;
     int ns = dims->ns;
 
-    int size = 0;
+    acados_size_t size = 0;
 
     size += sizeof(ocp_nlp_constraints_bgh_workspace);
 

--- a/acados/ocp_nlp/ocp_nlp_constraints_bgh.h
+++ b/acados/ocp_nlp/ocp_nlp_constraints_bgh.h
@@ -78,7 +78,7 @@ typedef struct
 } ocp_nlp_constraints_bgh_dims;
 
 //
-int ocp_nlp_constraints_bgh_dims_calculate_size(void *config);
+acados_size_t ocp_nlp_constraints_bgh_dims_calculate_size(void *config);
 //
 void *ocp_nlp_constraints_bgh_dims_assign(void *config, void *raw_memory);
 //
@@ -109,7 +109,7 @@ typedef struct
 } ocp_nlp_constraints_bgh_model;
 
 //
-int ocp_nlp_constraints_bgh_model_calculate_size(void *config, void *dims);
+acados_size_t ocp_nlp_constraints_bgh_model_calculate_size(void *config, void *dims);
 //
 void *ocp_nlp_constraints_bgh_model_assign(void *config, void *dims, void *raw_memory);
 //
@@ -129,7 +129,7 @@ typedef struct
 } ocp_nlp_constraints_bgh_opts;
 
 //
-int ocp_nlp_constraints_bgh_opts_calculate_size(void *config, void *dims);
+acados_size_t ocp_nlp_constraints_bgh_opts_calculate_size(void *config, void *dims);
 //
 void *ocp_nlp_constraints_bgh_opts_assign(void *config, void *dims, void *raw_memory);
 //
@@ -163,7 +163,7 @@ typedef struct
 } ocp_nlp_constraints_bgh_memory;
 
 //
-int ocp_nlp_constraints_bgh_memory_calculate_size(void *config, void *dims, void *opts);
+acados_size_t ocp_nlp_constraints_bgh_memory_calculate_size(void *config, void *dims, void *opts);
 //
 void *ocp_nlp_constraints_bgh_memory_assign(void *config, void *dims, void *opts, void *raw_memory);
 //
@@ -211,7 +211,7 @@ typedef struct
 } ocp_nlp_constraints_bgh_workspace;
 
 //
-int ocp_nlp_constraints_bgh_workspace_calculate_size(void *config, void *dims, void *opts);
+acados_size_t ocp_nlp_constraints_bgh_workspace_calculate_size(void *config, void *dims, void *opts);
 
 /* functions */
 

--- a/acados/ocp_nlp/ocp_nlp_constraints_bgp.c
+++ b/acados/ocp_nlp/ocp_nlp_constraints_bgp.c
@@ -49,9 +49,9 @@
 
 /* dims */
 
-int ocp_nlp_constraints_bgp_dims_calculate_size(void *config_)
+acados_size_t ocp_nlp_constraints_bgp_dims_calculate_size(void *config_)
 {
-    int size = sizeof(ocp_nlp_constraints_bgp_dims);
+    acados_size_t size = sizeof(ocp_nlp_constraints_bgp_dims);
 
     return size;
 }
@@ -527,7 +527,7 @@ void ocp_nlp_constraints_bgp_dims_get(void *config_, void *dims_, const char *fi
 
 /* model */
 
-int ocp_nlp_constraints_bgp_model_calculate_size(void *config, void *dims_)
+acados_size_t ocp_nlp_constraints_bgp_model_calculate_size(void *config, void *dims_)
 {
     ocp_nlp_constraints_bgp_dims *dims = dims_;
 
@@ -543,7 +543,7 @@ int ocp_nlp_constraints_bgp_model_calculate_size(void *config, void *dims_)
     int nge = dims->nge;
     int nphie = dims->nphie;
 
-    int size = 0;
+    acados_size_t size = 0;
 
     size += sizeof(ocp_nlp_constraints_bgp_model);
 
@@ -818,9 +818,9 @@ int ocp_nlp_constraints_bgp_model_set(void *config_, void *dims_,
 
 /* options */
 
-int ocp_nlp_constraints_bgp_opts_calculate_size(void *config_, void *dims_)
+acados_size_t ocp_nlp_constraints_bgp_opts_calculate_size(void *config_, void *dims_)
 {
-    int size = 0;
+    acados_size_t size = 0;
 
     size += sizeof(ocp_nlp_constraints_bgp_opts);
 
@@ -894,7 +894,7 @@ void ocp_nlp_constraints_bgp_opts_set(void *config_, void *opts_, char *field, v
 
 /* memory */
 
-int ocp_nlp_constraints_bgp_memory_calculate_size(void *config_, void *dims_, void *opts_)
+acados_size_t ocp_nlp_constraints_bgp_memory_calculate_size(void *config_, void *dims_, void *opts_)
 {
     ocp_nlp_constraints_bgp_dims *dims = dims_;
 
@@ -906,7 +906,7 @@ int ocp_nlp_constraints_bgp_memory_calculate_size(void *config_, void *dims_, vo
     int nphi = dims->nphi;
     int ns = dims->ns;
 
-    int size = 0;
+    acados_size_t size = 0;
 
     size += sizeof(ocp_nlp_constraints_bgp_memory);
 
@@ -1076,7 +1076,7 @@ void ocp_nlp_constraints_bgp_memory_set_idxe_ptr(int *idxe, void *memory_)
 
 /* workspace */
 
-int ocp_nlp_constraints_bgp_workspace_calculate_size(void *config_, void *dims_, void *opts_)
+acados_size_t ocp_nlp_constraints_bgp_workspace_calculate_size(void *config_, void *dims_, void *opts_)
 {
     ocp_nlp_constraints_bgp_dims *dims = dims_;
 
@@ -1092,7 +1092,7 @@ int ocp_nlp_constraints_bgp_workspace_calculate_size(void *config_, void *dims_,
 
     int nv = nx + nu;
 
-    int size = 0;
+    acados_size_t size = 0;
 
     size += sizeof(ocp_nlp_constraints_bgp_workspace);
 

--- a/acados/ocp_nlp/ocp_nlp_constraints_bgp.h
+++ b/acados/ocp_nlp/ocp_nlp_constraints_bgp.h
@@ -77,7 +77,7 @@ typedef struct
 } ocp_nlp_constraints_bgp_dims;
 
 //
-int ocp_nlp_constraints_bgp_dims_calculate_size(void *config);
+acados_size_t ocp_nlp_constraints_bgp_dims_calculate_size(void *config);
 //
 void *ocp_nlp_constraints_bgp_dims_assign(void *config, void *raw_memory);
 //
@@ -103,7 +103,7 @@ typedef struct
 } ocp_nlp_constraints_bgp_model;
 
 //
-int ocp_nlp_constraints_bgp_calculate_size(void *config, void *dims);
+acados_size_t ocp_nlp_constraints_bgp_calculate_size(void *config, void *dims);
 //
 void *ocp_nlp_constraints_bgp_assign(void *config, void *dims, void *raw_memory);
 //
@@ -119,7 +119,7 @@ typedef struct
 } ocp_nlp_constraints_bgp_opts;
 
 //
-int ocp_nlp_constraints_bgp_opts_calculate_size(void *config, void *dims);
+acados_size_t ocp_nlp_constraints_bgp_opts_calculate_size(void *config, void *dims);
 //
 void *ocp_nlp_constraints_bgp_opts_assign(void *config, void *dims, void *raw_memory);
 //
@@ -149,7 +149,7 @@ typedef struct
 } ocp_nlp_constraints_bgp_memory;
 
 //
-int ocp_nlp_constraints_bgp_memory_calculate_size(void *config, void *dims, void *opts);
+acados_size_t ocp_nlp_constraints_bgp_memory_calculate_size(void *config, void *dims, void *opts);
 //
 void *ocp_nlp_constraints_bgp_memory_assign(void *config, void *dims, void *opts,
     void *raw_memory);
@@ -191,7 +191,7 @@ typedef struct
 } ocp_nlp_constraints_bgp_workspace;
 
 //
-int ocp_nlp_constraints_bgp_workspace_calculate_size(void *config, void *dims, void *opts);
+acados_size_t ocp_nlp_constraints_bgp_workspace_calculate_size(void *config, void *dims, void *opts);
 
 /* functions */
 

--- a/acados/ocp_nlp/ocp_nlp_constraints_common.c
+++ b/acados/ocp_nlp/ocp_nlp_constraints_common.c
@@ -49,9 +49,9 @@
  * config
  ************************************************/
 
-int ocp_nlp_constraints_config_calculate_size()
+acados_size_t ocp_nlp_constraints_config_calculate_size()
 {
-    int size = 0;
+    acados_size_t size = 0;
 
     size += sizeof(ocp_nlp_constraints_config);
 

--- a/acados/ocp_nlp/ocp_nlp_constraints_common.h
+++ b/acados/ocp_nlp/ocp_nlp_constraints_common.h
@@ -58,19 +58,19 @@ extern "C" {
 
 typedef struct
 {
-    int (*dims_calculate_size)(void *config);
+    acados_size_t (*dims_calculate_size)(void *config);
     void *(*dims_assign)(void *config, void *raw_memory);
     void (*dims_initialize)(void *config, void *dims, int nx, int nu, int nz, int nbx, int nbu, int ng,
                             int nh, int nq, int ns);
-    int (*model_calculate_size)(void *config, void *dims);
+    acados_size_t (*model_calculate_size)(void *config, void *dims);
     void *(*model_assign)(void *config, void *dims, void *raw_memory);
     int (*model_set)(void *config_, void *dims_, void *model_, const char *field, void *value);
-    int (*opts_calculate_size)(void *config, void *dims);
+    acados_size_t (*opts_calculate_size)(void *config, void *dims);
     void *(*opts_assign)(void *config, void *dims, void *raw_memory);
     void (*opts_initialize_default)(void *config, void *dims, void *opts);
     void (*opts_update)(void *config, void *dims, void *opts);
     void (*opts_set)(void *config, void *opts, char *field, void *value);
-    int (*memory_calculate_size)(void *config, void *dims, void *opts);
+    acados_size_t (*memory_calculate_size)(void *config, void *dims, void *opts);
     struct blasfeo_dvec *(*memory_get_fun_ptr)(void *memory);
     struct blasfeo_dvec *(*memory_get_adj_ptr)(void *memory);
     void (*memory_set_ux_ptr)(struct blasfeo_dvec *ux, void *memory);
@@ -85,7 +85,7 @@ typedef struct
     void (*memory_set_idxs_rev_ptr)(int *idxs_rev, void *memory);
     void (*memory_set_idxe_ptr)(int *idxe, void *memory);
     void *(*memory_assign)(void *config, void *dims, void *opts, void *raw_memory);
-    int (*workspace_calculate_size)(void *config, void *dims, void *opts);
+    acados_size_t (*workspace_calculate_size)(void *config, void *dims, void *opts);
     void (*initialize)(void *config, void *dims, void *model, void *opts, void *mem, void *work);
     void (*update_qp_matrices)(void *config, void *dims, void *model, void *opts, void *mem, void *work);
     void (*compute_fun)(void *config, void *dims, void *model, void *opts, void *mem, void *work);
@@ -97,7 +97,7 @@ typedef struct
 } ocp_nlp_constraints_config;
 
 //
-int ocp_nlp_constraints_config_calculate_size();
+acados_size_t ocp_nlp_constraints_config_calculate_size();
 //
 ocp_nlp_constraints_config *ocp_nlp_constraints_config_assign(void *raw_memory);
 

--- a/acados/ocp_nlp/ocp_nlp_cost_common.c
+++ b/acados/ocp_nlp/ocp_nlp_cost_common.c
@@ -50,9 +50,9 @@
  * config
  ************************************************/
 
-int ocp_nlp_cost_config_calculate_size()
+acados_size_t ocp_nlp_cost_config_calculate_size()
 {
-    int size = 0;
+    acados_size_t size = 0;
 
     size += sizeof(ocp_nlp_cost_config);
 

--- a/acados/ocp_nlp/ocp_nlp_cost_common.h
+++ b/acados/ocp_nlp/ocp_nlp_cost_common.h
@@ -60,20 +60,20 @@ extern "C" {
 
 typedef struct
 {
-    int (*dims_calculate_size)(void *config);
+    acados_size_t (*dims_calculate_size)(void *config);
     void *(*dims_assign)(void *config, void *raw_memory);
     void (*dims_initialize)(void *config, void *dims, int nx, int nu, int ny, int ns, int nz);
     void (*dims_set)(void *config_, void *dims_, const char *field, int *value);
     void (*dims_get)(void *config_, void *dims_, const char *field, int *value);
-    int (*model_calculate_size)(void *config, void *dims);
+    acados_size_t (*model_calculate_size)(void *config, void *dims);
     void *(*model_assign)(void *config, void *dims, void *raw_memory);
     int (*model_set)(void *config_, void *dims_, void *model_, const char *field, void *value_);
-    int (*opts_calculate_size)(void *config, void *dims);
+    acados_size_t (*opts_calculate_size)(void *config, void *dims);
     void *(*opts_assign)(void *config, void *dims, void *raw_memory);
     void (*opts_initialize_default)(void *config, void *dims, void *opts);
     void (*opts_update)(void *config, void *dims, void *opts);
     void (*opts_set)(void *config, void *opts, const char *field, void *value);
-    int (*memory_calculate_size)(void *config, void *dims, void *opts);
+    acados_size_t (*memory_calculate_size)(void *config, void *dims, void *opts);
 	double *(*memory_get_fun_ptr)(void *memory);
     struct blasfeo_dvec *(*memory_get_grad_ptr)(void *memory);
     void (*memory_set_ux_ptr)(struct blasfeo_dvec *ux, void *memory);
@@ -83,7 +83,7 @@ typedef struct
     void (*memory_set_RSQrq_ptr)(struct blasfeo_dmat *RSQrq, void *memory);
     void (*memory_set_Z_ptr)(struct blasfeo_dvec *Z, void *memory);
     void *(*memory_assign)(void *config, void *dims, void *opts, void *raw_memory);
-    int (*workspace_calculate_size)(void *config, void *dims, void *opts);
+    acados_size_t (*workspace_calculate_size)(void *config, void *dims, void *opts);
     void (*initialize)(void *config_, void *dims, void *model_, void *opts_, void *mem_, void *work_);
 
     // computes the function value, gradient and hessian (approximation) of the cost function
@@ -94,7 +94,7 @@ typedef struct
 } ocp_nlp_cost_config;
 
 //
-int ocp_nlp_cost_config_calculate_size();
+acados_size_t ocp_nlp_cost_config_calculate_size();
 //
 ocp_nlp_cost_config *ocp_nlp_cost_config_assign(void *raw_memory);
 

--- a/acados/ocp_nlp/ocp_nlp_cost_external.c
+++ b/acados/ocp_nlp/ocp_nlp_cost_external.c
@@ -52,9 +52,9 @@
  * dims
  ************************************************/
 
-int ocp_nlp_cost_external_dims_calculate_size(void *config_)
+acados_size_t ocp_nlp_cost_external_dims_calculate_size(void *config_)
 {
-    int size = sizeof(ocp_nlp_cost_external_dims);
+    acados_size_t size = sizeof(ocp_nlp_cost_external_dims);
 
     return size;
 }
@@ -134,7 +134,7 @@ void ocp_nlp_cost_external_dims_get(void *config_, void *dims_, const char *fiel
  * model
  ************************************************/
 
-int ocp_nlp_cost_external_model_calculate_size(void *config_, void *dims_)
+acados_size_t ocp_nlp_cost_external_model_calculate_size(void *config_, void *dims_)
 {
     ocp_nlp_cost_external_dims *dims = dims_;
 
@@ -142,7 +142,7 @@ int ocp_nlp_cost_external_model_calculate_size(void *config_, void *dims_)
     int nu = dims->nu;
     int ns = dims->ns;
 
-    int size = 0;
+    acados_size_t size = 0;
 
     size += sizeof(ocp_nlp_cost_external_model);
 
@@ -279,11 +279,11 @@ int ocp_nlp_cost_external_model_set(void *config_, void *dims_, void *model_,
  * options
  ************************************************/
 
-int ocp_nlp_cost_external_opts_calculate_size(void *config_, void *dims_)
+acados_size_t ocp_nlp_cost_external_opts_calculate_size(void *config_, void *dims_)
 {
     // ocp_nlp_cost_config *config = config_;
 
-    int size = 0;
+    acados_size_t size = 0;
 
     size += sizeof(ocp_nlp_cost_external_opts);
 
@@ -363,7 +363,7 @@ void ocp_nlp_cost_external_opts_set(void *config_, void *opts_, const char *fiel
  * memory
  ************************************************/
 
-int ocp_nlp_cost_external_memory_calculate_size(void *config_, void *dims_, void *opts_)
+acados_size_t ocp_nlp_cost_external_memory_calculate_size(void *config_, void *dims_, void *opts_)
 {
     // ocp_nlp_cost_config *config = config_;
     ocp_nlp_cost_external_dims *dims = dims_;
@@ -373,7 +373,7 @@ int ocp_nlp_cost_external_memory_calculate_size(void *config_, void *dims_, void
     int nu = dims->nu;
     int ns = dims->ns;
 
-    int size = 0;
+    acados_size_t size = 0;
 
     size += sizeof(ocp_nlp_cost_external_memory);
 
@@ -500,7 +500,7 @@ void ocp_nlp_cost_external_memory_set_dzdux_tran_ptr(struct blasfeo_dmat *dzdux_
  * workspace
  ************************************************/
 
-int ocp_nlp_cost_external_workspace_calculate_size(void *config_, void *dims_, void *opts_)
+acados_size_t ocp_nlp_cost_external_workspace_calculate_size(void *config_, void *dims_, void *opts_)
 {
     ocp_nlp_cost_external_dims *dims = dims_;
 
@@ -509,7 +509,7 @@ int ocp_nlp_cost_external_workspace_calculate_size(void *config_, void *dims_, v
     int nu = dims->nu;
     int ns = dims->ns;
 
-    int size = 0;
+    acados_size_t size = 0;
 
     size += sizeof(ocp_nlp_cost_external_workspace);
 

--- a/acados/ocp_nlp/ocp_nlp_cost_external.h
+++ b/acados/ocp_nlp/ocp_nlp_cost_external.h
@@ -59,7 +59,7 @@ typedef struct
 } ocp_nlp_cost_external_dims;
 
 //
-int ocp_nlp_cost_external_dims_calculate_size(void *config);
+acados_size_t ocp_nlp_cost_external_dims_calculate_size(void *config);
 //
 void *ocp_nlp_cost_external_dims_assign(void *config, void *raw_memory);
 //
@@ -86,7 +86,7 @@ typedef struct
 } ocp_nlp_cost_external_model;
 
 //
-int ocp_nlp_cost_external_model_calculate_size(void *config, void *dims);
+acados_size_t ocp_nlp_cost_external_model_calculate_size(void *config, void *dims);
 //
 void *ocp_nlp_cost_external_model_assign(void *config, void *dims, void *raw_memory);
 
@@ -102,7 +102,7 @@ typedef struct
 } ocp_nlp_cost_external_opts;
 
 //
-int ocp_nlp_cost_external_opts_calculate_size(void *config, void *dims);
+acados_size_t ocp_nlp_cost_external_opts_calculate_size(void *config, void *dims);
 //
 void *ocp_nlp_cost_external_opts_assign(void *config, void *dims, void *raw_memory);
 //
@@ -131,7 +131,7 @@ typedef struct
 } ocp_nlp_cost_external_memory;
 
 //
-int ocp_nlp_cost_external_memory_calculate_size(void *config, void *dims, void *opts);
+acados_size_t ocp_nlp_cost_external_memory_calculate_size(void *config, void *dims, void *opts);
 //
 void *ocp_nlp_cost_external_memory_assign(void *config, void *dims, void *opts, void *raw_memory);
 //
@@ -162,7 +162,7 @@ typedef struct
 } ocp_nlp_cost_external_workspace;
 
 //
-int ocp_nlp_cost_external_workspace_calculate_size(void *config, void *dims, void *opts);
+acados_size_t ocp_nlp_cost_external_workspace_calculate_size(void *config, void *dims, void *opts);
 
 /************************************************
  * functions

--- a/acados/ocp_nlp/ocp_nlp_cost_ls.c
+++ b/acados/ocp_nlp/ocp_nlp_cost_ls.c
@@ -60,10 +60,10 @@
 
 
 
-int ocp_nlp_cost_ls_dims_calculate_size(void *config_)
+acados_size_t ocp_nlp_cost_ls_dims_calculate_size(void *config_)
 {
 
-    int size = sizeof(ocp_nlp_cost_ls_dims);
+    acados_size_t size = sizeof(ocp_nlp_cost_ls_dims);
 
     return size;
 }
@@ -218,7 +218,7 @@ void ocp_nlp_cost_ls_dims_get(void *config_, void *dims_, const char *field, int
 
 
 
-int ocp_nlp_cost_ls_model_calculate_size(void *config_, void *dims_)
+acados_size_t ocp_nlp_cost_ls_model_calculate_size(void *config_, void *dims_)
 {
     ocp_nlp_cost_ls_dims *dims = dims_;
 
@@ -229,7 +229,7 @@ int ocp_nlp_cost_ls_model_calculate_size(void *config_, void *dims_)
     int ny = dims->ny;
     int ns = dims->ns;
 
-    int size = 0;
+    acados_size_t size = 0;
 
     size += sizeof(ocp_nlp_cost_ls_model);
 
@@ -408,9 +408,9 @@ int ocp_nlp_cost_ls_model_set(void *config_, void *dims_, void *model_,
 
 
 
-int ocp_nlp_cost_ls_opts_calculate_size(void *config_, void *dims_)
+acados_size_t ocp_nlp_cost_ls_opts_calculate_size(void *config_, void *dims_)
 {
-    int size = 0;
+    acados_size_t size = 0;
 
     size += sizeof(ocp_nlp_cost_ls_opts);
 
@@ -480,7 +480,7 @@ void ocp_nlp_cost_ls_opts_set(void *config_, void *opts_, const char *field, voi
 
 
 
-int ocp_nlp_cost_ls_memory_calculate_size(void *config_, 
+acados_size_t ocp_nlp_cost_ls_memory_calculate_size(void *config_, 
     void *dims_, void *opts_)
 {
     ocp_nlp_cost_ls_dims *dims = dims_;
@@ -491,7 +491,7 @@ int ocp_nlp_cost_ls_memory_calculate_size(void *config_,
     int ny = dims->ny;
     int ns = dims->ns;
 
-    int size = 0;
+    acados_size_t size = 0;
 
     size += sizeof(ocp_nlp_cost_ls_memory);
 
@@ -623,7 +623,7 @@ void ocp_nlp_cost_ls_memory_set_dzdux_tran_ptr(struct blasfeo_dmat *dzdux_tran, 
 
 
 
-int ocp_nlp_cost_ls_workspace_calculate_size(void *config_, 
+acados_size_t ocp_nlp_cost_ls_workspace_calculate_size(void *config_, 
     void *dims_, void *opts_)
 {
     ocp_nlp_cost_ls_dims *dims = dims_;
@@ -635,7 +635,7 @@ int ocp_nlp_cost_ls_workspace_calculate_size(void *config_,
     int ns = dims->ns;
     int nz = dims->nz;
 
-    int size = 0;
+    acados_size_t size = 0;
 
     size += sizeof(ocp_nlp_cost_ls_workspace);
 

--- a/acados/ocp_nlp/ocp_nlp_cost_ls.h
+++ b/acados/ocp_nlp/ocp_nlp_cost_ls.h
@@ -75,11 +75,11 @@ typedef struct
 
 ///  Calculate the size of the ocp_nlp_cost_ls_dims struct
 ///
-///  \param[in] config structure containing configuration of ocp_nlp_cost 
+///  \param[in] config_ structure containing configuration of ocp_nlp_cost
 ///  module
 ///  \param[out] []
-///  \return \c size of ocp_nlp_dims struct 
-int ocp_nlp_cost_ls_dims_calculate_size(void *config);
+///  \return \c size of ocp_nlp_dims struct
+acados_size_t ocp_nlp_cost_ls_dims_calculate_size(void *config);
 
 
 ///  Assign memory pointed to by raw_memory to ocp_nlp-cost_ls dims struct 
@@ -131,7 +131,7 @@ typedef struct
 } ocp_nlp_cost_ls_model;
 
 //
-int ocp_nlp_cost_ls_model_calculate_size(void *config, void *dims);
+acados_size_t ocp_nlp_cost_ls_model_calculate_size(void *config, void *dims);
 //
 void *ocp_nlp_cost_ls_model_assign(void *config, void *dims, void *raw_memory);
 //
@@ -152,7 +152,7 @@ typedef struct
 } ocp_nlp_cost_ls_opts;
 
 //
-int ocp_nlp_cost_ls_opts_calculate_size(void *config, void *dims);
+acados_size_t ocp_nlp_cost_ls_opts_calculate_size(void *config, void *dims);
 //
 void *ocp_nlp_cost_ls_opts_assign(void *config, void *dims, void *raw_memory);
 //
@@ -188,7 +188,7 @@ typedef struct
 } ocp_nlp_cost_ls_memory;
 
 //
-int ocp_nlp_cost_ls_memory_calculate_size(void *config, void *dims, void *opts);
+acados_size_t ocp_nlp_cost_ls_memory_calculate_size(void *config, void *dims, void *opts);
 //
 void *ocp_nlp_cost_ls_memory_assign(void *config, void *dims, void *opts, void *raw_memory);
 //
@@ -228,7 +228,7 @@ typedef struct
 } ocp_nlp_cost_ls_workspace;
 
 //
-int ocp_nlp_cost_ls_workspace_calculate_size(void *config, void *dims, void *opts);
+acados_size_t ocp_nlp_cost_ls_workspace_calculate_size(void *config, void *dims, void *opts);
 
 
 

--- a/acados/ocp_nlp/ocp_nlp_cost_nls.c
+++ b/acados/ocp_nlp/ocp_nlp_cost_nls.c
@@ -51,9 +51,9 @@
  * dims
  ************************************************/
 
-int ocp_nlp_cost_nls_dims_calculate_size(void *config_)
+acados_size_t ocp_nlp_cost_nls_dims_calculate_size(void *config_)
 {
-    int size = sizeof(ocp_nlp_cost_nls_dims);
+    acados_size_t size = sizeof(ocp_nlp_cost_nls_dims);
 
     return size;
 }
@@ -182,7 +182,7 @@ void ocp_nlp_cost_nls_dims_get(void *config_, void *dims_, const char *field, in
  * model
  ************************************************/
 
-int ocp_nlp_cost_nls_model_calculate_size(void *config_, void *dims_)
+acados_size_t ocp_nlp_cost_nls_model_calculate_size(void *config_, void *dims_)
 {
     ocp_nlp_cost_nls_dims *dims = dims_;
 
@@ -192,7 +192,7 @@ int ocp_nlp_cost_nls_model_calculate_size(void *config_, void *dims_)
     int ny = dims->ny;
     int ns = dims->ns;
 
-    int size = 0;
+    acados_size_t size = 0;
 
     size += sizeof(ocp_nlp_cost_nls_model);
 
@@ -347,11 +347,11 @@ int ocp_nlp_cost_nls_model_set(void *config_, void *dims_, void *model_,
  * options
  ************************************************/
 
-int ocp_nlp_cost_nls_opts_calculate_size(void *config_, void *dims_)
+acados_size_t ocp_nlp_cost_nls_opts_calculate_size(void *config_, void *dims_)
 {
     // ocp_nlp_cost_config *config = config_;
 
-    int size = 0;
+    acados_size_t size = 0;
 
     size += sizeof(ocp_nlp_cost_nls_opts);
 
@@ -436,7 +436,7 @@ void ocp_nlp_cost_nls_opts_set(void *config_, void *opts_, const char *field, vo
  * memory
  ************************************************/
 
-int ocp_nlp_cost_nls_memory_calculate_size(void *config_, void *dims_, void *opts_)
+acados_size_t ocp_nlp_cost_nls_memory_calculate_size(void *config_, void *dims_, void *opts_)
 {
     // ocp_nlp_cost_config *config = config_;
     ocp_nlp_cost_nls_dims *dims = dims_;
@@ -448,7 +448,7 @@ int ocp_nlp_cost_nls_memory_calculate_size(void *config_, void *dims_, void *opt
     int ny = dims->ny;
     int ns = dims->ns;
 
-    int size = 0;
+    acados_size_t size = 0;
 
     size += sizeof(ocp_nlp_cost_nls_memory);
 
@@ -586,7 +586,7 @@ void ocp_nlp_cost_nls_memory_set_dzdux_tran_ptr(struct blasfeo_dmat *dzdux_tran,
  * workspace
  ************************************************/
 
-int ocp_nlp_cost_nls_workspace_calculate_size(void *config_, void *dims_, void *opts_)
+acados_size_t ocp_nlp_cost_nls_workspace_calculate_size(void *config_, void *dims_, void *opts_)
 {
     // ocp_nlp_cost_config *config = config_;
     ocp_nlp_cost_nls_dims *dims = dims_;
@@ -598,7 +598,7 @@ int ocp_nlp_cost_nls_workspace_calculate_size(void *config_, void *dims_, void *
     int ny = dims->ny;
     int ns = dims->ns;
 
-    int size = 0;
+    acados_size_t size = 0;
 
     size += sizeof(ocp_nlp_cost_nls_workspace);
 

--- a/acados/ocp_nlp/ocp_nlp_cost_nls.h
+++ b/acados/ocp_nlp/ocp_nlp_cost_nls.h
@@ -71,7 +71,7 @@ typedef struct
 } ocp_nlp_cost_nls_dims;
 
 //
-int ocp_nlp_cost_nls_dims_calculate_size(void *config);
+acados_size_t ocp_nlp_cost_nls_dims_calculate_size(void *config);
 //
 void *ocp_nlp_cost_nls_dims_assign(void *config, void *raw_memory);
 //
@@ -102,7 +102,7 @@ typedef struct
 } ocp_nlp_cost_nls_model;
 
 //
-int ocp_nlp_cost_nls_model_calculate_size(void *config, void *dims);
+acados_size_t ocp_nlp_cost_nls_model_calculate_size(void *config, void *dims);
 //
 void *ocp_nlp_cost_nls_model_assign(void *config, void *dims, void *raw_memory);
 //
@@ -120,7 +120,7 @@ typedef struct
 } ocp_nlp_cost_nls_opts;
 
 //
-int ocp_nlp_cost_nls_opts_calculate_size(void *config, void *dims);
+acados_size_t ocp_nlp_cost_nls_opts_calculate_size(void *config, void *dims);
 //
 void *ocp_nlp_cost_nls_opts_assign(void *config, void *dims, void *raw_memory);
 //
@@ -152,7 +152,7 @@ typedef struct
 } ocp_nlp_cost_nls_memory;
 
 //
-int ocp_nlp_cost_nls_memory_calculate_size(void *config, void *dims, void *opts);
+acados_size_t ocp_nlp_cost_nls_memory_calculate_size(void *config, void *dims, void *opts);
 //
 void *ocp_nlp_cost_nls_memory_assign(void *config, void *dims, void *opts, void *raw_memory);
 //
@@ -185,7 +185,7 @@ typedef struct
 } ocp_nlp_cost_nls_workspace;
 
 //
-int ocp_nlp_cost_nls_workspace_calculate_size(void *config, void *dims, void *opts);
+acados_size_t ocp_nlp_cost_nls_workspace_calculate_size(void *config, void *dims, void *opts);
 
 /************************************************
  * functions

--- a/acados/ocp_nlp/ocp_nlp_dynamics_common.c
+++ b/acados/ocp_nlp/ocp_nlp_dynamics_common.c
@@ -48,9 +48,9 @@
  * config
  ************************************************/
 
-int ocp_nlp_dynamics_config_calculate_size()
+acados_size_t ocp_nlp_dynamics_config_calculate_size()
 {
-    int size = 0;
+    acados_size_t size = 0;
 
     size += sizeof(ocp_nlp_dynamics_config);
 

--- a/acados/ocp_nlp/ocp_nlp_dynamics_common.h
+++ b/acados/ocp_nlp/ocp_nlp_dynamics_common.h
@@ -66,23 +66,23 @@ typedef struct
     void (*config_initialize_default)(void *config);
     sim_config *sim_solver;
     /* dims */
-    int (*dims_calculate_size)(void *config);
+    acados_size_t (*dims_calculate_size)(void *config);
     void *(*dims_assign)(void *config, void *raw_memory);
     void (*dims_initialize)(void *config, void *dims, int nx, int nu, int nx1, int nu1, int nz);
     void (*dims_set)(void *config_, void *dims_, const char *field, int *value);
     void (*dims_get)(void *config_, void *dims_, const char *field, int* value);
     /* model */
-    int (*model_calculate_size)(void *config, void *dims);
+    acados_size_t (*model_calculate_size)(void *config, void *dims);
     void *(*model_assign)(void *config, void *dims, void *raw_memory);
     void (*model_set)(void *config_, void *dims_, void *model_, const char *field, void *value_);
     /* opts */
-    int (*opts_calculate_size)(void *config, void *dims);
+    acados_size_t (*opts_calculate_size)(void *config, void *dims);
     void *(*opts_assign)(void *config, void *dims, void *raw_memory);
     void (*opts_initialize_default)(void *config, void *dims, void *opts);
     void (*opts_set)(void *config_, void *opts_, const char *field, void *value);
     void (*opts_update)(void *config, void *dims, void *opts);
     /* memory */
-    int (*memory_calculate_size)(void *config, void *dims, void *opts);
+    acados_size_t (*memory_calculate_size)(void *config, void *dims, void *opts);
     void *(*memory_assign)(void *config, void *dims, void *opts, void *raw_memory);
     struct blasfeo_dvec *(*memory_get_fun_ptr)(void *memory_);
     struct blasfeo_dvec *(*memory_get_adj_ptr)(void *memory_);
@@ -99,7 +99,7 @@ typedef struct
     void (*memory_set_z_alg_ptr)(struct blasfeo_dvec *vec, void *memory_);
     void (*memory_get)(void *config, void *dims, void *mem, const char *field, void* value);
     /* workspace */
-    int (*workspace_calculate_size)(void *config, void *dims, void *opts);
+    acados_size_t (*workspace_calculate_size)(void *config, void *dims, void *opts);
     void (*initialize)(void *config_, void *dims, void *model_, void *opts_, void *mem_, void *work_);
     void (*update_qp_matrices)(void *config_, void *dims, void *model_, void *opts_, void *mem_, void *work_);
     void (*compute_fun)(void *config_, void *dims, void *model_, void *opts_, void *mem_, void *work_);
@@ -107,7 +107,7 @@ typedef struct
 } ocp_nlp_dynamics_config;
 
 //
-int ocp_nlp_dynamics_config_calculate_size();
+acados_size_t ocp_nlp_dynamics_config_calculate_size();
 //
 ocp_nlp_dynamics_config *ocp_nlp_dynamics_config_assign(void *raw_memory);
 

--- a/acados/ocp_nlp/ocp_nlp_dynamics_cont.c
+++ b/acados/ocp_nlp/ocp_nlp_dynamics_cont.c
@@ -51,11 +51,11 @@
  * dims
  ************************************************/
 
-int ocp_nlp_dynamics_cont_dims_calculate_size(void *config_)
+acados_size_t ocp_nlp_dynamics_cont_dims_calculate_size(void *config_)
 {
     ocp_nlp_dynamics_config *dyn_config = (ocp_nlp_dynamics_config *) config_;
     sim_config *sim_sol_config = (sim_config *) dyn_config->sim_solver;
-    int size = 0;
+    acados_size_t size = 0;
 
     size += sizeof(ocp_nlp_dynamics_cont_dims);
 
@@ -223,12 +223,12 @@ void ocp_nlp_dynamics_cont_dims_get(void *config_, void *dims_, const char *fiel
  * options
  ************************************************/
 
-int ocp_nlp_dynamics_cont_opts_calculate_size(void *config_, void *dims_)
+acados_size_t ocp_nlp_dynamics_cont_opts_calculate_size(void *config_, void *dims_)
 {
     ocp_nlp_dynamics_config *config = config_;
     ocp_nlp_dynamics_cont_dims *dims = dims_;
 
-    int size = 0;
+    acados_size_t size = 0;
 
     size += sizeof(ocp_nlp_dynamics_cont_opts);
 
@@ -345,7 +345,7 @@ void ocp_nlp_dynamics_cont_opts_set(void *config_, void *opts_, const char *fiel
  * memory
  ************************************************/
 
-int ocp_nlp_dynamics_cont_memory_calculate_size(void *config_, void *dims_, void *opts_)
+acados_size_t ocp_nlp_dynamics_cont_memory_calculate_size(void *config_, void *dims_, void *opts_)
 {
     ocp_nlp_dynamics_config *config = config_;
     ocp_nlp_dynamics_cont_dims *dims = dims_;
@@ -357,7 +357,7 @@ int ocp_nlp_dynamics_cont_memory_calculate_size(void *config_, void *dims_, void
     int nu = dims->nu;
     int nx1 = dims->nx1;
 
-    int size = 0;
+    acados_size_t size = 0;
 
     size += sizeof(ocp_nlp_dynamics_cont_memory);
 
@@ -584,7 +584,7 @@ void ocp_nlp_dynamics_cont_memory_get(void *config_, void *dims_, void *mem_, co
  * workspace
  ************************************************/
 
-int ocp_nlp_dynamics_cont_workspace_calculate_size(void *config_, void *dims_, void *opts_)
+acados_size_t ocp_nlp_dynamics_cont_workspace_calculate_size(void *config_, void *dims_, void *opts_)
 {
     ocp_nlp_dynamics_config *config = config_;
     ocp_nlp_dynamics_cont_dims *dims = dims_;
@@ -594,7 +594,7 @@ int ocp_nlp_dynamics_cont_workspace_calculate_size(void *config_, void *dims_, v
     int nx = dims->nx;
     int nu = dims->nu;
 
-    int size = 0;
+    acados_size_t size = 0;
 
     size += sizeof(ocp_nlp_dynamics_cont_workspace);
 
@@ -654,7 +654,7 @@ static void ocp_nlp_dynamics_cont_cast_workspace(void *config_, void *dims_, voi
  * model
  ************************************************/
 
-int ocp_nlp_dynamics_cont_model_calculate_size(void *config_, void *dims_)
+acados_size_t ocp_nlp_dynamics_cont_model_calculate_size(void *config_, void *dims_)
 {
     ocp_nlp_dynamics_config *config = config_;
     ocp_nlp_dynamics_cont_dims *dims = dims_;
@@ -663,7 +663,7 @@ int ocp_nlp_dynamics_cont_model_calculate_size(void *config_, void *dims_)
     // int nx = dims->nx;
     // int nu = dims->nu;
 
-    int size = 0;
+    acados_size_t size = 0;
 
     size += sizeof(ocp_nlp_dynamics_cont_model);
 

--- a/acados/ocp_nlp/ocp_nlp_dynamics_cont.h
+++ b/acados/ocp_nlp/ocp_nlp_dynamics_cont.h
@@ -72,7 +72,7 @@ typedef struct
 } ocp_nlp_dynamics_cont_dims;
 
 //
-int ocp_nlp_dynamics_cont_dims_calculate_size(void *config);
+acados_size_t ocp_nlp_dynamics_cont_dims_calculate_size(void *config);
 //
 void *ocp_nlp_dynamics_cont_dims_assign(void *config, void *raw_memory);
 //
@@ -94,7 +94,7 @@ typedef struct
 } ocp_nlp_dynamics_cont_opts;
 
 //
-int ocp_nlp_dynamics_cont_opts_calculate_size(void *config, void *dims);
+acados_size_t ocp_nlp_dynamics_cont_opts_calculate_size(void *config, void *dims);
 //
 void *ocp_nlp_dynamics_cont_opts_assign(void *config, void *dims, void *raw_memory);
 //
@@ -131,7 +131,7 @@ typedef struct
 } ocp_nlp_dynamics_cont_memory;
 
 //
-int ocp_nlp_dynamics_cont_memory_calculate_size(void *config, void *dims, void *opts);
+acados_size_t ocp_nlp_dynamics_cont_memory_calculate_size(void *config, void *dims, void *opts);
 //
 void *ocp_nlp_dynamics_cont_memory_assign(void *config, void *dims, void *opts, void *raw_memory);
 //
@@ -167,7 +167,7 @@ typedef struct
     void *sim_solver;  // sim solver workspace
 } ocp_nlp_dynamics_cont_workspace;
 
-int ocp_nlp_dynamics_cont_workspace_calculate_size(void *config, void *dims, void *opts);
+acados_size_t ocp_nlp_dynamics_cont_workspace_calculate_size(void *config, void *dims, void *opts);
 
 
 
@@ -183,7 +183,7 @@ typedef struct
 } ocp_nlp_dynamics_cont_model;
 
 //
-int ocp_nlp_dynamics_cont_model_calculate_size(void *config, void *dims);
+acados_size_t ocp_nlp_dynamics_cont_model_calculate_size(void *config, void *dims);
 //
 void *ocp_nlp_dynamics_cont_model_assign(void *config, void *dims, void *raw_memory);
 //

--- a/acados/ocp_nlp/ocp_nlp_dynamics_disc.c
+++ b/acados/ocp_nlp/ocp_nlp_dynamics_disc.c
@@ -50,9 +50,9 @@
  * dims
  ************************************************/
 
-int ocp_nlp_dynamics_disc_dims_calculate_size(void *config_)
+acados_size_t ocp_nlp_dynamics_disc_dims_calculate_size(void *config_)
 {
-    int size = 0;
+    acados_size_t size = 0;
 
     size += sizeof(ocp_nlp_dynamics_disc_dims);
 
@@ -187,11 +187,11 @@ void ocp_nlp_dynamics_disc_dims_get(void *config_, void *dims_, const char *dim,
  * options
  ************************************************/
 
-int ocp_nlp_dynamics_disc_opts_calculate_size(void *config_, void *dims_)
+acados_size_t ocp_nlp_dynamics_disc_opts_calculate_size(void *config_, void *dims_)
 {
     // ocp_nlp_dynamics_config *config = config_;
 
-    int size = 0;
+    acados_size_t size = 0;
 
     size += sizeof(ocp_nlp_dynamics_disc_opts);
 
@@ -271,7 +271,7 @@ void ocp_nlp_dynamics_disc_opts_set(void *config_, void *opts_, const char *fiel
  * memory
  ************************************************/
 
-int ocp_nlp_dynamics_disc_memory_calculate_size(void *config_, void *dims_, void *opts_)
+acados_size_t ocp_nlp_dynamics_disc_memory_calculate_size(void *config_, void *dims_, void *opts_)
 {
     // ocp_nlp_dynamics_config *config = config_;
     ocp_nlp_dynamics_disc_dims *dims = dims_;
@@ -282,7 +282,7 @@ int ocp_nlp_dynamics_disc_memory_calculate_size(void *config_, void *dims_, void
     int nu = dims->nu;
     int nx1 = dims->nx1;
 
-    int size = 0;
+    acados_size_t size = 0;
 
     size += sizeof(ocp_nlp_dynamics_disc_memory);
 
@@ -481,7 +481,7 @@ void ocp_nlp_dynamics_disc_memory_get(void *config_, void *dims_, void *mem_, co
  * workspace
  ************************************************/
 
-int ocp_nlp_dynamics_disc_workspace_calculate_size(void *config_, void *dims_, void *opts_)
+acados_size_t ocp_nlp_dynamics_disc_workspace_calculate_size(void *config_, void *dims_, void *opts_)
 {
     // ocp_nlp_dynamics_config *config = config_;
     ocp_nlp_dynamics_disc_dims *dims = dims_;
@@ -491,7 +491,7 @@ int ocp_nlp_dynamics_disc_workspace_calculate_size(void *config_, void *dims_, v
     int nu = dims->nu;
     // int nx1 = dims->nx1;
 
-    int size = 0;
+    acados_size_t size = 0;
 
     size += sizeof(ocp_nlp_dynamics_disc_workspace);
 
@@ -544,7 +544,7 @@ static void ocp_nlp_dynamics_disc_cast_workspace(void *config_, void *dims_, voi
  * model
  ************************************************/
 
-int ocp_nlp_dynamics_disc_model_calculate_size(void *config_, void *dims_)
+acados_size_t ocp_nlp_dynamics_disc_model_calculate_size(void *config_, void *dims_)
 {
     // ocp_nlp_dynamics_config *config = config_;
 
@@ -552,7 +552,7 @@ int ocp_nlp_dynamics_disc_model_calculate_size(void *config_, void *dims_)
     // int nx = dims->nx;
     // int nu = dims->nu;
 
-    int size = 0;
+    acados_size_t size = 0;
 
     size += sizeof(ocp_nlp_dynamics_disc_model);
 

--- a/acados/ocp_nlp/ocp_nlp_dynamics_disc.h
+++ b/acados/ocp_nlp/ocp_nlp_dynamics_disc.h
@@ -65,7 +65,7 @@ typedef struct
 } ocp_nlp_dynamics_disc_dims;
 
 //
-int ocp_nlp_dynamics_disc_dims_calculate_size(void *config);
+acados_size_t ocp_nlp_dynamics_disc_dims_calculate_size(void *config);
 //
 void *ocp_nlp_dynamics_disc_dims_assign(void *config, void *raw_memory);
 //
@@ -87,7 +87,7 @@ typedef struct
 } ocp_nlp_dynamics_disc_opts;
 
 //
-int ocp_nlp_dynamics_disc_opts_calculate_size(void *config, void *dims);
+acados_size_t ocp_nlp_dynamics_disc_opts_calculate_size(void *config, void *dims);
 //
 void *ocp_nlp_dynamics_disc_opts_assign(void *config, void *dims, void *raw_memory);
 //
@@ -118,7 +118,7 @@ typedef struct
 } ocp_nlp_dynamics_disc_memory;
 
 //
-int ocp_nlp_dynamics_disc_memory_calculate_size(void *config, void *dims, void *opts);
+acados_size_t ocp_nlp_dynamics_disc_memory_calculate_size(void *config, void *dims, void *opts);
 //
 void *ocp_nlp_dynamics_disc_memory_assign(void *config, void *dims, void *opts, void *raw_memory);
 //
@@ -151,7 +151,7 @@ typedef struct
     struct blasfeo_dmat tmp_nv_nv;
 } ocp_nlp_dynamics_disc_workspace;
 
-int ocp_nlp_dynamics_disc_workspace_calculate_size(void *config, void *dims, void *opts);
+acados_size_t ocp_nlp_dynamics_disc_workspace_calculate_size(void *config, void *dims, void *opts);
 
 
 
@@ -167,7 +167,7 @@ typedef struct
 } ocp_nlp_dynamics_disc_model;
 
 //
-int ocp_nlp_dynamics_disc_model_calculate_size(void *config, void *dims);
+acados_size_t ocp_nlp_dynamics_disc_model_calculate_size(void *config, void *dims);
 //
 void *ocp_nlp_dynamics_disc_model_assign(void *config, void *dims, void *raw_memory);
 //

--- a/acados/ocp_nlp/ocp_nlp_reg_common.c
+++ b/acados/ocp_nlp/ocp_nlp_reg_common.c
@@ -47,7 +47,7 @@
  * config
  ************************************************/
 
-int ocp_nlp_reg_config_calculate_size(void)
+acados_size_t ocp_nlp_reg_config_calculate_size(void)
 {
     return sizeof(ocp_nlp_reg_config);
 }
@@ -65,9 +65,9 @@ void *ocp_nlp_reg_config_assign(void *raw_memory)
  * dims
  ************************************************/
 
-int ocp_nlp_reg_dims_calculate_size(int N)
+acados_size_t ocp_nlp_reg_dims_calculate_size(int N)
 {
-    int size = sizeof(ocp_nlp_reg_dims);
+    acados_size_t size = sizeof(ocp_nlp_reg_dims);
 
     size += 5*(N+1)*sizeof(int); // nx nu nbu nbx ng
 

--- a/acados/ocp_nlp/ocp_nlp_reg_common.h
+++ b/acados/ocp_nlp/ocp_nlp_reg_common.h
@@ -63,7 +63,7 @@ typedef struct
 } ocp_nlp_reg_dims;
 
 //
-int ocp_nlp_reg_dims_calculate_size(int N);
+acados_size_t ocp_nlp_reg_dims_calculate_size(int N);
 //
 ocp_nlp_reg_dims *ocp_nlp_reg_dims_assign(int N, void *raw_memory);
 //
@@ -76,16 +76,16 @@ void ocp_nlp_reg_dims_set(void *config_, ocp_nlp_reg_dims *dims, int stage, char
 typedef struct
 {
     /* dims */
-    int (*dims_calculate_size)(int N);
+    acados_size_t (*dims_calculate_size)(int N);
     ocp_nlp_reg_dims *(*dims_assign)(int N, void *raw_memory);
     void (*dims_set)(void *config, ocp_nlp_reg_dims *dims, int stage, char *field, int *value);
     /* opts */
-    int (*opts_calculate_size)(void);
+    acados_size_t (*opts_calculate_size)(void);
     void *(*opts_assign)(void *raw_memory);
     void (*opts_initialize_default)(void *config, ocp_nlp_reg_dims *dims, void *opts);
     void (*opts_set)(void *config, ocp_nlp_reg_dims *dims, void *opts, char *field, void* value);
     /* memory */
-    int (*memory_calculate_size)(void *config, ocp_nlp_reg_dims *dims, void *opts);
+    acados_size_t (*memory_calculate_size)(void *config, ocp_nlp_reg_dims *dims, void *opts);
     void *(*memory_assign)(void *config, ocp_nlp_reg_dims *dims, void *opts, void *raw_memory);
     void (*memory_set)(void *config, ocp_nlp_reg_dims *dims, void *memory, char *field, void* value);
     void (*memory_set_RSQrq_ptr)(ocp_nlp_reg_dims *dims, struct blasfeo_dmat *mat, void *memory);
@@ -103,7 +103,7 @@ typedef struct
 } ocp_nlp_reg_config;
 
 //
-int ocp_nlp_reg_config_calculate_size(void);
+acados_size_t ocp_nlp_reg_config_calculate_size(void);
 //
 void *ocp_nlp_reg_config_assign(void *raw_memory);
 

--- a/acados/ocp_nlp/ocp_nlp_reg_convexify.c
+++ b/acados/ocp_nlp/ocp_nlp_reg_convexify.c
@@ -52,7 +52,7 @@
  * opts
  ************************************************/
 
-int ocp_nlp_reg_convexify_opts_calculate_size(void)
+acados_size_t ocp_nlp_reg_convexify_opts_calculate_size(void)
 {
     return sizeof(ocp_nlp_reg_convexify_opts);
 }
@@ -108,7 +108,7 @@ void ocp_nlp_reg_convexify_opts_set(void *config_, ocp_nlp_reg_dims *dims, void 
  * memory
  ************************************************/
 
-int ocp_nlp_reg_convexify_calculate_memory_size(void *config_, ocp_nlp_reg_dims *dims, void *opts_)
+acados_size_t ocp_nlp_reg_convexify_calculate_memory_size(void *config_, ocp_nlp_reg_dims *dims, void *opts_)
 {
 
     int N = dims->N;
@@ -144,7 +144,7 @@ int ocp_nlp_reg_convexify_calculate_memory_size(void *config_, ocp_nlp_reg_dims 
         nbgM = nbu[ii]+nbx[ii]+ng[ii]>nbgM ? nbu[ii]+nbx[ii]+ng[ii] : nbgM;
     }
 
-    int size = 0;
+    acados_size_t size = 0;
 
     size += sizeof(ocp_nlp_reg_convexify_memory);
 

--- a/acados/ocp_nlp/ocp_nlp_reg_convexify.h
+++ b/acados/ocp_nlp/ocp_nlp_reg_convexify.h
@@ -72,7 +72,7 @@ typedef struct
 } ocp_nlp_reg_convexify_opts;
 
 //
-int ocp_nlp_reg_convexify_opts_calculate_size(void);
+acados_size_t ocp_nlp_reg_convexify_opts_calculate_size(void);
 //
 void *ocp_nlp_reg_convexify_opts_assign(void *raw_memory);
 //
@@ -123,7 +123,7 @@ typedef struct {
 } ocp_nlp_reg_convexify_memory;
 
 //
-int ocp_nlp_reg_convexify_calculate_memory_size(void *config, ocp_nlp_reg_dims *dims, void *opts);
+acados_size_t ocp_nlp_reg_convexify_calculate_memory_size(void *config, ocp_nlp_reg_dims *dims, void *opts);
 //
 void *ocp_nlp_reg_convexify_assign_memory(void *config, ocp_nlp_reg_dims *dims, void *opts, void *raw_memory);
 

--- a/acados/ocp_nlp/ocp_nlp_reg_mirror.c
+++ b/acados/ocp_nlp/ocp_nlp_reg_mirror.c
@@ -51,7 +51,7 @@
  * opts
  ************************************************/
 
-int ocp_nlp_reg_mirror_opts_calculate_size(void)
+acados_size_t ocp_nlp_reg_mirror_opts_calculate_size(void)
 {
     return sizeof(ocp_nlp_reg_mirror_opts);
 }
@@ -101,7 +101,7 @@ void ocp_nlp_reg_mirror_opts_set(void *config_, ocp_nlp_reg_dims *dims, void *op
  * memory
  ************************************************/
 
-int ocp_nlp_reg_mirror_memory_calculate_size(void *config_, ocp_nlp_reg_dims *dims, void *opts_)
+acados_size_t ocp_nlp_reg_mirror_memory_calculate_size(void *config_, ocp_nlp_reg_dims *dims, void *opts_)
 {
     int *nx = dims->nx;
     int *nu = dims->nu;
@@ -115,7 +115,7 @@ int ocp_nlp_reg_mirror_memory_calculate_size(void *config_, ocp_nlp_reg_dims *di
         nuxM = nu[ii]+nx[ii]>nuxM ? nu[ii]+nx[ii] : nuxM;
     }
 
-    int size = 0;
+    acados_size_t size = 0;
 
     size += sizeof(ocp_nlp_reg_mirror_memory);
 

--- a/acados/ocp_nlp/ocp_nlp_reg_mirror.h
+++ b/acados/ocp_nlp/ocp_nlp_reg_mirror.h
@@ -70,7 +70,7 @@ typedef struct
 } ocp_nlp_reg_mirror_opts;
 
 //
-int ocp_nlp_reg_mirror_opts_calculate_size(void);
+acados_size_t ocp_nlp_reg_mirror_opts_calculate_size(void);
 //
 void *ocp_nlp_reg_mirror_opts_assign(void *raw_memory);
 //
@@ -96,7 +96,7 @@ typedef struct
 } ocp_nlp_reg_mirror_memory;
 
 //
-int ocp_nlp_reg_mirror_memory_calculate_size(void *config, ocp_nlp_reg_dims *dims, void *opts);
+acados_size_t ocp_nlp_reg_mirror_memory_calculate_size(void *config, ocp_nlp_reg_dims *dims, void *opts);
 //
 void *ocp_nlp_reg_mirror_memory_assign(void *config, ocp_nlp_reg_dims *dims, void *opts, void *raw_memory);
 

--- a/acados/ocp_nlp/ocp_nlp_reg_noreg.c
+++ b/acados/ocp_nlp/ocp_nlp_reg_noreg.c
@@ -51,7 +51,7 @@
  * opts
  ************************************************/
 
-int ocp_nlp_reg_noreg_opts_calculate_size(void)
+acados_size_t ocp_nlp_reg_noreg_opts_calculate_size(void)
 {
     return sizeof(ocp_nlp_reg_noreg_opts);
 }
@@ -87,9 +87,9 @@ void ocp_nlp_reg_noreg_opts_set(void *config_, ocp_nlp_reg_dims *dims, void *opt
  * memory
  ************************************************/
 
-int ocp_nlp_reg_noreg_memory_calculate_size(void *config_, ocp_nlp_reg_dims *dims, void *opts_)
+acados_size_t ocp_nlp_reg_noreg_memory_calculate_size(void *config_, ocp_nlp_reg_dims *dims, void *opts_)
 {
-    int size = 0;
+    acados_size_t size = 0;
 
     return size;
 }

--- a/acados/ocp_nlp/ocp_nlp_reg_noreg.h
+++ b/acados/ocp_nlp/ocp_nlp_reg_noreg.h
@@ -71,7 +71,7 @@ typedef struct
 } ocp_nlp_reg_noreg_opts;
 
 //
-int ocp_nlp_reg_noreg_opts_calculate_size(void);
+acados_size_t ocp_nlp_reg_noreg_opts_calculate_size(void);
 //
 void *ocp_nlp_reg_noreg_opts_assign(void *raw_memory);
 //
@@ -91,7 +91,7 @@ typedef struct
 } ocp_nlp_reg_noreg_memory;
 
 //
-int ocp_nlp_reg_noreg_memory_calculate_size(void *config, ocp_nlp_reg_dims *dims, void *opts);
+acados_size_t ocp_nlp_reg_noreg_memory_calculate_size(void *config, ocp_nlp_reg_dims *dims, void *opts);
 //
 void *ocp_nlp_reg_noreg_memory_assign(void *config, ocp_nlp_reg_dims *dims, void *opts, void *raw_memory);
 

--- a/acados/ocp_nlp/ocp_nlp_reg_project.c
+++ b/acados/ocp_nlp/ocp_nlp_reg_project.c
@@ -51,7 +51,7 @@
  * opts
  ************************************************/
 
-int ocp_nlp_reg_project_opts_calculate_size(void)
+acados_size_t ocp_nlp_reg_project_opts_calculate_size(void)
 {
     return sizeof(ocp_nlp_reg_project_opts);
 }
@@ -101,7 +101,7 @@ void ocp_nlp_reg_project_opts_set(void *config_, ocp_nlp_reg_dims *dims, void *o
  * memory
  ************************************************/
 
-int ocp_nlp_reg_project_memory_calculate_size(void *config_, ocp_nlp_reg_dims *dims, void *opts_)
+acados_size_t ocp_nlp_reg_project_memory_calculate_size(void *config_, ocp_nlp_reg_dims *dims, void *opts_)
 {
     int *nx = dims->nx;
     int *nu = dims->nu;
@@ -115,7 +115,7 @@ int ocp_nlp_reg_project_memory_calculate_size(void *config_, ocp_nlp_reg_dims *d
         nuxM = nu[ii]+nx[ii]>nuxM ? nu[ii]+nx[ii] : nuxM;
     }
 
-    int size = 0;
+    acados_size_t size = 0;
 
     size += sizeof(ocp_nlp_reg_project_memory);
 

--- a/acados/ocp_nlp/ocp_nlp_reg_project.h
+++ b/acados/ocp_nlp/ocp_nlp_reg_project.h
@@ -70,7 +70,7 @@ typedef struct
 } ocp_nlp_reg_project_opts;
 
 //
-int ocp_nlp_reg_project_opts_calculate_size(void);
+acados_size_t ocp_nlp_reg_project_opts_calculate_size(void);
 //
 void *ocp_nlp_reg_project_opts_assign(void *raw_memory);
 //
@@ -96,7 +96,7 @@ typedef struct
 } ocp_nlp_reg_project_memory;
 
 //
-int ocp_nlp_reg_project_memory_calculate_size(void *config, ocp_nlp_reg_dims *dims, void *opts);
+acados_size_t ocp_nlp_reg_project_memory_calculate_size(void *config, ocp_nlp_reg_dims *dims, void *opts);
 //
 void *ocp_nlp_reg_project_memory_assign(void *config, ocp_nlp_reg_dims *dims, void *opts, void *raw_memory);
 

--- a/acados/ocp_nlp/ocp_nlp_reg_project_reduc_hess.c
+++ b/acados/ocp_nlp/ocp_nlp_reg_project_reduc_hess.c
@@ -52,7 +52,7 @@
  * opts
  ************************************************/
 
-int ocp_nlp_reg_project_reduc_hess_opts_calculate_size(void)
+acados_size_t ocp_nlp_reg_project_reduc_hess_opts_calculate_size(void)
 {
     return sizeof(ocp_nlp_reg_project_reduc_hess_opts);
 }
@@ -120,7 +120,7 @@ void ocp_nlp_reg_project_reduc_hess_opts_set(void *config_, ocp_nlp_reg_dims *di
  * memory
  ************************************************/
 
-int ocp_nlp_reg_project_reduc_hess_memory_calculate_size(void *config_, ocp_nlp_reg_dims *dims, void *opts_)
+acados_size_t ocp_nlp_reg_project_reduc_hess_memory_calculate_size(void *config_, ocp_nlp_reg_dims *dims, void *opts_)
 {
     int *nx = dims->nx;
     int *nu = dims->nu;
@@ -138,7 +138,7 @@ int ocp_nlp_reg_project_reduc_hess_memory_calculate_size(void *config_, ocp_nlp_
         nxM = nx[ii]>nxM ? nx[ii] : nxM;
     }
 
-    int size = 0;
+    acados_size_t size = 0;
 
     size += sizeof(ocp_nlp_reg_project_reduc_hess_memory);
 

--- a/acados/ocp_nlp/ocp_nlp_reg_project_reduc_hess.h
+++ b/acados/ocp_nlp/ocp_nlp_reg_project_reduc_hess.h
@@ -73,7 +73,7 @@ typedef struct
 } ocp_nlp_reg_project_reduc_hess_opts;
 
 //
-int ocp_nlp_reg_project_reduc_hess_opts_calculate_size(void);
+acados_size_t ocp_nlp_reg_project_reduc_hess_opts_calculate_size(void);
 //
 void *ocp_nlp_reg_project_reduc_hess_opts_assign(void *raw_memory);
 //
@@ -107,7 +107,7 @@ typedef struct
 } ocp_nlp_reg_project_reduc_hess_memory;
 
 //
-int ocp_nlp_reg_project_reduc_hess_memory_calculate_size(void *config, ocp_nlp_reg_dims *dims, void *opts);
+acados_size_t ocp_nlp_reg_project_reduc_hess_memory_calculate_size(void *config, ocp_nlp_reg_dims *dims, void *opts);
 //
 void *ocp_nlp_reg_project_reduc_hess_memory_assign(void *config, ocp_nlp_reg_dims *dims, void *opts, void *raw_memory);
 

--- a/acados/ocp_nlp/ocp_nlp_sqp.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp.c
@@ -65,12 +65,12 @@
  * options
  ************************************************/
 
-int ocp_nlp_sqp_opts_calculate_size(void *config_, void *dims_)
+acados_size_t ocp_nlp_sqp_opts_calculate_size(void *config_, void *dims_)
 {
     ocp_nlp_dims *dims = dims_;
     ocp_nlp_config *config = config_;
 
-    int size = 0;
+    acados_size_t size = 0;
 
     size += sizeof(ocp_nlp_sqp_opts);
 
@@ -277,7 +277,7 @@ void ocp_nlp_sqp_opts_set(void *config_, void *opts_, const char *field, void* v
 
 
 
-void ocp_nlp_sqp_opts_set_at_stage(void *config_, void *opts_, int stage, const char *field, void* value)
+void ocp_nlp_sqp_opts_set_at_stage(void *config_, void *opts_, size_t stage, const char *field, void* value)
 {
     ocp_nlp_config *config = config_;
     ocp_nlp_sqp_opts *opts = (ocp_nlp_sqp_opts *) opts_;
@@ -295,7 +295,7 @@ void ocp_nlp_sqp_opts_set_at_stage(void *config_, void *opts_, int stage, const 
  * memory
  ************************************************/
 
-int ocp_nlp_sqp_memory_calculate_size(void *config_, void *dims_, void *opts_)
+acados_size_t ocp_nlp_sqp_memory_calculate_size(void *config_, void *dims_, void *opts_)
 {
     ocp_nlp_dims *dims = dims_;
     ocp_nlp_config *config = config_;
@@ -307,7 +307,7 @@ int ocp_nlp_sqp_memory_calculate_size(void *config_, void *dims_, void *opts_)
     // int *nu = dims->nu;
     // int *nz = dims->nz;
 
-    int size = 0;
+    acados_size_t size = 0;
 
     size += sizeof(ocp_nlp_sqp_memory);
 
@@ -384,14 +384,14 @@ void *ocp_nlp_sqp_memory_assign(void *config_, void *dims_, void *opts_, void *r
  * workspace
  ************************************************/
 
-int ocp_nlp_sqp_workspace_calculate_size(void *config_, void *dims_, void *opts_)
+acados_size_t ocp_nlp_sqp_workspace_calculate_size(void *config_, void *dims_, void *opts_)
 {
     ocp_nlp_dims *dims = dims_;
     ocp_nlp_config *config = config_;
     ocp_nlp_sqp_opts *opts = opts_;
     ocp_nlp_opts *nlp_opts = opts->nlp_opts;
 
-    int size = 0;
+    acados_size_t size = 0;
 
     // sqp
     size += sizeof(ocp_nlp_sqp_workspace);

--- a/acados/ocp_nlp/ocp_nlp_sqp.h
+++ b/acados/ocp_nlp/ocp_nlp_sqp.h
@@ -74,7 +74,7 @@ typedef struct
 } ocp_nlp_sqp_opts;
 
 //
-int ocp_nlp_sqp_opts_calculate_size(void *config, void *dims);
+acados_size_t ocp_nlp_sqp_opts_calculate_size(void *config, void *dims);
 //
 void *ocp_nlp_sqp_opts_assign(void *config, void *dims, void *raw_memory);
 //
@@ -84,7 +84,7 @@ void ocp_nlp_sqp_opts_update(void *config, void *dims, void *opts);
 //
 void ocp_nlp_sqp_opts_set(void *config_, void *opts_, const char *field, void* value);
 //
-void ocp_nlp_sqp_opts_set_at_stage(void *config_, void *opts_, int stage, const char *field, void* value);
+void ocp_nlp_sqp_opts_set_at_stage(void *config_, void *opts_, size_t stage, const char *field, void* value);
 
 
 
@@ -116,7 +116,7 @@ typedef struct
 } ocp_nlp_sqp_memory;
 
 //
-int ocp_nlp_sqp_memory_calculate_size(void *config, void *dims, void *opts_);
+acados_size_t ocp_nlp_sqp_memory_calculate_size(void *config, void *dims, void *opts_);
 //
 void *ocp_nlp_sqp_memory_assign(void *config, void *dims, void *opts_, void *raw_memory);
 
@@ -141,7 +141,7 @@ typedef struct
 } ocp_nlp_sqp_workspace;
 
 //
-int ocp_nlp_sqp_workspace_calculate_size(void *config, void *dims, void *opts_);
+acados_size_t ocp_nlp_sqp_workspace_calculate_size(void *config, void *dims, void *opts_);
 
 
 

--- a/acados/ocp_nlp/ocp_nlp_sqp_rti.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp_rti.c
@@ -65,12 +65,12 @@
  * options
  ************************************************/
 
-int ocp_nlp_sqp_rti_opts_calculate_size(void *config_, void *dims_)
+acados_size_t ocp_nlp_sqp_rti_opts_calculate_size(void *config_, void *dims_)
 {
     ocp_nlp_dims *dims = dims_;
     ocp_nlp_config *config = config_;
 
-    int size = 0;
+    acados_size_t size = 0;
 
     size += sizeof(ocp_nlp_sqp_rti_opts);
 
@@ -243,17 +243,13 @@ void ocp_nlp_sqp_rti_opts_set(void *config_, void *opts_,
 
 
 
-void ocp_nlp_sqp_rti_opts_set_at_stage(void *config_, void *opts_,
-    int stage, const char *field, void* value)
+void ocp_nlp_sqp_rti_opts_set_at_stage(void *config_, void *opts_, size_t stage, const char *field, void* value)
 {
     ocp_nlp_config *config = config_;
     ocp_nlp_sqp_rti_opts *opts = (ocp_nlp_sqp_rti_opts *) opts_;
     ocp_nlp_opts *nlp_opts = opts->nlp_opts;
 
     ocp_nlp_opts_set_at_stage(config, nlp_opts, stage, field, value);
-
-    return;
-
 }
 
 
@@ -262,7 +258,7 @@ void ocp_nlp_sqp_rti_opts_set_at_stage(void *config_, void *opts_,
  * memory
  ************************************************/
 
-int ocp_nlp_sqp_rti_memory_calculate_size(void *config_,
+acados_size_t ocp_nlp_sqp_rti_memory_calculate_size(void *config_,
     void *dims_, void *opts_)
 {
     ocp_nlp_dims *dims = dims_;
@@ -280,7 +276,7 @@ int ocp_nlp_sqp_rti_memory_calculate_size(void *config_,
     // int *nu = dims->nu;
     // int *nz = dims->nz;
 
-    int size = 0;
+    acados_size_t size = 0;
 
     size += sizeof(ocp_nlp_sqp_rti_memory);
 
@@ -357,7 +353,7 @@ void *ocp_nlp_sqp_rti_memory_assign(void *config_, void *dims_,
  * workspace
  ************************************************/
 
-int ocp_nlp_sqp_rti_workspace_calculate_size(void *config_,
+acados_size_t ocp_nlp_sqp_rti_workspace_calculate_size(void *config_,
     void *dims_, void *opts_)
 {
     ocp_nlp_dims *dims = dims_;
@@ -365,7 +361,7 @@ int ocp_nlp_sqp_rti_workspace_calculate_size(void *config_,
     ocp_nlp_sqp_rti_opts *opts = opts_;
     ocp_nlp_opts *nlp_opts = opts->nlp_opts;
 
-    int size = 0;
+    acados_size_t size = 0;
 
     // sqp
     size += sizeof(ocp_nlp_sqp_rti_workspace);

--- a/acados/ocp_nlp/ocp_nlp_sqp_rti.h
+++ b/acados/ocp_nlp/ocp_nlp_sqp_rti.h
@@ -69,7 +69,7 @@ typedef struct
 } ocp_nlp_sqp_rti_opts;
 
 //
-int ocp_nlp_sqp_rti_opts_calculate_size(void *config_, void *dims_);
+acados_size_t ocp_nlp_sqp_rti_opts_calculate_size(void *config_, void *dims_);
 //
 void *ocp_nlp_sqp_rti_opts_assign(void *config_, void *dims_, void *raw_memory);
 //
@@ -79,7 +79,7 @@ void ocp_nlp_sqp_rti_opts_update(void *config_, void *dims_, void *opts_);
 //
 void ocp_nlp_sqp_rti_opts_set(void *config_, void *opts_, const char *field, void* value);
 //
-void ocp_nlp_sqp_rti_opts_set_at_stage(void *config_, void *opts_, int stage,
+void ocp_nlp_sqp_rti_opts_set_at_stage(void *config_, void *opts_, size_t stage,
     const char *field, void* value);
 
 
@@ -111,7 +111,7 @@ typedef struct
 } ocp_nlp_sqp_rti_memory;
 
 //
-int ocp_nlp_sqp_rti_memory_calculate_size(void *config_, void *dims_, void *opts_);
+acados_size_t ocp_nlp_sqp_rti_memory_calculate_size(void *config_, void *dims_, void *opts_);
 //
 void *ocp_nlp_sqp_rti_memory_assign(void *config_, void *dims_, void *opts_,
     void *raw_memory);
@@ -138,7 +138,7 @@ typedef struct
 } ocp_nlp_sqp_rti_workspace;
 
 //
-int ocp_nlp_sqp_rti_workspace_calculate_size(void *config_, void *dims_, void *opts_);
+acados_size_t ocp_nlp_sqp_rti_workspace_calculate_size(void *config_, void *dims_, void *opts_);
 
 
 

--- a/acados/ocp_qp/ocp_qp_common.c
+++ b/acados/ocp_qp/ocp_qp_common.c
@@ -60,9 +60,9 @@
  * config
  ************************************************/
 
-int ocp_qp_solver_config_calculate_size()
+acados_size_t ocp_qp_solver_config_calculate_size()
 {
-    int size = 0;
+    acados_size_t size = 0;
 
     size += sizeof(qp_solver_config);
 
@@ -83,9 +83,9 @@ qp_solver_config *ocp_qp_solver_config_assign(void *raw_memory)
 
 
 
-int ocp_qp_condensing_config_calculate_size()
+acados_size_t ocp_qp_condensing_config_calculate_size()
 {
-    int size = 0;
+    acados_size_t size = 0;
 
     size += sizeof(ocp_qp_xcond_config);
 
@@ -110,9 +110,9 @@ ocp_qp_xcond_config *ocp_qp_condensing_config_assign(void *raw_memory)
  * dims
  ************************************************/
 
-int ocp_qp_dims_calculate_size(int N)
+acados_size_t ocp_qp_dims_calculate_size(int N)
 {
-    int size = sizeof(ocp_qp_dims);
+    acados_size_t size = sizeof(ocp_qp_dims);
 
     size += d_ocp_qp_dim_memsize(N);
     make_int_multiple_of(8, &size);
@@ -167,9 +167,9 @@ void ocp_qp_dims_get(void *config_, void *dims, int stage, const char *field, in
  * in
  ************************************************/
 
-int ocp_qp_in_calculate_size(ocp_qp_dims *dims)
+acados_size_t ocp_qp_in_calculate_size(ocp_qp_dims *dims)
 {
-    int size = sizeof(ocp_qp_in);
+    acados_size_t size = sizeof(ocp_qp_in);
     size += d_ocp_qp_memsize(dims);
     size += ocp_qp_dims_calculate_size(dims->N);  // TODO(all): remove !!!
     size += 2*8; // aligns
@@ -211,9 +211,9 @@ ocp_qp_in *ocp_qp_in_assign(ocp_qp_dims *dims, void *raw_memory)
  * out
  ************************************************/
 
-int ocp_qp_out_calculate_size(ocp_qp_dims *dims)
+acados_size_t ocp_qp_out_calculate_size(ocp_qp_dims *dims)
 {
-    int size = sizeof(ocp_qp_out);
+    acados_size_t size = sizeof(ocp_qp_out);
     size += d_ocp_qp_sol_memsize(dims);
     size += ocp_qp_dims_calculate_size(dims->N);  // TODO(all): remove !!!
     size += sizeof(qp_info); // TODO move to memory !!!
@@ -261,9 +261,9 @@ ocp_qp_out *ocp_qp_out_assign(ocp_qp_dims *dims, void *raw_memory)
  * res
  ************************************************/
 
-int ocp_qp_res_calculate_size(ocp_qp_dims *dims)
+acados_size_t ocp_qp_res_calculate_size(ocp_qp_dims *dims)
 {
-    int size = sizeof(ocp_qp_res);
+    acados_size_t size = sizeof(ocp_qp_res);
     size += d_ocp_qp_res_memsize(dims);
     return size;
 }
@@ -287,9 +287,9 @@ ocp_qp_res *ocp_qp_res_assign(ocp_qp_dims *dims, void *raw_memory)
 
 
 
-int ocp_qp_res_workspace_calculate_size(ocp_qp_dims *dims)
+acados_size_t ocp_qp_res_workspace_calculate_size(ocp_qp_dims *dims)
 {
-    int size = sizeof(ocp_qp_res_ws);
+    acados_size_t size = sizeof(ocp_qp_res_ws);
     size += d_ocp_qp_res_ws_memsize(dims);
     return size;
 }

--- a/acados/ocp_qp/ocp_qp_common.h
+++ b/acados/ocp_qp/ocp_qp_common.h
@@ -62,15 +62,15 @@ typedef struct d_ocp_qp_res_ws ocp_qp_res_ws;
 typedef struct
 {
     void (*dims_set)(void *config_, void *dims_, int stage, const char *field, int* value);
-    int (*opts_calculate_size)(void *config, void *dims);
+    acados_size_t (*opts_calculate_size)(void *config, void *dims);
     void *(*opts_assign)(void *config, void *dims, void *raw_memory);
     void (*opts_initialize_default)(void *config, void *dims, void *opts);
     void (*opts_update)(void *config, void *dims, void *opts);
     void (*opts_set)(void *config_, void *opts_, const char *field, void* value);
-    int (*memory_calculate_size)(void *config, void *dims, void *opts);
+    acados_size_t (*memory_calculate_size)(void *config, void *dims, void *opts);
     void *(*memory_assign)(void *config, void *dims, void *opts, void *raw_memory);
     void (*memory_get)(void *config_, void *mem_, const char *field, void* value);
-    int (*workspace_calculate_size)(void *config, void *dims, void *opts);
+    acados_size_t (*workspace_calculate_size)(void *config, void *dims, void *opts);
     int (*evaluate)(void *config, void *qp_in, void *qp_out, void *opts, void *mem, void *work);
     void (*eval_sens)(void *config, void *qp_in, void *qp_out, void *opts, void *mem, void *work);
 } qp_solver_config;
@@ -80,20 +80,20 @@ typedef struct
 
 typedef struct
 {
-    int (*dims_calculate_size)(void *config, int N);
+    acados_size_t (*dims_calculate_size)(void *config, int N);
     void *(*dims_assign)(void *config, int N, void *raw_memory);
     void (*dims_set)(void *config, void *dims_, int stage, const char *field, int* value);
     void (*dims_get)(void *config, void *dims, const char *field, void* value);
     // TODO add config everywhere !!!!!
-    int (*opts_calculate_size)(void *dims);
+    acados_size_t (*opts_calculate_size)(void *dims);
     void *(*opts_assign)(void *dims, void *raw_memory);
     void (*opts_initialize_default)(void *dims, void *opts);
     void (*opts_update)(void *dims, void *opts);
     void (*opts_set)(void *opts_, const char *field, void* value);
-    int (*memory_calculate_size)(void *dims, void *opts);
+    acados_size_t (*memory_calculate_size)(void *dims, void *opts);
     void *(*memory_assign)(void *dims, void *opts, void *raw_memory);
     void (*memory_get)(void *config, void *mem, const char *field, void* value);
-    int (*workspace_calculate_size)(void *dims, void *opts);
+    acados_size_t (*workspace_calculate_size)(void *dims, void *opts);
     int (*condensing)(void *qp_in, void *qp_out, void *opts, void *mem, void *work);
     int (*condensing_rhs)(void *qp_in, void *qp_out, void *opts, void *mem, void *work);
     int (*expansion)(void *qp_in, void *qp_out, void *opts, void *mem, void *work);
@@ -119,18 +119,18 @@ typedef struct
 
 /* config */
 //
-int ocp_qp_solver_config_calculate_size();
+acados_size_t ocp_qp_solver_config_calculate_size();
 //
 qp_solver_config *ocp_qp_solver_config_assign(void *raw_memory);
 //
-int ocp_qp_condensing_config_calculate_size();
+acados_size_t ocp_qp_condensing_config_calculate_size();
 //
 ocp_qp_xcond_config *ocp_qp_condensing_config_assign(void *raw_memory);
 
 
 /* dims */
 //
-int ocp_qp_dims_calculate_size(int N);
+acados_size_t ocp_qp_dims_calculate_size(int N);
 //
 ocp_qp_dims *ocp_qp_dims_assign(int N, void *raw_memory);
 //
@@ -141,24 +141,24 @@ void ocp_qp_dims_get(void *config_, void *dims, int stage, const char *field, in
 
 /* in */
 //
-int ocp_qp_in_calculate_size(ocp_qp_dims *dims);
+acados_size_t ocp_qp_in_calculate_size(ocp_qp_dims *dims);
 //
 ocp_qp_in *ocp_qp_in_assign(ocp_qp_dims *dims, void *raw_memory);
 
 
 /* out */
 //
-int ocp_qp_out_calculate_size(ocp_qp_dims *dims);
+acados_size_t ocp_qp_out_calculate_size(ocp_qp_dims *dims);
 //
 ocp_qp_out *ocp_qp_out_assign(ocp_qp_dims *dims, void *raw_memory);
 
 /* res */
 //
-int ocp_qp_res_calculate_size(ocp_qp_dims *dims);
+acados_size_t ocp_qp_res_calculate_size(ocp_qp_dims *dims);
 //
 ocp_qp_res *ocp_qp_res_assign(ocp_qp_dims *dims, void *raw_memory);
 //
-int ocp_qp_res_workspace_calculate_size(ocp_qp_dims *dims);
+acados_size_t ocp_qp_res_workspace_calculate_size(ocp_qp_dims *dims);
 //
 ocp_qp_res_ws *ocp_qp_res_workspace_assign(ocp_qp_dims *dims, void *raw_memory);
 //

--- a/acados/ocp_qp/ocp_qp_common_frontend.c
+++ b/acados/ocp_qp/ocp_qp_common_frontend.c
@@ -52,15 +52,15 @@
 
 
 
-int colmaj_ocp_qp_in_calculate_size(ocp_qp_dims *dims)
+acados_size_t colmaj_ocp_qp_in_calculate_size(ocp_qp_dims *dims)
 {
-    int N = dims->N;
+    size_t N = dims->N;
     int *nx = dims->nx;
     int *nu = dims->nu;
     int *nb = dims->nb;
     int *nc = dims->ng;
 
-    int size = sizeof(colmaj_ocp_qp_in);
+    acados_size_t size = sizeof(colmaj_ocp_qp_in);
 
     size += 4 * (N + 1) * sizeof(int);        // nx, nu, nb, nc
     size += 3 * N * sizeof(double *);         // A, B, b
@@ -249,20 +249,20 @@ char *assign_colmaj_ocp_qp_in(ocp_qp_dims *dims, colmaj_ocp_qp_in **qp_in, void 
 
 
 
-int colmaj_ocp_qp_out_calculate_size(ocp_qp_dims *dims)
+acados_size_t colmaj_ocp_qp_out_calculate_size(ocp_qp_dims *dims)
 {
-    int N = dims->N;
+    size_t N = dims->N;
     int *nx = dims->nx;
     int *nu = dims->nu;
     int *nb = dims->nb;
     int *nc = dims->ng;
 
-    int size = sizeof(colmaj_ocp_qp_out);
+    acados_size_t size = sizeof(colmaj_ocp_qp_out);
 
     size += 3 * (N + 1) * sizeof(double *);  // u, x, lam
     size += N * sizeof(double *);            // pi
 
-    for (int k = 0; k < N + 1; k++)
+    for (size_t k = 0; k < N + 1; k++)
     {
         size += (nx[k] + nu[k]) * sizeof(double);         // u, x
         if (k < N) size += (nx[k + 1]) * sizeof(double);  // pi
@@ -335,21 +335,21 @@ char *assign_colmaj_ocp_qp_out(ocp_qp_dims *dims, colmaj_ocp_qp_out **qp_out, vo
 
 
 
-int colmaj_ocp_qp_res_calculate_size(ocp_qp_dims *dims)
+acados_size_t colmaj_ocp_qp_res_calculate_size(ocp_qp_dims *dims)
 {
-    int N = dims->N;
+    size_t N = dims->N;
     int *nx = dims->nx;
     int *nu = dims->nu;
     int *nb = dims->nb;
     int *ng = dims->ng;
     int *ns = dims->ns;
 
-    int size = sizeof(colmaj_ocp_qp_res);
+    acados_size_t size = sizeof(colmaj_ocp_qp_res);
 
     size += 1 * N * sizeof(double *);         // res_b
     size += 16 * (N + 1) * sizeof(double *);  // everything else
 
-    for (int k = 0; k <= N; k++)
+    for (size_t k = 0; k <= N; k++)
     {
         size += nu[k] * sizeof(double);      // res_r
         size += nx[k] * sizeof(double);      // res_q

--- a/acados/ocp_qp/ocp_qp_common_frontend.h
+++ b/acados/ocp_qp/ocp_qp_common_frontend.h
@@ -96,15 +96,15 @@ typedef struct
 } colmaj_ocp_qp_res;
 
 //
-int colmaj_ocp_qp_in_calculate_size(ocp_qp_dims *dims);
+acados_size_t colmaj_ocp_qp_in_calculate_size(ocp_qp_dims *dims);
 //
 char *assign_colmaj_ocp_qp_in(ocp_qp_dims *dims, colmaj_ocp_qp_in **qp_in, void *ptr);
 //
-int colmaj_ocp_qp_out_calculate_size(ocp_qp_dims *dims);
+acados_size_t colmaj_ocp_qp_out_calculate_size(ocp_qp_dims *dims);
 //
 char *assign_colmaj_ocp_qp_out(ocp_qp_dims *dims, colmaj_ocp_qp_out **qp_out, void *ptr);
 //
-int colmaj_ocp_qp_res_calculate_size(ocp_qp_dims *dims);
+acados_size_t colmaj_ocp_qp_res_calculate_size(ocp_qp_dims *dims);
 //
 char *assign_colmaj_ocp_qp_res(ocp_qp_dims *dims, colmaj_ocp_qp_res **qp_res, void *ptr);
 //

--- a/acados/ocp_qp/ocp_qp_full_condensing.c
+++ b/acados/ocp_qp/ocp_qp_full_condensing.c
@@ -58,9 +58,9 @@
  * dims
  ************************************************/
 
-int ocp_qp_full_condensing_dims_calculate_size(void *config, int N)
+acados_size_t ocp_qp_full_condensing_dims_calculate_size(void *config, int N)
 {
-    int size = 0;
+    acados_size_t size = 0;
 
     size += sizeof(ocp_qp_full_condensing_dims);
 
@@ -153,7 +153,7 @@ void ocp_qp_full_condensing_dims_get(void *config_, void *dims_, const char *fie
  * opts
  ************************************************/
 
-int ocp_qp_full_condensing_opts_calculate_size(void *dims_)
+acados_size_t ocp_qp_full_condensing_opts_calculate_size(void *dims_)
 {
     ocp_qp_full_condensing_dims *dims = dims_;
 
@@ -166,7 +166,7 @@ int ocp_qp_full_condensing_opts_calculate_size(void *dims_)
 //d_ocp_qp_dim_print(dims->red_dims);
 //exit(1);
 
-    int size = 0;
+    acados_size_t size = 0;
 
     size += sizeof(ocp_qp_full_condensing_opts);
 
@@ -301,7 +301,7 @@ void ocp_qp_full_condensing_opts_set(void *opts_, const char *field, void* value
  * memory
  ************************************************/
 
-int ocp_qp_full_condensing_memory_calculate_size(void *dims_, void *opts_)
+acados_size_t ocp_qp_full_condensing_memory_calculate_size(void *dims_, void *opts_)
 {
     ocp_qp_full_condensing_dims *dims = dims_;
     ocp_qp_full_condensing_opts *opts = opts_;
@@ -313,7 +313,7 @@ int ocp_qp_full_condensing_memory_calculate_size(void *dims_, void *opts_)
 //    d_cond_qp_compute_dim(dims->orig_dims, dims->fcond_dims);
 //    d_cond_qp_compute_dim(dims->red_dims, dims->fcond_dims);
 
-    int size = 0;
+    acados_size_t size = 0;
 
     size += sizeof(ocp_qp_full_condensing_memory);
 
@@ -431,7 +431,7 @@ void ocp_qp_full_condensing_memory_get(void *config_, void *mem_, const char *fi
  * workspace
  ************************************************/
 
-int ocp_qp_full_condensing_workspace_calculate_size(void *dims_, void *opts_)
+acados_size_t ocp_qp_full_condensing_workspace_calculate_size(void *dims_, void *opts_)
 {
 
     return 0;

--- a/acados/ocp_qp/ocp_qp_full_condensing.h
+++ b/acados/ocp_qp/ocp_qp_full_condensing.h
@@ -88,7 +88,7 @@ typedef struct ocp_qp_full_condensing_memory_
 
 
 //
-int ocp_qp_full_condensing_opts_calculate_size(void *dims);
+acados_size_t ocp_qp_full_condensing_opts_calculate_size(void *dims);
 //
 void *ocp_qp_full_condensing_opts_assign(void *dims, void *raw_memory);
 //
@@ -98,11 +98,11 @@ void ocp_qp_full_condensing_opts_update(void *dims, void *opts_);
 //
 void ocp_qp_full_condensing_opts_set(void *opts_, const char *field, void* value);
 //
-int ocp_qp_full_condensing_memory_calculate_size(void *dims, void *opts_);
+acados_size_t ocp_qp_full_condensing_memory_calculate_size(void *dims, void *opts_);
 //
 void *ocp_qp_full_condensing_memory_assign(void *dims, void *opts_, void *raw_memory);
 //
-int ocp_qp_full_condensing_workspace_calculate_size(void *dims, void *opts_);
+acados_size_t ocp_qp_full_condensing_workspace_calculate_size(void *dims, void *opts_);
 //
 int ocp_qp_full_condensing(void *in, void *out, void *opts, void *mem, void *work);
 //

--- a/acados/ocp_qp/ocp_qp_hpipm.c
+++ b/acados/ocp_qp/ocp_qp_hpipm.c
@@ -54,11 +54,11 @@
  * opts
  ************************************************/
 
-int ocp_qp_hpipm_opts_calculate_size(void *config_, void *dims_)
+acados_size_t ocp_qp_hpipm_opts_calculate_size(void *config_, void *dims_)
 {
     ocp_qp_dims *dims = dims_;
 
-    int size = 0;
+    acados_size_t size = 0;
     size += sizeof(ocp_qp_hpipm_opts);
     size += sizeof(struct d_ocp_qp_ipm_arg);
     size += d_ocp_qp_ipm_arg_memsize(dims);
@@ -144,12 +144,12 @@ void ocp_qp_hpipm_opts_set(void *config_, void *opts_, const char *field, void *
  * memory
  ************************************************/
 
-int ocp_qp_hpipm_memory_calculate_size(void *config_, void *dims_, void *opts_)
+acados_size_t ocp_qp_hpipm_memory_calculate_size(void *config_, void *dims_, void *opts_)
 {
     ocp_qp_dims *dims = dims_;
     ocp_qp_hpipm_opts *opts = opts_;
 
-    int size = 0;
+    acados_size_t size = 0;
     size += sizeof(ocp_qp_hpipm_memory);
 
     size += sizeof(struct d_ocp_qp_ipm_ws);
@@ -226,7 +226,7 @@ void ocp_qp_hpipm_memory_get(void *config_, void *mem_, const char *field, void*
  * workspace
  ************************************************/
 
-int ocp_qp_hpipm_workspace_calculate_size(void *config_, void *dims_, void *opts_)
+acados_size_t ocp_qp_hpipm_workspace_calculate_size(void *config_, void *dims_, void *opts_)
 {
     return 0;
 }

--- a/acados/ocp_qp/ocp_qp_hpipm.h
+++ b/acados/ocp_qp/ocp_qp_hpipm.h
@@ -69,7 +69,7 @@ typedef struct ocp_qp_hpipm_memory_
 
 
 //
-int ocp_qp_hpipm_opts_calculate_size(void *config, void *dims);
+acados_size_t ocp_qp_hpipm_opts_calculate_size(void *config, void *dims);
 //
 void *ocp_qp_hpipm_opts_assign(void *config, void *dims, void *raw_memory);
 //
@@ -79,11 +79,11 @@ void ocp_qp_hpipm_opts_update(void *config, void *dims, void *opts_);
 //
 void ocp_qp_hpipm_opts_set(void *config_, void *opts_, const char *field, void *value);
 //
-int ocp_qp_hpipm_memory_calculate_size(void *config, void *dims, void *opts_);
+acados_size_t ocp_qp_hpipm_memory_calculate_size(void *config, void *dims, void *opts_);
 //
 void *ocp_qp_hpipm_memory_assign(void *config, void *dims, void *opts_, void *raw_memory);
 //
-int ocp_qp_hpipm_workspace_calculate_size(void *config, void *dims, void *opts_);
+acados_size_t ocp_qp_hpipm_workspace_calculate_size(void *config, void *dims, void *opts_);
 //
 int ocp_qp_hpipm(void *config, void *qp_in, void *qp_out, void *opts_, void *mem_, void *work_);
 //

--- a/acados/ocp_qp/ocp_qp_hpmpc.c
+++ b/acados/ocp_qp/ocp_qp_hpmpc.c
@@ -59,9 +59,9 @@
  * opts
  ************************************************/
 
-int ocp_qp_hpmpc_opts_calculate_size(void *config_, ocp_qp_dims *dims)
+acados_size_t ocp_qp_hpmpc_opts_calculate_size(void *config_, ocp_qp_dims *dims)
 {
-    int size = sizeof(ocp_qp_hpmpc_opts);
+    acados_size_t size = sizeof(ocp_qp_hpmpc_opts);
     size = (size + 63) / 64 * 64;  // make multiple of typical cache line size
     size += 1 * 64;                // align once to typical cache line size
     return size;
@@ -160,20 +160,20 @@ void ocp_qp_hpmpc_opts_set(void *config_, void *opts_, const char *field, void *
  * memory
  ************************************************/
 
-int ocp_qp_hpmpc_memory_calculate_size(void *config_, ocp_qp_dims *dims, void *opts_)
+acados_size_t ocp_qp_hpmpc_memory_calculate_size(void *config_, ocp_qp_dims *dims, void *opts_)
 {
     ocp_qp_hpmpc_opts *args = (ocp_qp_hpmpc_opts *) opts_;
 
-    int N = dims->N;
-    int N2 = args->N2;
-    int M = args->M;
-    int *nx = dims->nx;
-    int *nu = dims->nu;
-    int *nb = dims->nb;
-    int *ng = dims->ng;
+    size_t N = dims->N;
+    size_t N2 = args->N2;
+    size_t M = args->M;
+    size_t *nx = dims->nx;
+    size_t *nu = dims->nu;
+    size_t *nb = dims->nb;
+    size_t *ng = dims->ng;
 
-    int ii;
-    int ws_size = sizeof(ocp_qp_hpmpc_memory);
+    size_t ii;
+    acados_size_t ws_size = sizeof(ocp_qp_hpmpc_memory);
 
     ws_size += 6 * args->max_iter * sizeof(double);  // stats
 
@@ -360,7 +360,7 @@ void ocp_qp_hpmpc_memory_get(void *config_, void *mem_, const char *field, void*
  * workspace
  ************************************************/
 
-int ocp_qp_hpmpc_workspace_calculate_size(void *config_, ocp_qp_dims *dims, void *opts_)
+acados_size_t ocp_qp_hpmpc_workspace_calculate_size(void *config_, ocp_qp_dims *dims, void *opts_)
 {
     return 0;
 }
@@ -568,19 +568,19 @@ void ocp_qp_hpmpc_config_initialize_default(void *config_)
     qp_solver_config *config = config_;
 
     config->dims_set = &ocp_qp_dims_set;
-    config->opts_calculate_size = (int (*)(void *, void *)) & ocp_qp_hpmpc_opts_calculate_size;
+    config->opts_calculate_size = (size_t (*)(void *, void *)) & ocp_qp_hpmpc_opts_calculate_size;
     config->opts_assign = (void *(*) (void *, void *, void *) ) & ocp_qp_hpmpc_opts_assign;
     config->opts_initialize_default =
         (void (*)(void *, void *, void *)) & ocp_qp_hpmpc_opts_initialize_default;
     config->opts_update = (void (*)(void *, void *, void *)) & ocp_qp_hpmpc_opts_update;
     config->opts_set = &ocp_qp_hpmpc_opts_set;
     config->memory_calculate_size =
-        (int (*)(void *, void *, void *)) & ocp_qp_hpmpc_memory_calculate_size;
+        (size_t (*)(void *, void *, void *)) & ocp_qp_hpmpc_memory_calculate_size;
     config->memory_assign =
         (void *(*) (void *, void *, void *, void *) ) & ocp_qp_hpmpc_memory_assign;
     config->memory_get = &ocp_qp_hpmpc_memory_get;
     config->workspace_calculate_size =
-        (int (*)(void *, void *, void *)) & ocp_qp_hpmpc_workspace_calculate_size;
+        (size_t (*)(void *, void *, void *)) & ocp_qp_hpmpc_workspace_calculate_size;
     config->evaluate = &ocp_qp_hpmpc;
     config->eval_sens = &ocp_qp_hpmpc_eval_sens;
 

--- a/acados/ocp_qp/ocp_qp_hpmpc.h
+++ b/acados/ocp_qp/ocp_qp_hpmpc.h
@@ -102,7 +102,7 @@ typedef struct ocp_qp_hpmpc_memory_
 
 } ocp_qp_hpmpc_memory;
 
-int ocp_qp_hpmpc_opts_calculate_size(void *config_, ocp_qp_dims *dims);
+acados_size_t ocp_qp_hpmpc_opts_calculate_size(void *config_, ocp_qp_dims *dims);
 //
 void *ocp_qp_hpmpc_opts_assign(void *config_, ocp_qp_dims *dims, void *raw_memory);
 //
@@ -110,11 +110,11 @@ void ocp_qp_hpmpc_opts_initialize_default(void *config_, ocp_qp_dims *dims, void
 //
 void ocp_qp_hpmpc_opts_update(void *config_, ocp_qp_dims *dims, void *opts_);
 //
-int ocp_qp_hpmpc_memory_calculate_size(void *config_, ocp_qp_dims *dims, void *opts_);
+acados_size_t ocp_qp_hpmpc_memory_calculate_size(void *config_, ocp_qp_dims *dims, void *opts_);
 //
 void *ocp_qp_hpmpc_memory_assign(void *config_, ocp_qp_dims *dims, void *opts_, void *raw_memory);
 //
-int ocp_qp_hpmpc_workspace_calculate_size(void *config_, ocp_qp_dims *dims, void *opts_);
+acados_size_t ocp_qp_hpmpc_workspace_calculate_size(void *config_, ocp_qp_dims *dims, void *opts_);
 //
 int ocp_qp_hpmpc(void *config_, void *qp_in, void *qp_out, void *opts_, void *mem_, void *work_);
 //

--- a/acados/ocp_qp/ocp_qp_ooqp.c
+++ b/acados/ocp_qp/ocp_qp_ooqp.c
@@ -815,9 +815,9 @@ static void fill_in_qp_out(const ocp_qp_in *in, ocp_qp_out *out, ocp_qp_ooqp_wor
 
 
 
-int ocp_qp_ooqp_opts_calculate_size(void *config_, ocp_qp_dims *dims)
+acados_size_t ocp_qp_ooqp_opts_calculate_size(void *config_, ocp_qp_dims *dims)
 {
-    int size = 0;
+    acados_size_t size = 0;
     size += sizeof(ocp_qp_ooqp_opts);
     return size;
 }
@@ -899,17 +899,17 @@ void ocp_qp_ooqp_opts_set(void *config_, void *opts_, const char *field, void *v
 
 
 
-int ocp_qp_ooqp_memory_calculate_size(void *config_, ocp_qp_dims *dims, void *opts_)
+acados_size_t ocp_qp_ooqp_memory_calculate_size(void *config_, ocp_qp_dims *dims, void *opts_)
 {
-    int nx = get_number_of_primal_vars(dims);
-    int my = get_number_of_equalities(dims);
-    int mz = get_number_of_inequalities(dims);
-    int nnzQ = get_nnzQ(dims);
-    int nnzA = get_nnzA(dims);
-    int nnzC = get_nnzC(dims);
+    size_t nx = get_number_of_primal_vars(dims);
+    size_t my = get_number_of_equalities(dims);
+    size_t mz = get_number_of_inequalities(dims);
+    size_t nnzQ = get_nnzQ(dims);
+    size_t nnzA = get_nnzA(dims);
+    size_t nnzC = get_nnzC(dims);
     // int nnz = max_of_three(nnzQ, nnzA, nnzC);
 
-    int size = 0;
+    acados_size_t size = 0;
     size += sizeof(ocp_qp_ooqp_memory);
 
     size += 1 *   nx * sizeof(double);  // c
@@ -1033,11 +1033,11 @@ void ocp_qp_ooqp_memory_get(void *config_, void *mem_, const char *field, void* 
  * workspace
  ************************************************/
 
-int ocp_qp_ooqp_workspace_calculate_size(void *config_, ocp_qp_dims *dims, void *opts_)
+acados_size_t ocp_qp_ooqp_workspace_calculate_size(void *config_, ocp_qp_dims *dims, void *opts_)
 {
     UNUSED(opts_);
 
-    int size = 0;
+    acados_size_t size = 0;
     int nx, my, mz, nnzQ, nnzA, nnzC, nnz;
 
     nx = get_number_of_primal_vars(dims);
@@ -1169,19 +1169,19 @@ void ocp_qp_ooqp_config_initialize_default(void *config_)
     qp_solver_config *config = config_;
 
     config->dims_set = &ocp_qp_dims_set;
-    config->opts_calculate_size = (int (*)(void *, void *)) & ocp_qp_ooqp_opts_calculate_size;
+    config->opts_calculate_size = (size_t (*)(void *, void *)) & ocp_qp_ooqp_opts_calculate_size;
     config->opts_assign = (void *(*) (void *, void *, void *) ) & ocp_qp_ooqp_opts_assign;
     config->opts_initialize_default =
         (void (*)(void *, void *, void *)) & ocp_qp_ooqp_opts_initialize_default;
     config->opts_update = (void (*)(void *, void *, void *)) & ocp_qp_ooqp_opts_update;
     config->opts_set = &ocp_qp_ooqp_opts_set;
     config->memory_calculate_size =
-        (int (*)(void *, void *, void *)) & ocp_qp_ooqp_memory_calculate_size;
+        (size_t (*)(void *, void *, void *)) & ocp_qp_ooqp_memory_calculate_size;
     config->memory_assign =
         (void *(*) (void *, void *, void *, void *) ) & ocp_qp_ooqp_memory_assign;
     config->memory_get = &ocp_qp_ooqp_memory_get;
     config->workspace_calculate_size =
-        (int (*)(void *, void *, void *)) & ocp_qp_ooqp_workspace_calculate_size;
+        (size_t (*)(void *, void *, void *)) & ocp_qp_ooqp_workspace_calculate_size;
     config->evaluate = (int (*)(void *, void *, void *, void *, void *, void *)) & ocp_qp_ooqp;
     config->eval_sens = &ocp_qp_ooqp_eval_sens;
 }

--- a/acados/ocp_qp/ocp_qp_ooqp.h
+++ b/acados/ocp_qp/ocp_qp_ooqp.h
@@ -116,7 +116,7 @@ typedef struct ocp_qp_ooqp_memory_
 } ocp_qp_ooqp_memory;
 
 //
-int ocp_qp_ooqp_opts_calculate_size(void *config_, ocp_qp_dims *dims);
+acados_size_t ocp_qp_ooqp_opts_calculate_size(void *config_, ocp_qp_dims *dims);
 //
 void *ocp_qp_ooqp_opts_assign(void *config_, ocp_qp_dims *dims, void *raw_memory);
 //
@@ -124,11 +124,11 @@ void ocp_qp_ooqp_opts_initialize_default(void *config_, ocp_qp_dims *dims, void 
 //
 void ocp_qp_ooqp_opts_update(void *config_, ocp_qp_dims *dims, void *opts_);
 //
-int ocp_qp_ooqp_memory_calculate_size(void *config_, ocp_qp_dims *dims, void *opts_);
+acados_size_t ocp_qp_ooqp_memory_calculate_size(void *config_, ocp_qp_dims *dims, void *opts_);
 //
 void *ocp_qp_ooqp_memory_assign(void *config_, ocp_qp_dims *dims, void *opts_, void *raw_memory);
 //
-int ocp_qp_ooqp_workspace_calculate_size(void *config_, ocp_qp_dims *dims, void *opts_);
+acados_size_t ocp_qp_ooqp_workspace_calculate_size(void *config_, ocp_qp_dims *dims, void *opts_);
 //
 int ocp_qp_ooqp(void *config_, ocp_qp_in *qp_in, ocp_qp_out *qp_out, void *opts_, void *memory_,
                 void *work_);

--- a/acados/ocp_qp/ocp_qp_osqp.c
+++ b/acados/ocp_qp/ocp_qp_osqp.c
@@ -603,9 +603,9 @@ static void ocp_qp_osqp_update_memory(const ocp_qp_in *in, const ocp_qp_osqp_opt
  * opts
  ************************************************/
 
-int ocp_qp_osqp_opts_calculate_size(void *config_, void *dims_)
+acados_size_t ocp_qp_osqp_opts_calculate_size(void *config_, void *dims_)
 {
-    int size = 0;
+    acados_size_t size = 0;
     size += sizeof(ocp_qp_osqp_opts);
     size += sizeof(OSQPSettings);
 
@@ -722,9 +722,9 @@ void ocp_qp_osqp_opts_set(void *config_, void *opts_, const char *field, void *v
  * memory
  ************************************************/
 
-static int osqp_workspace_calculate_size(int n, int m, int P_nnzmax, int A_nnzmax)
+static acados_size_t osqp_workspace_calculate_size(int n, int m, int P_nnzmax, int A_nnzmax)
 {
-    int size = 0;
+    acados_size_t size = 0;
 
     size += sizeof(OSQPWorkspace);
     size += sizeof(OSQPData);
@@ -795,17 +795,17 @@ static int osqp_workspace_calculate_size(int n, int m, int P_nnzmax, int A_nnzma
 }
 
 
-int ocp_qp_osqp_memory_calculate_size(void *config_, void *dims_, void *opts_)
+acados_size_t ocp_qp_osqp_memory_calculate_size(void *config_, void *dims_, void *opts_)
 {
     ocp_qp_dims *dims = dims_;
 
-    int n = acados_osqp_num_vars(dims);
-    int m = acados_osqp_num_constr(dims);
+    size_t n = acados_osqp_num_vars(dims);
+    size_t m = acados_osqp_num_constr(dims);
 
-    int P_nnzmax = acados_osqp_nnzmax_P(dims);
-    int A_nnzmax = acados_osqp_nnzmax_A(dims);
+    size_t P_nnzmax = acados_osqp_nnzmax_P(dims);
+    size_t A_nnzmax = acados_osqp_nnzmax_A(dims);
 
-    int size = 0;
+    acados_size_t size = 0;
     size += sizeof(ocp_qp_osqp_memory);
 
     size += 1 * n * sizeof(c_float);  // q
@@ -1226,7 +1226,7 @@ void ocp_qp_osqp_memory_get(void *config_, void *mem_, const char *field, void* 
  * workspace
  ************************************************/
 
-int ocp_qp_osqp_workspace_calculate_size(void *config_, void *dims_, void *opts_)
+acados_size_t ocp_qp_osqp_workspace_calculate_size(void *config_, void *dims_, void *opts_)
 {
     return 0;
 }

--- a/acados/ocp_qp/ocp_qp_osqp.h
+++ b/acados/ocp_qp/ocp_qp_osqp.h
@@ -78,7 +78,7 @@ typedef struct ocp_qp_osqp_memory_
 
 } ocp_qp_osqp_memory;
 
-int ocp_qp_osqp_opts_calculate_size(void *config, void *dims);
+acados_size_t ocp_qp_osqp_opts_calculate_size(void *config, void *dims);
 //
 void *ocp_qp_osqp_opts_assign(void *config, void *dims, void *raw_memory);
 //
@@ -86,11 +86,11 @@ void ocp_qp_osqp_opts_initialize_default(void *config, void *dims, void *opts_);
 //
 void ocp_qp_osqp_opts_update(void *config, void *dims, void *opts_);
 //
-int ocp_qp_osqp_memory_calculate_size(void *config, void *dims, void *opts_);
+acados_size_t ocp_qp_osqp_memory_calculate_size(void *config, void *dims, void *opts_);
 //
 void *ocp_qp_osqp_memory_assign(void *config, void *dims, void *opts_, void *raw_memory);
 //
-int ocp_qp_osqp_workspace_calculate_size(void *config, void *dims, void *opts_);
+acados_size_t ocp_qp_osqp_workspace_calculate_size(void *config, void *dims, void *opts_);
 //
 int ocp_qp_osqp(void *config, void *qp_in, void *qp_out, void *opts_, void *mem_, void *work_);
 //

--- a/acados/ocp_qp/ocp_qp_partial_condensing.c
+++ b/acados/ocp_qp/ocp_qp_partial_condensing.c
@@ -57,9 +57,9 @@
  * dims
  ************************************************/
 
-int ocp_qp_partial_condensing_dims_calculate_size(void *config_, int N)
+acados_size_t ocp_qp_partial_condensing_dims_calculate_size(void *config_, int N)
 {
-    int size = 0;
+    acados_size_t size = 0;
 
     size += sizeof(ocp_qp_partial_condensing_dims);
 
@@ -163,23 +163,23 @@ void ocp_qp_partial_condensing_dims_get(void *config_, void *dims_, const char *
  * opts
  ************************************************/
 
-int ocp_qp_partial_condensing_opts_calculate_size(void *dims_)
+acados_size_t ocp_qp_partial_condensing_opts_calculate_size(void *dims_)
 {
     ocp_qp_partial_condensing_dims *dims = dims_;
 
-    int N = dims->orig_dims->N;
+    size_t N = dims->orig_dims->N;
 
     // populate dimensions of reduced qp
     d_ocp_qp_dim_reduce_eq_dof(dims->orig_dims, dims->red_dims);
 
     // (temporarely) populate dimensions of new ocp_qp based on N2==N
-    int N2 = N;
+    size_t N2 = N;
     dims->pcond_dims->N = N2;
     // TODO(all): user-defined block size
     d_part_cond_qp_compute_block_size(dims->red_dims->N, N2, dims->block_size);
     d_part_cond_qp_compute_dim(dims->red_dims, dims->block_size, dims->pcond_dims);
 
-    int size = 0;
+    acados_size_t size = 0;
 
     size += sizeof(ocp_qp_partial_condensing_opts);
 
@@ -314,7 +314,7 @@ void ocp_qp_partial_condensing_opts_set(void *opts_, const char *field, void* va
  * memory
  ************************************************/
 
-int ocp_qp_partial_condensing_memory_calculate_size(void *dims_, void *opts_)
+acados_size_t ocp_qp_partial_condensing_memory_calculate_size(void *dims_, void *opts_)
 {
     ocp_qp_partial_condensing_opts *opts = opts_;
     ocp_qp_partial_condensing_dims *dims = dims_;
@@ -328,7 +328,7 @@ int ocp_qp_partial_condensing_memory_calculate_size(void *dims_, void *opts_)
     d_part_cond_qp_compute_block_size(dims->red_dims->N, opts->N2, dims->block_size);
     d_part_cond_qp_compute_dim(dims->red_dims, dims->block_size, dims->pcond_dims);
 
-    int size = 0;
+    acados_size_t size = 0;
 
     size += sizeof(ocp_qp_partial_condensing_memory);
 
@@ -447,7 +447,7 @@ void ocp_qp_partial_condensing_memory_get(void *config_, void *mem_, const char 
  * workspace
  ************************************************/
 
-int ocp_qp_partial_condensing_workspace_calculate_size(void *dims_, void *opts_)
+acados_size_t ocp_qp_partial_condensing_workspace_calculate_size(void *dims_, void *opts_)
 {
     return 0;
 }

--- a/acados/ocp_qp/ocp_qp_partial_condensing.h
+++ b/acados/ocp_qp/ocp_qp_partial_condensing.h
@@ -92,7 +92,7 @@ typedef struct ocp_qp_partial_condensing_memory_
 
 
 //
-int ocp_qp_partial_condensing_opts_calculate_size(void *dims);
+acados_size_t ocp_qp_partial_condensing_opts_calculate_size(void *dims);
 //
 void *ocp_qp_partial_condensing_opts_assign(void *dims, void *raw_memory);
 //
@@ -102,11 +102,11 @@ void ocp_qp_partial_condensing_opts_update(void *dims, void *opts_);
 //
 void ocp_qp_partial_condensing_opts_set(void *opts_, const char *field, void* value);
 //
-int ocp_qp_partial_condensing_memory_calculate_size(void *dims, void *opts_);
+acados_size_t ocp_qp_partial_condensing_memory_calculate_size(void *dims, void *opts_);
 //
 void *ocp_qp_partial_condensing_memory_assign(void *dims, void *opts, void *raw_memory);
 //
-int ocp_qp_partial_condensing_workspace_calculate_size(void *dims, void *opts_);
+acados_size_t ocp_qp_partial_condensing_workspace_calculate_size(void *dims, void *opts_);
 //
 int ocp_qp_partial_condensing(void *in, void *out, void *opts, void *mem, void *work);
 //

--- a/acados/ocp_qp/ocp_qp_qpdunes.c
+++ b/acados/ocp_qp/ocp_qp_qpdunes.c
@@ -134,9 +134,9 @@ static qpdunes_stage_qp_solver_t check_stage_qp_solver(ocp_qp_qpdunes_opts *opts
  * opts
  ************************************************/
 
-int ocp_qp_qpdunes_opts_calculate_size(void *config_, ocp_qp_dims *dims)
+acados_size_t ocp_qp_qpdunes_opts_calculate_size(void *config_, ocp_qp_dims *dims)
 {
-    int size = 0;
+    acados_size_t size = 0;
     size += sizeof(ocp_qp_qpdunes_opts);
     return size;
 }
@@ -272,10 +272,10 @@ void ocp_qp_qpdunes_opts_set(void *config_, void *opts_, const char *field, void
  * memory
  ************************************************/
 
-int ocp_qp_qpdunes_memory_calculate_size(void *config_, ocp_qp_dims *dims, void *opts_)
+acados_size_t ocp_qp_qpdunes_memory_calculate_size(void *config_, ocp_qp_dims *dims, void *opts_)
 {
     // NOTE(dimitris): calculate size does NOT include the memory required by qpDUNES
-    int size = 0;
+    acados_size_t size = 0;
     size += sizeof(ocp_qp_qpdunes_memory);
     return size;
 }
@@ -519,14 +519,14 @@ static void form_inequalities(double *Ct, double *lc, double *uc, int nx, int nu
  * workspace
  ************************************************/
 
-int ocp_qp_qpdunes_workspace_calculate_size(void *config_, ocp_qp_dims *dims, void *opts_)
+acados_size_t ocp_qp_qpdunes_workspace_calculate_size(void *config_, ocp_qp_dims *dims, void *opts_)
 {
     int nx = dims->nx[0];
     int nu = dims->nu[0];
     int nDmax = get_maximum_number_of_inequality_constraints(dims);
-    int nz = nx + nu;
+    size_t nz = nx + nu;
 
-    int size = sizeof(ocp_qp_qpdunes_workspace);
+    acados_size_t size = sizeof(ocp_qp_qpdunes_workspace);
 
     size += nz * nz * sizeof(double);     // H
     size += nx * nx * sizeof(double);     // Q
@@ -916,19 +916,19 @@ void ocp_qp_qpdunes_config_initialize_default(void *config_)
     qp_solver_config *config = config_;
 
     config->dims_set = &ocp_qp_dims_set;
-    config->opts_calculate_size = (int (*)(void *, void *)) & ocp_qp_qpdunes_opts_calculate_size;
+    config->opts_calculate_size = (acados_size_t (*)(void *, void *)) & ocp_qp_qpdunes_opts_calculate_size;
     config->opts_assign = (void *(*) (void *, void *, void *) ) & ocp_qp_qpdunes_opts_assign;
     config->opts_initialize_default =
         (void (*)(void *, void *, void *)) & ocp_qp_qpdunes_opts_initialize_default;
     config->opts_update = (void (*)(void *, void *, void *)) & ocp_qp_qpdunes_opts_update;
     config->opts_set = &ocp_qp_qpdunes_opts_set;
     config->memory_calculate_size =
-        (int (*)(void *, void *, void *)) & ocp_qp_qpdunes_memory_calculate_size;
+        (acados_size_t (*)(void *, void *, void *)) & ocp_qp_qpdunes_memory_calculate_size;
     config->memory_assign =
         (void *(*) (void *, void *, void *, void *) ) & ocp_qp_qpdunes_memory_assign;
     config->memory_get = &ocp_qp_qpdunes_memory_get;
     config->workspace_calculate_size =
-        (int (*)(void *, void *, void *)) & ocp_qp_qpdunes_workspace_calculate_size;
+        (acados_size_t (*)(void *, void *, void *)) & ocp_qp_qpdunes_workspace_calculate_size;
     config->evaluate = (int (*)(void *, void *, void *, void *, void *, void *)) & ocp_qp_qpdunes;
     config->eval_sens = &ocp_qp_qpdunes_eval_sens;
 

--- a/acados/ocp_qp/ocp_qp_qpdunes.h
+++ b/acados/ocp_qp/ocp_qp_qpdunes.h
@@ -91,7 +91,7 @@ typedef struct ocp_qp_qpdunes_workspace_
 } ocp_qp_qpdunes_workspace;
 
 //
-int ocp_qp_qpdunes_opts_calculate_size(void *config_, ocp_qp_dims *dims);
+acados_size_t ocp_qp_qpdunes_opts_calculate_size(void *config_, ocp_qp_dims *dims);
 //
 void *ocp_qp_qpdunes_opts_assign(void *config_, ocp_qp_dims *dims, void *raw_memory);
 //
@@ -99,11 +99,11 @@ void ocp_qp_qpdunes_opts_initialize_default(void *config_, ocp_qp_dims *dims, vo
 //
 void ocp_qp_qpdunes_opts_update(void *config_, ocp_qp_dims *dims, void *opts_);
 //
-int ocp_qp_qpdunes_memory_calculate_size(void *config_, ocp_qp_dims *dims, void *opts_);
+acados_size_t ocp_qp_qpdunes_memory_calculate_size(void *config_, ocp_qp_dims *dims, void *opts_);
 //
 void *ocp_qp_qpdunes_memory_assign(void *config_, ocp_qp_dims *dims, void *opts_, void *raw_memory);
 //
-int ocp_qp_qpdunes_workspace_calculate_size(void *config_, ocp_qp_dims *dims, void *opts_);
+acados_size_t ocp_qp_qpdunes_workspace_calculate_size(void *config_, ocp_qp_dims *dims, void *opts_);
 //
 int ocp_qp_qpdunes(void *config_, ocp_qp_in *qp_in, ocp_qp_out *qp_out, void *opts_, void *memory_,
                    void *work_);

--- a/acados/ocp_qp/ocp_qp_xcond_solver.c
+++ b/acados/ocp_qp/ocp_qp_xcond_solver.c
@@ -50,9 +50,9 @@
  * config
  ************************************************/
 
-int ocp_qp_xcond_solver_config_calculate_size()
+acados_size_t ocp_qp_xcond_solver_config_calculate_size()
 {
-    int size = 0;
+    acados_size_t size = 0;
 
     size += sizeof(ocp_qp_xcond_solver_config);
 
@@ -86,11 +86,11 @@ ocp_qp_xcond_solver_config *ocp_qp_xcond_solver_config_assign(void *raw_memory)
  * dims
  ************************************************/
 
-int ocp_qp_xcond_solver_dims_calculate_size(void *config_, int N)
+acados_size_t ocp_qp_xcond_solver_dims_calculate_size(void *config_, int N)
 {
     ocp_qp_xcond_solver_config *config = config_;
 
-    int size = sizeof(ocp_qp_xcond_solver_dims);
+    acados_size_t size = sizeof(ocp_qp_xcond_solver_dims);
 
     // orig_dims
     size += ocp_qp_dims_calculate_size(N);
@@ -147,7 +147,7 @@ void ocp_qp_xcond_solver_dims_set_(void *config_, ocp_qp_xcond_solver_dims *dims
  * opts
  ************************************************/
 
-int ocp_qp_xcond_solver_opts_calculate_size(void *config_, ocp_qp_xcond_solver_dims *dims)
+acados_size_t ocp_qp_xcond_solver_opts_calculate_size(void *config_, ocp_qp_xcond_solver_dims *dims)
 {
     ocp_qp_xcond_solver_config *config = config_;
     qp_solver_config *qp_solver = config->qp_solver;
@@ -156,7 +156,7 @@ int ocp_qp_xcond_solver_opts_calculate_size(void *config_, ocp_qp_xcond_solver_d
     void *xcond_qp_dims;
     xcond->dims_get(xcond, dims->xcond_dims, "xcond_dims", &xcond_qp_dims);
 
-    int size = 0;
+    acados_size_t size = 0;
 
     size += sizeof(ocp_qp_xcond_solver_opts);
 
@@ -281,7 +281,7 @@ void ocp_qp_xcond_solver_opts_set_(void *config_, void *opts_, const char *field
  * memory
  ************************************************/
 
-int ocp_qp_xcond_solver_memory_calculate_size(void *config_, ocp_qp_xcond_solver_dims *dims, void *opts_)
+acados_size_t ocp_qp_xcond_solver_memory_calculate_size(void *config_, ocp_qp_xcond_solver_dims *dims, void *opts_)
 {
     ocp_qp_xcond_solver_config *config = config_;
     qp_solver_config *qp_solver = config->qp_solver;
@@ -289,7 +289,7 @@ int ocp_qp_xcond_solver_memory_calculate_size(void *config_, ocp_qp_xcond_solver
 
     ocp_qp_xcond_solver_opts *opts = (ocp_qp_xcond_solver_opts *) opts_;
 
-    int size = 0;
+    acados_size_t size = 0;
     size += sizeof(ocp_qp_xcond_solver_memory);
 
     // set up dimesions of partially condensed qp
@@ -381,7 +381,7 @@ void ocp_qp_xcond_solver_memory_get(void *config_, void *mem_, const char *field
  * workspace
  ************************************************/
 
-int ocp_qp_xcond_solver_workspace_calculate_size(void *config_, ocp_qp_xcond_solver_dims *dims, void *opts_)
+acados_size_t ocp_qp_xcond_solver_workspace_calculate_size(void *config_, ocp_qp_xcond_solver_dims *dims, void *opts_)
 {
     ocp_qp_xcond_solver_config *config = config_;
     qp_solver_config *qp_solver = config->qp_solver;
@@ -389,7 +389,7 @@ int ocp_qp_xcond_solver_workspace_calculate_size(void *config_, ocp_qp_xcond_sol
 
     ocp_qp_xcond_solver_opts *opts = (ocp_qp_xcond_solver_opts *) opts_;
 
-    int size = sizeof(ocp_qp_xcond_solver_workspace);
+    acados_size_t size = sizeof(ocp_qp_xcond_solver_workspace);
 
 //    size += xcond->workspace_calculate_size(dims->orig_dims, opts->xcond_opts);
     size += xcond->workspace_calculate_size(dims->xcond_dims, opts->xcond_opts);

--- a/acados/ocp_qp/ocp_qp_xcond_solver.h
+++ b/acados/ocp_qp/ocp_qp_xcond_solver.h
@@ -81,18 +81,18 @@ typedef struct ocp_qp_xcond_solver_workspace_
 
 typedef struct
 {
-    int (*dims_calculate_size)(void *config, int N);
+    acados_size_t (*dims_calculate_size)(void *config, int N);
     ocp_qp_xcond_solver_dims *(*dims_assign)(void *config, int N, void *raw_memory);
     void (*dims_set)(void *config_, ocp_qp_xcond_solver_dims *dims, int stage, const char *field, int* value);
-    int (*opts_calculate_size)(void *config, ocp_qp_xcond_solver_dims *dims);
+    acados_size_t (*opts_calculate_size)(void *config, ocp_qp_xcond_solver_dims *dims);
     void *(*opts_assign)(void *config, ocp_qp_xcond_solver_dims *dims, void *raw_memory);
     void (*opts_initialize_default)(void *config, ocp_qp_xcond_solver_dims *dims, void *opts);
     void (*opts_update)(void *config, ocp_qp_xcond_solver_dims *dims, void *opts);
     void (*opts_set)(void *config_, void *opts_, const char *field, void* value);
-    int (*memory_calculate_size)(void *config, ocp_qp_xcond_solver_dims *dims, void *opts);
+    acados_size_t (*memory_calculate_size)(void *config, ocp_qp_xcond_solver_dims *dims, void *opts);
     void *(*memory_assign)(void *config, ocp_qp_xcond_solver_dims *dims, void *opts, void *raw_memory);
     void (*memory_get)(void *config_, void *mem_, const char *field, void* value);
-    int (*workspace_calculate_size)(void *config, ocp_qp_xcond_solver_dims *dims, void *opts);
+    acados_size_t (*workspace_calculate_size)(void *config, ocp_qp_xcond_solver_dims *dims, void *opts);
     int (*evaluate)(void *config, ocp_qp_xcond_solver_dims *dims, ocp_qp_in *qp_in, ocp_qp_out *qp_out, void *opts, void *mem, void *work);
     void (*eval_sens)(void *config, ocp_qp_xcond_solver_dims *dims, ocp_qp_in *param_qp_in, ocp_qp_out *sens_qp_out, void *opts, void *mem, void *work);
     qp_solver_config *qp_solver;  // either ocp_qp_solver or dense_solver
@@ -103,13 +103,13 @@ typedef struct
 
 /* config */
 //
-int ocp_qp_xcond_solver_config_calculate_size();
+acados_size_t ocp_qp_xcond_solver_config_calculate_size();
 //
 ocp_qp_xcond_solver_config *ocp_qp_xcond_solver_config_assign(void *raw_memory);
 
 /* dims */
 //
-int ocp_qp_xcond_solver_dims_calculate_size(void *config, int N);
+acados_size_t ocp_qp_xcond_solver_dims_calculate_size(void *config, int N);
 //
 ocp_qp_xcond_solver_dims *ocp_qp_xcond_solver_dims_assign(void *config, int N, void *raw_memory);
 //
@@ -117,7 +117,7 @@ void ocp_qp_xcond_solver_dims_set_(void *config, ocp_qp_xcond_solver_dims *dims,
 
 /* opts */
 //
-int ocp_qp_xcond_solver_opts_calculate_size(void *config, ocp_qp_xcond_solver_dims *dims);
+acados_size_t ocp_qp_xcond_solver_opts_calculate_size(void *config, ocp_qp_xcond_solver_dims *dims);
 //
 void *ocp_qp_xcond_solver_opts_assign(void *config, ocp_qp_xcond_solver_dims *dims, void *raw_memory);
 //
@@ -129,13 +129,13 @@ void ocp_qp_xcond_solver_opts_set_(void *config_, void *opts_, const char *field
 
 /* memory */
 //
-int ocp_qp_xcond_solver_memory_calculate_size(void *config, ocp_qp_xcond_solver_dims *dims, void *opts_);
+acados_size_t ocp_qp_xcond_solver_memory_calculate_size(void *config, ocp_qp_xcond_solver_dims *dims, void *opts_);
 //
 void *ocp_qp_xcond_solver_memory_assign(void *config, ocp_qp_xcond_solver_dims *dims, void *opts_, void *raw_memory);
 
 /* workspace */
 //
-int ocp_qp_xcond_solver_workspace_calculate_size(void *config, ocp_qp_xcond_solver_dims *dims, void *opts_);
+acados_size_t ocp_qp_xcond_solver_workspace_calculate_size(void *config, ocp_qp_xcond_solver_dims *dims, void *opts_);
 
 /* config */
 //

--- a/acados/sim/sim_collocation_utils.c
+++ b/acados/sim/sim_collocation_utils.c
@@ -155,13 +155,13 @@ static double lu_system_solve(double *A, double *b, int *perm, int dim, int dim_
 
 
 
-int gauss_nodes_work_calculate_size(int ns)
+acados_size_t gauss_nodes_work_calculate_size(int ns)
 {
     int N = ns - 1;
     int N1 = N + 1;
     int N2 = N + 2;
 
-    int size = 0;
+    acados_size_t size = 0;
 
     size += 4 * N1 * sizeof(double);       // x_init, y, y_prev, der_lgvm
     size += 1 * N1 * N2 * sizeof(double);  // lgvm
@@ -248,9 +248,9 @@ void gauss_nodes(int ns, double *nodes, void *work)
 
 
 
-int gauss_simplified_work_calculate_size(int ns)
+acados_size_t gauss_simplified_work_calculate_size(int ns)
 {
-    int size = 0;
+    acados_size_t size = 0;
 
     size += 1 * 2 * ns * sizeof(double);   // D
     size += 3 * ns * ns * sizeof(double);  // T, T_inv, lu_work
@@ -377,9 +377,9 @@ void gauss_simplified(int ns, Newton_scheme *scheme, void *work)
 
 
 
-int butcher_table_work_calculate_size(int ns)
+acados_size_t butcher_table_work_calculate_size(int ns)
 {
-    int size = 0;
+    acados_size_t size = 0;
 
     size += 3 * ns * ns * sizeof(double);  // can_vm, rhs, lu_work
 

--- a/acados/sim/sim_collocation_utils.h
+++ b/acados/sim/sim_collocation_utils.h
@@ -70,15 +70,15 @@ typedef struct
 
 
 //
-int gauss_nodes_work_calculate_size(int ns);
+acados_size_t gauss_nodes_work_calculate_size(int ns);
 //
 void gauss_nodes(int ns, double *nodes, void *raw_memory);
 //
-int gauss_simplified_work_calculate_size(int ns);
+acados_size_t gauss_simplified_work_calculate_size(int ns);
 //
 void gauss_simplified(int ns, Newton_scheme *scheme, void *work);
 //
-int butcher_table_work_calculate_size(int ns);
+acados_size_t butcher_table_work_calculate_size(int ns);
 //
 void butcher_table(int ns, double *nodes, double *b, double *A, void *work);
 

--- a/acados/sim/sim_common.c
+++ b/acados/sim/sim_common.c
@@ -48,9 +48,9 @@
  * config
  ************************************************/
 
-int sim_config_calculate_size()
+acados_size_t sim_config_calculate_size()
 {
-    int size = 0;
+    acados_size_t size = 0;
 
     size += sizeof(sim_config);
 
@@ -77,11 +77,11 @@ sim_config *sim_config_assign(void *raw_memory)
  * in
  ************************************************/
 
-int sim_in_calculate_size(void *config_, void *dims)
+acados_size_t sim_in_calculate_size(void *config_, void *dims)
 {
     sim_config *config = config_;
 
-    int size = sizeof(sim_in);
+    acados_size_t size = sizeof(sim_in);
 
     int nx, nu, nz;
 
@@ -235,11 +235,11 @@ int sim_in_set_(void *config_, void *dims_, sim_in *in, const char *field, void 
  * out
  ************************************************/
 
-int sim_out_calculate_size(void *config_, void *dims)
+acados_size_t sim_out_calculate_size(void *config_, void *dims)
 {
     sim_config *config = config_;
 
-    int size = sizeof(sim_out);
+    acados_size_t size = sizeof(sim_out);
 
     int nx, nu, nz;
     config->dims_get(config_, dims, "nx", &nx);

--- a/acados/sim/sim_common.h
+++ b/acados/sim/sim_common.h
@@ -160,28 +160,28 @@ typedef struct
     int (*evaluate)(void *config_, sim_in *in, sim_out *out, void *opts, void *mem, void *work);
     int (*precompute)(void *config_, sim_in *in, sim_out *out, void *opts, void *mem, void *work);
     // opts
-    int (*opts_calculate_size)(void *config_, void *dims);
+    acados_size_t (*opts_calculate_size)(void *config_, void *dims);
     void *(*opts_assign)(void *config_, void *dims, void *raw_memory);
     void (*opts_initialize_default)(void *config_, void *dims, void *opts);
     void (*opts_update)(void *config_, void *dims, void *opts);
     void (*opts_set)(void *config_, void *opts_, const char *field, void *value);
     void (*opts_get)(void *config_, void *opts_, const char *field, void *value);
     // mem
-    int (*memory_calculate_size)(void *config, void *dims, void *opts);
+    acados_size_t (*memory_calculate_size)(void *config, void *dims, void *opts);
     void *(*memory_assign)(void *config, void *dims, void *opts, void *raw_memory);
     int (*memory_set)(void *config, void *dims, void *mem, const char *field, void *value);
     int (*memory_set_to_zero)(void *config, void *dims, void *opts, void *mem, const char *field);
     void (*memory_get)(void *config, void *dims, void *mem, const char *field, void *value);
     // work
-    int (*workspace_calculate_size)(void *config, void *dims, void *opts);
+    acados_size_t (*workspace_calculate_size)(void *config, void *dims, void *opts);
     // model
-    int (*model_calculate_size)(void *config, void *dims);
+    acados_size_t (*model_calculate_size)(void *config, void *dims);
     void *(*model_assign)(void *config, void *dims, void *raw_memory);
     int (*model_set)(void *model, const char *field, void *value);
     // config
     void (*config_initialize_default)(void *config);
     // dims
-    int (*dims_calculate_size)();
+    acados_size_t (*dims_calculate_size)();
     void *(*dims_assign)(void *config, void *raw_memory);
     void (*dims_set)(void *config, void *dims, const char *field, const int *value);
     void (*dims_get)(void *config, void *dims, const char *field, int *value);
@@ -192,13 +192,13 @@ typedef struct
 
 /* config */
 //
-int sim_config_calculate_size();
+acados_size_t sim_config_calculate_size();
 //
 sim_config *sim_config_assign(void *raw_memory);
 
 /* in */
 //
-int sim_in_calculate_size(void *config, void *dims);
+acados_size_t sim_in_calculate_size(void *config, void *dims);
 //
 sim_in *sim_in_assign(void *config, void *dims, void *raw_memory);
 //
@@ -206,7 +206,7 @@ int sim_in_set_(void *config_, void *dims_, sim_in *in, const char *field, void 
 
 /* out */
 //
-int sim_out_calculate_size(void *config, void *dims);
+acados_size_t sim_out_calculate_size(void *config, void *dims);
 //
 sim_out *sim_out_assign(void *config, void *dims, void *raw_memory);
 //

--- a/acados/sim/sim_erk_integrator.c
+++ b/acados/sim/sim_erk_integrator.c
@@ -46,9 +46,9 @@
  * dims
  ************************************************/
 
-int sim_erk_dims_calculate_size()
+acados_size_t sim_erk_dims_calculate_size()
 {
-    int size = sizeof(sim_erk_dims);
+    acados_size_t size = sizeof(sim_erk_dims);
 
     return size;
 }
@@ -132,9 +132,9 @@ void sim_erk_dims_get(void *config_, void *dims_, const char *field, int *value)
  * model
  ************************************************/
 
-int sim_erk_model_calculate_size(void *config, void *dims)
+acados_size_t sim_erk_model_calculate_size(void *config, void *dims)
 {
-    int size = 0;
+    acados_size_t size = 0;
 
     size += sizeof(erk_model);
 
@@ -190,11 +190,11 @@ int sim_erk_model_set(void *model_, const char *field, void *value)
  * opts
  ************************************************/
 
-int sim_erk_opts_calculate_size(void *config_, void *dims)
+acados_size_t sim_erk_opts_calculate_size(void *config_, void *dims)
 {
     int ns_max = NS_MAX;
 
-    int size = sizeof(sim_opts);
+    acados_size_t size = sizeof(sim_opts);
 
     size += ns_max * ns_max * sizeof(double);  // A_mat
     size += ns_max * sizeof(double);           // b_vec
@@ -439,9 +439,9 @@ void sim_erk_opts_update(void *config_, void *dims, void *opts_)
  * memory
  ************************************************/
 
-int sim_erk_memory_calculate_size(void *config, void *dims, void *opts_)
+acados_size_t sim_erk_memory_calculate_size(void *config, void *dims, void *opts_)
 {
-    int size = sizeof(sim_erk_memory);
+    acados_size_t size = sizeof(sim_erk_memory);
 
     return size;
 }
@@ -519,7 +519,7 @@ void sim_erk_memory_get(void *config_, void *dims_, void *mem_, const char *fiel
  * workspace
  ************************************************/
 
-int sim_erk_workspace_calculate_size(void *config_, void *dims_, void *opts_)
+acados_size_t sim_erk_workspace_calculate_size(void *config_, void *dims_, void *opts_)
 {
     sim_opts *opts = opts_;
     sim_erk_dims *dims = (sim_erk_dims *) dims_;
@@ -534,7 +534,7 @@ int sim_erk_workspace_calculate_size(void *config_, void *dims_, void *opts_)
     int nhess = (nf + 1) * nf / 2;
     int num_steps = opts->num_steps;  // number of steps
 
-    int size = sizeof(sim_erk_workspace);
+    acados_size_t size = sizeof(sim_erk_workspace);
 
     size += (nX + nu) * sizeof(double);  // rhs_forw_in
 

--- a/acados/sim/sim_erk_integrator.h
+++ b/acados/sim/sim_erk_integrator.h
@@ -98,18 +98,18 @@ typedef struct
 
 
 // dims
-int sim_erk_dims_calculate_size();
+acados_size_t sim_erk_dims_calculate_size();
 void *sim_erk_dims_assign(void *config_, void *raw_memory);
 void sim_erk_dims_set(void *config_, void *dims_, const char *field, const int* value);
 void sim_erk_dims_get(void *config_, void *dims_, const char *field, int* value);
 
 // model
-int sim_erk_model_calculate_size(void *config, void *dims);
+acados_size_t sim_erk_model_calculate_size(void *config, void *dims);
 void *sim_erk_model_assign(void *config, void *dims, void *raw_memory);
 int sim_erk_model_set(void *model, const char *field, void *value);
 
 // opts
-int sim_erk_opts_calculate_size(void *config, void *dims);
+acados_size_t sim_erk_opts_calculate_size(void *config, void *dims);
 //
 void sim_erk_opts_update(void *config_, void *dims, void *opts_);
 //
@@ -121,7 +121,7 @@ void sim_erk_opts_set(void *config_, void *opts_, const char *field, void *value
 
 
 // memory
-int sim_erk_memory_calculate_size(void *config, void *dims, void *opts_);
+acados_size_t sim_erk_memory_calculate_size(void *config, void *dims, void *opts_);
 //
 void *sim_erk_memory_assign(void *config, void *dims, void *opts_, void *raw_memory);
 //
@@ -129,7 +129,7 @@ int sim_erk_memory_set(void *config_, void *dims_, void *mem_, const char *field
 
 
 // workspace
-int sim_erk_workspace_calculate_size(void *config, void *dims, void *opts_);
+acados_size_t sim_erk_workspace_calculate_size(void *config, void *dims, void *opts_);
 
 //
 int sim_erk(void *config, sim_in *in, sim_out *out, void *opts_, void *mem_, void *work_);

--- a/acados/sim/sim_gnsf.c
+++ b/acados/sim/sim_gnsf.c
@@ -62,9 +62,9 @@
  * dims
  ************************************************/
 
-int sim_gnsf_dims_calculate_size()
+acados_size_t sim_gnsf_dims_calculate_size()
 {
-    int size = sizeof(sim_gnsf_dims);
+    acados_size_t size = sizeof(sim_gnsf_dims);
     return size;
 }
 
@@ -249,11 +249,11 @@ static void sim_gnsf_import_matrices(void *dims_, gnsf_model *model)
  * opts
  ************************************************/
 
-int sim_gnsf_opts_calculate_size(void *config_, void *dims)
+acados_size_t sim_gnsf_opts_calculate_size(void *config_, void *dims)
 {
     int ns_max = NS_MAX;
 
-    int size = 0;
+    acados_size_t size = 0;
 
     size += sizeof(sim_opts);
 
@@ -261,9 +261,9 @@ int sim_gnsf_opts_calculate_size(void *config_, void *dims)
     size += ns_max * sizeof(double);           // b_vec
     size += ns_max * sizeof(double);           // c_vec
 
-    int tmp0 = gauss_nodes_work_calculate_size(ns_max);
-    int tmp1 = butcher_table_work_calculate_size(ns_max);
-    int work_size = tmp0 > tmp1 ? tmp0 : tmp1;
+    size_t tmp0 = gauss_nodes_work_calculate_size(ns_max);
+    size_t tmp1 = butcher_table_work_calculate_size(ns_max);
+    acados_size_t work_size = tmp0 > tmp1 ? tmp0 : tmp1;
     size += work_size;  // work
 
     make_int_multiple_of(8, &size);
@@ -288,9 +288,9 @@ void *sim_gnsf_opts_assign(void *config_, void *dims, void *raw_memory)
     assign_and_advance_double(ns_max, &opts->c_vec, &c_ptr);
 
     // work
-    int tmp0 = gauss_nodes_work_calculate_size(ns_max);
-    int tmp1 = butcher_table_work_calculate_size(ns_max);
-    int work_size = tmp0 > tmp1 ? tmp0 : tmp1;
+    acados_size_t tmp0 = gauss_nodes_work_calculate_size(ns_max);
+    acados_size_t tmp1 = butcher_table_work_calculate_size(ns_max);
+    acados_size_t work_size = tmp0 > tmp1 ? tmp0 : tmp1;
     opts->work = c_ptr;
     c_ptr += work_size;
 
@@ -388,7 +388,7 @@ void sim_gnsf_opts_get(void *config_, void *opts_, const char *field, void *valu
  * model
  ************************************************/
 
-int sim_gnsf_model_calculate_size(void *config, void *dims_)
+acados_size_t sim_gnsf_model_calculate_size(void *config, void *dims_)
 {
     // typecast
     sim_gnsf_dims *dims = (sim_gnsf_dims *) dims_;
@@ -405,7 +405,7 @@ int sim_gnsf_model_calculate_size(void *config, void *dims_)
     int nx2     = nx - nx1;
     int nz2     = nz - nz1;
 
-    int size = 0;
+    acados_size_t size = 0;
     size += sizeof(gnsf_model);
 
     // model defining matrices
@@ -1185,7 +1185,7 @@ int sim_gnsf_precompute(void *config_, sim_in *in, sim_out *out, void *opts_, vo
  * memory
  ************************************************/
 
-int sim_gnsf_memory_calculate_size(void *config, void *dims_, void *opts_)
+acados_size_t sim_gnsf_memory_calculate_size(void *config, void *dims_, void *opts_)
 {
     // typecast
     sim_gnsf_dims *dims = (sim_gnsf_dims *) dims_;
@@ -1212,7 +1212,7 @@ int sim_gnsf_memory_calculate_size(void *config, void *dims_, void *opts_)
     int nK2 = num_stages * nxz2;
     int nZ1 = num_stages * nz1;
 
-    int size = sizeof(sim_gnsf_memory);
+    acados_size_t size = sizeof(sim_gnsf_memory);
 
     // scaled butcher table
     size += num_stages * num_stages * sizeof(double);  // A_dt
@@ -1510,7 +1510,7 @@ void sim_gnsf_memory_get(void *config_, void *dims_, void *mem_, const char *fie
  * workspace
  ************************************************/
 
-int sim_gnsf_workspace_calculate_size(void *config, void *dims_, void *opts_)
+acados_size_t sim_gnsf_workspace_calculate_size(void *config, void *dims_, void *opts_)
 {
     // typecast
     sim_gnsf_dims *dims = (sim_gnsf_dims *) dims_;
@@ -1539,7 +1539,7 @@ int sim_gnsf_workspace_calculate_size(void *config, void *dims_, void *opts_)
     int nxz2 = nx2 + nz2;
 
     /* Calculate workspace size for precompute function */
-    int pre_size = sizeof(gnsf_pre_workspace);
+    acados_size_t pre_size = sizeof(gnsf_pre_workspace);
 
     make_int_multiple_of(8, &pre_size);
     pre_size += 1 * 8;
@@ -1591,7 +1591,7 @@ int sim_gnsf_workspace_calculate_size(void *config, void *dims_, void *opts_)
     pre_size += 1 * 8;
 
     /* Calculate workspace size for simulation function */
-    int size = sizeof(gnsf_workspace);
+    acados_size_t size = sizeof(gnsf_workspace);
     make_int_multiple_of(8, &size);
     size += 1 * 8;
 

--- a/acados/sim/sim_gnsf.h
+++ b/acados/sim/sim_gnsf.h
@@ -326,7 +326,7 @@ typedef struct
 
 
 // gnsf dims
-int sim_gnsf_dims_calculate_size();
+acados_size_t sim_gnsf_dims_calculate_size();
 void *sim_gnsf_dims_assign(void *config_, void *raw_memory);
 
 // get & set functions
@@ -334,14 +334,14 @@ void sim_gnsf_dims_set(void *config_, void *dims_, const char *field, const int 
 void sim_gnsf_dims_get(void *config_, void *dims_, const char *field, int* value);
 
 // opts
-int sim_gnsf_opts_calculate_size(void *config, void *dims);
+acados_size_t sim_gnsf_opts_calculate_size(void *config, void *dims);
 void *sim_gnsf_opts_assign(void *config, void *dims, void *raw_memory);
 void sim_gnsf_opts_initialize_default(void *config, void *dims, void *opts_);
 void sim_gnsf_opts_update(void *config_, void *dims, void *opts_);
 void sim_gnsf_opts_set(void *config_, void *opts_, const char *field, void *value);
 
 // model
-int sim_gnsf_model_calculate_size(void *config, void *dims_);
+acados_size_t sim_gnsf_model_calculate_size(void *config, void *dims_);
 void *sim_gnsf_model_assign(void *config, void *dims_, void *raw_memory);
 int sim_gnsf_model_set(void *model_, const char *field, void *value);
 
@@ -350,8 +350,8 @@ int sim_gnsf_precompute(void *config_, sim_in *in, sim_out *out, void *opts_, vo
                        void *work_);
 
 // workspace & memory
-int sim_gnsf_workspace_calculate_size(void *config, void *dims_, void *args);
-int sim_gnsf_memory_calculate_size(void *config, void *dims_, void *opts_);
+acados_size_t sim_gnsf_workspace_calculate_size(void *config, void *dims_, void *args);
+acados_size_t sim_gnsf_memory_calculate_size(void *config, void *dims_, void *opts_);
 void *sim_gnsf_memory_assign(void *config, void *dims_, void *opts_, void *raw_memory);
 
 // interface

--- a/acados/sim/sim_irk_integrator.c
+++ b/acados/sim/sim_irk_integrator.c
@@ -59,9 +59,9 @@
  * dims
  ************************************************/
 
-int sim_irk_dims_calculate_size()
+acados_size_t sim_irk_dims_calculate_size()
 {
-    int size = sizeof(sim_irk_dims);
+    acados_size_t size = sizeof(sim_irk_dims);
 
     return size;
 }
@@ -138,9 +138,9 @@ void sim_irk_dims_get(void *config_, void *dims_, const char *field, int *value)
  * model
  ************************************************/
 
-int sim_irk_model_calculate_size(void *config, void *dims)
+acados_size_t sim_irk_model_calculate_size(void *config, void *dims)
 {
-    int size = 0;
+    acados_size_t size = 0;
 
     size += sizeof(irk_model);
 
@@ -208,11 +208,11 @@ int sim_irk_model_set(void *model_, const char *field, void *value)
  * opts
  ************************************************/
 
-int sim_irk_opts_calculate_size(void *config_, void *dims)
+acados_size_t sim_irk_opts_calculate_size(void *config_, void *dims)
 {
     int ns_max = NS_MAX;
 
-    int size = 0;
+    acados_size_t size = 0;
 
     size += sizeof(sim_opts);
 
@@ -220,9 +220,9 @@ int sim_irk_opts_calculate_size(void *config_, void *dims)
     size += ns_max * sizeof(double);           // b_vec
     size += ns_max * sizeof(double);           // c_vec
 
-    int tmp0 = gauss_nodes_work_calculate_size(ns_max);
-    int tmp1 = butcher_table_work_calculate_size(ns_max);
-    int work_size = tmp0 > tmp1 ? tmp0 : tmp1;
+    acados_size_t tmp0 = gauss_nodes_work_calculate_size(ns_max);
+    acados_size_t tmp1 = butcher_table_work_calculate_size(ns_max);
+    acados_size_t work_size = tmp0 > tmp1 ? tmp0 : tmp1;
     size += work_size;  // work
 
     make_int_multiple_of(8, &size);
@@ -347,7 +347,7 @@ void sim_irk_opts_get(void *config_, void *opts_, const char *field, void *value
  * memory
  ************************************************/
 
-int sim_irk_memory_calculate_size(void *config, void *dims_, void *opts_)
+acados_size_t sim_irk_memory_calculate_size(void *config, void *dims_, void *opts_)
 {
     // typecast
     sim_irk_dims *dims = (sim_irk_dims *) dims_;
@@ -357,7 +357,7 @@ int sim_irk_memory_calculate_size(void *config, void *dims_, void *opts_)
     int nx = dims->nx;
     int nz = dims->nz;
 
-    int size = sizeof(sim_irk_memory);
+    acados_size_t size = sizeof(sim_irk_memory);
 
     size += nx * sizeof(double); // xdot
     size += nz * sizeof(double); // z
@@ -504,7 +504,7 @@ void sim_irk_memory_get(void *config_, void *dims_, void *mem_, const char *fiel
  * workspace
  ************************************************/
 
-int sim_irk_workspace_calculate_size(void *config_, void *dims_, void *opts_)
+acados_size_t sim_irk_workspace_calculate_size(void *config_, void *dims_, void *opts_)
 {
     sim_irk_dims *dims = (sim_irk_dims *) dims_;
     sim_opts *opts = opts_;
@@ -519,7 +519,7 @@ int sim_irk_workspace_calculate_size(void *config_, void *dims_, void *opts_)
 
     int steps = opts->num_steps;
 
-    int size = sizeof(sim_irk_workspace);
+    acados_size_t size = sizeof(sim_irk_workspace);
 
     if (opts->sens_algebraic || opts->output_z)
     {

--- a/acados/sim/sim_irk_integrator.c
+++ b/acados/sim/sim_irk_integrator.c
@@ -247,9 +247,9 @@ void *sim_irk_opts_assign(void *config_, void *dims, void *raw_memory)
     assign_and_advance_double(ns_max, &opts->c_vec, &c_ptr);
 
     // work
-    int tmp0 = gauss_nodes_work_calculate_size(ns_max);
-    int tmp1 = butcher_table_work_calculate_size(ns_max);
-    int work_size = tmp0 > tmp1 ? tmp0 : tmp1;
+    acados_size_t tmp0 = gauss_nodes_work_calculate_size(ns_max);
+    acados_size_t tmp1 = butcher_table_work_calculate_size(ns_max);
+    acados_size_t work_size = tmp0 > tmp1 ? tmp0 : tmp1;
     opts->work = c_ptr;
     c_ptr += work_size;
 

--- a/acados/sim/sim_irk_integrator.h
+++ b/acados/sim/sim_irk_integrator.h
@@ -152,28 +152,28 @@ void sim_irk_dims_set(void *config_, void *dims_, const char *field, const int *
 void sim_irk_dims_get(void *config_, void *dims_, const char *field, int* value);
 
 // dims
-int sim_irk_dims_calculate_size();
+acados_size_t sim_irk_dims_calculate_size();
 void *sim_irk_dims_assign(void *config_, void *raw_memory);
 
 // model
-int sim_irk_model_calculate_size(void *config, void *dims);
+acados_size_t sim_irk_model_calculate_size(void *config, void *dims);
 void *sim_irk_model_assign(void *config, void *dims, void *raw_memory);
 int sim_irk_model_set(void *model, const char *field, void *value);
 
 // opts
-int sim_irk_opts_calculate_size(void *config, void *dims);
+acados_size_t sim_irk_opts_calculate_size(void *config, void *dims);
 void *sim_irk_opts_assign(void *config, void *dims, void *raw_memory);
 void sim_irk_opts_initialize_default(void *config, void *dims, void *opts_);
 void sim_irk_opts_update(void *config_, void *dims, void *opts_);
 void sim_irk_opts_set(void *config_, void *opts_, const char *field, void *value);
 
 // memory
-int sim_irk_memory_calculate_size(void *config, void *dims, void *opts_);
+acados_size_t sim_irk_memory_calculate_size(void *config, void *dims, void *opts_);
 void *sim_irk_memory_assign(void *config, void *dims, void *opts_, void *raw_memory);
 int sim_irk_memory_set(void *config_, void *dims_, void *mem_, const char *field, void *value);
 
 // workspace
-int sim_irk_workspace_calculate_size(void *config, void *dims, void *opts_);
+acados_size_t sim_irk_workspace_calculate_size(void *config, void *dims, void *opts_);
 void sim_irk_config_initialize_default(void *config);
 
 // main

--- a/acados/sim/sim_lifted_irk_integrator.c
+++ b/acados/sim/sim_lifted_irk_integrator.c
@@ -57,9 +57,9 @@
 * dims
 ************************************************/
 
-int sim_lifted_irk_dims_calculate_size()
+acados_size_t sim_lifted_irk_dims_calculate_size()
 {
-    int size = sizeof(sim_lifted_irk_dims);
+    acados_size_t size = sizeof(sim_lifted_irk_dims);
 
     return size;
 }
@@ -136,9 +136,9 @@ void sim_lifted_irk_dims_get(void *config_, void *dims_, const char *field, int 
 * model
 ************************************************/
 
-int sim_lifted_irk_model_calculate_size(void *config, void *dims)
+acados_size_t sim_lifted_irk_model_calculate_size(void *config, void *dims)
 {
-    int size = 0;
+    acados_size_t size = 0;
 
     size += sizeof(lifted_irk_model);
 
@@ -188,11 +188,11 @@ int sim_lifted_irk_model_set(void *model_, const char *field, void *value)
 * opts
 ************************************************/
 
-int sim_lifted_irk_opts_calculate_size(void *config_, void *dims)
+acados_size_t sim_lifted_irk_opts_calculate_size(void *config_, void *dims)
 {
     int ns_max = NS_MAX;
 
-    int size = 0;
+    acados_size_t size = 0;
 
     size += sizeof(sim_opts);
 
@@ -200,9 +200,9 @@ int sim_lifted_irk_opts_calculate_size(void *config_, void *dims)
     size += ns_max * sizeof(double);           // b_vec
     size += ns_max * sizeof(double);           // c_vec
 
-    int tmp0 = gauss_nodes_work_calculate_size(ns_max);
-    int tmp1 = butcher_table_work_calculate_size(ns_max);
-    int work_size = tmp0 > tmp1 ? tmp0 : tmp1;
+    acados_size_t tmp0 = gauss_nodes_work_calculate_size(ns_max);
+    acados_size_t tmp1 = butcher_table_work_calculate_size(ns_max);
+    acados_size_t work_size = tmp0 > tmp1 ? tmp0 : tmp1;
     size += work_size;  // work
 
     make_int_multiple_of(8, &size);
@@ -229,9 +229,9 @@ void *sim_lifted_irk_opts_assign(void *config_, void *dims, void *raw_memory)
     assign_and_advance_double(ns_max, &opts->c_vec, &c_ptr);
 
     // work
-    int tmp0 = gauss_nodes_work_calculate_size(ns_max);
-    int tmp1 = butcher_table_work_calculate_size(ns_max);
-    int work_size = tmp0 > tmp1 ? tmp0 : tmp1;
+    acados_size_t tmp0 = gauss_nodes_work_calculate_size(ns_max);
+    acados_size_t tmp1 = butcher_table_work_calculate_size(ns_max);
+    acados_size_t work_size = tmp0 > tmp1 ? tmp0 : tmp1;
     opts->work = c_ptr;
     c_ptr += work_size;
 
@@ -322,7 +322,7 @@ void sim_lifted_irk_opts_get(void *config_, void *opts_, const char *field, void
 * memory
 ************************************************/
 
-int sim_lifted_irk_memory_calculate_size(void *config, void *dims_, void *opts_)
+acados_size_t sim_lifted_irk_memory_calculate_size(void *config, void *dims_, void *opts_)
 {
     sim_opts *opts = opts_;
     sim_lifted_irk_dims *dims = (sim_lifted_irk_dims *) dims_;
@@ -334,7 +334,7 @@ int sim_lifted_irk_memory_calculate_size(void *config, void *dims_, void *opts_)
 
     int num_steps = opts->num_steps;
 
-    int size = sizeof(sim_lifted_irk_memory);
+    acados_size_t size = sizeof(sim_lifted_irk_memory);
 
     size += 1 * sizeof(struct blasfeo_dmat);            // S_forw
     size += 2 * sizeof(struct blasfeo_dmat);            // JGK, JGf
@@ -502,7 +502,7 @@ void sim_lifted_irk_memory_get(void *config_, void *dims_, void *mem_, const cha
 * workspace
 ************************************************/
 
-int sim_lifted_irk_workspace_calculate_size(void *config_, void *dims_, void *opts_)
+acados_size_t sim_lifted_irk_workspace_calculate_size(void *config_, void *dims_, void *opts_)
 {
     sim_opts *opts = opts_;
     sim_lifted_irk_dims *dims = (sim_lifted_irk_dims *) dims_;
@@ -512,7 +512,7 @@ int sim_lifted_irk_workspace_calculate_size(void *config_, void *dims_, void *op
     int nx = dims->nx;
     int nu = dims->nu;
 
-    int size = sizeof(sim_lifted_irk_workspace);
+    acados_size_t size = sizeof(sim_lifted_irk_workspace);
 
     size += 3 * sizeof(struct blasfeo_dmat);  // J_temp_x, J_temp_xdot, J_temp_u
 

--- a/acados/sim/sim_lifted_irk_integrator.h
+++ b/acados/sim/sim_lifted_irk_integrator.h
@@ -109,13 +109,13 @@ typedef struct
 void sim_lifted_irk_dims_set(void *config_, void *dims_, const char *field, const int *value);
 void sim_lifted_irk_dims_get(void *config_, void *dims_, const char *field, int* value);
 
-int sim_lifted_irk_dims_calculate_size();
+acados_size_t sim_lifted_irk_dims_calculate_size();
 //
 void *sim_lifted_irk_dims_assign(void* config_, void *raw_memory);
 
 /* model */
 //
-int sim_lifted_irk_model_calculate_size(void *config, void *dims);
+acados_size_t sim_lifted_irk_model_calculate_size(void *config, void *dims);
 //
 void *sim_lifted_irk_model_assign(void *config, void *dims, void *raw_memory);
 //
@@ -123,7 +123,7 @@ int sim_lifted_irk_model_set(void *model_, const char *field, void *value);
 
 /* opts */
 //
-int sim_lifted_irk_opts_calculate_size(void *config, void *dims);
+acados_size_t sim_lifted_irk_opts_calculate_size(void *config, void *dims);
 //
 void *sim_lifted_irk_opts_assign(void *config, void *dims, void *raw_memory);
 //
@@ -135,13 +135,13 @@ void sim_lifted_irk_opts_set(void *config_, void *opts_, const char *field, void
 
 /* memory */
 //
-int sim_lifted_irk_memory_calculate_size(void *config, void *dims, void *opts_);
+acados_size_t sim_lifted_irk_memory_calculate_size(void *config, void *dims, void *opts_);
 //
 void *sim_lifted_irk_memory_assign(void *config, void *dims, void *opts_, void *raw_memory);
 
 /* workspace */
 //
-int sim_lifted_irk_workspace_calculate_size(void *config, void *dims, void *opts_);
+acados_size_t sim_lifted_irk_workspace_calculate_size(void *config, void *dims, void *opts_);
 //
 void sim_lifted_irk_config_initialize_default(void *config);
 

--- a/acados/utils/external_function_generic.c
+++ b/acados/utils/external_function_generic.c
@@ -48,7 +48,7 @@
  * generic external parametric function
  ************************************************/
 
-int external_function_param_generic_struct_size()
+acados_size_t external_function_param_generic_struct_size()
 {
     return sizeof(external_function_param_generic);
 }
@@ -75,7 +75,7 @@ static void external_function_param_generic_set_param_sparse(void *self, int n_u
 }
 
 
-int external_function_param_generic_calculate_size(external_function_param_generic *fun, int np)
+acados_size_t external_function_param_generic_calculate_size(external_function_param_generic *fun, int np)
 {
     // wrapper as evaluate function
     fun->evaluate = &external_function_param_generic_wrapper;
@@ -88,7 +88,7 @@ int external_function_param_generic_calculate_size(external_function_param_gener
     // set number of parameters
     fun->np = np;
 
-    int size = 0;
+    acados_size_t size = 0;
 
     // doubles
     size += fun->np * sizeof(double); // p
@@ -672,7 +672,7 @@ static void d_cvt_dvec_args_to_casadi(struct blasfeo_dvec_args *in, double *out,
  * casadi external function
  ************************************************/
 
-int external_function_casadi_struct_size()
+acados_size_t external_function_casadi_struct_size()
 {
     return sizeof(external_function_casadi);
 }
@@ -727,7 +727,7 @@ void external_function_casadi_set_n_out(external_function_casadi *fun, void *val
 
 
 
-int external_function_casadi_calculate_size(external_function_casadi *fun)
+acados_size_t external_function_casadi_calculate_size(external_function_casadi *fun)
 {
     // casadi wrapper as evaluate
     fun->evaluate = &external_function_casadi_wrapper;
@@ -750,7 +750,7 @@ int external_function_casadi_calculate_size(external_function_casadi *fun)
     for (ii = 0; ii < fun->res_num; ii++)
         fun->res_size_tot += casadi_nnz(fun->casadi_sparsity_out(ii));
 
-    int size = 0;
+    acados_size_t size = 0;
 
     // double pointers
     size += fun->args_num * sizeof(double *);  // args
@@ -937,7 +937,7 @@ void external_function_casadi_wrapper(void *self, ext_fun_arg_t *type_in, void *
  * casadi external parametric function
  ************************************************/
 
-int external_function_param_casadi_struct_size()
+acados_size_t external_function_param_casadi_struct_size()
 {
     return sizeof(external_function_param_casadi);
 }
@@ -1018,7 +1018,7 @@ static void external_function_param_casadi_set_param_sparse(void *self, int n_up
 }
 
 
-int external_function_param_casadi_calculate_size(external_function_param_casadi *fun, int np)
+acados_size_t external_function_param_casadi_calculate_size(external_function_param_casadi *fun, int np)
 {
     // loop index
     int ii;
@@ -1049,7 +1049,7 @@ int external_function_param_casadi_calculate_size(external_function_param_casadi
     for (ii = 0; ii < fun->res_num; ii++)
         fun->res_size_tot += casadi_nnz(fun->casadi_sparsity_out(ii));
 
-    int size = 0;
+    acados_size_t size = 0;
 
     // double pointers
     size += fun->args_num * sizeof(double *);  // args

--- a/acados/utils/external_function_generic.h
+++ b/acados/utils/external_function_generic.h
@@ -108,11 +108,11 @@ typedef struct
 } external_function_param_generic;
 
 //
-int external_function_param_generic_struct_size();
+acados_size_t external_function_param_generic_struct_size();
 //
 void external_function_param_generic_set_fun(external_function_param_generic *fun, void *value);
 //
-int external_function_param_generic_calculate_size(external_function_param_generic *fun, int np);
+acados_size_t external_function_param_generic_calculate_size(external_function_param_generic *fun, int np);
 //
 void external_function_param_generic_assign(external_function_param_generic *fun, void *mem);
 //
@@ -156,7 +156,7 @@ typedef struct
 } external_function_casadi;
 
 //
-int external_function_casadi_struct_size();
+acados_size_t external_function_casadi_struct_size();
 //
 void external_function_casadi_set_fun(external_function_casadi *fun, void *value);
 //
@@ -170,7 +170,7 @@ void external_function_casadi_set_n_in(external_function_casadi *fun, void *valu
 //
 void external_function_casadi_set_n_out(external_function_casadi *fun, void *value);
 //
-int external_function_casadi_calculate_size(external_function_casadi *fun);
+acados_size_t external_function_casadi_calculate_size(external_function_casadi *fun);
 //
 void external_function_casadi_assign(external_function_casadi *fun, void *mem);
 //
@@ -215,7 +215,7 @@ typedef struct
 } external_function_param_casadi;
 
 //
-int external_function_param_casadi_struct_size();
+acados_size_t external_function_param_casadi_struct_size();
 //
 void external_function_param_casadi_set_fun(external_function_param_casadi *fun, void *value);
 //
@@ -229,7 +229,7 @@ void external_function_param_casadi_set_n_in(external_function_param_casadi *fun
 //
 void external_function_param_casadi_set_n_out(external_function_param_casadi *fun, void *value);
 //
-int external_function_param_casadi_calculate_size(external_function_param_casadi *fun, int np);
+acados_size_t external_function_param_casadi_calculate_size(external_function_param_casadi *fun, int np);
 //
 void external_function_param_casadi_assign(external_function_param_casadi *fun, void *mem);
 //

--- a/acados/utils/mem.c
+++ b/acados/utils/mem.c
@@ -51,6 +51,8 @@
 
 void make_int_multiple_of(acados_size_t num, acados_size_t *size)
 {
+    // avoid changes for num < 2
+    if(num>1)
     // round integer size up to next multiple of num;
 	*size = (*size + num - 1) / num * num;
 }

--- a/acados/utils/mem.c
+++ b/acados/utils/mem.c
@@ -49,7 +49,7 @@
 
 // #define _USE_MALLOC_  // acados_malloc = malloc / acados_malloc = calloc
 
-void make_int_multiple_of(int num, int *size)
+void make_int_multiple_of(acados_size_t num, acados_size_t *size)
 {
     // round integer size up to next multiple of num;
 	*size = (*size + num - 1) / num * num;
@@ -71,7 +71,7 @@ int align_char_to(int num, char **c_ptr)
 static void print_warning() { printf(" -- using dynamically allocated memory for debugging --\n"); }
 #endif
 
-void *acados_malloc(size_t nitems, size_t size)
+void *acados_malloc(size_t nitems, acados_size_t size)
 {
 #if defined(_USE_MALLOC_)
     void *ptr = malloc(nitems * size);
@@ -81,7 +81,7 @@ void *acados_malloc(size_t nitems, size_t size)
     return ptr;
 }
 
-void *acados_calloc(size_t nitems, size_t size)
+void *acados_calloc(size_t nitems, acados_size_t size)
 {
     void *ptr = calloc(nitems, size);
     return ptr;

--- a/acados/utils/mem.h
+++ b/acados/utils/mem.h
@@ -42,6 +42,8 @@ extern "C" {
 #include <stdio.h>
 #include <stdbool.h>
 
+#include "types.h"
+
 // blasfeo
 #include "blasfeo/include/blasfeo_d_aux.h"
 #include "blasfeo/include/blasfeo_d_aux_ext_dep.h"
@@ -59,17 +61,17 @@ typedef struct
 } module_solver;
 
 // make int counter of memory multiple of a number (typically 8 or 64)
-void make_int_multiple_of(int num, int *size);
+void make_int_multiple_of(acados_size_t num, acados_size_t *size);
 
 // align char pointer to number (typically 8 for pointers and doubles,
 // 64 for blasfeo structs) and return offset
 int align_char_to(int num, char **c_ptr);
 
 // switch between malloc and calloc (for valgrinding)
-void *acados_malloc(size_t nitems, size_t size);
+void *acados_malloc(size_t nitems, acados_size_t size);
 
 // uses always calloc
-void *acados_calloc(size_t nitems, size_t size);
+void *acados_calloc(size_t nitems, acados_size_t size);
 
 // allocate vector of pointers to vectors of doubles and advance pointer
 void assign_and_advance_double_ptrs(int n, double ***v, char **ptr);

--- a/acados/utils/mem.h
+++ b/acados/utils/mem.h
@@ -52,12 +52,12 @@ extern "C" {
 typedef struct
 {
     int (*fun)(void *);
-    int (*calculate_args_size)(void *);
+    acados_size_t (*calculate_args_size)(void *);
     void *(*assign_args)(void *);
     void (*initialize_default_args)(void *);
-    int (*calculate_memory_size)(void *);
+    acados_size_t (*calculate_memory_size)(void *);
     void *(*assign_memory)(void *);
-    int (*calculate_workspace_size)(void *);
+    acados_size_t (*calculate_workspace_size)(void *);
 } module_solver;
 
 // make int counter of memory multiple of a number (typically 8 or 64)

--- a/acados/utils/types.h
+++ b/acados/utils/types.h
@@ -40,6 +40,7 @@ extern "C" {
 #endif
 
 #include <stdbool.h>
+#include <stddef.h>
 
 #define MAX_STR_LEN 256
 #define ACADOS_EPS 1e-12
@@ -51,7 +52,7 @@ extern "C" {
 
 typedef double real_t;
 typedef int int_t;
-
+typedef size_t acados_size_t;
 
 
 typedef int (*casadi_function_t)(const double** arg, double** res, int* iw, double* w, void* mem);

--- a/examples/c/no_interface_examples/mass_spring_example_no_interface.c
+++ b/examples/c/no_interface_examples/mass_spring_example_no_interface.c
@@ -118,20 +118,20 @@ int main() {
         {
             int N2 = N2_values[jj];
 
-			int config_size = ocp_qp_xcond_solver_config_calculate_size();
+			acados_size_t config_size = ocp_qp_xcond_solver_config_calculate_size();
 			void *config_mem = malloc(config_size);
 			ocp_qp_xcond_solver_config *solver_config = ocp_qp_xcond_solver_config_assign(config_mem);
 
-			int solver_opts_size;
+			acados_size_t solver_opts_size;
 			void *solver_opts_mem;
 			void *solver_opts = NULL;
 			ocp_qp_xcond_solver_opts *xcond_solver_opts;
 			ocp_qp_hpipm_opts *hpipm_opts;
 			ocp_qp_partial_condensing_opts *part_cond_opts;
-			int solver_mem_size;
+			acados_size_t solver_mem_size;
 			void *solver_mem_mem;
 			void *solver_mem;
-			int solver_work_size;
+			acados_size_t solver_work_size;
 			void *solver_work;
 			dense_qp_hpipm_opts *dense_hpipm_opts;
 
@@ -328,7 +328,7 @@ int main() {
 			 * ocp qp out
 			 ************************************************/
 
-			int qp_out_size = ocp_qp_out_calculate_size(solver_config, qp_dims);
+			acados_size_t qp_out_size = ocp_qp_out_calculate_size(solver_config, qp_dims);
 			void *qp_out_mem = malloc(qp_out_size);
 			ocp_qp_out *qp_out = ocp_qp_out_assign(solver_config, qp_dims, qp_out_mem);
 
@@ -382,12 +382,12 @@ int main() {
             * compute residuals
             ************************************************/
 
-			int res_size = ocp_qp_res_calculate_size(qp_dims);
+			acados_size_t res_size = ocp_qp_res_calculate_size(qp_dims);
 // 		printf("\nres size = %d\n", res_size);
 			void *res_mem = malloc(res_size);
 			ocp_qp_res *qp_res = ocp_qp_res_assign(qp_dims, res_mem);
 
-			int res_work_size = ocp_qp_res_workspace_calculate_size(qp_dims);
+			acados_size_t res_work_size = ocp_qp_res_workspace_calculate_size(qp_dims);
 // 		printf("\nres work size = %d\n", res_work_size);
 			void *res_work_mem = malloc(res_work_size);
 			ocp_qp_res_ws *res_ws = ocp_qp_res_workspace_assign(qp_dims, res_work_mem);

--- a/examples/c/no_interface_examples/mass_spring_example_no_interface.c
+++ b/examples/c/no_interface_examples/mass_spring_example_no_interface.c
@@ -118,20 +118,20 @@ int main() {
         {
             int N2 = N2_values[jj];
 
-			acados_size_t config_size = ocp_qp_xcond_solver_config_calculate_size();
+			int config_size = ocp_qp_xcond_solver_config_calculate_size();
 			void *config_mem = malloc(config_size);
 			ocp_qp_xcond_solver_config *solver_config = ocp_qp_xcond_solver_config_assign(config_mem);
 
-			acados_size_t solver_opts_size;
+			int solver_opts_size;
 			void *solver_opts_mem;
 			void *solver_opts = NULL;
 			ocp_qp_xcond_solver_opts *xcond_solver_opts;
 			ocp_qp_hpipm_opts *hpipm_opts;
 			ocp_qp_partial_condensing_opts *part_cond_opts;
-			acados_size_t solver_mem_size;
+			int solver_mem_size;
 			void *solver_mem_mem;
 			void *solver_mem;
-			acados_size_t solver_work_size;
+			int solver_work_size;
 			void *solver_work;
 			dense_qp_hpipm_opts *dense_hpipm_opts;
 
@@ -328,7 +328,7 @@ int main() {
 			 * ocp qp out
 			 ************************************************/
 
-			acados_size_t qp_out_size = ocp_qp_out_calculate_size(solver_config, qp_dims);
+			int qp_out_size = ocp_qp_out_calculate_size(solver_config, qp_dims);
 			void *qp_out_mem = malloc(qp_out_size);
 			ocp_qp_out *qp_out = ocp_qp_out_assign(solver_config, qp_dims, qp_out_mem);
 
@@ -382,12 +382,12 @@ int main() {
             * compute residuals
             ************************************************/
 
-			acados_size_t res_size = ocp_qp_res_calculate_size(qp_dims);
+			int res_size = ocp_qp_res_calculate_size(qp_dims);
 // 		printf("\nres size = %d\n", res_size);
 			void *res_mem = malloc(res_size);
 			ocp_qp_res *qp_res = ocp_qp_res_assign(qp_dims, res_mem);
 
-			acados_size_t res_work_size = ocp_qp_res_workspace_calculate_size(qp_dims);
+			int res_work_size = ocp_qp_res_workspace_calculate_size(qp_dims);
 // 		printf("\nres work size = %d\n", res_work_size);
 			void *res_work_mem = malloc(res_work_size);
 			ocp_qp_res_ws *res_ws = ocp_qp_res_workspace_assign(qp_dims, res_work_mem);

--- a/examples/c/no_interface_examples/mass_spring_model/mass_spring_qp.c
+++ b/examples/c/no_interface_examples/mass_spring_model/mass_spring_qp.c
@@ -202,7 +202,7 @@ ocp_qp_xcond_solver_dims *create_ocp_qp_dims_mass_spring(ocp_qp_xcond_solver_con
 
 
     // dims
-    int dims_size = ocp_qp_xcond_solver_dims_calculate_size(config, N);
+    acados_size_t dims_size = ocp_qp_xcond_solver_dims_calculate_size(config, N);
     void *dims_mem = malloc(dims_size);
     ocp_qp_xcond_solver_dims *dims = ocp_qp_xcond_solver_dims_assign(config, N, dims_mem);
 
@@ -656,7 +656,7 @@ ocp_qp_dims *create_ocp_qp_dims_mass_spring_soft_constr(int N, int nx_, int nu_,
 
 
     // dims
-    int dims_size = ocp_qp_dims_calculate_size(N);
+    acados_size_t dims_size = ocp_qp_dims_calculate_size(N);
     void *dims_mem = malloc(dims_size);
     ocp_qp_dims *dims = ocp_qp_dims_assign(N, dims_mem);
 

--- a/examples/c/no_interface_examples/mass_spring_model/mass_spring_qp.c
+++ b/examples/c/no_interface_examples/mass_spring_model/mass_spring_qp.c
@@ -202,7 +202,7 @@ ocp_qp_xcond_solver_dims *create_ocp_qp_dims_mass_spring(ocp_qp_xcond_solver_con
 
 
     // dims
-    acados_size_t dims_size = ocp_qp_xcond_solver_dims_calculate_size(config, N);
+    int dims_size = ocp_qp_xcond_solver_dims_calculate_size(config, N);
     void *dims_mem = malloc(dims_size);
     ocp_qp_xcond_solver_dims *dims = ocp_qp_xcond_solver_dims_assign(config, N, dims_mem);
 
@@ -656,7 +656,7 @@ ocp_qp_dims *create_ocp_qp_dims_mass_spring_soft_constr(int N, int nx_, int nu_,
 
 
     // dims
-    acados_size_t dims_size = ocp_qp_dims_calculate_size(N);
+    int dims_size = ocp_qp_dims_calculate_size(N);
     void *dims_mem = malloc(dims_size);
     ocp_qp_dims *dims = ocp_qp_dims_assign(N, dims_mem);
 

--- a/examples/c/no_interface_examples/mass_spring_nmpc_example.c
+++ b/examples/c/no_interface_examples/mass_spring_nmpc_example.c
@@ -426,7 +426,7 @@ int main() {
     * config
     ************************************************/
 
-    acados_size_t config_size = ocp_nlp_config_calculate_size(N);
+    int config_size = ocp_nlp_config_calculate_size(N);
     void *config_mem = malloc(config_size);
     ocp_nlp_config *config = ocp_nlp_config_assign(N, config_mem);
 
@@ -470,7 +470,7 @@ int main() {
     * ocp_nlp_dims
     ************************************************/
 
-    acados_size_t dims_size = ocp_nlp_dims_calculate_size(config);
+    int dims_size = ocp_nlp_dims_calculate_size(config);
     void *dims_mem = malloc(dims_size);
     ocp_nlp_dims *dims = ocp_nlp_dims_assign(config, dims_mem);
 
@@ -805,7 +805,7 @@ int main() {
     * sqp workspace
     ************************************************/
 
-    acados_size_t workspace_size = ocp_nlp_sqp_workspace_calculate_size(config, dims, nlp_opts);
+    int workspace_size = ocp_nlp_sqp_workspace_calculate_size(config, dims, nlp_opts);
     void *nlp_work = acados_malloc(workspace_size, 1);
 
     /************************************************

--- a/examples/c/no_interface_examples/mass_spring_nmpc_example.c
+++ b/examples/c/no_interface_examples/mass_spring_nmpc_example.c
@@ -426,7 +426,7 @@ int main() {
     * config
     ************************************************/
 
-    int config_size = ocp_nlp_config_calculate_size(N);
+    acados_size_t config_size = ocp_nlp_config_calculate_size(N);
     void *config_mem = malloc(config_size);
     ocp_nlp_config *config = ocp_nlp_config_assign(N, config_mem);
 
@@ -470,7 +470,7 @@ int main() {
     * ocp_nlp_dims
     ************************************************/
 
-    int dims_size = ocp_nlp_dims_calculate_size(config);
+    acados_size_t dims_size = ocp_nlp_dims_calculate_size(config);
     void *dims_mem = malloc(dims_size);
     ocp_nlp_dims *dims = ocp_nlp_dims_assign(config, dims_mem);
 
@@ -805,7 +805,7 @@ int main() {
     * sqp workspace
     ************************************************/
 
-    int workspace_size = ocp_nlp_sqp_workspace_calculate_size(config, dims, nlp_opts);
+    acados_size_t workspace_size = ocp_nlp_sqp_workspace_calculate_size(config, dims, nlp_opts);
     void *nlp_work = acados_malloc(workspace_size, 1);
 
     /************************************************

--- a/examples/c/no_interface_examples/nonlinear_chain_ocp_nlp_no_interface.c
+++ b/examples/c/no_interface_examples/nonlinear_chain_ocp_nlp_no_interface.c
@@ -1211,7 +1211,7 @@ int main() {
     * config
     ************************************************/
 
-	int config_size = ocp_nlp_config_calculate_size(NN);
+	acados_size_t config_size = ocp_nlp_config_calculate_size(NN);
 	void *config_mem = malloc(config_size);
 	ocp_nlp_config *config = ocp_nlp_config_assign(NN, config_mem);
 
@@ -1296,7 +1296,7 @@ int main() {
     * ocp_nlp_dims
     ************************************************/
 
-	int dims_size = ocp_nlp_dims_calculate_size(config);
+	acados_size_t dims_size = ocp_nlp_dims_calculate_size(config);
 	void *dims_mem = malloc(dims_size);
 	ocp_nlp_dims *dims = ocp_nlp_dims_assign(config, dims_mem);
 //	ocp_nlp_dims_initialize(config, nx, nu, ny, nbx, nbu, ng, nh, nq, ns, nz, dims);
@@ -1332,7 +1332,7 @@ int main() {
 
 	select_dynamics_casadi(NN, NMF, expl_vde_for, expl_ode_jac, impl_ode_fun, impl_ode_fun_jac_x_xdot, impl_ode_fun_jac_x_xdot_u, impl_ode_jac_x_xdot_u, erk4_casadi);
 
-	int tmp_size;
+	acados_size_t tmp_size;
 	char *c_ptr;
 #if DYNAMICS==0 | DYNAMICS==1
 
@@ -1944,7 +1944,7 @@ int main() {
     * sqp workspace
     ************************************************/
 
-    int workspace_size = ocp_nlp_sqp_workspace_calculate_size(config, dims, nlp_opts);
+    acados_size_t workspace_size = ocp_nlp_sqp_workspace_calculate_size(config, dims, nlp_opts);
     void *nlp_work = acados_malloc(workspace_size, 1);
 
     /************************************************

--- a/examples/c/no_interface_examples/nonlinear_chain_ocp_nlp_no_interface.c
+++ b/examples/c/no_interface_examples/nonlinear_chain_ocp_nlp_no_interface.c
@@ -1211,7 +1211,7 @@ int main() {
     * config
     ************************************************/
 
-	acados_size_t config_size = ocp_nlp_config_calculate_size(NN);
+	int config_size = ocp_nlp_config_calculate_size(NN);
 	void *config_mem = malloc(config_size);
 	ocp_nlp_config *config = ocp_nlp_config_assign(NN, config_mem);
 
@@ -1296,7 +1296,7 @@ int main() {
     * ocp_nlp_dims
     ************************************************/
 
-	acados_size_t dims_size = ocp_nlp_dims_calculate_size(config);
+	int dims_size = ocp_nlp_dims_calculate_size(config);
 	void *dims_mem = malloc(dims_size);
 	ocp_nlp_dims *dims = ocp_nlp_dims_assign(config, dims_mem);
 //	ocp_nlp_dims_initialize(config, nx, nu, ny, nbx, nbu, ng, nh, nq, ns, nz, dims);
@@ -1332,7 +1332,7 @@ int main() {
 
 	select_dynamics_casadi(NN, NMF, expl_vde_for, expl_ode_jac, impl_ode_fun, impl_ode_fun_jac_x_xdot, impl_ode_fun_jac_x_xdot_u, impl_ode_jac_x_xdot_u, erk4_casadi);
 
-	acados_size_t tmp_size;
+	int tmp_size;
 	char *c_ptr;
 #if DYNAMICS==0 | DYNAMICS==1
 
@@ -1944,7 +1944,7 @@ int main() {
     * sqp workspace
     ************************************************/
 
-    acados_size_t workspace_size = ocp_nlp_sqp_workspace_calculate_size(config, dims, nlp_opts);
+    int workspace_size = ocp_nlp_sqp_workspace_calculate_size(config, dims, nlp_opts);
     void *nlp_work = acados_malloc(workspace_size, 1);
 
     /************************************************

--- a/examples/c/no_interface_examples/sim_wt_model_no_interface.c
+++ b/examples/c/no_interface_examples/sim_wt_model_no_interface.c
@@ -97,7 +97,7 @@ int main()
 	exfun_forw_vde.casadi_n_in = &vde_energy_balanced_model_n_in;
 	exfun_forw_vde.casadi_n_out = &vde_energy_balanced_model_n_out;
 
-	acados_size_t forw_vde_size = external_function_casadi_calculate_size(&exfun_forw_vde);
+	int forw_vde_size = external_function_casadi_calculate_size(&exfun_forw_vde);
 	void *forw_vde_mem = malloc(forw_vde_size);
 	external_function_casadi_assign(&exfun_forw_vde, forw_vde_mem);
 
@@ -111,7 +111,7 @@ int main()
 	exfun_adj_vde.casadi_n_in = &vde_adj_energy_balanced_model_n_in;
 	exfun_adj_vde.casadi_n_out = &vde_adj_energy_balanced_model_n_out;
 
-	acados_size_t adj_vde_size = external_function_casadi_calculate_size(&exfun_adj_vde);
+	int adj_vde_size = external_function_casadi_calculate_size(&exfun_adj_vde);
 	void *adj_vde_mem = malloc(adj_vde_size);
 	external_function_casadi_assign(&exfun_adj_vde, adj_vde_mem);
 
@@ -125,7 +125,7 @@ int main()
 	exfun_jac.casadi_n_in = &jac_energy_balanced_model_n_in;
 	exfun_jac.casadi_n_out = &jac_energy_balanced_model_n_out;
 
-	acados_size_t jac_size = external_function_casadi_calculate_size(&exfun_jac);
+	int jac_size = external_function_casadi_calculate_size(&exfun_jac);
 	void *jac_mem = malloc(jac_size);
 	external_function_casadi_assign(&exfun_jac, jac_mem);
 
@@ -139,7 +139,7 @@ int main()
 	exfun_hess_ode.casadi_n_in = &vde_hess_energy_balanced_model_n_in;
 	exfun_hess_ode.casadi_n_out = &vde_hess_energy_balanced_model_n_out;
 
-	acados_size_t hess_ode_size = external_function_casadi_calculate_size(&exfun_hess_ode);
+	int hess_ode_size = external_function_casadi_calculate_size(&exfun_hess_ode);
 	void *hess_ode_mem = malloc(hess_ode_size);
 	external_function_casadi_assign(&exfun_hess_ode, hess_ode_mem);
 
@@ -157,7 +157,7 @@ int main()
 	exfun_ode.casadi_n_in = &impl_odeFun_energy_balanced_model_n_in;
 	exfun_ode.casadi_n_out = &impl_odeFun_energy_balanced_model_n_out;
 
-	acados_size_t ode_size = external_function_casadi_calculate_size(&exfun_ode);
+	int ode_size = external_function_casadi_calculate_size(&exfun_ode);
 	void *ode_mem = malloc(ode_size);
 	external_function_casadi_assign(&exfun_ode, ode_mem);
 
@@ -171,7 +171,7 @@ int main()
 	exfun_jac_x_ode.casadi_n_in = &impl_jacFun_x_energy_balanced_model_n_in;
 	exfun_jac_x_ode.casadi_n_out = &impl_jacFun_x_energy_balanced_model_n_out;
 
-	acados_size_t jac_x_ode_size = external_function_casadi_calculate_size(&exfun_jac_x_ode);
+	int jac_x_ode_size = external_function_casadi_calculate_size(&exfun_jac_x_ode);
 	void *jac_x_ode_mem = malloc(jac_x_ode_size);
 	external_function_casadi_assign(&exfun_jac_x_ode, jac_x_ode_mem);
 
@@ -185,7 +185,7 @@ int main()
 	exfun_jac_xdot_ode.casadi_n_in = &impl_jacFun_xdot_energy_balanced_model_n_in;
 	exfun_jac_xdot_ode.casadi_n_out = &impl_jacFun_xdot_energy_balanced_model_n_out;
 
-	acados_size_t jac_xdot_ode_size = external_function_casadi_calculate_size(&exfun_jac_xdot_ode);
+	int jac_xdot_ode_size = external_function_casadi_calculate_size(&exfun_jac_xdot_ode);
 	void *jac_xdot_ode_mem = malloc(jac_xdot_ode_size);
 	external_function_casadi_assign(&exfun_jac_xdot_ode, jac_xdot_ode_mem);
 
@@ -199,7 +199,7 @@ int main()
 	exfun_jac_u_ode.casadi_n_in = &impl_jacFun_u_energy_balanced_model_n_in;
 	exfun_jac_u_ode.casadi_n_out = &impl_jacFun_u_energy_balanced_model_n_out;
 
-	acados_size_t jac_u_ode_size = external_function_casadi_calculate_size(&exfun_jac_u_ode);
+	int jac_u_ode_size = external_function_casadi_calculate_size(&exfun_jac_u_ode);
 	void *jac_u_ode_mem = malloc(jac_u_ode_size);
 	external_function_casadi_assign(&exfun_jac_u_ode, jac_u_ode_mem);
 
@@ -215,7 +215,7 @@ int main()
 * sim config
 ************************************************/
 
-		acados_size_t config_size = sim_config_calculate_size();
+		int config_size = sim_config_calculate_size();
 		void *config_mem = malloc(config_size);
 		sim_config *config = sim_config_assign(config_mem);
 
@@ -250,7 +250,7 @@ int main()
 * sim dims
 ************************************************/
 
-		acados_size_t dims_size = sim_dims_calculate_size();
+		int dims_size = sim_dims_calculate_size();
 		void *dims_mem = malloc(dims_size);
 		sim_dims *dims = sim_dims_assign(dims_mem);
 
@@ -261,7 +261,7 @@ int main()
 * sim opts
 ************************************************/
 
-		acados_size_t opts_size = config->opts_calculate_size(config, dims);
+		int opts_size = config->opts_calculate_size(config, dims);
 		void *opts_mem = malloc(opts_size);
 		sim_opts *opts = config->opts_assign(config, dims, opts_mem);
 		config->opts_initialize_default(config, dims, opts);
@@ -273,7 +273,7 @@ int main()
 * sim memory
 ************************************************/
 
-		acados_size_t mem_size = config->memory_calculate_size(config, dims, opts);
+		int mem_size = config->memory_calculate_size(config, dims, opts);
 		void *mem_mem = malloc(mem_size);
 		void *mem = config->memory_assign(config, dims, opts, mem_mem);
 
@@ -281,14 +281,14 @@ int main()
 * sim workspace
 ************************************************/
 
-		acados_size_t work_size = config->workspace_calculate_size(config, dims, opts);
+		int work_size = config->workspace_calculate_size(config, dims, opts);
 		void *work = malloc(work_size);
 
 /************************************************
 * sim in
 ************************************************/
 
-		acados_size_t in_size = sim_in_calculate_size(config, dims);
+		int in_size = sim_in_calculate_size(config, dims);
 		void *in_mem = malloc(in_size);
 		sim_in *in = sim_in_assign(config, dims, in_mem);
 
@@ -352,7 +352,7 @@ int main()
 * sim out
 ************************************************/
 
-		acados_size_t out_size = sim_out_calculate_size(config, dims);
+		int out_size = sim_out_calculate_size(config, dims);
 		void *out_mem = malloc(out_size);
 		sim_out *out = sim_out_assign(config, dims, out_mem);
 

--- a/examples/c/no_interface_examples/sim_wt_model_no_interface.c
+++ b/examples/c/no_interface_examples/sim_wt_model_no_interface.c
@@ -97,7 +97,7 @@ int main()
 	exfun_forw_vde.casadi_n_in = &vde_energy_balanced_model_n_in;
 	exfun_forw_vde.casadi_n_out = &vde_energy_balanced_model_n_out;
 
-	int forw_vde_size = external_function_casadi_calculate_size(&exfun_forw_vde);
+	acados_size_t forw_vde_size = external_function_casadi_calculate_size(&exfun_forw_vde);
 	void *forw_vde_mem = malloc(forw_vde_size);
 	external_function_casadi_assign(&exfun_forw_vde, forw_vde_mem);
 
@@ -111,7 +111,7 @@ int main()
 	exfun_adj_vde.casadi_n_in = &vde_adj_energy_balanced_model_n_in;
 	exfun_adj_vde.casadi_n_out = &vde_adj_energy_balanced_model_n_out;
 
-	int adj_vde_size = external_function_casadi_calculate_size(&exfun_adj_vde);
+	acados_size_t adj_vde_size = external_function_casadi_calculate_size(&exfun_adj_vde);
 	void *adj_vde_mem = malloc(adj_vde_size);
 	external_function_casadi_assign(&exfun_adj_vde, adj_vde_mem);
 
@@ -125,7 +125,7 @@ int main()
 	exfun_jac.casadi_n_in = &jac_energy_balanced_model_n_in;
 	exfun_jac.casadi_n_out = &jac_energy_balanced_model_n_out;
 
-	int jac_size = external_function_casadi_calculate_size(&exfun_jac);
+	acados_size_t jac_size = external_function_casadi_calculate_size(&exfun_jac);
 	void *jac_mem = malloc(jac_size);
 	external_function_casadi_assign(&exfun_jac, jac_mem);
 
@@ -139,7 +139,7 @@ int main()
 	exfun_hess_ode.casadi_n_in = &vde_hess_energy_balanced_model_n_in;
 	exfun_hess_ode.casadi_n_out = &vde_hess_energy_balanced_model_n_out;
 
-	int hess_ode_size = external_function_casadi_calculate_size(&exfun_hess_ode);
+	acados_size_t hess_ode_size = external_function_casadi_calculate_size(&exfun_hess_ode);
 	void *hess_ode_mem = malloc(hess_ode_size);
 	external_function_casadi_assign(&exfun_hess_ode, hess_ode_mem);
 
@@ -157,7 +157,7 @@ int main()
 	exfun_ode.casadi_n_in = &impl_odeFun_energy_balanced_model_n_in;
 	exfun_ode.casadi_n_out = &impl_odeFun_energy_balanced_model_n_out;
 
-	int ode_size = external_function_casadi_calculate_size(&exfun_ode);
+	acados_size_t ode_size = external_function_casadi_calculate_size(&exfun_ode);
 	void *ode_mem = malloc(ode_size);
 	external_function_casadi_assign(&exfun_ode, ode_mem);
 
@@ -171,7 +171,7 @@ int main()
 	exfun_jac_x_ode.casadi_n_in = &impl_jacFun_x_energy_balanced_model_n_in;
 	exfun_jac_x_ode.casadi_n_out = &impl_jacFun_x_energy_balanced_model_n_out;
 
-	int jac_x_ode_size = external_function_casadi_calculate_size(&exfun_jac_x_ode);
+	acados_size_t jac_x_ode_size = external_function_casadi_calculate_size(&exfun_jac_x_ode);
 	void *jac_x_ode_mem = malloc(jac_x_ode_size);
 	external_function_casadi_assign(&exfun_jac_x_ode, jac_x_ode_mem);
 
@@ -185,7 +185,7 @@ int main()
 	exfun_jac_xdot_ode.casadi_n_in = &impl_jacFun_xdot_energy_balanced_model_n_in;
 	exfun_jac_xdot_ode.casadi_n_out = &impl_jacFun_xdot_energy_balanced_model_n_out;
 
-	int jac_xdot_ode_size = external_function_casadi_calculate_size(&exfun_jac_xdot_ode);
+	acados_size_t jac_xdot_ode_size = external_function_casadi_calculate_size(&exfun_jac_xdot_ode);
 	void *jac_xdot_ode_mem = malloc(jac_xdot_ode_size);
 	external_function_casadi_assign(&exfun_jac_xdot_ode, jac_xdot_ode_mem);
 
@@ -199,7 +199,7 @@ int main()
 	exfun_jac_u_ode.casadi_n_in = &impl_jacFun_u_energy_balanced_model_n_in;
 	exfun_jac_u_ode.casadi_n_out = &impl_jacFun_u_energy_balanced_model_n_out;
 
-	int jac_u_ode_size = external_function_casadi_calculate_size(&exfun_jac_u_ode);
+	acados_size_t jac_u_ode_size = external_function_casadi_calculate_size(&exfun_jac_u_ode);
 	void *jac_u_ode_mem = malloc(jac_u_ode_size);
 	external_function_casadi_assign(&exfun_jac_u_ode, jac_u_ode_mem);
 
@@ -215,7 +215,7 @@ int main()
 * sim config
 ************************************************/
 
-		int config_size = sim_config_calculate_size();
+		acados_size_t config_size = sim_config_calculate_size();
 		void *config_mem = malloc(config_size);
 		sim_config *config = sim_config_assign(config_mem);
 
@@ -250,7 +250,7 @@ int main()
 * sim dims
 ************************************************/
 
-		int dims_size = sim_dims_calculate_size();
+		acados_size_t dims_size = sim_dims_calculate_size();
 		void *dims_mem = malloc(dims_size);
 		sim_dims *dims = sim_dims_assign(dims_mem);
 
@@ -261,7 +261,7 @@ int main()
 * sim opts
 ************************************************/
 
-		int opts_size = config->opts_calculate_size(config, dims);
+		acados_size_t opts_size = config->opts_calculate_size(config, dims);
 		void *opts_mem = malloc(opts_size);
 		sim_opts *opts = config->opts_assign(config, dims, opts_mem);
 		config->opts_initialize_default(config, dims, opts);
@@ -273,7 +273,7 @@ int main()
 * sim memory
 ************************************************/
 
-		int mem_size = config->memory_calculate_size(config, dims, opts);
+		acados_size_t mem_size = config->memory_calculate_size(config, dims, opts);
 		void *mem_mem = malloc(mem_size);
 		void *mem = config->memory_assign(config, dims, opts, mem_mem);
 
@@ -281,14 +281,14 @@ int main()
 * sim workspace
 ************************************************/
 
-		int work_size = config->workspace_calculate_size(config, dims, opts);
+		acados_size_t work_size = config->workspace_calculate_size(config, dims, opts);
 		void *work = malloc(work_size);
 
 /************************************************
 * sim in
 ************************************************/
 
-		int in_size = sim_in_calculate_size(config, dims);
+		acados_size_t in_size = sim_in_calculate_size(config, dims);
 		void *in_mem = malloc(in_size);
 		sim_in *in = sim_in_assign(config, dims, in_mem);
 
@@ -352,7 +352,7 @@ int main()
 * sim out
 ************************************************/
 
-		int out_size = sim_out_calculate_size(config, dims);
+		acados_size_t out_size = sim_out_calculate_size(config, dims);
 		void *out_mem = malloc(out_size);
 		sim_out *out = sim_out_assign(config, dims, out_mem);
 

--- a/examples/c/regularization.c
+++ b/examples/c/regularization.c
@@ -58,7 +58,7 @@ int main()
      * config
      ************************************************/
 
-	int config_size = ocp_nlp_reg_config_calculate_size();
+	acados_size_t config_size = ocp_nlp_reg_config_calculate_size();
 	void * config_mem = malloc(config_size);
 	ocp_nlp_reg_config *config = ocp_nlp_reg_config_assign(config_mem);
 
@@ -85,7 +85,7 @@ int main()
 		nu[ii] = nu_;
 	nu[N] = 0;
 
-	int dims_size = config->dims_calculate_size(N);
+	acados_size_t dims_size = config->dims_calculate_size(N);
 	void * dims_mem = malloc(dims_size);
 	ocp_nlp_reg_dims *dims = config->dims_assign(N, dims_mem);
 
@@ -99,7 +99,7 @@ int main()
      * opts
      ************************************************/
 
-	int opts_size = config->opts_calculate_size();
+	acados_size_t opts_size = config->opts_calculate_size();
 	void * opts_mem = malloc(opts_size);
 	void *opts = config->opts_assign(opts_mem);
 
@@ -114,7 +114,7 @@ int main()
      * memory
      ************************************************/
 
-	int memory_size = config->memory_calculate_size(config, dims, opts);
+	acados_size_t memory_size = config->memory_calculate_size(config, dims, opts);
 	void * memory_mem = malloc(memory_size);
 	void *memory = config->memory_assign(config, dims, opts, memory_mem);
 

--- a/examples/c/sim_gnsf_crane.c
+++ b/examples/c/sim_gnsf_crane.c
@@ -142,7 +142,7 @@ int main() {
     // sim_dims *dims = (sim_dims *) gnsf_dim; // typecasting works as gnsf_dims has entries of sim_dims at the beginning
 
     // set up gnsf_opts
-    int opts_size = config->opts_calculate_size(config, dims);
+    acados_size_t opts_size = config->opts_calculate_size(config, dims);
 	void *opts_mem = malloc(opts_size);
     sim_opts *opts = config->opts_assign(config, dims, opts_mem);
     config->opts_initialize_default(config, dims, opts);

--- a/interfaces/acados_c/condensing_interface.c
+++ b/interfaces/acados_c/condensing_interface.c
@@ -46,7 +46,7 @@
 
 ocp_qp_xcond_config *ocp_qp_condensing_config_create(condensing_plan *plan)
 {
-    int bytes = ocp_qp_condensing_config_calculate_size();
+    acados_size_t bytes = ocp_qp_condensing_config_calculate_size();
     void *ptr = calloc(1, bytes);
     ocp_qp_xcond_config *config = ocp_qp_condensing_config_assign(ptr);
 
@@ -64,7 +64,7 @@ ocp_qp_xcond_config *ocp_qp_condensing_config_create(condensing_plan *plan)
 
 void *ocp_qp_condensing_opts_create(ocp_qp_xcond_config *config, void *dims_)
 {
-    int bytes = config->opts_calculate_size(dims_);
+    acados_size_t bytes = config->opts_calculate_size(dims_);
 
     void *ptr = calloc(1, bytes);
 
@@ -75,9 +75,9 @@ void *ocp_qp_condensing_opts_create(ocp_qp_xcond_config *config, void *dims_)
     return opts;
 }
 
-int ocp_qp_condensing_calculate_size(ocp_qp_xcond_config *config, void *dims_, void *opts_)
+acados_size_t ocp_qp_condensing_calculate_size(ocp_qp_xcond_config *config, void *dims_, void *opts_)
 {
-    int bytes = sizeof(condensing_module);
+    acados_size_t bytes = sizeof(condensing_module);
 
     bytes += config->memory_calculate_size(dims_, opts_);
     bytes += config->workspace_calculate_size(dims_, opts_);
@@ -112,7 +112,7 @@ condensing_module *ocp_qp_condensing_create(ocp_qp_xcond_config *config, void *d
                                             void *opts_)
 {
     config->opts_update(dims_, opts_);
-    int bytes = ocp_qp_condensing_calculate_size(config, dims_, opts_);
+    acados_size_t bytes = ocp_qp_condensing_calculate_size(config, dims_, opts_);
 
     void *ptr = calloc(1, bytes);
 

--- a/interfaces/acados_c/condensing_interface.h
+++ b/interfaces/acados_c/condensing_interface.h
@@ -65,7 +65,7 @@ ocp_qp_xcond_config *ocp_qp_condensing_config_create(condensing_plan *plan);
 //
 void *ocp_qp_condensing_opts_create(ocp_qp_xcond_config *config, void *dims_);
 //
-int ocp_qp_condensing_calculate_size(ocp_qp_xcond_config *config, void *dims_, void *opts_);
+acados_size_t ocp_qp_condensing_calculate_size(ocp_qp_xcond_config *config, void *dims_, void *opts_);
 //
 condensing_module *ocp_qp_condensing_assign(ocp_qp_xcond_config *config, void *dims_,
                                             void *opts_, void *raw_memory);

--- a/interfaces/acados_c/dense_qp_interface.c
+++ b/interfaces/acados_c/dense_qp_interface.c
@@ -59,7 +59,7 @@
 
 qp_solver_config *dense_qp_config_create(dense_qp_solver_plan *plan)
 {
-    int bytes = dense_qp_solver_config_calculate_size();
+    acados_size_t bytes = dense_qp_solver_config_calculate_size();
     void *ptr = calloc(1, bytes);
     qp_solver_config *solver_config = dense_qp_solver_config_assign(ptr);
 
@@ -96,7 +96,7 @@ qp_solver_config *dense_qp_config_create(dense_qp_solver_plan *plan)
 
 dense_qp_dims *dense_qp_dims_create()
 {
-    int bytes = dense_qp_dims_calculate_size();
+    acados_size_t bytes = dense_qp_dims_calculate_size();
 
     void *ptr = calloc(1, bytes);
 
@@ -107,7 +107,7 @@ dense_qp_dims *dense_qp_dims_create()
 
 dense_qp_in *dense_qp_in_create(qp_solver_config *config, dense_qp_dims *dims)
 {
-    int bytes = dense_qp_in_calculate_size(dims);
+    acados_size_t bytes = dense_qp_in_calculate_size(dims);
 
     void *ptr = calloc(1, bytes);
 
@@ -118,7 +118,7 @@ dense_qp_in *dense_qp_in_create(qp_solver_config *config, dense_qp_dims *dims)
 
 dense_qp_out *dense_qp_out_create(qp_solver_config *config, dense_qp_dims *dims)
 {
-    int bytes = dense_qp_out_calculate_size(dims);
+    acados_size_t bytes = dense_qp_out_calculate_size(dims);
 
     void *ptr = calloc(1, bytes);
 
@@ -129,7 +129,7 @@ dense_qp_out *dense_qp_out_create(qp_solver_config *config, dense_qp_dims *dims)
 
 void *dense_qp_opts_create(qp_solver_config *config, dense_qp_dims *dims)
 {
-    int bytes = config->opts_calculate_size(config, dims);
+    acados_size_t bytes = config->opts_calculate_size(config, dims);
 
     void *ptr = calloc(1, bytes);
 
@@ -140,9 +140,9 @@ void *dense_qp_opts_create(qp_solver_config *config, dense_qp_dims *dims)
     return opts;
 }
 
-int dense_qp_calculate_size(qp_solver_config *config, dense_qp_dims *dims, void *opts_)
+acados_size_t dense_qp_calculate_size(qp_solver_config *config, dense_qp_dims *dims, void *opts_)
 {
-    int bytes = sizeof(dense_qp_solver);
+    acados_size_t bytes = sizeof(dense_qp_solver);
 
     bytes += config->memory_calculate_size(config, dims, opts_);
     bytes += config->workspace_calculate_size(config, dims, opts_);
@@ -177,7 +177,7 @@ dense_qp_solver *dense_qp_assign(qp_solver_config *config, dense_qp_dims *dims, 
 
 dense_qp_solver *dense_qp_create(qp_solver_config *config, dense_qp_dims *dims, void *opts_)
 {
-    int bytes = dense_qp_calculate_size(config, dims, opts_);
+    acados_size_t bytes = dense_qp_calculate_size(config, dims, opts_);
 
     void *ptr = calloc(1, bytes);
 
@@ -194,7 +194,7 @@ int dense_qp_solve(dense_qp_solver *solver, dense_qp_in *qp_in, dense_qp_out *qp
 
 static dense_qp_res *dense_qp_res_create(dense_qp_dims *dims)
 {
-    int size = dense_qp_res_calculate_size(dims);
+    acados_size_t size = dense_qp_res_calculate_size(dims);
     void *ptr = acados_malloc(size, 1);
     dense_qp_res *qp_res = dense_qp_res_assign(dims, ptr);
     return qp_res;
@@ -202,7 +202,7 @@ static dense_qp_res *dense_qp_res_create(dense_qp_dims *dims)
 
 static dense_qp_res_ws *dense_qp_res_workspace_create(dense_qp_dims *dims)
 {
-    int size = dense_qp_res_workspace_calculate_size(dims);
+    acados_size_t size = dense_qp_res_workspace_calculate_size(dims);
     void *ptr = acados_malloc(size, 1);
     dense_qp_res_ws *res_ws = dense_qp_res_workspace_assign(dims, ptr);
     return res_ws;

--- a/interfaces/acados_c/dense_qp_interface.h
+++ b/interfaces/acados_c/dense_qp_interface.h
@@ -67,7 +67,7 @@ dense_qp_out *dense_qp_out_create(qp_solver_config *config, dense_qp_dims *dims)
 //
 void *dense_qp_opts_create(qp_solver_config *config, dense_qp_dims *dims);
 //
-int dense_qp_calculate_size(qp_solver_config *config, dense_qp_dims *dims, void *opts_);
+acados_size_t dense_qp_calculate_size(qp_solver_config *config, dense_qp_dims *dims, void *opts_);
 //
 dense_qp_solver *dense_qp_assign(qp_solver_config *config, dense_qp_dims *dims, void *opts_,
                                  void *raw_memory);

--- a/interfaces/acados_c/external_function_interface.c
+++ b/interfaces/acados_c/external_function_interface.c
@@ -50,7 +50,7 @@
 
 void external_function_param_generic_create(external_function_param_generic *fun, int np)
 {
-    int fun_size = external_function_param_generic_calculate_size(fun, np);
+    acados_size_t fun_size = external_function_param_generic_calculate_size(fun, np);
     void *fun_mem = acados_malloc(1, fun_size);
     external_function_param_generic_assign(fun, fun_mem);
 
@@ -74,7 +74,7 @@ void external_function_param_generic_free(external_function_param_generic *fun)
 
 void external_function_casadi_create(external_function_casadi *fun)
 {
-    int fun_size = external_function_casadi_calculate_size(fun);
+    acados_size_t fun_size = external_function_casadi_calculate_size(fun);
     void *fun_mem = acados_malloc(1, fun_size);
     external_function_casadi_assign(fun, fun_mem);
 
@@ -91,9 +91,9 @@ void external_function_casadi_create_array(int size, external_function_casadi *f
     char *c_ptr;
 
     // create size array
-    int *funs_size = (int *) acados_malloc(1, size * sizeof(int));
-    // int *funs_size = malloc(size * sizeof(int));
-    int funs_size_tot = 0;
+    acados_size_t *funs_size = (acados_size_t *) acados_malloc(1, size * sizeof(acados_size_t));
+    // acados_size_t *funs_size = malloc(size * sizeof(acados_size_t));
+    acados_size_t funs_size_tot = 0;
 
     // compute sizes
     for (ii = 0; ii < size; ii++)
@@ -145,7 +145,7 @@ void external_function_casadi_free_array(int size, external_function_casadi *fun
 
 void external_function_param_casadi_create(external_function_param_casadi *fun, int np)
 {
-    int fun_size = external_function_param_casadi_calculate_size(fun, np);
+    acados_size_t fun_size = external_function_param_casadi_calculate_size(fun, np);
     void *fun_mem = acados_malloc(1, fun_size);
     external_function_param_casadi_assign(fun, fun_mem);
 
@@ -162,9 +162,9 @@ void external_function_param_casadi_create_array(int size, external_function_par
     char *c_ptr;
 
     // create size array
-    int *funs_size = (int *) acados_malloc(1, size * sizeof(int));
-    // int *funs_size = malloc(size * sizeof(int));
-    int funs_size_tot = 0;
+    acados_size_t *funs_size = (acados_size_t *) acados_malloc(1, size * sizeof(acados_size_t));
+    // acados_size_t *funs_size = malloc(size * sizeof(acados_size_t));
+    acados_size_t funs_size_tot = 0;
 
     // compute sizes
     for (ii = 0; ii < size; ii++)

--- a/interfaces/acados_c/ocp_nlp_interface.c
+++ b/interfaces/acados_c/ocp_nlp_interface.c
@@ -63,10 +63,10 @@
 * plan
 ************************************************/
 
-static int ocp_nlp_plan_calculate_size(int N)
+static acados_size_t ocp_nlp_plan_calculate_size(int N)
 {
     // N - number of shooting nodes
-    int bytes = sizeof(ocp_nlp_plan);
+    acados_size_t bytes = sizeof(ocp_nlp_plan);
     bytes += N * sizeof(sim_solver_plan);
     bytes += (N + 1) * sizeof(ocp_nlp_cost_t);
     bytes += N * sizeof(ocp_nlp_dynamics_t);
@@ -145,7 +145,7 @@ static void ocp_nlp_plan_initialize_default(ocp_nlp_plan *plan)
 
 ocp_nlp_plan *ocp_nlp_plan_create(int N)
 {
-    int bytes = ocp_nlp_plan_calculate_size(N);
+    acados_size_t bytes = ocp_nlp_plan_calculate_size(N);
     void *ptr = acados_malloc(bytes, 1);
 
     ocp_nlp_plan *plan = ocp_nlp_plan_assign(N, ptr);
@@ -174,7 +174,7 @@ ocp_nlp_config *ocp_nlp_config_create(ocp_nlp_plan plan)
 
     /* calculate_size & malloc & assign */
 
-    int bytes = ocp_nlp_config_calculate_size(N);
+    acados_size_t bytes = ocp_nlp_config_calculate_size(N);
     void *config_mem = acados_calloc(1, bytes);
     ocp_nlp_config *config = ocp_nlp_config_assign(N, config_mem);
 
@@ -327,7 +327,7 @@ ocp_nlp_dims *ocp_nlp_dims_create(void *config_)
 {
     ocp_nlp_config *config = config_;
 
-    int bytes = ocp_nlp_dims_calculate_size(config);
+    acados_size_t bytes = ocp_nlp_dims_calculate_size(config);
 
     void *ptr = acados_calloc(1, bytes);
 
@@ -351,7 +351,7 @@ void ocp_nlp_dims_destroy(void *dims_)
 
 ocp_nlp_in *ocp_nlp_in_create(ocp_nlp_config *config, ocp_nlp_dims *dims)
 {
-    int bytes = ocp_nlp_in_calculate_size(config, dims);
+    acados_size_t bytes = ocp_nlp_in_calculate_size(config, dims);
 
     void *ptr = acados_calloc(1, bytes);
 
@@ -427,7 +427,7 @@ int ocp_nlp_constraints_model_set(ocp_nlp_config *config, ocp_nlp_dims *dims,
 
 ocp_nlp_out *ocp_nlp_out_create(ocp_nlp_config *config, ocp_nlp_dims *dims)
 {
-    int bytes = ocp_nlp_out_calculate_size(config, dims);
+    acados_size_t bytes = ocp_nlp_out_calculate_size(config, dims);
 
     void *ptr = acados_calloc(1, bytes);
 
@@ -782,7 +782,7 @@ void ocp_nlp_cost_dims_get_from_attr(ocp_nlp_config *config, ocp_nlp_dims *dims,
 
 void *ocp_nlp_solver_opts_create(ocp_nlp_config *config, ocp_nlp_dims *dims)
 {
-    int bytes = config->opts_calculate_size(config, dims);
+    acados_size_t bytes = config->opts_calculate_size(config, dims);
 
     void *ptr = acados_calloc(1, bytes);
 
@@ -827,9 +827,9 @@ void ocp_nlp_solver_opts_destroy(void *opts)
 * solver
 ************************************************/
 
-static int ocp_nlp_calculate_size(ocp_nlp_config *config, ocp_nlp_dims *dims, void *opts_)
+static acados_size_t ocp_nlp_calculate_size(ocp_nlp_config *config, ocp_nlp_dims *dims, void *opts_)
 {
-    int bytes = sizeof(ocp_nlp_solver);
+    acados_size_t bytes = sizeof(ocp_nlp_solver);
 
     bytes += config->memory_calculate_size(config, dims, opts_);
     bytes += config->workspace_calculate_size(config, dims, opts_);
@@ -869,7 +869,7 @@ ocp_nlp_solver *ocp_nlp_solver_create(ocp_nlp_config *config, ocp_nlp_dims *dims
 {
     config->opts_update(config, dims, opts_);
 
-    int bytes = ocp_nlp_calculate_size(config, dims, opts_);
+    acados_size_t bytes = ocp_nlp_calculate_size(config, dims, opts_);
 
     void *ptr = acados_calloc(1, bytes);
 

--- a/interfaces/acados_c/ocp_qp_interface.c
+++ b/interfaces/acados_c/ocp_qp_interface.c
@@ -158,7 +158,7 @@ void ocp_qp_xcond_solver_config_initialize_from_plan(
 
 ocp_qp_xcond_solver_config *ocp_qp_xcond_solver_config_create(ocp_qp_solver_plan plan)
 {
-    int bytes = ocp_qp_xcond_solver_config_calculate_size();
+    acados_size_t bytes = ocp_qp_xcond_solver_config_calculate_size();
     void *ptr = calloc(1, bytes);
     ocp_qp_xcond_solver_config *solver_config = ocp_qp_xcond_solver_config_assign(ptr);
 
@@ -180,7 +180,7 @@ void ocp_qp_xcond_solver_config_free(ocp_qp_xcond_solver_config *config)
 
 ocp_qp_dims *ocp_qp_dims_create(int N)
 {
-    int bytes = ocp_qp_dims_calculate_size(N);
+    acados_size_t bytes = ocp_qp_dims_calculate_size(N);
 
     void *ptr = calloc(1, bytes);
 
@@ -200,7 +200,7 @@ void ocp_qp_dims_free(void *dims_)
 
 ocp_qp_xcond_solver_dims *ocp_qp_xcond_solver_dims_create(ocp_qp_xcond_solver_config *config, int N)
 {
-    int bytes = ocp_qp_xcond_solver_dims_calculate_size(config, N);
+    acados_size_t bytes = ocp_qp_xcond_solver_dims_calculate_size(config, N);
 
     void *ptr = calloc(1, bytes);
 
@@ -264,7 +264,7 @@ void ocp_qp_xcond_solver_dims_free(ocp_qp_xcond_solver_dims *dims)
 
 ocp_qp_in *ocp_qp_in_create(ocp_qp_dims *dims)
 {
-    int bytes = ocp_qp_in_calculate_size(dims);
+    acados_size_t bytes = ocp_qp_in_calculate_size(dims);
 
     void *ptr = calloc(1, bytes);
 
@@ -293,7 +293,7 @@ void ocp_qp_in_free(void *in_)
 
 ocp_qp_out *ocp_qp_out_create(ocp_qp_dims *dims)
 {
-    int bytes = ocp_qp_out_calculate_size(dims);
+    acados_size_t bytes = ocp_qp_out_calculate_size(dims);
 
     void *ptr = calloc(1, bytes);
 
@@ -330,7 +330,7 @@ void ocp_qp_out_get(ocp_qp_out *out, const char *field, void *value)
 /* opts */
 void *ocp_qp_xcond_solver_opts_create(ocp_qp_xcond_solver_config *config, ocp_qp_xcond_solver_dims *dims)
 {
-    int bytes = config->opts_calculate_size(config, dims);
+    acados_size_t bytes = config->opts_calculate_size(config, dims);
 
     void *ptr = calloc(1, bytes);
 
@@ -357,9 +357,9 @@ void ocp_qp_xcond_solver_opts_set(ocp_qp_xcond_solver_config *config,
 
 /* solver */
 
-int ocp_qp_calculate_size(ocp_qp_xcond_solver_config *config, ocp_qp_xcond_solver_dims *dims, void *opts_)
+acados_size_t ocp_qp_calculate_size(ocp_qp_xcond_solver_config *config, ocp_qp_xcond_solver_dims *dims, void *opts_)
 {
-    int bytes = sizeof(ocp_qp_solver);
+    acados_size_t bytes = sizeof(ocp_qp_solver);
 
     bytes += config->memory_calculate_size(config, dims, opts_);
     bytes += config->workspace_calculate_size(config, dims, opts_);
@@ -402,7 +402,7 @@ ocp_qp_solver *ocp_qp_create(ocp_qp_xcond_solver_config *config,
 
     config->opts_update(config, dims, opts_);
 
-    int bytes = ocp_qp_calculate_size(config, dims, opts_);
+    acados_size_t bytes = ocp_qp_calculate_size(config, dims, opts_);
 
     void *ptr = calloc(1, bytes);
 
@@ -429,7 +429,7 @@ void ocp_qp_solver_destroy(ocp_qp_solver *solver)
 // qp residual
 static ocp_qp_res *ocp_qp_res_create(ocp_qp_dims *dims)
 {
-    int size = ocp_qp_res_calculate_size(dims);
+    acados_size_t size = ocp_qp_res_calculate_size(dims);
     void *ptr = acados_malloc(size, 1);
     ocp_qp_res *qp_res = ocp_qp_res_assign(dims, ptr);
     return qp_res;
@@ -439,7 +439,7 @@ static ocp_qp_res *ocp_qp_res_create(ocp_qp_dims *dims)
 
 static ocp_qp_res_ws *ocp_qp_res_workspace_create(ocp_qp_dims *dims)
 {
-    int size = ocp_qp_res_workspace_calculate_size(dims);
+    acados_size_t size = ocp_qp_res_workspace_calculate_size(dims);
     void *ptr = acados_malloc(size, 1);
     ocp_qp_res_ws *res_ws = ocp_qp_res_workspace_assign(dims, ptr);
     return res_ws;

--- a/interfaces/acados_c/ocp_qp_interface.h
+++ b/interfaces/acados_c/ocp_qp_interface.h
@@ -207,7 +207,7 @@ void ocp_qp_xcond_solver_opts_set(ocp_qp_xcond_solver_config *config,
            ocp_qp_xcond_solver_opts *opts, const char *field, void* value);
 
 /// TBC Should be private/static?
-int ocp_qp_calculate_size(ocp_qp_xcond_solver_config *config, ocp_qp_xcond_solver_dims *dims, void *opts_);
+acados_size_t ocp_qp_calculate_size(ocp_qp_xcond_solver_config *config, ocp_qp_xcond_solver_dims *dims, void *opts_);
 
 
 /// TBC Reserves memory? TBC Should this be private?

--- a/interfaces/acados_c/sim_interface.c
+++ b/interfaces/acados_c/sim_interface.c
@@ -57,7 +57,7 @@ sim_config *sim_config_create(sim_solver_plan plan)
 {
     /* calculate_size & malloc & assign */
 
-    int bytes = sim_config_calculate_size();
+    acados_size_t bytes = sim_config_calculate_size();
     void *ptr = calloc(1, bytes);
     sim_config *solver_config = sim_config_assign(ptr);
 
@@ -106,8 +106,8 @@ void sim_config_destroy(void *config)
 void *sim_dims_create(void *config_)
 {
     sim_config *config = (sim_config *) config_;
-//    int bytes = config->dims_calculate_size(config_);
-    int bytes = config->dims_calculate_size();
+//    acados_size_t bytes = config->dims_calculate_size(config_);
+    acados_size_t bytes = config->dims_calculate_size();
 
     void *ptr = calloc(1, bytes);
 
@@ -145,7 +145,7 @@ void sim_dims_get(sim_config *config, void *dims, const char *field, int* value)
 
 sim_in *sim_in_create(sim_config *config, void *dims)
 {
-    int bytes = sim_in_calculate_size(config, dims);
+    acados_size_t bytes = sim_in_calculate_size(config, dims);
 
     void *ptr = calloc(1, bytes);
 
@@ -177,7 +177,7 @@ int sim_in_set(void *config_, void *dims_, sim_in *in, const char *field, void *
 
 sim_out *sim_out_create(sim_config *config, void *dims)
 {
-    int bytes = sim_out_calculate_size(config, dims);
+    acados_size_t bytes = sim_out_calculate_size(config, dims);
 
     void *ptr = calloc(1, bytes);
 
@@ -207,7 +207,7 @@ int sim_out_get(void *config, void *dims, sim_out *out, const char *field, void 
 
 void *sim_opts_create(sim_config *config, void *dims)
 {
-    int bytes = config->opts_calculate_size(config, dims);
+    acados_size_t bytes = config->opts_calculate_size(config, dims);
 
     void *ptr = calloc(1, bytes);
 
@@ -242,9 +242,9 @@ void sim_opts_get(sim_config *config, void *opts, const char *field, void *value
 * solver
 ************************************************/
 
-int sim_calculate_size(sim_config *config, void *dims, void *opts_)
+acados_size_t sim_calculate_size(sim_config *config, void *dims, void *opts_)
 {
-    int bytes = sizeof(sim_solver);
+    acados_size_t bytes = sizeof(sim_solver);
 
     bytes += config->memory_calculate_size(config, dims, opts_);
     bytes += config->workspace_calculate_size(config, dims, opts_);
@@ -284,7 +284,7 @@ sim_solver *sim_solver_create(sim_config *config, void *dims, void *opts_)
 {
     // update Butcher tableau (needed if the user changed ns)
     config->opts_update(config, dims, opts_);
-    int bytes = sim_calculate_size(config, dims, opts_);
+    acados_size_t bytes = sim_calculate_size(config, dims, opts_);
 
     void *ptr = calloc(1, bytes);
 

--- a/interfaces/acados_c/sim_interface.h
+++ b/interfaces/acados_c/sim_interface.h
@@ -117,7 +117,7 @@ void sim_opts_get(sim_config *config, void *opts, const char *field, void *value
 
 /* solver */
 //
-int sim_calculate_size(sim_config *config, void *dims, void *opts_);
+acados_size_t sim_calculate_size(sim_config *config, void *dims, void *opts_);
 //
 sim_solver *sim_assign(sim_config *config, void *dims, void *opts_, void *raw_memory);
 //


### PR DESCRIPTION
This allows for changing the type of the return type. 
Previously, the return type was int which limited the max memory to approx 2GB and the solver crashed with larger
problems.
By changing typedef in the acados/utils/type.h the behavior can be changed.