### PR TITLE
fix bug in tql2, Symmetric tridiagonal QL algorithm;

### DIFF
--- a/acados/utils/math.c
+++ b/acados/utils/math.c
@@ -973,6 +973,7 @@ static void tql2(int dim, double *V, double *d, double *e)
     Bowdler, Martin, Reinsch, and Wilkinson, Handbook for
     Auto. Comp., Vol.ii-Linear Algebra, and the corresponding
     Fortran subroutine in EISPACK. */
+    // http://www.netlib.org/eispack/tql2.f
 
     int i, m, l, k;
     double g, p, r, dl1, h, f, tst1, eps;
@@ -993,7 +994,7 @@ static void tql2(int dim, double *V, double *d, double *e)
 
         tst1 = fmax(tst1, fabs(d[l]) + fabs(e[l]));
         m = l;
-        while (m < dim)
+        while (m < dim-1)
         {
             if (fabs(e[m]) <= eps * tst1)
             {


### PR DESCRIPTION
`m` was (in some cases) incremented once too much, resulting in a segmentation fault.

Found this bug with the example code from this forum post:
https://discourse.acados.org/t/matlab-crashing-on-difficult-non-linear-dynamics/329