### PR TITLE
acados_template: configurable code export directory

### DIFF
--- a/interfaces/acados_template/acados_template/acados_layout.json
+++ b/interfaces/acados_template/acados_template/acados_layout.json
@@ -1,4 +1,7 @@
 {
+    "code_export_directory": [
+        "str"
+    ],
     "acados_include_path": [
         "str"
     ],

--- a/interfaces/acados_template/acados_template/acados_ocp.py
+++ b/interfaces/acados_template/acados_template/acados_ocp.py
@@ -2723,6 +2723,9 @@ class AcadosOcp:
         self.__parameter_values = np.array([])
         self.__problem_class = 'OCP'
 
+        self.code_export_directory = 'c_generated_code'
+        """Path to where code will be exported. Default: `c_generated_code`."""
+
     @property
     def parameter_values(self):
         """:math:`p` - initial values for parameter - can be updated stagewise"""

--- a/interfaces/acados_template/acados_template/acados_sim.py
+++ b/interfaces/acados_template/acados_template/acados_sim.py
@@ -278,6 +278,8 @@ class AcadosSim:
         self.acados_lib_path = f'{acados_path}/lib'
         """Path to where acados library is located (set automatically), type: `string`"""
 
+        self.code_export_directory = 'c_generated_code'
+        """Path to where code will be exported. Default: `c_generated_code`."""
 
     def set(self, attr, value):
         # tokenize string

--- a/interfaces/acados_template/acados_template/acados_sim_solver.py
+++ b/interfaces/acados_template/acados_template/acados_sim_solver.py
@@ -155,7 +155,7 @@ def sim_generate_casadi_functions(acados_sim):
     integrator_type = acados_sim.solver_options.integrator_type
 
     opts = dict(generate_hess = acados_sim.solver_options.sens_hess,
-                code_export_directory = acados_ocp.code_export_directory)
+                code_export_directory = acados_sim.code_export_directory)
     # generate external functions
     if integrator_type == 'ERK':
         generate_c_code_explicit_ode(model, opts)

--- a/interfaces/acados_template/acados_template/generate_c_code_constraint.py
+++ b/interfaces/acados_template/acados_template/generate_c_code_constraint.py
@@ -85,9 +85,12 @@ def generate_c_code_constraint( model, con_name, is_terminal, opts ):
             lam_h = symbol('lam_h', nh, 1)
 
         # set up & change directory
-        if not os.path.exists('c_generated_code'):
-            os.mkdir('c_generated_code')
-        os.chdir('c_generated_code')
+        code_export_dir = opts["code_export_directory"]
+        if not os.path.exists(code_export_dir):
+            os.makedirs(code_export_dir)
+
+        cwd = os.getcwd()
+        os.chdir(code_export_dir)
         gen_dir = con_name + '_constraints'
         if not os.path.exists(gen_dir):
             os.mkdir(gen_dir)
@@ -172,6 +175,6 @@ def generate_c_code_constraint( model, con_name, is_terminal, opts ):
             constraint_phi.generate(fun_name, casadi_opts)
 
         # change directory back
-        os.chdir('../..')
+        os.chdir(cwd)
 
     return

--- a/interfaces/acados_template/acados_template/generate_c_code_discrete_dynamics.py
+++ b/interfaces/acados_template/acados_template/generate_c_code_discrete_dynamics.py
@@ -71,9 +71,12 @@ def generate_c_code_discrete_dynamics( model, opts ):
     hess_ux = jacobian(adj_ux, ux)
     
     ## change directory
-    if not os.path.exists('c_generated_code'):
-        os.mkdir('c_generated_code')
-    os.chdir('c_generated_code')
+    code_export_dir = opts["code_export_directory"]
+    if not os.path.exists(code_export_dir):
+        os.makedirs(code_export_dir)
+
+    cwd = os.getcwd()
+    os.chdir(code_export_dir)
     model_dir = model_name + '_model'
     if not os.path.exists(model_dir):
         os.mkdir(model_dir)
@@ -93,4 +96,4 @@ def generate_c_code_discrete_dynamics( model, opts ):
     phi_fun_jac_ut_xt_hess = Function(fun_name, [x, u, lam, p], [phi, jac_ux.T, hess_ux])
     phi_fun_jac_ut_xt_hess.generate(fun_name, casadi_opts)
     
-    os.chdir('../..')
+    os.chdir(cwd)

--- a/interfaces/acados_template/acados_template/generate_c_code_explicit_ode.py
+++ b/interfaces/acados_template/acados_template/generate_c_code_explicit_ode.py
@@ -44,6 +44,7 @@ def generate_c_code_explicit_ode( model, opts ):
 
 
     generate_hess = opts["generate_hess"]
+    code_export_dir = opts["code_export_directory"]
 
     # load model
     x = model.x
@@ -96,10 +97,11 @@ def generate_c_code_explicit_ode( model, opts ):
         expl_ode_hess = Function(fun_name, [x, Sx, Sp, lambdaX, u, p], [adj, hess2])
 
     ## generate C code
-    if not os.path.exists('c_generated_code'):
-        os.mkdir('c_generated_code')
+    if not os.path.exists(code_export_dir):
+        os.makedirs(code_export_dir)
 
-    os.chdir('c_generated_code')
+    cwd = os.getcwd()
+    os.chdir(code_export_dir)
     model_dir = model_name + '_model'
     if not os.path.exists(model_dir):
         os.mkdir(model_dir)
@@ -117,6 +119,6 @@ def generate_c_code_explicit_ode( model, opts ):
     if generate_hess:
         fun_name = model_name + '_expl_ode_hess'
         expl_ode_hess.generate(fun_name, casadi_opts)
-    os.chdir('../..')
+    os.chdir(cwd)
 
     return

--- a/interfaces/acados_template/acados_template/generate_c_code_external_cost.py
+++ b/interfaces/acados_template/acados_template/generate_c_code_external_cost.py
@@ -36,7 +36,7 @@ from casadi import SX, MX, Function, transpose, vertcat, horzcat, hessian, Casad
 from .utils import ALLOWED_CASADI_VERSIONS, casadi_version_warning
 
 
-def generate_c_code_external_cost(model, stage_type):
+def generate_c_code_external_cost(model, stage_type, opts):
 
     casadi_version = CasadiMeta.version()
     casadi_opts = dict(mex=False, casadi_int="int", casadi_real="double")
@@ -90,10 +90,12 @@ def generate_c_code_external_cost(model, stage_type):
     )
 
     # generate C code
-    if not os.path.exists("c_generated_code"):
-        os.mkdir("c_generated_code")
+    code_export_dir = opts["code_export_directory"]
+    if not os.path.exists(code_export_dir):
+        os.makedirs(code_export_dir)
 
-    os.chdir("c_generated_code")
+    cwd = os.getcwd()
+    os.chdir(code_export_dir)
     gen_dir = model.name + '_cost'
     if not os.path.exists(gen_dir):
         os.mkdir(gen_dir)
@@ -104,5 +106,5 @@ def generate_c_code_external_cost(model, stage_type):
     ext_cost_fun_jac_hess.generate(fun_name_hess, casadi_opts)
     ext_cost_fun_jac.generate(fun_name_jac, casadi_opts)
 
-    os.chdir("../..")
+    os.chdir(cwd)
     return

--- a/interfaces/acados_template/acados_template/generate_c_code_gnsf.py
+++ b/interfaces/acados_template/acados_template/generate_c_code_gnsf.py
@@ -35,7 +35,7 @@ import os
 from casadi import *
 from .utils import ALLOWED_CASADI_VERSIONS, is_empty, casadi_version_warning
 
-def generate_c_code_gnsf( model ):
+def generate_c_code_gnsf( model, opts ):
 
     casadi_version = CasadiMeta.version()
     casadi_opts = dict(mex=False, casadi_int='int', casadi_real='double')
@@ -43,12 +43,14 @@ def generate_c_code_gnsf( model ):
         casadi_version_warning(casadi_version)
 
     model_name = model.name
+    code_export_dir = opts["code_export_directory"]
 
     # set up directory
-    if not os.path.exists('c_generated_code'):
-        os.mkdir('c_generated_code')
+    if not os.path.exists(code_export_dir):
+        os.makedirs(code_export_dir)
 
-    os.chdir('c_generated_code')
+    cwd = os.getcwd()
+    os.chdir(code_export_dir)
     model_dir = model_name + '_model'
     if not os.path.exists(model_dir):
         os.mkdir(model_dir)
@@ -124,6 +126,6 @@ def generate_c_code_gnsf( model ):
     del model.f_lo_fun_jac_x1k1uz
     del model.get_matrices_fun
 
-    os.chdir('../..')
+    os.chdir(cwd)
 
     return

--- a/interfaces/acados_template/acados_template/generate_c_code_implicit_ode.py
+++ b/interfaces/acados_template/acados_template/generate_c_code_implicit_ode.py
@@ -43,6 +43,7 @@ def generate_c_code_implicit_ode( model, opts ):
         casadi_version_warning(casadi_version)
 
     generate_hess = opts["generate_hess"]
+    code_export_dir = opts["code_export_directory"]
 
     ## load model
     x = model.x
@@ -105,10 +106,11 @@ def generate_c_code_implicit_ode( model, opts ):
     impl_dae_hess = Function(fun_name, [x, xdot, u, z, multiplier, p], [HESS])
 
     # generate C code
-    if not os.path.exists('c_generated_code'):
-        os.mkdir('c_generated_code')
+    if not os.path.exists(code_export_dir):
+        os.makedirs(code_export_dir)
 
-    os.chdir('c_generated_code')
+    cwd = os.getcwd()
+    os.chdir(code_export_dir)
     model_dir = model_name + '_model'
     if not os.path.exists(model_dir):
         os.mkdir(model_dir)
@@ -131,4 +133,4 @@ def generate_c_code_implicit_ode( model, opts ):
         fun_name = model_name + '_impl_dae_hess'
         impl_dae_hess.generate(fun_name, casadi_opts)
 
-    os.chdir('../..')
+    os.chdir(cwd)

--- a/interfaces/acados_template/acados_template/generate_c_code_nls_cost.py
+++ b/interfaces/acados_template/acados_template/generate_c_code_nls_cost.py
@@ -35,7 +35,7 @@ import os
 from casadi import *
 from .utils import ALLOWED_CASADI_VERSIONS, casadi_length, casadi_version_warning
 
-def generate_c_code_nls_cost( model, cost_name, stage_type ):
+def generate_c_code_nls_cost( model, cost_name, stage_type, opts ):
 
     casadi_version = CasadiMeta.version()
     casadi_opts = dict(mex=False, casadi_int='int', casadi_real='double')
@@ -67,10 +67,12 @@ def generate_c_code_nls_cost( model, cost_name, stage_type ):
         cost_expr = model.cost_y_expr
 
     # set up directory
-    if not os.path.exists('c_generated_code'):
-        os.mkdir('c_generated_code')
+    code_export_dir = opts["code_export_directory"]
+    if not os.path.exists(code_export_dir):
+        os.makedirs(code_export_dir)
 
-    os.chdir('c_generated_code')
+    cwd = os.getcwd()
+    os.chdir(code_export_dir)
     gen_dir = cost_name + '_cost'
     if not os.path.exists(gen_dir):
         os.mkdir(gen_dir)
@@ -105,7 +107,7 @@ def generate_c_code_nls_cost( model, cost_name, stage_type ):
     y_hess = Function(fun_name, [x, u, y, p], [ y_hess ])
     y_hess.generate( fun_name, casadi_opts )
 
-    os.chdir('../..')
+    os.chdir(cwd)
 
     return
 


### PR DESCRIPTION
The code export directory can be set in AcadosOcp.code_export_directory and
AcadosSim.code_export_directory.
The constructor of AcadosSimSolver transfers the setting from AcadosOcp to
AcadosSim if initialized with an AcadosOcp object.