### PR TITLE
Python integrator interface improvements

### DIFF
--- a/acados/utils/timing.c
+++ b/acados/utils/timing.c
@@ -84,7 +84,7 @@ real_t acados_toc(acados_timer* t) { return ds1401_tic_read() - t->time; }
 
 #else
 
-#if __STDC_VERSION__ >= 199901L  // C99 Mode
+#if (__STDC_VERSION__ >= 199901L) && !(defined __MINGW32__ || defined __MINGW64__) // C99 Mode
 
 /* read current time */
 void acados_tic(acados_timer* t) { gettimeofday(&t->tic, 0); }

--- a/acados/utils/timing.h
+++ b/acados/utils/timing.h
@@ -81,7 +81,7 @@ typedef struct acados_timer_
 /* Use POSIX clock_gettime() for timing on non-Windows machines. */
 #include <time.h>
 
-#if __STDC_VERSION__ >= 199901L  // C99 Mode
+#if (__STDC_VERSION__ >= 199901L) && !(defined __MINGW32__ || defined __MINGW64__)  // C99 Mode
 
 #include <sys/stat.h>
 #include <sys/time.h>

--- a/examples/acados_python/getting_started/sim/minimal_example_sim.py
+++ b/examples/acados_python/getting_started/sim/minimal_example_sim.py
@@ -75,7 +75,10 @@ simX[0,:] = x0
 for i in range(N):
     # set initial state
     acados_integrator.set("x", simX[i,:])
-    acados_integrator.set("xdot", np.zeros((nx,)))
+    # initialize IRK
+    if sim.solver_options.integrator_type == 'IRK':
+        acados_integrator.set("xdot", np.zeros((nx,)))
+
     # solve
     status = acados_integrator.solve()
     # get solution

--- a/interfaces/acados_c/sim_interface.c
+++ b/interfaces/acados_c/sim_interface.c
@@ -138,6 +138,38 @@ void sim_dims_get(sim_config *config, void *dims, const char *field, int* value)
 }
 
 
+void sim_dims_get_from_attr(sim_config *config, void *dims, const char *field, int *dims_out)
+{
+    // vectors first
+    dims_out[1] = 0;
+
+    if (!strcmp(field, "x") || !strcmp(field, "xdot"))
+    {
+        sim_dims_get(config, dims, "nx", &dims_out[0]);
+    }
+    else if (!strcmp(field, "z"))
+    {
+        sim_dims_get(config, dims, "nz", &dims_out[0]);
+    }
+    else if (!strcmp(field, "u"))
+    {
+        sim_dims_get(config, dims, "nu", &dims_out[0]);
+    }
+    else if (!strcmp(field, "S_adj"))
+    {
+        int tmp;
+        sim_dims_get(config, dims, "nu", &tmp);
+        sim_dims_get(config, dims, "nx", &dims_out[0]);
+        dims_out[0] += tmp;
+    }
+    else
+    {
+        printf("\nerror: sim_dims_get_from_attr: field %s not available\n", field);
+        exit(1);
+    }
+
+    return;
+}
 
 /************************************************
 * in

--- a/interfaces/acados_c/sim_interface.h
+++ b/interfaces/acados_c/sim_interface.h
@@ -87,6 +87,8 @@ void sim_dims_destroy(void *dims);
 void sim_dims_set(sim_config *config, void *dims, const char *field, const int* value);
 //
 void sim_dims_get(sim_config *config, void *dims, const char *field, int* value);
+//
+void sim_dims_get_from_attr(sim_config *config, void *dims, const char *field, int *dims_out);
 
 /* in */
 //

--- a/interfaces/acados_template/acados_template/acados_sim_solver.py
+++ b/interfaces/acados_template/acados_template/acados_sim_solver.py
@@ -352,9 +352,9 @@ class AcadosSimSolver:
         # treat parameters separately
         if field_ == 'p':
             model_name = self.sim_struct.model.name
-            getattr(self.shared_lib, f"{model_name}_acados_sim_update_params").argtypes = [POINTER(c_double)]
+            getattr(self.shared_lib, f"{model_name}_acados_sim_update_params").argtypes = [c_void_p, POINTER(c_double), c_int]
             value_data = cast(value_.ctypes.data, POINTER(c_double))
-            getattr(self.shared_lib, f"{model_name}_acados_sim_update_params")(value_data, value_.shape[0])
+            getattr(self.shared_lib, f"{model_name}_acados_sim_update_params")(self.capsule, value_data, value_.shape[0])
         elif field_ in ['xdot', 'z']:
             # TODO(katrin): perform dimension check!
             self.shared_lib.sim_solver_set.argtypes = [c_void_p, c_char_p, c_void_p]

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_sim_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_sim_solver.in.c
@@ -57,37 +57,25 @@
 #include "acados_sim_solver_{{ model.name }}.h"
 
 
-// ** global data **
-sim_config  * {{ model.name }}_sim_config;
-sim_in      * {{ model.name }}_sim_in;
-sim_out     * {{ model.name }}_sim_out;
-void        * {{ model.name }}_sim_dims;
-sim_opts    * {{ model.name }}_sim_opts;
-sim_solver  * {{ model.name }}_sim_solver;
+// ** solver data **
 
-{% if solver_options.integrator_type == "ERK" %}
-external_function_param_casadi * sim_forw_vde_casadi;
-external_function_param_casadi * sim_expl_ode_fun_casadi;
-{%- if hessian_approx == "EXACT" %}
-external_function_param_casadi * sim_expl_ode_hess;
-{%- endif %}
-{% elif solver_options.integrator_type == "IRK" %}
-external_function_param_casadi * sim_impl_dae_fun;
-external_function_param_casadi * sim_impl_dae_fun_jac_x_xdot_z;
-external_function_param_casadi * sim_impl_dae_jac_x_xdot_u_z;
-{%- if hessian_approx == "EXACT" %}
-external_function_param_casadi * sim_impl_dae_hess;
-{%- endif %}
-{% elif solver_options.integrator_type == "GNSF" -%}
-external_function_param_casadi * sim_gnsf_phi_fun;
-external_function_param_casadi * sim_gnsf_phi_fun_jac_y;
-external_function_param_casadi * sim_gnsf_phi_jac_y_uhat;
-external_function_param_casadi * sim_gnsf_f_lo_jac_x1_x1dot_u_z;
-external_function_param_casadi * sim_gnsf_get_matrices_fun;
-{%- endif %}
+sim_solver_capsule * {{ model.name }}_acados_sim_solver_create_capsule()
+{
+    void* capsule_mem = malloc(sizeof(sim_solver_capsule));
+    sim_solver_capsule *capsule = (sim_solver_capsule *) capsule_mem;
+
+    return capsule;
+}
 
 
-int {{ model.name }}_acados_sim_create()
+int {{ model.name }}_acados_sim_solver_free_capsule(sim_solver_capsule * capsule)
+{
+    free(capsule);
+    return 0;
+}
+
+
+int {{ model.name }}_acados_sim_create(sim_solver_capsule * capsule)
 {
     // initialize
     int nx = {{ dims.nx }};
@@ -98,127 +86,127 @@ int {{ model.name }}_acados_sim_create()
     double Tsim = {{ solver_options.Tsim }};
 
     {% if solver_options.integrator_type == "IRK" %}
-    sim_impl_dae_fun = (external_function_param_casadi *) malloc(sizeof(external_function_param_casadi));
-    sim_impl_dae_fun_jac_x_xdot_z = (external_function_param_casadi *) malloc(sizeof(external_function_param_casadi));
-    sim_impl_dae_jac_x_xdot_u_z = (external_function_param_casadi *) malloc(sizeof(external_function_param_casadi));
+    capsule->sim_impl_dae_fun = (external_function_param_casadi *) malloc(sizeof(external_function_param_casadi));
+    capsule->sim_impl_dae_fun_jac_x_xdot_z = (external_function_param_casadi *) malloc(sizeof(external_function_param_casadi));
+    capsule->sim_impl_dae_jac_x_xdot_u_z = (external_function_param_casadi *) malloc(sizeof(external_function_param_casadi));
 
     // external functions (implicit model)
-    sim_impl_dae_fun->casadi_fun  = &{{ model.name }}_impl_dae_fun;
-    sim_impl_dae_fun->casadi_work = &{{ model.name }}_impl_dae_fun_work;
-    sim_impl_dae_fun->casadi_sparsity_in = &{{ model.name }}_impl_dae_fun_sparsity_in;
-    sim_impl_dae_fun->casadi_sparsity_out = &{{ model.name }}_impl_dae_fun_sparsity_out;
-    sim_impl_dae_fun->casadi_n_in = &{{ model.name }}_impl_dae_fun_n_in;
-    sim_impl_dae_fun->casadi_n_out = &{{ model.name }}_impl_dae_fun_n_out;
-    external_function_param_casadi_create(sim_impl_dae_fun, {{ dims.np }});
+    capsule->sim_impl_dae_fun->casadi_fun  = &{{ model.name }}_impl_dae_fun;
+    capsule->sim_impl_dae_fun->casadi_work = &{{ model.name }}_impl_dae_fun_work;
+    capsule->sim_impl_dae_fun->casadi_sparsity_in = &{{ model.name }}_impl_dae_fun_sparsity_in;
+    capsule->sim_impl_dae_fun->casadi_sparsity_out = &{{ model.name }}_impl_dae_fun_sparsity_out;
+    capsule->sim_impl_dae_fun->casadi_n_in = &{{ model.name }}_impl_dae_fun_n_in;
+    capsule->sim_impl_dae_fun->casadi_n_out = &{{ model.name }}_impl_dae_fun_n_out;
+    external_function_param_casadi_create(capsule->sim_impl_dae_fun, {{ dims.np }});
 
-    sim_impl_dae_fun_jac_x_xdot_z->casadi_fun = &{{ model.name }}_impl_dae_fun_jac_x_xdot_z;
-    sim_impl_dae_fun_jac_x_xdot_z->casadi_work = &{{ model.name }}_impl_dae_fun_jac_x_xdot_z_work;
-    sim_impl_dae_fun_jac_x_xdot_z->casadi_sparsity_in = &{{ model.name }}_impl_dae_fun_jac_x_xdot_z_sparsity_in;
-    sim_impl_dae_fun_jac_x_xdot_z->casadi_sparsity_out = &{{ model.name }}_impl_dae_fun_jac_x_xdot_z_sparsity_out;
-    sim_impl_dae_fun_jac_x_xdot_z->casadi_n_in = &{{ model.name }}_impl_dae_fun_jac_x_xdot_z_n_in;
-    sim_impl_dae_fun_jac_x_xdot_z->casadi_n_out = &{{ model.name }}_impl_dae_fun_jac_x_xdot_z_n_out;
-    external_function_param_casadi_create(sim_impl_dae_fun_jac_x_xdot_z, {{ dims.np }});
+    capsule->sim_impl_dae_fun_jac_x_xdot_z->casadi_fun = &{{ model.name }}_impl_dae_fun_jac_x_xdot_z;
+    capsule->sim_impl_dae_fun_jac_x_xdot_z->casadi_work = &{{ model.name }}_impl_dae_fun_jac_x_xdot_z_work;
+    capsule->sim_impl_dae_fun_jac_x_xdot_z->casadi_sparsity_in = &{{ model.name }}_impl_dae_fun_jac_x_xdot_z_sparsity_in;
+    capsule->sim_impl_dae_fun_jac_x_xdot_z->casadi_sparsity_out = &{{ model.name }}_impl_dae_fun_jac_x_xdot_z_sparsity_out;
+    capsule->sim_impl_dae_fun_jac_x_xdot_z->casadi_n_in = &{{ model.name }}_impl_dae_fun_jac_x_xdot_z_n_in;
+    capsule->sim_impl_dae_fun_jac_x_xdot_z->casadi_n_out = &{{ model.name }}_impl_dae_fun_jac_x_xdot_z_n_out;
+    external_function_param_casadi_create(capsule->sim_impl_dae_fun_jac_x_xdot_z, {{ dims.np }});
 
     // external_function_param_casadi impl_dae_jac_x_xdot_u_z;
-    sim_impl_dae_jac_x_xdot_u_z->casadi_fun = &{{ model.name }}_impl_dae_jac_x_xdot_u_z;
-    sim_impl_dae_jac_x_xdot_u_z->casadi_work = &{{ model.name }}_impl_dae_jac_x_xdot_u_z_work;
-    sim_impl_dae_jac_x_xdot_u_z->casadi_sparsity_in = &{{ model.name }}_impl_dae_jac_x_xdot_u_z_sparsity_in;
-    sim_impl_dae_jac_x_xdot_u_z->casadi_sparsity_out = &{{ model.name }}_impl_dae_jac_x_xdot_u_z_sparsity_out;
-    sim_impl_dae_jac_x_xdot_u_z->casadi_n_in = &{{ model.name }}_impl_dae_jac_x_xdot_u_z_n_in;
-    sim_impl_dae_jac_x_xdot_u_z->casadi_n_out = &{{ model.name }}_impl_dae_jac_x_xdot_u_z_n_out;
-    external_function_param_casadi_create(sim_impl_dae_jac_x_xdot_u_z, {{ dims.np }});
+    capsule->sim_impl_dae_jac_x_xdot_u_z->casadi_fun = &{{ model.name }}_impl_dae_jac_x_xdot_u_z;
+    capsule->sim_impl_dae_jac_x_xdot_u_z->casadi_work = &{{ model.name }}_impl_dae_jac_x_xdot_u_z_work;
+    capsule->sim_impl_dae_jac_x_xdot_u_z->casadi_sparsity_in = &{{ model.name }}_impl_dae_jac_x_xdot_u_z_sparsity_in;
+    capsule->sim_impl_dae_jac_x_xdot_u_z->casadi_sparsity_out = &{{ model.name }}_impl_dae_jac_x_xdot_u_z_sparsity_out;
+    capsule->sim_impl_dae_jac_x_xdot_u_z->casadi_n_in = &{{ model.name }}_impl_dae_jac_x_xdot_u_z_n_in;
+    capsule->sim_impl_dae_jac_x_xdot_u_z->casadi_n_out = &{{ model.name }}_impl_dae_jac_x_xdot_u_z_n_out;
+    external_function_param_casadi_create(capsule->sim_impl_dae_jac_x_xdot_u_z, {{ dims.np }});
 
 {%- if hessian_approx == "EXACT" %}
-    sim_impl_dae_hess = (external_function_param_casadi *) malloc(sizeof(external_function_param_casadi));
+    capsule->sim_impl_dae_hess = (external_function_param_casadi *) malloc(sizeof(external_function_param_casadi));
     // external_function_param_casadi impl_dae_jac_x_xdot_u_z;
-    sim_impl_dae_hess->casadi_fun = &{{ model.name }}_impl_dae_hess;
-    sim_impl_dae_hess->casadi_work = &{{ model.name }}_impl_dae_hess_work;
-    sim_impl_dae_hess->casadi_sparsity_in = &{{ model.name }}_impl_dae_hess_sparsity_in;
-    sim_impl_dae_hess->casadi_sparsity_out = &{{ model.name }}_impl_dae_hess_sparsity_out;
-    sim_impl_dae_hess->casadi_n_in = &{{ model.name }}_impl_dae_hess_n_in;
-    sim_impl_dae_hess->casadi_n_out = &{{ model.name }}_impl_dae_hess_n_out;
-    external_function_param_casadi_create(sim_impl_dae_hess, {{ dims.np }});
+    capsule->sim_impl_dae_hess->casadi_fun = &{{ model.name }}_impl_dae_hess;
+    capsule->sim_impl_dae_hess->casadi_work = &{{ model.name }}_impl_dae_hess_work;
+    capsule->sim_impl_dae_hess->casadi_sparsity_in = &{{ model.name }}_impl_dae_hess_sparsity_in;
+    capsule->sim_impl_dae_hess->casadi_sparsity_out = &{{ model.name }}_impl_dae_hess_sparsity_out;
+    capsule->sim_impl_dae_hess->casadi_n_in = &{{ model.name }}_impl_dae_hess_n_in;
+    capsule->sim_impl_dae_hess->casadi_n_out = &{{ model.name }}_impl_dae_hess_n_out;
+    external_function_param_casadi_create(capsule->sim_impl_dae_hess, {{ dims.np }});
 {%- endif %}
 
     {% elif solver_options.integrator_type == "ERK" %}
     // explicit ode
-    sim_forw_vde_casadi = (external_function_param_casadi *) malloc(sizeof(external_function_param_casadi));
-    sim_expl_ode_fun_casadi = (external_function_param_casadi *) malloc(sizeof(external_function_param_casadi));
+    capsule->sim_forw_vde_casadi = (external_function_param_casadi *) malloc(sizeof(external_function_param_casadi));
+    capsule->sim_expl_ode_fun_casadi = (external_function_param_casadi *) malloc(sizeof(external_function_param_casadi));
 
-    sim_forw_vde_casadi->casadi_fun = &{{ model.name }}_expl_vde_forw;
-    sim_forw_vde_casadi->casadi_n_in = &{{ model.name }}_expl_vde_forw_n_in;
-    sim_forw_vde_casadi->casadi_n_out = &{{ model.name }}_expl_vde_forw_n_out;
-    sim_forw_vde_casadi->casadi_sparsity_in = &{{ model.name }}_expl_vde_forw_sparsity_in;
-    sim_forw_vde_casadi->casadi_sparsity_out = &{{ model.name }}_expl_vde_forw_sparsity_out;
-    sim_forw_vde_casadi->casadi_work = &{{ model.name }}_expl_vde_forw_work;
-    external_function_param_casadi_create(sim_forw_vde_casadi, {{ dims.np }});
+    capsule->sim_forw_vde_casadi->casadi_fun = &{{ model.name }}_expl_vde_forw;
+    capsule->sim_forw_vde_casadi->casadi_n_in = &{{ model.name }}_expl_vde_forw_n_in;
+    capsule->sim_forw_vde_casadi->casadi_n_out = &{{ model.name }}_expl_vde_forw_n_out;
+    capsule->sim_forw_vde_casadi->casadi_sparsity_in = &{{ model.name }}_expl_vde_forw_sparsity_in;
+    capsule->sim_forw_vde_casadi->casadi_sparsity_out = &{{ model.name }}_expl_vde_forw_sparsity_out;
+    capsule->sim_forw_vde_casadi->casadi_work = &{{ model.name }}_expl_vde_forw_work;
+    external_function_param_casadi_create(capsule->sim_forw_vde_casadi, {{ dims.np }});
 
-    sim_expl_ode_fun_casadi->casadi_fun = &{{ model.name }}_expl_ode_fun;
-    sim_expl_ode_fun_casadi->casadi_n_in = &{{ model.name }}_expl_ode_fun_n_in;
-    sim_expl_ode_fun_casadi->casadi_n_out = &{{ model.name }}_expl_ode_fun_n_out;
-    sim_expl_ode_fun_casadi->casadi_sparsity_in = &{{ model.name }}_expl_ode_fun_sparsity_in;
-    sim_expl_ode_fun_casadi->casadi_sparsity_out = &{{ model.name }}_expl_ode_fun_sparsity_out;
-    sim_expl_ode_fun_casadi->casadi_work = &{{ model.name }}_expl_ode_fun_work;
-    external_function_param_casadi_create(sim_expl_ode_fun_casadi, {{ dims.np }});
+    capsule->sim_expl_ode_fun_casadi->casadi_fun = &{{ model.name }}_expl_ode_fun;
+    capsule->sim_expl_ode_fun_casadi->casadi_n_in = &{{ model.name }}_expl_ode_fun_n_in;
+    capsule->sim_expl_ode_fun_casadi->casadi_n_out = &{{ model.name }}_expl_ode_fun_n_out;
+    capsule->sim_expl_ode_fun_casadi->casadi_sparsity_in = &{{ model.name }}_expl_ode_fun_sparsity_in;
+    capsule->sim_expl_ode_fun_casadi->casadi_sparsity_out = &{{ model.name }}_expl_ode_fun_sparsity_out;
+    capsule->sim_expl_ode_fun_casadi->casadi_work = &{{ model.name }}_expl_ode_fun_work;
+    external_function_param_casadi_create(capsule->sim_expl_ode_fun_casadi, {{ dims.np }});
 
 {%- if hessian_approx == "EXACT" %}
-    sim_expl_ode_hess = (external_function_param_casadi *) malloc(sizeof(external_function_param_casadi));
+    capsule->sim_expl_ode_hess = (external_function_param_casadi *) malloc(sizeof(external_function_param_casadi));
     // external_function_param_casadi impl_dae_jac_x_xdot_u_z;
-    sim_expl_ode_hess->casadi_fun = &{{ model.name }}_expl_ode_hess;
-    sim_expl_ode_hess->casadi_work = &{{ model.name }}_expl_ode_hess_work;
-    sim_expl_ode_hess->casadi_sparsity_in = &{{ model.name }}_expl_ode_hess_sparsity_in;
-    sim_expl_ode_hess->casadi_sparsity_out = &{{ model.name }}_expl_ode_hess_sparsity_out;
-    sim_expl_ode_hess->casadi_n_in = &{{ model.name }}_expl_ode_hess_n_in;
-    sim_expl_ode_hess->casadi_n_out = &{{ model.name }}_expl_ode_hess_n_out;
-    external_function_param_casadi_create(sim_expl_ode_hess, {{ dims.np }});
+    capsule->sim_expl_ode_hess->casadi_fun = &{{ model.name }}_expl_ode_hess;
+    capsule->sim_expl_ode_hess->casadi_work = &{{ model.name }}_expl_ode_hess_work;
+    capsule->sim_expl_ode_hess->casadi_sparsity_in = &{{ model.name }}_expl_ode_hess_sparsity_in;
+    capsule->sim_expl_ode_hess->casadi_sparsity_out = &{{ model.name }}_expl_ode_hess_sparsity_out;
+    capsule->sim_expl_ode_hess->casadi_n_in = &{{ model.name }}_expl_ode_hess_n_in;
+    capsule->sim_expl_ode_hess->casadi_n_out = &{{ model.name }}_expl_ode_hess_n_out;
+    external_function_param_casadi_create(capsule->sim_expl_ode_hess, {{ dims.np }});
 {%- endif %}
 
     {% elif solver_options.integrator_type == "GNSF" -%}
-    sim_gnsf_phi_fun = (external_function_param_casadi *) malloc(sizeof(external_function_param_casadi));
-    sim_gnsf_phi_fun_jac_y = (external_function_param_casadi *) malloc(sizeof(external_function_param_casadi));
-    sim_gnsf_phi_jac_y_uhat = (external_function_param_casadi *) malloc(sizeof(external_function_param_casadi));
-    sim_gnsf_f_lo_jac_x1_x1dot_u_z = (external_function_param_casadi *) malloc(sizeof(external_function_param_casadi));
-    sim_gnsf_get_matrices_fun = (external_function_param_casadi *) malloc(sizeof(external_function_param_casadi));
+    capsule->sim_gnsf_phi_fun = (external_function_param_casadi *) malloc(sizeof(external_function_param_casadi));
+    capsule->sim_gnsf_phi_fun_jac_y = (external_function_param_casadi *) malloc(sizeof(external_function_param_casadi));
+    capsule->sim_gnsf_phi_jac_y_uhat = (external_function_param_casadi *) malloc(sizeof(external_function_param_casadi));
+    capsule->sim_gnsf_f_lo_jac_x1_x1dot_u_z = (external_function_param_casadi *) malloc(sizeof(external_function_param_casadi));
+    capsule->sim_gnsf_get_matrices_fun = (external_function_param_casadi *) malloc(sizeof(external_function_param_casadi));
 
-    sim_gnsf_phi_fun->casadi_fun = &{{ model.name }}_gnsf_phi_fun;
-    sim_gnsf_phi_fun->casadi_n_in = &{{ model.name }}_gnsf_phi_fun_n_in;
-    sim_gnsf_phi_fun->casadi_n_out = &{{ model.name }}_gnsf_phi_fun_n_out;
-    sim_gnsf_phi_fun->casadi_sparsity_in = &{{ model.name }}_gnsf_phi_fun_sparsity_in;
-    sim_gnsf_phi_fun->casadi_sparsity_out = &{{ model.name }}_gnsf_phi_fun_sparsity_out;
-    sim_gnsf_phi_fun->casadi_work = &{{ model.name }}_gnsf_phi_fun_work;
-    external_function_param_casadi_create(sim_gnsf_phi_fun, {{ dims.np }});
+    capsule->sim_gnsf_phi_fun->casadi_fun = &{{ model.name }}_gnsf_phi_fun;
+    capsule->sim_gnsf_phi_fun->casadi_n_in = &{{ model.name }}_gnsf_phi_fun_n_in;
+    capsule->sim_gnsf_phi_fun->casadi_n_out = &{{ model.name }}_gnsf_phi_fun_n_out;
+    capsule->sim_gnsf_phi_fun->casadi_sparsity_in = &{{ model.name }}_gnsf_phi_fun_sparsity_in;
+    capsule->sim_gnsf_phi_fun->casadi_sparsity_out = &{{ model.name }}_gnsf_phi_fun_sparsity_out;
+    capsule->sim_gnsf_phi_fun->casadi_work = &{{ model.name }}_gnsf_phi_fun_work;
+    external_function_param_casadi_create(capsule->sim_gnsf_phi_fun, {{ dims.np }});
 
-    sim_gnsf_phi_fun_jac_y->casadi_fun = &{{ model.name }}_gnsf_phi_fun_jac_y;
-    sim_gnsf_phi_fun_jac_y->casadi_n_in = &{{ model.name }}_gnsf_phi_fun_jac_y_n_in;
-    sim_gnsf_phi_fun_jac_y->casadi_n_out = &{{ model.name }}_gnsf_phi_fun_jac_y_n_out;
-    sim_gnsf_phi_fun_jac_y->casadi_sparsity_in = &{{ model.name }}_gnsf_phi_fun_jac_y_sparsity_in;
-    sim_gnsf_phi_fun_jac_y->casadi_sparsity_out = &{{ model.name }}_gnsf_phi_fun_jac_y_sparsity_out;
-    sim_gnsf_phi_fun_jac_y->casadi_work = &{{ model.name }}_gnsf_phi_fun_jac_y_work;
-    external_function_param_casadi_create(sim_gnsf_phi_fun_jac_y, {{ dims.np }});
+    capsule->sim_gnsf_phi_fun_jac_y->casadi_fun = &{{ model.name }}_gnsf_phi_fun_jac_y;
+    capsule->sim_gnsf_phi_fun_jac_y->casadi_n_in = &{{ model.name }}_gnsf_phi_fun_jac_y_n_in;
+    capsule->sim_gnsf_phi_fun_jac_y->casadi_n_out = &{{ model.name }}_gnsf_phi_fun_jac_y_n_out;
+    capsule->sim_gnsf_phi_fun_jac_y->casadi_sparsity_in = &{{ model.name }}_gnsf_phi_fun_jac_y_sparsity_in;
+    capsule->sim_gnsf_phi_fun_jac_y->casadi_sparsity_out = &{{ model.name }}_gnsf_phi_fun_jac_y_sparsity_out;
+    capsule->sim_gnsf_phi_fun_jac_y->casadi_work = &{{ model.name }}_gnsf_phi_fun_jac_y_work;
+    external_function_param_casadi_create(capsule->sim_gnsf_phi_fun_jac_y, {{ dims.np }});
 
-    sim_gnsf_phi_jac_y_uhat->casadi_fun = &{{ model.name }}_gnsf_phi_jac_y_uhat;
-    sim_gnsf_phi_jac_y_uhat->casadi_n_in = &{{ model.name }}_gnsf_phi_jac_y_uhat_n_in;
-    sim_gnsf_phi_jac_y_uhat->casadi_n_out = &{{ model.name }}_gnsf_phi_jac_y_uhat_n_out;
-    sim_gnsf_phi_jac_y_uhat->casadi_sparsity_in = &{{ model.name }}_gnsf_phi_jac_y_uhat_sparsity_in;
-    sim_gnsf_phi_jac_y_uhat->casadi_sparsity_out = &{{ model.name }}_gnsf_phi_jac_y_uhat_sparsity_out;
-    sim_gnsf_phi_jac_y_uhat->casadi_work = &{{ model.name }}_gnsf_phi_jac_y_uhat_work;
-    external_function_param_casadi_create(sim_gnsf_phi_jac_y_uhat, {{ dims.np }});
+    capsule->sim_gnsf_phi_jac_y_uhat->casadi_fun = &{{ model.name }}_gnsf_phi_jac_y_uhat;
+    capsule->sim_gnsf_phi_jac_y_uhat->casadi_n_in = &{{ model.name }}_gnsf_phi_jac_y_uhat_n_in;
+    capsule->sim_gnsf_phi_jac_y_uhat->casadi_n_out = &{{ model.name }}_gnsf_phi_jac_y_uhat_n_out;
+    capsule->sim_gnsf_phi_jac_y_uhat->casadi_sparsity_in = &{{ model.name }}_gnsf_phi_jac_y_uhat_sparsity_in;
+    capsule->sim_gnsf_phi_jac_y_uhat->casadi_sparsity_out = &{{ model.name }}_gnsf_phi_jac_y_uhat_sparsity_out;
+    capsule->sim_gnsf_phi_jac_y_uhat->casadi_work = &{{ model.name }}_gnsf_phi_jac_y_uhat_work;
+    external_function_param_casadi_create(capsule->sim_gnsf_phi_jac_y_uhat, {{ dims.np }});
 
-    sim_gnsf_f_lo_jac_x1_x1dot_u_z->casadi_fun = &{{ model.name }}_gnsf_f_lo_fun_jac_x1k1uz;
-    sim_gnsf_f_lo_jac_x1_x1dot_u_z->casadi_n_in = &{{ model.name }}_gnsf_f_lo_fun_jac_x1k1uz_n_in;
-    sim_gnsf_f_lo_jac_x1_x1dot_u_z->casadi_n_out = &{{ model.name }}_gnsf_f_lo_fun_jac_x1k1uz_n_out;
-    sim_gnsf_f_lo_jac_x1_x1dot_u_z->casadi_sparsity_in = &{{ model.name }}_gnsf_f_lo_fun_jac_x1k1uz_sparsity_in;
-    sim_gnsf_f_lo_jac_x1_x1dot_u_z->casadi_sparsity_out = &{{ model.name }}_gnsf_f_lo_fun_jac_x1k1uz_sparsity_out;
-    sim_gnsf_f_lo_jac_x1_x1dot_u_z->casadi_work = &{{ model.name }}_gnsf_f_lo_fun_jac_x1k1uz_work;
-    external_function_param_casadi_create(sim_gnsf_f_lo_jac_x1_x1dot_u_z, {{ dims.np }});
+    capsule->sim_gnsf_f_lo_jac_x1_x1dot_u_z->casadi_fun = &{{ model.name }}_gnsf_f_lo_fun_jac_x1k1uz;
+    capsule->sim_gnsf_f_lo_jac_x1_x1dot_u_z->casadi_n_in = &{{ model.name }}_gnsf_f_lo_fun_jac_x1k1uz_n_in;
+    capsule->sim_gnsf_f_lo_jac_x1_x1dot_u_z->casadi_n_out = &{{ model.name }}_gnsf_f_lo_fun_jac_x1k1uz_n_out;
+    capsule->sim_gnsf_f_lo_jac_x1_x1dot_u_z->casadi_sparsity_in = &{{ model.name }}_gnsf_f_lo_fun_jac_x1k1uz_sparsity_in;
+    capsule->sim_gnsf_f_lo_jac_x1_x1dot_u_z->casadi_sparsity_out = &{{ model.name }}_gnsf_f_lo_fun_jac_x1k1uz_sparsity_out;
+    capsule->sim_gnsf_f_lo_jac_x1_x1dot_u_z->casadi_work = &{{ model.name }}_gnsf_f_lo_fun_jac_x1k1uz_work;
+    external_function_param_casadi_create(capsule->sim_gnsf_f_lo_jac_x1_x1dot_u_z, {{ dims.np }});
 
-    sim_gnsf_get_matrices_fun->casadi_fun = &{{ model.name }}_gnsf_get_matrices_fun;
-    sim_gnsf_get_matrices_fun->casadi_n_in = &{{ model.name }}_gnsf_get_matrices_fun_n_in;
-    sim_gnsf_get_matrices_fun->casadi_n_out = &{{ model.name }}_gnsf_get_matrices_fun_n_out;
-    sim_gnsf_get_matrices_fun->casadi_sparsity_in = &{{ model.name }}_gnsf_get_matrices_fun_sparsity_in;
-    sim_gnsf_get_matrices_fun->casadi_sparsity_out = &{{ model.name }}_gnsf_get_matrices_fun_sparsity_out;
-    sim_gnsf_get_matrices_fun->casadi_work = &{{ model.name }}_gnsf_get_matrices_fun_work;
-    external_function_param_casadi_create(sim_gnsf_get_matrices_fun, {{ dims.np }});
+    capsule->sim_gnsf_get_matrices_fun->casadi_fun = &{{ model.name }}_gnsf_get_matrices_fun;
+    capsule->sim_gnsf_get_matrices_fun->casadi_n_in = &{{ model.name }}_gnsf_get_matrices_fun_n_in;
+    capsule->sim_gnsf_get_matrices_fun->casadi_n_out = &{{ model.name }}_gnsf_get_matrices_fun_n_out;
+    capsule->sim_gnsf_get_matrices_fun->casadi_sparsity_in = &{{ model.name }}_gnsf_get_matrices_fun_sparsity_in;
+    capsule->sim_gnsf_get_matrices_fun->casadi_sparsity_out = &{{ model.name }}_gnsf_get_matrices_fun_sparsity_out;
+    capsule->sim_gnsf_get_matrices_fun->casadi_work = &{{ model.name }}_gnsf_get_matrices_fun_work;
+    external_function_param_casadi_create(capsule->sim_gnsf_get_matrices_fun, {{ dims.np }});
     {% endif %}
 
     // sim plan & config
@@ -226,10 +214,12 @@ int {{ model.name }}_acados_sim_create()
     plan.sim_solver = {{ solver_options.integrator_type }};
 
     // create correct config based on plan
-    {{ model.name }}_sim_config = sim_config_create(plan);
+    sim_config * {{ model.name }}_sim_config = sim_config_create(plan);
+    capsule->acados_sim_config = {{ model.name }}_sim_config;
 
     // sim dims
-    {{ model.name }}_sim_dims = sim_dims_create({{ model.name }}_sim_config);
+    void *{{ model.name }}_sim_dims = sim_dims_create({{ model.name }}_sim_config);
+    capsule->acados_sim_dims = {{ model.name }}_sim_dims;
     sim_dims_set({{ model.name }}_sim_config, {{ model.name }}_sim_dims, "nx", &nx);
     sim_dims_set({{ model.name }}_sim_config, {{ model.name }}_sim_dims, "nu", &nu);
     sim_dims_set({{ model.name }}_sim_config, {{ model.name }}_sim_dims, "nz", &nz);
@@ -248,7 +238,8 @@ int {{ model.name }}_acados_sim_create()
 {% endif %}
 
     // sim opts
-    {{ model.name }}_sim_opts = sim_opts_create({{ model.name }}_sim_config, {{ model.name }}_sim_dims);
+    sim_opts *{{ model.name }}_sim_opts = sim_opts_create({{ model.name }}_sim_config, {{ model.name }}_sim_dims);
+    capsule->acados_sim_opts = {{ model.name }}_sim_opts;
     int tmp_int = {{ solver_options.sim_method_num_stages }};
     sim_opts_set({{ model.name }}_sim_config, {{ model.name }}_sim_opts, "num_stages", &tmp_int);
     tmp_int = {{ solver_options.sim_method_num_steps }};
@@ -274,49 +265,53 @@ int {{ model.name }}_acados_sim_create()
 {% endif %}
 
     // sim in / out
-    {{ model.name }}_sim_in  = sim_in_create({{ model.name }}_sim_config, {{ model.name }}_sim_dims);
-    {{ model.name }}_sim_out = sim_out_create({{ model.name }}_sim_config, {{ model.name }}_sim_dims);
+    sim_in *{{ model.name }}_sim_in = sim_in_create({{ model.name }}_sim_config, {{ model.name }}_sim_dims);
+    capsule->acados_sim_in = {{ model.name }}_sim_in;
+    sim_out *{{ model.name }}_sim_out = sim_out_create({{ model.name }}_sim_config, {{ model.name }}_sim_dims);
+    capsule->acados_sim_out = {{ model.name }}_sim_out;
+
     sim_in_set({{ model.name }}_sim_config, {{ model.name }}_sim_dims,
                {{ model.name }}_sim_in, "T", &Tsim);
 
     // model functions
 {%- if solver_options.integrator_type == "IRK" %}
     {{ model.name }}_sim_config->model_set({{ model.name }}_sim_in->model,
-                 "impl_ode_fun", sim_impl_dae_fun);
+                 "impl_ode_fun", capsule->sim_impl_dae_fun);
     {{ model.name }}_sim_config->model_set({{ model.name }}_sim_in->model,
-                 "impl_ode_fun_jac_x_xdot", sim_impl_dae_fun_jac_x_xdot_z);
+                 "impl_ode_fun_jac_x_xdot", capsule->sim_impl_dae_fun_jac_x_xdot_z);
     {{ model.name }}_sim_config->model_set({{ model.name }}_sim_in->model,
-                 "impl_ode_jac_x_xdot_u", sim_impl_dae_jac_x_xdot_u_z);
+                 "impl_ode_jac_x_xdot_u", capsule->sim_impl_dae_jac_x_xdot_u_z);
 {%- if hessian_approx == "EXACT" %}
     {{ model.name }}_sim_config->model_set({{ model.name }}_sim_in->model,
-                "impl_dae_hess", sim_impl_dae_hess);
+                "impl_dae_hess", capsule->sim_impl_dae_hess);
 {%- endif %}
 
 {%- elif solver_options.integrator_type == "ERK" %}
     {{ model.name }}_sim_config->model_set({{ model.name }}_sim_in->model,
-                 "expl_vde_for", sim_forw_vde_casadi);
+                 "expl_vde_for", capsule->sim_forw_vde_casadi);
     {{ model.name }}_sim_config->model_set({{ model.name }}_sim_in->model,
-                 "expl_ode_fun", sim_expl_ode_fun_casadi);
+                 "expl_ode_fun", capsule->sim_expl_ode_fun_casadi);
 {%- if hessian_approx == "EXACT" %}
     {{ model.name }}_sim_config->model_set({{ model.name }}_sim_in->model,
-                "expl_ode_hess", sim_expl_ode_hess);
+                "expl_ode_hess", capsule->sim_expl_ode_hess);
 {%- endif %}
 {%- elif solver_options.integrator_type == "GNSF" %}
     {{ model.name }}_sim_config->model_set({{ model.name }}_sim_in->model,
-                 "phi_fun", sim_gnsf_phi_fun);
+                 "phi_fun", capsule->sim_gnsf_phi_fun);
     {{ model.name }}_sim_config->model_set({{ model.name }}_sim_in->model,
-                 "phi_fun_jac_y", sim_gnsf_phi_fun_jac_y);
+                 "phi_fun_jac_y", capsule->sim_gnsf_phi_fun_jac_y);
     {{ model.name }}_sim_config->model_set({{ model.name }}_sim_in->model,
-                 "phi_jac_y_uhat", sim_gnsf_phi_jac_y_uhat);
+                 "phi_jac_y_uhat", capsule->sim_gnsf_phi_jac_y_uhat);
     {{ model.name }}_sim_config->model_set({{ model.name }}_sim_in->model,
-                 "f_lo_jac_x1_x1dot_u_z", sim_gnsf_f_lo_jac_x1_x1dot_u_z);
+                 "f_lo_jac_x1_x1dot_u_z", capsule->sim_gnsf_f_lo_jac_x1_x1dot_u_z);
     {{ model.name }}_sim_config->model_set({{ model.name }}_sim_in->model,
-                 "gnsf_get_matrices_fun", sim_gnsf_get_matrices_fun);
+                 "gnsf_get_matrices_fun", capsule->sim_gnsf_get_matrices_fun);
 {%- endif %}
 
     // sim solver
-    {{ model.name }}_sim_solver = sim_solver_create({{ model.name }}_sim_config,
+    sim_solver *{{ model.name }}_sim_solver = sim_solver_create({{ model.name }}_sim_config,
                                                {{ model.name }}_sim_dims, {{ model.name }}_sim_opts);
+    capsule->acados_sim_solver = {{ model.name }}_sim_solver;
 
     /* initialize parameter values */
     {% if dims.np > 0 %}
@@ -327,24 +322,24 @@ int {{ model.name }}_acados_sim_create()
     {%- endfor %}
 
 {%- if solver_options.integrator_type == "ERK" %}
-    sim_forw_vde_casadi[0].set_param(sim_forw_vde_casadi, p);
-    sim_expl_ode_fun_casadi[0].set_param(sim_expl_ode_fun_casadi, p);
+    capsule->sim_forw_vde_casadi[0].set_param(capsule->sim_forw_vde_casadi, p);
+    capsule->sim_expl_ode_fun_casadi[0].set_param(capsule->sim_expl_ode_fun_casadi, p);
 {%- if hessian_approx == "EXACT" %}
-    sim_expl_ode_hess[0].set_param(sim_expl_ode_hess, p);
+    capsule->sim_expl_ode_hess[0].set_param(capsule->sim_expl_ode_hess, p);
 {%- endif %}
 {%- elif solver_options.integrator_type == "IRK" %}
-    sim_impl_dae_fun[0].set_param(sim_impl_dae_fun, p);
-    sim_impl_dae_fun_jac_x_xdot_z[0].set_param(sim_impl_dae_fun_jac_x_xdot_z, p);
-    sim_impl_dae_jac_x_xdot_u_z[0].set_param(sim_impl_dae_jac_x_xdot_u_z, p);
+    capsule->sim_impl_dae_fun[0].set_param(capsule->sim_impl_dae_fun, p);
+    capsule->sim_impl_dae_fun_jac_x_xdot_z[0].set_param(capsule->sim_impl_dae_fun_jac_x_xdot_z, p);
+    capsule->sim_impl_dae_jac_x_xdot_u_z[0].set_param(capsule->sim_impl_dae_jac_x_xdot_u_z, p);
 {%- if hessian_approx == "EXACT" %}
-    sim_impl_dae_hess[0].set_param(sim_impl_dae_hess, p);
+    capsule->sim_impl_dae_hess[0].set_param(capsule->sim_impl_dae_hess, p);
 {%- endif %}
 {%- elif solver_options.integrator_type == "GNSF" %}
-    sim_gnsf_phi_fun[0].set_param(sim_gnsf_phi_fun, p);
-    sim_gnsf_phi_fun_jac_y[0].set_param(sim_gnsf_phi_fun_jac_y, p);
-    sim_gnsf_phi_jac_y_uhat[0].set_param(sim_gnsf_phi_jac_y_uhat, p);
-    sim_gnsf_f_lo_jac_x1_x1dot_u_z[0].set_param(sim_gnsf_f_lo_jac_x1_x1dot_u_z, p);
-    sim_gnsf_get_matrices_fun[0].set_param(sim_gnsf_get_matrices_fun, p);
+    capsule->sim_gnsf_phi_fun[0].set_param(capsule->sim_gnsf_phi_fun, p);
+    capsule->sim_gnsf_phi_fun_jac_y[0].set_param(capsule->sim_gnsf_phi_fun_jac_y, p);
+    capsule->sim_gnsf_phi_jac_y_uhat[0].set_param(capsule->sim_gnsf_phi_jac_y_uhat, p);
+    capsule->sim_gnsf_f_lo_jac_x1_x1dot_u_z[0].set_param(capsule->sim_gnsf_f_lo_jac_x1_x1dot_u_z, p);
+    capsule->sim_gnsf_get_matrices_fun[0].set_param(capsule->sim_gnsf_get_matrices_fun, p);
 {% endif %}
     {% endif %}{# if dims.np #}
 
@@ -383,11 +378,11 @@ int {{ model.name }}_acados_sim_create()
 }
 
 
-int {{ model.name }}_acados_sim_solve()
+int {{ model.name }}_acados_sim_solve(sim_solver_capsule *capsule)
 {
     // integrate dynamics using acados sim_solver
-    int status = sim_solve({{ model.name }}_sim_solver,
-                           {{ model.name }}_sim_in, {{ model.name }}_sim_out);
+    int status = sim_solve(capsule->acados_sim_solver,
+                           capsule->acados_sim_in, capsule->acados_sim_out);
     if (status != 0)
         printf("error in {{ model.name }}_acados_sim_solve()! Exiting.\n");
 
@@ -395,43 +390,43 @@ int {{ model.name }}_acados_sim_solve()
 }
 
 
-int {{ model.name }}_acados_sim_free()
+int {{ model.name }}_acados_sim_free(sim_solver_capsule *capsule)
 {
     // free memory
-    sim_solver_destroy({{ model.name }}_sim_solver);
-    sim_in_destroy({{ model.name }}_sim_in);
-    sim_out_destroy({{ model.name }}_sim_out);
-    sim_opts_destroy({{ model.name }}_sim_opts);
-    sim_dims_destroy({{ model.name }}_sim_dims);
-    sim_config_destroy({{ model.name }}_sim_config);
+    sim_solver_destroy(capsule->acados_sim_solver);
+    sim_in_destroy(capsule->acados_sim_in);
+    sim_out_destroy(capsule->acados_sim_out);
+    sim_opts_destroy(capsule->acados_sim_opts);
+    sim_dims_destroy(capsule->acados_sim_dims);
+    sim_config_destroy(capsule->acados_sim_config);
 
     // free external function
 {%- if solver_options.integrator_type == "IRK" %}
-    external_function_param_casadi_free(sim_impl_dae_fun);
-    external_function_param_casadi_free(sim_impl_dae_fun_jac_x_xdot_z);
-    external_function_param_casadi_free(sim_impl_dae_jac_x_xdot_u_z);
+    external_function_param_casadi_free(capsule->sim_impl_dae_fun);
+    external_function_param_casadi_free(capsule->sim_impl_dae_fun_jac_x_xdot_z);
+    external_function_param_casadi_free(capsule->sim_impl_dae_jac_x_xdot_u_z);
 {%- if hessian_approx == "EXACT" %}
-    external_function_param_casadi_free(sim_impl_dae_hess);
+    external_function_param_casadi_free(capsule->sim_impl_dae_hess);
 {%- endif %}
 {%- elif solver_options.integrator_type == "ERK" %}
-    external_function_param_casadi_free(sim_forw_vde_casadi);
-    external_function_param_casadi_free(sim_expl_ode_fun_casadi);
+    external_function_param_casadi_free(capsule->sim_forw_vde_casadi);
+    external_function_param_casadi_free(capsule->sim_expl_ode_fun_casadi);
 {%- if hessian_approx == "EXACT" %}
-    external_function_param_casadi_free(sim_expl_ode_hess);
+    external_function_param_casadi_free(capsule->sim_expl_ode_hess);
 {%- endif %}
 {%- elif solver_options.integrator_type == "GNSF" %}
-    external_function_param_casadi_free(sim_gnsf_phi_fun);
-    external_function_param_casadi_free(sim_gnsf_phi_fun_jac_y);
-    external_function_param_casadi_free(sim_gnsf_phi_jac_y_uhat);
-    external_function_param_casadi_free(sim_gnsf_f_lo_jac_x1_x1dot_u_z);
-    external_function_param_casadi_free(sim_gnsf_get_matrices_fun);
+    external_function_param_casadi_free(capsule->sim_gnsf_phi_fun);
+    external_function_param_casadi_free(capsule->sim_gnsf_phi_fun_jac_y);
+    external_function_param_casadi_free(capsule->sim_gnsf_phi_jac_y_uhat);
+    external_function_param_casadi_free(capsule->sim_gnsf_f_lo_jac_x1_x1dot_u_z);
+    external_function_param_casadi_free(capsule->sim_gnsf_get_matrices_fun);
 {% endif %}
 
     return 0;
 }
 
 
-int {{ model.name }}_acados_sim_update_params(double *p, int np)
+int {{ model.name }}_acados_sim_update_params(sim_solver_capsule *capsule, double *p, int np)
 {
     int status = 0;
     int casadi_np = {{ dims.np }};
@@ -443,57 +438,57 @@ int {{ model.name }}_acados_sim_update_params(double *p, int np)
     }
 
 {%- if solver_options.integrator_type == "ERK" %}
-    sim_forw_vde_casadi[0].set_param(sim_forw_vde_casadi, p);
-    sim_expl_ode_fun_casadi[0].set_param(sim_expl_ode_fun_casadi, p);
+    capsule->sim_forw_vde_casadi[0].set_param(capsule->sim_forw_vde_casadi, p);
+    capsule->sim_expl_ode_fun_casadi[0].set_param(capsule->sim_expl_ode_fun_casadi, p);
 {%- if hessian_approx == "EXACT" %}
-    sim_expl_ode_hess[0].set_param(sim_expl_ode_hess, p);
+    capsule->sim_expl_ode_hess[0].set_param(capsule->sim_expl_ode_hess, p);
 {%- endif %}
 {%- elif solver_options.integrator_type == "IRK" %}
-    sim_impl_dae_fun[0].set_param(sim_impl_dae_fun, p);
-    sim_impl_dae_fun_jac_x_xdot_z[0].set_param(sim_impl_dae_fun_jac_x_xdot_z, p);
-    sim_impl_dae_jac_x_xdot_u_z[0].set_param(sim_impl_dae_jac_x_xdot_u_z, p);
+    capsule->sim_impl_dae_fun[0].set_param(capsule->sim_impl_dae_fun, p);
+    capsule->sim_impl_dae_fun_jac_x_xdot_z[0].set_param(capsule->sim_impl_dae_fun_jac_x_xdot_z, p);
+    capsule->sim_impl_dae_jac_x_xdot_u_z[0].set_param(capsule->sim_impl_dae_jac_x_xdot_u_z, p);
 {%- if hessian_approx == "EXACT" %}
-    sim_impl_dae_hess[0].set_param(sim_impl_dae_hess, p);
+    capsule->sim_impl_dae_hess[0].set_param(capsule->sim_impl_dae_hess, p);
 {%- endif %}
 {%- elif solver_options.integrator_type == "GNSF" %}
-    sim_gnsf_phi_fun[0].set_param(sim_gnsf_phi_fun, p);
-    sim_gnsf_phi_fun_jac_y[0].set_param(sim_gnsf_phi_fun_jac_y, p);
-    sim_gnsf_phi_jac_y_uhat[0].set_param(sim_gnsf_phi_jac_y_uhat, p);
-    sim_gnsf_f_lo_jac_x1_x1dot_u_z[0].set_param(sim_gnsf_f_lo_jac_x1_x1dot_u_z, p);
-    sim_gnsf_get_matrices_fun[0].set_param(sim_gnsf_get_matrices_fun, p);
+    capsule->sim_gnsf_phi_fun[0].set_param(capsule->sim_gnsf_phi_fun, p);
+    capsule->sim_gnsf_phi_fun_jac_y[0].set_param(capsule->sim_gnsf_phi_fun_jac_y, p);
+    capsule->sim_gnsf_phi_jac_y_uhat[0].set_param(capsule->sim_gnsf_phi_jac_y_uhat, p);
+    capsule->sim_gnsf_f_lo_jac_x1_x1dot_u_z[0].set_param(capsule->sim_gnsf_f_lo_jac_x1_x1dot_u_z, p);
+    capsule->sim_gnsf_get_matrices_fun[0].set_param(capsule->sim_gnsf_get_matrices_fun, p);
 {% endif %}
 
     return status;
 }
 
 /* getters pointers to C objects*/
-sim_config * {{ model.name }}_acados_get_sim_config()
+sim_config * {{ model.name }}_acados_get_sim_config(sim_solver_capsule *capsule)
 {
-    return {{ model.name }}_sim_config;
+    return capsule->acados_sim_config;
 };
 
-sim_in * {{ model.name }}_acados_get_sim_in()
+sim_in * {{ model.name }}_acados_get_sim_in(sim_solver_capsule *capsule)
 {
-    return {{ model.name }}_sim_in;
+    return capsule->acados_sim_in;
 };
 
-sim_out * {{ model.name }}_acados_get_sim_out()
+sim_out * {{ model.name }}_acados_get_sim_out(sim_solver_capsule *capsule)
 {
-    return {{ model.name }}_sim_out;
+    return capsule->acados_sim_out;
 };
 
-void * {{ model.name }}_acados_get_sim_dims()
+void * {{ model.name }}_acados_get_sim_dims(sim_solver_capsule *capsule)
 {
-    return {{ model.name }}_sim_dims;
+    return capsule->acados_sim_dims;
 };
 
-sim_opts * {{ model.name }}_acados_get_sim_opts()
+sim_opts * {{ model.name }}_acados_get_sim_opts(sim_solver_capsule *capsule)
 {
-    return {{ model.name }}_sim_opts;
+    return capsule->acados_sim_opts;
 };
 
-sim_solver  * {{ model.name }}_acados_get_sim_solver()
+sim_solver  * {{ model.name }}_acados_get_sim_solver(sim_solver_capsule *capsule)
 {
-    return {{ model.name }}_sim_solver;
+    return capsule->acados_sim_solver;
 };
 

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_sim_solver.in.h
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_sim_solver.in.h
@@ -41,37 +41,58 @@
 extern "C" {
 #endif
 
-int {{ model.name }}_acados_sim_create();
-int {{ model.name }}_acados_sim_solve();
-int {{ model.name }}_acados_sim_free();
-int {{ model.name }}_acados_sim_update_params(double *value, int np);
 
-sim_config  * {{ model.name }}_acados_get_sim_config();
-sim_in      * {{ model.name }}_acados_get_sim_in();
-sim_out     * {{ model.name }}_acados_get_sim_out();
-void        * {{ model.name }}_acados_get_sim_dims();
-sim_opts    * {{ model.name }}_acados_get_sim_opts();
-sim_solver  * {{ model.name }}_acados_get_sim_solver();
+// ** capsule for solver data **
+typedef struct sim_solver_capsule
+{
+    // acados objects
+    sim_in *acados_sim_in;
+    sim_out *acados_sim_out;
+    sim_solver *acados_sim_solver;
+    sim_opts *acados_sim_opts;
+    sim_config *acados_sim_config;
+    void *acados_sim_dims;
 
-// ** global data **
-extern sim_config  * {{ model.name }}_sim_config;
-extern sim_in      * {{ model.name }}_sim_in;
-extern sim_out     * {{ model.name }}_sim_out;
-extern void        * {{ model.name }}_sim_dims;
-extern sim_opts    * {{ model.name }}_sim_opts;
-extern sim_solver  * {{ model.name }}_sim_solver;
+    /* external functions */
+    // ERK
+    external_function_param_casadi * sim_forw_vde_casadi;
+    external_function_param_casadi * sim_expl_ode_fun_casadi;
+    external_function_param_casadi * sim_expl_ode_hess;
+
+    // IRK
+    external_function_param_casadi * sim_impl_dae_fun;
+    external_function_param_casadi * sim_impl_dae_fun_jac_x_xdot_z;
+    external_function_param_casadi * sim_impl_dae_jac_x_xdot_u_z;
+    external_function_param_casadi * sim_impl_dae_hess;
+
+    // GNSF
+    external_function_param_casadi * sim_gnsf_phi_fun;
+    external_function_param_casadi * sim_gnsf_phi_fun_jac_y;
+    external_function_param_casadi * sim_gnsf_phi_jac_y_uhat;
+    external_function_param_casadi * sim_gnsf_f_lo_jac_x1_x1dot_u_z;
+    external_function_param_casadi * sim_gnsf_get_matrices_fun;
+
+} sim_solver_capsule;
+
+
+int {{ model.name }}_acados_sim_create(sim_solver_capsule *capsule);
+int {{ model.name }}_acados_sim_solve(sim_solver_capsule *capsule);
+int {{ model.name }}_acados_sim_free(sim_solver_capsule *capsule);
+int {{ model.name }}_acados_sim_update_params(sim_solver_capsule *capsule, double *value, int np);
+
+sim_config * {{ model.name }}_acados_get_sim_config(sim_solver_capsule *capsule);
+sim_in * {{ model.name }}_acados_get_sim_in(sim_solver_capsule *capsule);
+sim_out * {{ model.name }}_acados_get_sim_out(sim_solver_capsule *capsule);
+void * {{ model.name }}_acados_get_sim_dims(sim_solver_capsule *capsule);
+sim_opts * {{ model.name }}_acados_get_sim_opts(sim_solver_capsule *capsule);
+sim_solver * {{ model.name }}_acados_get_sim_solver(sim_solver_capsule *capsule);
+
+
+sim_solver_capsule * {{ model.name }}_acados_sim_solver_create_capsule();
+int {{ model.name }}_acados_sim_solver_free_capsule(sim_solver_capsule *capsule);
 
 #ifdef __cplusplus
 }
 #endif
-
-{% if solver_options.integrator_type == "ERK" %}
-extern external_function_param_casadi * sim_forw_vde_casadi;
-extern external_function_param_casadi * sim_expl_ode_fun_casadi;
-{% elif solver_options.integrator_type == "IRK" %}
-extern external_function_param_casadi * sim_impl_dae_fun;
-extern external_function_param_casadi * sim_impl_dae_fun_jac_x_xdot_z;
-extern external_function_param_casadi * sim_impl_dae_jac_x_xdot_u_z;
-{% endif %}
 
 #endif  // ACADOS_SIM_{{ model.name }}_H_


### PR DESCRIPTION
- Introduced capsule to avoid global memory
- according changes in S Function & main_sim
- dimension check
- improved acados timings on minGW, see https://discourse.acados.org/t/resolution-of-internal-timers-used-for-returning-solution-timings/396/4 thanks to @Hespe 