### PR TITLE
Wip msvc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -281,7 +281,7 @@ message(STATUS " ")
 
 # Write libraries to be linked into a json file
 if(${ACADOS_WITH_OPENMP})
-    set(LINK_FLAG_OPENMP -fopenmp)
+    set(LINK_FLAG_OPENMP ${OpenMP_C_FLAGS})
 endif()
 if(${ACADOS_WITH_QPOASES})
     set(LINK_FLAG_QPOASES -lqpOASES_e)

--- a/interfaces/acados_matlab_octave/ocp_compile_interface.m
+++ b/interfaces/acados_matlab_octave/ocp_compile_interface.m
@@ -161,7 +161,7 @@ for ii=1:length(mex_files)
         end
         % NOTE: multiple linker flags in 1 argument do not work in Matlab
         mex(acados_include, acados_interfaces_include, external_include, blasfeo_include, hpipm_include,...
-            acdaos_lib_path, linker_flags, mex_files{ii})
+            acados_lib_path, linker_flags, mex_files{ii})
     else
         % gcc uses FLAGS, LDFLAGS
         % MSVC uses COMPFLAGS, COMPDEFINES

--- a/interfaces/acados_matlab_octave/ocp_generate_casadi_ext_fun.m
+++ b/interfaces/acados_matlab_octave/ocp_generate_casadi_ext_fun.m
@@ -190,10 +190,11 @@ if contains(mexOpts.ShortName,  'MSVC') ... % MSVC compiler used
     assert(isfile(msvc_env), 'Cannot find definition of MSVC env vars.');
 
     % assemble build command for MSVC
-    out = fullfile(opts_struct.output_dir, [model_name, '.dll']);
-    build_cmd = sprintf('cl /O2 /EHsc /I %s /I %s /LD %s /Fe%s', ...
+    out_obj_dir = [fullfile(opts_struct.output_dir), '\\'];
+    out_lib = fullfile(opts_struct.output_dir, [model_name, '.dll']);
+    build_cmd = sprintf('cl /O2 /EHsc /I %s /I %s /LD %s /Fo%s /Fe%s', ...
         acados_folder, fullfile(acados_folder, 'external' , 'blasfeo', 'include'), ...
-        strjoin(unique(c_files_path), ' '), out);
+        strjoin(unique(c_files_path), ' '), out_obj_dir, out_lib);
 
     % build
     system(sprintf('"%s" & %s', msvc_env, build_cmd));
@@ -203,13 +204,13 @@ else
     blasfeo_include = ['-I' fullfile(acados_folder, 'external' , 'blasfeo', 'include')];
 
     if ispc
-        out = fullfile(opts_struct.output_dir, ['lib', model_name, '.lib']);
+        out_lib = fullfile(opts_struct.output_dir, ['lib', model_name, '.lib']);
         system(['gcc -O2 -fPIC -shared ', acados_include, ' ', blasfeo_include,...
-            ' ', strjoin(unique(c_files_path), ' '), ' -o ', out]);
+            ' ', strjoin(unique(c_files_path), ' '), ' -o ', out_lib]);
     else
-        out = fullfile(opts_struct.output_dir, ['lib', model_name, '.so']);
+        out_lib = fullfile(opts_struct.output_dir, ['lib', model_name, '.so']);
         system(['gcc -O2 -fPIC -shared ', acados_include, ' ', blasfeo_include,...
-           ' ', strjoin(unique(c_files_path), ' '), ' -o ', out]);
+           ' ', strjoin(unique(c_files_path), ' '), ' -o ', out_lib]);
     end
 end
 

--- a/interfaces/acados_matlab_octave/ocp_set_ext_fun.m
+++ b/interfaces/acados_matlab_octave/ocp_set_ext_fun.m
@@ -568,6 +568,9 @@ end
 %phase_end
 if (strcmp(opts_struct.compile_interface, 'true') || strcmp(opts_struct.codgen_model, 'true'))
 
+    % load linking information
+    libs = loadjson(fileread(fullfile(acados_folder, 'lib', 'link_libs.json')));
+
     if is_octave()
         if ~exist(fullfile(opts_struct.output_dir, 'cflags_octave.txt'), 'file')
             diary(fullfile(opts_struct.output_dir, 'cflags_octave.txt'))
@@ -577,11 +580,7 @@ if (strcmp(opts_struct.compile_interface, 'true') || strcmp(opts_struct.codgen_m
             input_file = fopen(fullfile(opts_struct.output_dir, 'cflags_octave.txt'), 'r');
             cflags_tmp = fscanf(input_file, '%[^\n]s');
             fclose(input_file);
-            if ~ismac()
-                cflags_tmp = [cflags_tmp, ' -std=c99 -fopenmp'];
-            else
-                cflags_tmp = [cflags_tmp, ' -std=c99'];
-            end
+            cflags_tmp = [cflags_tmp, ' -std=c99'];
             input_file = fopen(fullfile(opts_struct.output_dir, 'cflags_octave.txt'), 'w');
             fprintf(input_file, '%s', cflags_tmp);
             fclose(input_file);
@@ -605,20 +604,24 @@ if (strcmp(opts_struct.compile_interface, 'true') || strcmp(opts_struct.codgen_m
             cflags_tmp = [cflags_tmp, ' -DN0=', num2str(phase_start{ii})];
             cflags_tmp = [cflags_tmp, ' -DN1=', num2str(phase_end{ii})];
             setenv('CFLAGS', cflags_tmp);
+            if ~ismac() && ~isempty(libs.openmp)
+                setenv('LDFLAGS', libs.openmp);
+                setenv('COMPFLAGS', libs.openmp); % seems unnecessary
+            end
             mex(acados_include, acados_interfaces_include, external_include, blasfeo_include,...
                 hpipm_include, acados_lib_path, acados_matlab_octave_lib_path, model_lib_path, '-lacados',...
                  '-lhpipm', '-lblasfeo', ['-l', model_name], mex_files{ii});
         else
-            if ~ismac()
-                FLAGS = 'CFLAGS=$CFLAGS -std=c99 -fopenmp';
-                LDFLAGS = 'LDFLAGS=$LDFLAGS -fopenmp';
-            else
-                FLAGS = 'CFLAGS=$CFLAGS -std=c99';
-                LDFLAGS = 'LDFLAGS=$LDFLAGS';
+            FLAGS = 'CFLAGS=$CFLAGS -std=c99';
+            LDFLAGS = 'LDFLAGS=$LDFLAGS';
+            COMPFLAGS = 'COMPFLAGS=$COMPFLAGS';
+            if ~ismac() && ~isempty(libs.openmp)
+                LDFLAGS = [LDFLAGS, ' ', libs.openmp];
+                COMPFLAGS = [COMPFLAGS, ' ', libs.openmp]; % seems unnecessary
             end
-            % load linking information
-            libs = loadjson(fileread(fullfile(acados_folder, 'lib', 'link_libs.json')));
-            mex(mex_flags, FLAGS, LDFLAGS, ['-DSETTER=', setter{ii}],...
+            % gcc uses FLAGS, LDFLAGS
+            % MSVC uses COMPFLAGS
+            mex(mex_flags, FLAGS, LDFLAGS, COMPFLAGS, ['-DSETTER=', setter{ii}],...
                 ['-DSET_FIELD=', set_fields{ii}], ['-DMEX_FIELD=', mex_fields{ii}],...
                 ['-DFUN_NAME=', fun_names{ii}], ['-DPHASE=', num2str(phase{ii})],...
                 ['-DN0=', num2str(phase_start{ii})], ['-DN1=', num2str(phase_end{ii})],...

--- a/interfaces/acados_matlab_octave/sim_compile_interface.m
+++ b/interfaces/acados_matlab_octave/sim_compile_interface.m
@@ -70,11 +70,7 @@ if is_octave()
         input_file = fopen(fullfile(opts.output_dir, 'cflags_octave.txt'), 'r');
         cflags_tmp = fscanf(input_file, '%[^\n]s');
         fclose(input_file);
-        if ~ismac()
-            cflags_tmp = [cflags_tmp, ' -std=c99 -fopenmp'];
-        else
-            cflags_tmp = [cflags_tmp, ' -std=c99'];
-        end
+        cflags_tmp = [cflags_tmp, ' -std=c99'];
         input_file = fopen(fullfile(opts.output_dir, 'cflags_octave.txt'), 'w');
         fprintf(input_file, '%s', cflags_tmp);
         fclose(input_file);
@@ -93,11 +89,7 @@ for ii=1:length(mex_files)
         mex(acados_include, acados_interfaces_include, acados_lib_path,...
             '-lacados', '-lhpipm', '-lblasfeo', mex_files{ii})
     else
-        if ismac()
-            FLAGS = 'CFLAGS=$CFLAGS -std=c99';
-        else
-            FLAGS = 'CFLAGS=$CFLAGS -std=c99 -fopenmp';
-        end
+        FLAGS = 'CFLAGS=$CFLAGS -std=c99';
         mex(mex_flags, FLAGS, acados_include, acados_interfaces_include, acados_lib_path, ...
              '-lacados', '-lhpipm', '-lblasfeo', mex_files{ii}, '-outdir', opts.output_dir)
     end

--- a/interfaces/acados_matlab_octave/sim_generate_casadi_ext_fun.m
+++ b/interfaces/acados_matlab_octave/sim_generate_casadi_ext_fun.m
@@ -99,19 +99,20 @@ if contains(mexOpts.ShortName,  'MSVC') ... % MSVC compiler used
     assert(isfile(msvc_env), 'Cannot find definition of MSVC env vars.');
 
     % assemble build command for MSVC
-    out = fullfile(opts_struct.output_dir, [model_name, '.dll']);
-    build_cmd = sprintf('cl /O2 /EHsc /LD %s /Fe%s', ...
-        strjoin(unique(c_files_path), ' '), out);
+    out_obj_dir = [fullfile(opts_struct.output_dir), '\\'];
+    out_lib = fullfile(opts_struct.output_dir, [model_name, '.dll']);
+    build_cmd = sprintf('cl /O2 /EHsc /LD %s /Fo%s /Fe%s', ...
+        strjoin(unique(c_files_path), ' '), out_obj_dir, out_lib);
 
     % build
     system(sprintf('"%s" & %s', msvc_env, build_cmd));
 else
     if ispc
-        out = fullfile(opts_struct.output_dir, ['lib', model_name, '.lib']);
-        system(['gcc -O2 -fPIC -shared ', strjoin(unique(c_files_path), ' '), ' -o ', out]);
+        out_lib = fullfile(opts_struct.output_dir, ['lib', model_name, '.lib']);
+        system(['gcc -O2 -fPIC -shared ', strjoin(unique(c_files_path), ' '), ' -o ', out_lib]);
     else
-        out = fullfile(opts_struct.output_dir, ['lib', model_name, '.so']);
-        system(['gcc -O2 -fPIC -shared ', strjoin(unique(c_files_path), ' '), ' -o ', out]);
+        out_lib = fullfile(opts_struct.output_dir, ['lib', model_name, '.so']);
+        system(['gcc -O2 -fPIC -shared ', strjoin(unique(c_files_path), ' '), ' -o ', out_lib]);
     end
 end
 

--- a/interfaces/acados_matlab_octave/sim_generate_casadi_ext_fun.m
+++ b/interfaces/acados_matlab_octave/sim_generate_casadi_ext_fun.m
@@ -79,14 +79,6 @@ else
     return;
 end
 
-if ispc
-    ldext = '.lib';
-else
-    ldext = '.so';
-end
-
-lib_name = ['lib', model_name];
-
 if (strcmp(opts_struct.codgen_model, 'true'))
 	for k=1:length(c_files)
 		movefile(c_files{k}, opts_struct.output_dir);
@@ -98,11 +90,26 @@ for k=1:length(c_files)
 	c_files_path{k} = fullfile(opts_struct.output_dir, c_files{k});
 end
 
-if ispc
-    % mbuild(c_files_path{:}, '-output', lib_name, 'CFLAGS="$CFLAGS"', 'LDTYPE="-shared"', ['LDEXT=', ldext]);
-    system(['gcc -O2 -fPIC -shared ', strjoin(c_files_path, ' '), ' -o ', [lib_name, ldext]]);
+mexOpts = mex.getCompilerConfigurations('C', 'Selected');
+if contains(mexOpts.ShortName,  'MSVC')
+    % get env vars for MSVC
+    msvc_env = fullfile(mexOpts.Location, 'VC\Auxiliary\Build\vcvars64.bat');
+    assert(isfile(msvc_env), 'Cannot find definition of MSVC env vars.');
+
+    % assemble build command for MSVC
+    lib = [model_name, '.dll'];
+    build_cmd = sprintf('cl /O2 /EHsc /LD %s /o%s', strjoin(c_files_path, ' '), lib);
+
+    % build
+    system(sprintf('"%s" & %s', msvc_env, build_cmd));
 else
-    system(['gcc -O2 -fPIC -shared ', strjoin(c_files_path, ' '), ' -o ', [lib_name, ldext]]);
+    if ispc
+        lib = ['lib', model_name, '.lib'];
+        system(['gcc -O2 -fPIC -shared ', strjoin(c_files_path, ' '), ' -o ', lib]);
+    else
+        lib = ['lib', model_name, '.so'];
+        system(['gcc -O2 -fPIC -shared ', strjoin(c_files_path, ' '), ' -o ', lib]);
+    end
 end
 
-movefile([lib_name, ldext], fullfile(opts_struct.output_dir, [lib_name, ldext]));
+movefile(lib, fullfile(opts_struct.output_dir, lib));

--- a/interfaces/acados_matlab_octave/sim_generate_casadi_ext_fun.m
+++ b/interfaces/acados_matlab_octave/sim_generate_casadi_ext_fun.m
@@ -91,25 +91,29 @@ for k=1:length(c_files)
 end
 
 mexOpts = mex.getCompilerConfigurations('C', 'Selected');
-if contains(mexOpts.ShortName,  'MSVC')
+if contains(mexOpts.ShortName,  'MSVC') ... % MSVC compiler used
+        && ~(exist("OCTAVE_VERSION", "builtin") > 0) % Matlab used
+
     % get env vars for MSVC
     msvc_env = fullfile(mexOpts.Location, 'VC\Auxiliary\Build\vcvars64.bat');
     assert(isfile(msvc_env), 'Cannot find definition of MSVC env vars.');
 
     % assemble build command for MSVC
-    lib = [model_name, '.dll'];
-    build_cmd = sprintf('cl /O2 /EHsc /LD %s /Fe%s', strjoin(c_files_path, ' '), lib);
+    out = fullfile(opts_struct.output_dir, [model_name, '.dll']);
+    build_cmd = sprintf('cl /O2 /EHsc /LD %s /Fe%s', ...
+        strjoin(unique(c_files_path), ' '), out);
 
     % build
     system(sprintf('"%s" & %s', msvc_env, build_cmd));
 else
     if ispc
-        lib = ['lib', model_name, '.lib'];
-        system(['gcc -O2 -fPIC -shared ', strjoin(c_files_path, ' '), ' -o ', lib]);
+        out = fullfile(opts_struct.output_dir, ['lib', model_name, '.lib']);
+        system(['gcc -O2 -fPIC -shared ', strjoin(unique(c_files_path), ' '), ' -o ', out]);
     else
-        lib = ['lib', model_name, '.so'];
-        system(['gcc -O2 -fPIC -shared ', strjoin(c_files_path, ' '), ' -o ', lib]);
+        out = fullfile(opts_struct.output_dir, ['lib', model_name, '.so']);
+        system(['gcc -O2 -fPIC -shared ', strjoin(unique(c_files_path), ' '), ' -o ', out]);
     end
 end
 
-movefile(lib, fullfile(opts_struct.output_dir, lib));
+end
+

--- a/interfaces/acados_matlab_octave/sim_generate_casadi_ext_fun.m
+++ b/interfaces/acados_matlab_octave/sim_generate_casadi_ext_fun.m
@@ -98,7 +98,7 @@ if contains(mexOpts.ShortName,  'MSVC')
 
     % assemble build command for MSVC
     lib = [model_name, '.dll'];
-    build_cmd = sprintf('cl /O2 /EHsc /LD %s /o%s', strjoin(c_files_path, ' '), lib);
+    build_cmd = sprintf('cl /O2 /EHsc /LD %s /Fe%s', strjoin(c_files_path, ' '), lib);
 
     % build
     system(sprintf('"%s" & %s', msvc_env, build_cmd));

--- a/interfaces/acados_matlab_octave/sim_set_ext_fun.m
+++ b/interfaces/acados_matlab_octave/sim_set_ext_fun.m
@@ -175,11 +175,7 @@ if (strcmp(opts_struct.compile_interface, 'true') || strcmp(opts_struct.codgen_m
             input_file = fopen(fullfile(opts_struct.output_dir, 'cflags_octave.txt'), 'r');
             cflags_tmp = fscanf(input_file, '%[^\n]s');
             fclose(input_file);
-            if ~ismac()
-                cflags_tmp = [cflags_tmp, ' -std=c99 -fopenmp'];
-            else
-                cflags_tmp = [cflags_tmp, ' -std=c99'];
-            end
+            cflags_tmp = [cflags_tmp, ' -std=c99'];
             input_file = fopen(fullfile(opts_struct.output_dir, 'cflags_octave.txt'), 'w');
             fprintf(input_file, '%s', cflags_tmp);
             fclose(input_file);
@@ -205,11 +201,7 @@ if (strcmp(opts_struct.compile_interface, 'true') || strcmp(opts_struct.codgen_m
             setenv('CFLAGS', cflags_tmp);
             mex(acados_include, acados_interfaces_include, acados_lib_path, acados_matlab_octave_lib_path, model_lib_path, '-lacados', '-lhpipm', '-lblasfeo', ['-l', model_name], mex_files{1});
         else
-            if ~ismac()
-                FLAGS = 'CFLAGS=$CFLAGS -std=c99 -fopenmp';
-            else
-                FLAGS = 'CFLAGS=$CFLAGS -std=c99';
-            end
+            FLAGS = 'CFLAGS=$CFLAGS -std=c99';
             mex( mex_flags, FLAGS, ['-DSET_FIELD=', set_fields{ii}],...
                  ['-DMEX_FIELD=', mex_fields{ii}], ['-DFUN_NAME=', fun_names{ii}],...
                  acados_include, acados_interfaces_include, acados_lib_path,...

--- a/interfaces/acados_template/acados_template/c_templates_tera/make_sfun.in.m
+++ b/interfaces/acados_template/acados_template/c_templates_tera/make_sfun.in.m
@@ -117,15 +117,21 @@ INCS{end+1} = ['-I', fullfile(INC_PATH, 'qpOASES_e')];
 
 CFLAGS = 'CFLAGS=$CFLAGS';
 LDFLAGS = 'LDFLAGS=$LDFLAGS';
+COMPFLAGS = 'COMPFLAGS=$COMPFLAGS';
+COMPDEFINES = 'COMPDEFINES=$COMPDEFINES';
 
 {% if solver_options.qp_solver is containing("QPOASES") %}
 CFLAGS = [ CFLAGS, ' -DACADOS_WITH_QPOASES ' ];
+COMPDEFINES = [ COMPDEFINES, ' -DACADOS_WITH_QPOASES ' ];
 {%- elif solver_options.qp_solver is containing("OSQP") %}
 CFLAGS = [ CFLAGS, ' -DACADOS_WITH_OSQP ' ];
+COMPDEFINES = [ COMPDEFINES, ' -DACADOS_WITH_OSQP ' ];
 {%- elif solver_options.qp_solver is containing("QPDUNES") %}
 CFLAGS = [ CFLAGS, ' -DACADOS_WITH_QPDUNES ' ];
+COMPDEFINES = [ COMPDEFINES, ' -DACADOS_WITH_QPDUNES ' ];
 {%- elif solver_options.qp_solver is containing("HPMPC") %}
 CFLAGS = [ CFLAGS, ' -DACADOS_WITH_HPMPC ' ];
+COMPDEFINES = [ COMPDEFINES, ' -DACADOS_WITH_HPMPC ' ];
 {% endif %}
 
 LIB_PATH = ['-L', fullfile('{{ acados_lib_path }}')];
@@ -134,8 +140,8 @@ LIBS = {'-lacados', '-lhpipm', '-lblasfeo'};
 
 % acados linking libraries and flags
 {%- if acados_link_libs and os and os == "pc" %}
-CFLAGS = [CFLAGS ' {{ acados_link_libs.openmp }}'];
 LDFLAGS = [LDFLAGS ' {{ acados_link_libs.openmp }}'];
+COMPFLAGS = [COMPFLAGS ' {{ acados_link_libs.openmp }}'];
 LIBS{end+1} = '{{ acados_link_libs.qpoases }}';
 LIBS{end+1} = '{{ acados_link_libs.hpmpc }}';
 LIBS{end+1} = '{{ acados_link_libs.osqp }}';
@@ -145,7 +151,7 @@ LIBS{end+1} = '-lqpOASES_e';
     {% endif %}
 {%- endif %}
 
-mex('-v', '-O', CFLAGS, LDFLAGS, INCS{:}, ...
+mex('-v', '-O', CFLAGS, LDFLAGS, COMPFLAGS, COMPDEFINES, INCS{:}, ...
     LIB_PATH, LIBS{:}, SOURCES{:}, ...
     '-output', 'acados_solver_sfunction_{{ model.name }}' );
 


### PR DESCRIPTION
Enabled MSVC compiler for Matlab interface, including multiple solver support and sfunction compilation.

Compilation (assuming MSVC 2017 compiler, 64 bit)
- cmake:

        cmake -G "Visual Studio 15 2017 Win64" -DBLASFEO_TARGET=GENERIC -DACADOS_INSTALL_DIR=.. -DBUILD_SHARED_LIBS=OFF ..

- build (don't use PowerShell, as that creates some issues with env vars): 

        cmake --build . -j10 --target INSTALL --config Release

- Matlab: change mex setup to MSVC via `mex -setup C`

Remarks:
- untested for 32 bit (I think I'd need a 32-bit Matlab version to compile 32-bit mex files)
- untested for e.g. MSVC 2015 or 2019 compiler. Biggest challenge here is the location of the `.bat` file that sets the env vars that MSVC's `cl.exe` and `link.exe` need. On my system, I can find this `.bat` file as follows (but I see warnings throughout the internet that say that this location might not be fixed across MSVC versions :roll_eyes:):

        mexOpts = mex.getCompilerConfigurations('C', 'Selected');
        msvc_env = fullfile(mexOpts.Location, 'VC\Auxiliary\Build\vcvars64.bat');

- it seems that MSVC (as opposed to mingw/gcc) does not require the `-openmp` (not `-fopenmp`) linker flag, although I did add it everywhere. 

