### PR TITLE
acados_template: make tera path configurable

### DIFF
--- a/interfaces/acados_template/acados_template/utils.py
+++ b/interfaces/acados_template/acados_template/utils.py
@@ -55,8 +55,10 @@ def get_acados_path():
 
 
 def get_tera_exec_path():
-    ACADOS_PATH = get_acados_path()
-    return os.path.join(ACADOS_PATH, 'bin/t_renderer')
+    TERA_PATH = os.environ.get('TERA_PATH')
+    if not TERA_PATH:
+      TERA_PATH = os.path.join(get_acados_path(), 'bin/t_renderer')
+    return TERA_PATH
 
 
 platform2tera = {

--- a/interfaces/acados_template/acados_template/utils.py
+++ b/interfaces/acados_template/acados_template/utils.py
@@ -57,7 +57,7 @@ def get_acados_path():
 def get_tera_exec_path():
     TERA_PATH = os.environ.get('TERA_PATH')
     if not TERA_PATH:
-      TERA_PATH = os.path.join(get_acados_path(), 'bin/t_renderer')
+        TERA_PATH = os.path.join(get_acados_path(), 'bin/t_renderer')
     return TERA_PATH
 
 


### PR DESCRIPTION
Since `ACADOS_SOURCE_DIR` is current only used to find the tera path, we could remove it, but not sure if it's wanted for future use.