### PR TITLE
fix warning strict-prototypes

### DIFF
--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_sim_solver.in.h
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_sim_solver.in.h
@@ -88,7 +88,7 @@ sim_opts * {{ model.name }}_acados_get_sim_opts(sim_solver_capsule *capsule);
 sim_solver * {{ model.name }}_acados_get_sim_solver(sim_solver_capsule *capsule);
 
 
-sim_solver_capsule * {{ model.name }}_acados_sim_solver_create_capsule();
+sim_solver_capsule * {{ model.name }}_acados_sim_solver_create_capsule(void);
 int {{ model.name }}_acados_sim_solver_free_capsule(sim_solver_capsule *capsule);
 
 #ifdef __cplusplus

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.h
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.h
@@ -108,7 +108,7 @@ typedef struct nlp_solver_capsule
     external_function_param_casadi nl_constr_h_e_fun_jac_hess;
 } nlp_solver_capsule;
 
-nlp_solver_capsule * {{ model.name }}_acados_create_capsule();
+nlp_solver_capsule * {{ model.name }}_acados_create_capsule(void);
 int {{ model.name }}_acados_free_capsule(nlp_solver_capsule *capsule);
 
 int {{ model.name }}_acados_create(nlp_solver_capsule * capsule);

--- a/interfaces/acados_template/acados_template/c_templates_tera/cost_y_0_fun.in.h
+++ b/interfaces/acados_template/acados_template/c_templates_tera/cost_y_0_fun.in.h
@@ -44,22 +44,22 @@ int {{ model.name }}_cost_y_0_fun(const real_t** arg, real_t** res, int* iw, rea
 int {{ model.name }}_cost_y_0_fun_work(int *, int *, int *, int *);
 const int *{{ model.name }}_cost_y_0_fun_sparsity_in(int);
 const int *{{ model.name }}_cost_y_0_fun_sparsity_out(int);
-int {{ model.name }}_cost_y_0_fun_n_in();
-int {{ model.name }}_cost_y_0_fun_n_out();
+int {{ model.name }}_cost_y_0_fun_n_in(void);
+int {{ model.name }}_cost_y_0_fun_n_out(void);
 
 int {{ model.name }}_cost_y_0_fun_jac_ut_xt(const real_t** arg, real_t** res, int* iw, real_t* w, void *mem);
 int {{ model.name }}_cost_y_0_fun_jac_ut_xt_work(int *, int *, int *, int *);
 const int *{{ model.name }}_cost_y_0_fun_jac_ut_xt_sparsity_in(int);
 const int *{{ model.name }}_cost_y_0_fun_jac_ut_xt_sparsity_out(int);
-int {{ model.name }}_cost_y_0_fun_jac_ut_xt_n_in();
-int {{ model.name }}_cost_y_0_fun_jac_ut_xt_n_out();
+int {{ model.name }}_cost_y_0_fun_jac_ut_xt_n_in(void);
+int {{ model.name }}_cost_y_0_fun_jac_ut_xt_n_out(void);
 
 int {{ model.name }}_cost_y_0_hess(const real_t** arg, real_t** res, int* iw, real_t* w, void *mem);
 int {{ model.name }}_cost_y_0_hess_work(int *, int *, int *, int *);
 const int *{{ model.name }}_cost_y_0_hess_sparsity_in(int);
 const int *{{ model.name }}_cost_y_0_hess_sparsity_out(int);
-int {{ model.name }}_cost_y_0_hess_n_in();
-int {{ model.name }}_cost_y_0_hess_n_out();
+int {{ model.name }}_cost_y_0_hess_n_in(void);
+int {{ model.name }}_cost_y_0_hess_n_out(void);
 {% endif %}
 
 #ifdef __cplusplus

--- a/interfaces/acados_template/acados_template/c_templates_tera/cost_y_e_fun.in.h
+++ b/interfaces/acados_template/acados_template/c_templates_tera/cost_y_e_fun.in.h
@@ -44,22 +44,22 @@ int {{ model.name }}_cost_y_e_fun(const real_t** arg, real_t** res, int* iw, rea
 int {{ model.name }}_cost_y_e_fun_work(int *, int *, int *, int *);
 const int *{{ model.name }}_cost_y_e_fun_sparsity_in(int);
 const int *{{ model.name }}_cost_y_e_fun_sparsity_out(int);
-int {{ model.name }}_cost_y_e_fun_n_in();
-int {{ model.name }}_cost_y_e_fun_n_out();
+int {{ model.name }}_cost_y_e_fun_n_in(void);
+int {{ model.name }}_cost_y_e_fun_n_out(void);
 
 int {{ model.name }}_cost_y_e_fun_jac_ut_xt(const real_t** arg, real_t** res, int* iw, real_t* w, void *mem);
 int {{ model.name }}_cost_y_e_fun_jac_ut_xt_work(int *, int *, int *, int *);
 const int *{{ model.name }}_cost_y_e_fun_jac_ut_xt_sparsity_in(int);
 const int *{{ model.name }}_cost_y_e_fun_jac_ut_xt_sparsity_out(int);
-int {{ model.name }}_cost_y_e_fun_jac_ut_xt_n_in();
-int {{ model.name }}_cost_y_e_fun_jac_ut_xt_n_out();
+int {{ model.name }}_cost_y_e_fun_jac_ut_xt_n_in(void);
+int {{ model.name }}_cost_y_e_fun_jac_ut_xt_n_out(void);
 
 int {{ model.name }}_cost_y_e_hess(const real_t** arg, real_t** res, int* iw, real_t* w, void *mem);
 int {{ model.name }}_cost_y_e_hess_work(int *, int *, int *, int *);
 const int *{{ model.name }}_cost_y_e_hess_sparsity_in(int);
 const int *{{ model.name }}_cost_y_e_hess_sparsity_out(int);
-int {{ model.name }}_cost_y_e_hess_n_in();
-int {{ model.name }}_cost_y_e_hess_n_out();
+int {{ model.name }}_cost_y_e_hess_n_in(void);
+int {{ model.name }}_cost_y_e_hess_n_out(void);
 {% endif %}
 
 #ifdef __cplusplus

--- a/interfaces/acados_template/acados_template/c_templates_tera/cost_y_fun.in.h
+++ b/interfaces/acados_template/acados_template/c_templates_tera/cost_y_fun.in.h
@@ -44,22 +44,22 @@ int {{ model.name }}_cost_y_fun(const real_t** arg, real_t** res, int* iw, real_
 int {{ model.name }}_cost_y_fun_work(int *, int *, int *, int *);
 const int *{{ model.name }}_cost_y_fun_sparsity_in(int);
 const int *{{ model.name }}_cost_y_fun_sparsity_out(int);
-int {{ model.name }}_cost_y_fun_n_in();
-int {{ model.name }}_cost_y_fun_n_out();
+int {{ model.name }}_cost_y_fun_n_in(void);
+int {{ model.name }}_cost_y_fun_n_out(void);
 
 int {{ model.name }}_cost_y_fun_jac_ut_xt(const real_t** arg, real_t** res, int* iw, real_t* w, void *mem);
 int {{ model.name }}_cost_y_fun_jac_ut_xt_work(int *, int *, int *, int *);
 const int *{{ model.name }}_cost_y_fun_jac_ut_xt_sparsity_in(int);
 const int *{{ model.name }}_cost_y_fun_jac_ut_xt_sparsity_out(int);
-int {{ model.name }}_cost_y_fun_jac_ut_xt_n_in();
-int {{ model.name }}_cost_y_fun_jac_ut_xt_n_out();
+int {{ model.name }}_cost_y_fun_jac_ut_xt_n_in(void);
+int {{ model.name }}_cost_y_fun_jac_ut_xt_n_out(void);
 
 int {{ model.name }}_cost_y_hess(const real_t** arg, real_t** res, int* iw, real_t* w, void *mem);
 int {{ model.name }}_cost_y_hess_work(int *, int *, int *, int *);
 const int *{{ model.name }}_cost_y_hess_sparsity_in(int);
 const int *{{ model.name }}_cost_y_hess_sparsity_out(int);
-int {{ model.name }}_cost_y_hess_n_in();
-int {{ model.name }}_cost_y_hess_n_out();
+int {{ model.name }}_cost_y_hess_n_in(void);
+int {{ model.name }}_cost_y_hess_n_out(void);
 {% endif %}
 
 #ifdef __cplusplus

--- a/interfaces/acados_template/acados_template/c_templates_tera/external_cost.in.h
+++ b/interfaces/acados_template/acados_template/c_templates_tera/external_cost.in.h
@@ -45,22 +45,22 @@ int {{ model.name }}_cost_ext_cost_fun(const real_t** arg, real_t** res, int* iw
 int {{ model.name }}_cost_ext_cost_fun_work(int *, int *, int *, int *);
 const int *{{ model.name }}_cost_ext_cost_fun_sparsity_in(int);
 const int *{{ model.name }}_cost_ext_cost_fun_sparsity_out(int);
-int {{ model.name }}_cost_ext_cost_fun_n_in();
-int {{ model.name }}_cost_ext_cost_fun_n_out();
+int {{ model.name }}_cost_ext_cost_fun_n_in(void);
+int {{ model.name }}_cost_ext_cost_fun_n_out(void);
 
 int {{ model.name }}_cost_ext_cost_fun_jac_hess(const real_t** arg, real_t** res, int* iw, real_t* w, void *mem);
 int {{ model.name }}_cost_ext_cost_fun_jac_hess_work(int *, int *, int *, int *);
 const int *{{ model.name }}_cost_ext_cost_fun_jac_hess_sparsity_in(int);
 const int *{{ model.name }}_cost_ext_cost_fun_jac_hess_sparsity_out(int);
-int {{ model.name }}_cost_ext_cost_fun_jac_hess_n_in();
-int {{ model.name }}_cost_ext_cost_fun_jac_hess_n_out();
+int {{ model.name }}_cost_ext_cost_fun_jac_hess_n_in(void);
+int {{ model.name }}_cost_ext_cost_fun_jac_hess_n_out(void);
 
 int {{ model.name }}_cost_ext_cost_fun_jac(const real_t** arg, real_t** res, int* iw, real_t* w, void *mem);
 int {{ model.name }}_cost_ext_cost_fun_jac_work(int *, int *, int *, int *);
 const int *{{ model.name }}_cost_ext_cost_fun_jac_sparsity_in(int);
 const int *{{ model.name }}_cost_ext_cost_fun_jac_sparsity_out(int);
-int {{ model.name }}_cost_ext_cost_fun_jac_n_in();
-int {{ model.name }}_cost_ext_cost_fun_jac_n_out();
+int {{ model.name }}_cost_ext_cost_fun_jac_n_in(void);
+int {{ model.name }}_cost_ext_cost_fun_jac_n_out(void);
 {% endif %}
 
 {% else %}

--- a/interfaces/acados_template/acados_template/c_templates_tera/external_cost_0.in.h
+++ b/interfaces/acados_template/acados_template/c_templates_tera/external_cost_0.in.h
@@ -46,22 +46,22 @@ int {{ model.name }}_cost_ext_cost_0_fun(const real_t** arg, real_t** res, int* 
 int {{ model.name }}_cost_ext_cost_0_fun_work(int *, int *, int *, int *);
 const int *{{ model.name }}_cost_ext_cost_0_fun_sparsity_in(int);
 const int *{{ model.name }}_cost_ext_cost_0_fun_sparsity_out(int);
-int {{ model.name }}_cost_ext_cost_0_fun_n_in();
-int {{ model.name }}_cost_ext_cost_0_fun_n_out();
+int {{ model.name }}_cost_ext_cost_0_fun_n_in(void);
+int {{ model.name }}_cost_ext_cost_0_fun_n_out(void);
 
 int {{ model.name }}_cost_ext_cost_0_fun_jac_hess(const real_t** arg, real_t** res, int* iw, real_t* w, void *mem);
 int {{ model.name }}_cost_ext_cost_0_fun_jac_hess_work(int *, int *, int *, int *);
 const int *{{ model.name }}_cost_ext_cost_0_fun_jac_hess_sparsity_in(int);
 const int *{{ model.name }}_cost_ext_cost_0_fun_jac_hess_sparsity_out(int);
-int {{ model.name }}_cost_ext_cost_0_fun_jac_hess_n_in();
-int {{ model.name }}_cost_ext_cost_0_fun_jac_hess_n_out();
+int {{ model.name }}_cost_ext_cost_0_fun_jac_hess_n_in(void);
+int {{ model.name }}_cost_ext_cost_0_fun_jac_hess_n_out(void);
 
 int {{ model.name }}_cost_ext_cost_0_fun_jac(const real_t** arg, real_t** res, int* iw, real_t* w, void *mem);
 int {{ model.name }}_cost_ext_cost_0_fun_jac_work(int *, int *, int *, int *);
 const int *{{ model.name }}_cost_ext_cost_0_fun_jac_sparsity_in(int);
 const int *{{ model.name }}_cost_ext_cost_0_fun_jac_sparsity_out(int);
-int {{ model.name }}_cost_ext_cost_0_fun_jac_n_in();
-int {{ model.name }}_cost_ext_cost_0_fun_jac_n_out();
+int {{ model.name }}_cost_ext_cost_0_fun_jac_n_in(void);
+int {{ model.name }}_cost_ext_cost_0_fun_jac_n_out(void);
 {% endif %}
 
 {% else %}

--- a/interfaces/acados_template/acados_template/c_templates_tera/external_cost_e.in.h
+++ b/interfaces/acados_template/acados_template/c_templates_tera/external_cost_e.in.h
@@ -45,22 +45,22 @@ int {{ model.name }}_cost_ext_cost_e_fun(const real_t** arg, real_t** res, int* 
 int {{ model.name }}_cost_ext_cost_e_fun_work(int *, int *, int *, int *);
 const int *{{ model.name }}_cost_ext_cost_e_fun_sparsity_in(int);
 const int *{{ model.name }}_cost_ext_cost_e_fun_sparsity_out(int);
-int {{ model.name }}_cost_ext_cost_e_fun_n_in();
-int {{ model.name }}_cost_ext_cost_e_fun_n_out();
+int {{ model.name }}_cost_ext_cost_e_fun_n_in(void);
+int {{ model.name }}_cost_ext_cost_e_fun_n_out(void);
 
 int {{ model.name }}_cost_ext_cost_e_fun_jac_hess(const real_t** arg, real_t** res, int* iw, real_t* w, void *mem);
 int {{ model.name }}_cost_ext_cost_e_fun_jac_hess_work(int *, int *, int *, int *);
 const int *{{ model.name }}_cost_ext_cost_e_fun_jac_hess_sparsity_in(int);
 const int *{{ model.name }}_cost_ext_cost_e_fun_jac_hess_sparsity_out(int);
-int {{ model.name }}_cost_ext_cost_e_fun_jac_hess_n_in();
-int {{ model.name }}_cost_ext_cost_e_fun_jac_hess_n_out();
+int {{ model.name }}_cost_ext_cost_e_fun_jac_hess_n_in(void);
+int {{ model.name }}_cost_ext_cost_e_fun_jac_hess_n_out(void);
 
 int {{ model.name }}_cost_ext_cost_e_fun_jac(const real_t** arg, real_t** res, int* iw, real_t* w, void *mem);
 int {{ model.name }}_cost_ext_cost_e_fun_jac_work(int *, int *, int *, int *);
 const int *{{ model.name }}_cost_ext_cost_e_fun_jac_sparsity_in(int);
 const int *{{ model.name }}_cost_ext_cost_e_fun_jac_sparsity_out(int);
-int {{ model.name }}_cost_ext_cost_e_fun_jac_n_in();
-int {{ model.name }}_cost_ext_cost_e_fun_jac_n_out();
+int {{ model.name }}_cost_ext_cost_e_fun_jac_n_in(void);
+int {{ model.name }}_cost_ext_cost_e_fun_jac_n_out(void);
 {% endif %}
 
 {% else %}

--- a/interfaces/acados_template/acados_template/c_templates_tera/h_constraint.in.h
+++ b/interfaces/acados_template/acados_template/c_templates_tera/h_constraint.in.h
@@ -43,23 +43,23 @@ int {{ model.name }}_constr_h_fun_jac_uxt_zt(const real_t** arg, real_t** res, i
 int {{ model.name }}_constr_h_fun_jac_uxt_zt_work(int *, int *, int *, int *);
 const int *{{ model.name }}_constr_h_fun_jac_uxt_zt_sparsity_in(int);
 const int *{{ model.name }}_constr_h_fun_jac_uxt_zt_sparsity_out(int);
-int {{ model.name }}_constr_h_fun_jac_uxt_zt_n_in();
-int {{ model.name }}_constr_h_fun_jac_uxt_zt_n_out();
+int {{ model.name }}_constr_h_fun_jac_uxt_zt_n_in(void);
+int {{ model.name }}_constr_h_fun_jac_uxt_zt_n_out(void);
 
 int {{ model.name }}_constr_h_fun(const real_t** arg, real_t** res, int* iw, real_t* w, void *mem);
 int {{ model.name }}_constr_h_fun_work(int *, int *, int *, int *);
 const int *{{ model.name }}_constr_h_fun_sparsity_in(int);
 const int *{{ model.name }}_constr_h_fun_sparsity_out(int);
-int {{ model.name }}_constr_h_fun_n_in();
-int {{ model.name }}_constr_h_fun_n_out();
+int {{ model.name }}_constr_h_fun_n_in(void);
+int {{ model.name }}_constr_h_fun_n_out(void);
 
 {% if solver_options.hessian_approx == "EXACT" -%}
 int {{ model.name }}_constr_h_fun_jac_uxt_zt_hess(const real_t** arg, real_t** res, int* iw, real_t* w, void *mem);
 int {{ model.name }}_constr_h_fun_jac_uxt_zt_hess_work(int *, int *, int *, int *);
 const int *{{ model.name }}_constr_h_fun_jac_uxt_zt_hess_sparsity_in(int);
 const int *{{ model.name }}_constr_h_fun_jac_uxt_zt_hess_sparsity_out(int);
-int {{ model.name }}_constr_h_fun_jac_uxt_zt_hess_n_in();
-int {{ model.name }}_constr_h_fun_jac_uxt_zt_hess_n_out();
+int {{ model.name }}_constr_h_fun_jac_uxt_zt_hess_n_in(void);
+int {{ model.name }}_constr_h_fun_jac_uxt_zt_hess_n_out(void);
 {% endif %}
 {% endif %}
 

--- a/interfaces/acados_template/acados_template/c_templates_tera/h_e_constraint.in.h
+++ b/interfaces/acados_template/acados_template/c_templates_tera/h_e_constraint.in.h
@@ -44,23 +44,23 @@ int {{ model.name }}_constr_h_e_fun_jac_uxt_zt(const real_t** arg, real_t** res,
 int {{ model.name }}_constr_h_e_fun_jac_uxt_zt_work(int *, int *, int *, int *);
 const int *{{ model.name }}_constr_h_e_fun_jac_uxt_zt_sparsity_in(int);
 const int *{{ model.name }}_constr_h_e_fun_jac_uxt_zt_sparsity_out(int);
-int {{ model.name }}_constr_h_e_fun_jac_uxt_zt_n_in();
-int {{ model.name }}_constr_h_e_fun_jac_uxt_zt_n_out();
+int {{ model.name }}_constr_h_e_fun_jac_uxt_zt_n_in(void);
+int {{ model.name }}_constr_h_e_fun_jac_uxt_zt_n_out(void);
 
 int {{ model.name }}_constr_h_e_fun(const real_t** arg, real_t** res, int* iw, real_t* w, void *mem);
 int {{ model.name }}_constr_h_e_fun_work(int *, int *, int *, int *);
 const int *{{ model.name }}_constr_h_e_fun_sparsity_in(int);
 const int *{{ model.name }}_constr_h_e_fun_sparsity_out(int);
-int {{ model.name }}_constr_h_e_fun_n_in();
-int {{ model.name }}_constr_h_e_fun_n_out();
+int {{ model.name }}_constr_h_e_fun_n_in(void);
+int {{ model.name }}_constr_h_e_fun_n_out(void);
 
 {% if solver_options.hessian_approx == "EXACT" -%}
 int {{ model.name }}_constr_h_e_fun_jac_uxt_zt_hess(const real_t** arg, real_t** res, int* iw, real_t* w, void *mem);
 int {{ model.name }}_constr_h_e_fun_jac_uxt_zt_hess_work(int *, int *, int *, int *);
 const int *{{ model.name }}_constr_h_e_fun_jac_uxt_zt_hess_sparsity_in(int);
 const int *{{ model.name }}_constr_h_e_fun_jac_uxt_zt_hess_sparsity_out(int);
-int {{ model.name }}_constr_h_e_fun_jac_uxt_zt_hess_n_in();
-int {{ model.name }}_constr_h_e_fun_jac_uxt_zt_hess_n_out();
+int {{ model.name }}_constr_h_e_fun_jac_uxt_zt_hess_n_in(void);
+int {{ model.name }}_constr_h_e_fun_jac_uxt_zt_hess_n_out(void);
 {% endif %}
 {% endif %}
 

--- a/interfaces/acados_template/acados_template/c_templates_tera/model.in.h
+++ b/interfaces/acados_template/acados_template/c_templates_tera/model.in.h
@@ -52,24 +52,24 @@ int {{ model.name }}_impl_dae_fun(const real_t** arg, real_t** res, int* iw, rea
 int {{ model.name }}_impl_dae_fun_work(int *, int *, int *, int *);
 const int *{{ model.name }}_impl_dae_fun_sparsity_in(int);
 const int *{{ model.name }}_impl_dae_fun_sparsity_out(int);
-int {{ model.name }}_impl_dae_fun_n_in();
-int {{ model.name }}_impl_dae_fun_n_out();
+int {{ model.name }}_impl_dae_fun_n_in(void);
+int {{ model.name }}_impl_dae_fun_n_out(void);
 
 // implicit ODE
 int {{ model.name }}_impl_dae_fun_jac_x_xdot_z(const real_t** arg, real_t** res, int* iw, real_t* w, void *mem);
 int {{ model.name }}_impl_dae_fun_jac_x_xdot_z_work(int *, int *, int *, int *);
 const int *{{ model.name }}_impl_dae_fun_jac_x_xdot_z_sparsity_in(int);
 const int *{{ model.name }}_impl_dae_fun_jac_x_xdot_z_sparsity_out(int);
-int {{ model.name }}_impl_dae_fun_jac_x_xdot_z_n_in();
-int {{ model.name }}_impl_dae_fun_jac_x_xdot_z_n_out();
+int {{ model.name }}_impl_dae_fun_jac_x_xdot_z_n_in(void);
+int {{ model.name }}_impl_dae_fun_jac_x_xdot_z_n_out(void);
 
 // implicit ODE
 int {{ model.name }}_impl_dae_jac_x_xdot_u_z(const real_t** arg, real_t** res, int* iw, real_t* w, void *mem);
 int {{ model.name }}_impl_dae_jac_x_xdot_u_z_work(int *, int *, int *, int *);
 const int *{{ model.name }}_impl_dae_jac_x_xdot_u_z_sparsity_in(int);
 const int *{{ model.name }}_impl_dae_jac_x_xdot_u_z_sparsity_out(int);
-int {{ model.name }}_impl_dae_jac_x_xdot_u_z_n_in();
-int {{ model.name }}_impl_dae_jac_x_xdot_u_z_n_out();
+int {{ model.name }}_impl_dae_jac_x_xdot_u_z_n_in(void);
+int {{ model.name }}_impl_dae_jac_x_xdot_u_z_n_out(void);
 
 // // implicit ODE - for lifted_irk
 // int {{ model.name }}_impl_dae_fun_jac_x_xdot_u(const real_t** arg, real_t** res, int* iw, real_t* w, void *mem);
@@ -84,8 +84,8 @@ int {{ model.name }}_impl_dae_hess(const real_t** arg, real_t** res, int* iw, re
 int {{ model.name }}_impl_dae_hess_work(int *, int *, int *, int *);
 const int *{{ model.name }}_impl_dae_hess_sparsity_in(int);
 const int *{{ model.name }}_impl_dae_hess_sparsity_out(int);
-int {{ model.name }}_impl_dae_hess_n_in();
-int {{ model.name }}_impl_dae_hess_n_out();
+int {{ model.name }}_impl_dae_hess_n_in(void);
+int {{ model.name }}_impl_dae_hess_n_out(void);
 {%- endif %}
 
 {% elif solver_options.integrator_type == "GNSF" %}
@@ -95,40 +95,40 @@ int        {{ model.name }}_gnsf_get_matrices_fun(const double** arg, double** r
 int        {{ model.name }}_gnsf_get_matrices_fun_work(int *, int *, int *, int *);
 const int *{{ model.name }}_gnsf_get_matrices_fun_sparsity_in(int);
 const int *{{ model.name }}_gnsf_get_matrices_fun_sparsity_out(int);
-int        {{ model.name }}_gnsf_get_matrices_fun_n_in();
-int        {{ model.name }}_gnsf_get_matrices_fun_n_out();
+int        {{ model.name }}_gnsf_get_matrices_fun_n_in(void);
+int        {{ model.name }}_gnsf_get_matrices_fun_n_out(void);
 
 // phi_fun
 int        {{ model.name }}_gnsf_phi_fun(const double** arg, double** res, int* iw, double* w, void *mem);
 int        {{ model.name }}_gnsf_phi_fun_work(int *, int *, int *, int *);
 const int *{{ model.name }}_gnsf_phi_fun_sparsity_in(int);
 const int *{{ model.name }}_gnsf_phi_fun_sparsity_out(int);
-int        {{ model.name }}_gnsf_phi_fun_n_in();
-int        {{ model.name }}_gnsf_phi_fun_n_out();
+int        {{ model.name }}_gnsf_phi_fun_n_in(void);
+int        {{ model.name }}_gnsf_phi_fun_n_out(void);
 
 // phi_fun_jac_y
 int        {{ model.name }}_gnsf_phi_fun_jac_y(const double** arg, double** res, int* iw, double* w, void *mem);
 int        {{ model.name }}_gnsf_phi_fun_jac_y_work(int *, int *, int *, int *);
 const int *{{ model.name }}_gnsf_phi_fun_jac_y_sparsity_in(int);
 const int *{{ model.name }}_gnsf_phi_fun_jac_y_sparsity_out(int);
-int        {{ model.name }}_gnsf_phi_fun_jac_y_n_in();
-int        {{ model.name }}_gnsf_phi_fun_jac_y_n_out();
+int        {{ model.name }}_gnsf_phi_fun_jac_y_n_in(void);
+int        {{ model.name }}_gnsf_phi_fun_jac_y_n_out(void);
 
 // phi_jac_y_uhat
 int        {{ model.name }}_gnsf_phi_jac_y_uhat(const double** arg, double** res, int* iw, double* w, void *mem);
 int        {{ model.name }}_gnsf_phi_jac_y_uhat_work(int *, int *, int *, int *);
 const int *{{ model.name }}_gnsf_phi_jac_y_uhat_sparsity_in(int);
 const int *{{ model.name }}_gnsf_phi_jac_y_uhat_sparsity_out(int);
-int        {{ model.name }}_gnsf_phi_jac_y_uhat_n_in();
-int        {{ model.name }}_gnsf_phi_jac_y_uhat_n_out();
+int        {{ model.name }}_gnsf_phi_jac_y_uhat_n_in(void);
+int        {{ model.name }}_gnsf_phi_jac_y_uhat_n_out(void);
 
 // f_lo_fun_jac_x1k1uz
 int        {{ model.name }}_gnsf_f_lo_fun_jac_x1k1uz(const double** arg, double** res, int* iw, double* w, void *mem);
 int        {{ model.name }}_gnsf_f_lo_fun_jac_x1k1uz_work(int *, int *, int *, int *);
 const int *{{ model.name }}_gnsf_f_lo_fun_jac_x1k1uz_sparsity_in(int);
 const int *{{ model.name }}_gnsf_f_lo_fun_jac_x1k1uz_sparsity_out(int);
-int        {{ model.name }}_gnsf_f_lo_fun_jac_x1k1uz_n_in();
-int        {{ model.name }}_gnsf_f_lo_fun_jac_x1k1uz_n_out();
+int        {{ model.name }}_gnsf_f_lo_fun_jac_x1k1uz_n_in(void);
+int        {{ model.name }}_gnsf_f_lo_fun_jac_x1k1uz_n_out(void);
 
 {% elif solver_options.integrator_type == "ERK" %}
 /* explicit ODE */
@@ -138,32 +138,32 @@ int {{ model.name }}_expl_ode_fun(const real_t** arg, real_t** res, int* iw, rea
 int {{ model.name }}_expl_ode_fun_work(int *, int *, int *, int *);
 const int *{{ model.name }}_expl_ode_fun_sparsity_in(int);
 const int *{{ model.name }}_expl_ode_fun_sparsity_out(int);
-int {{ model.name }}_expl_ode_fun_n_in();
-int {{ model.name }}_expl_ode_fun_n_out();
+int {{ model.name }}_expl_ode_fun_n_in(void);
+int {{ model.name }}_expl_ode_fun_n_out(void);
 
 // explicit forward VDE
 int {{ model.name }}_expl_vde_forw(const real_t** arg, real_t** res, int* iw, real_t* w, void *mem);
 int {{ model.name }}_expl_vde_forw_work(int *, int *, int *, int *);
 const int *{{ model.name }}_expl_vde_forw_sparsity_in(int);
 const int *{{ model.name }}_expl_vde_forw_sparsity_out(int);
-int {{ model.name }}_expl_vde_forw_n_in();
-int {{ model.name }}_expl_vde_forw_n_out();
+int {{ model.name }}_expl_vde_forw_n_in(void);
+int {{ model.name }}_expl_vde_forw_n_out(void);
 
 // explicit adjoint VDE
 int {{ model.name }}_expl_vde_adj(const real_t** arg, real_t** res, int* iw, real_t* w, void *mem);
 int {{ model.name }}_expl_vde_adj_work(int *, int *, int *, int *);
 const int *{{ model.name }}_expl_vde_adj_sparsity_in(int);
 const int *{{ model.name }}_expl_vde_adj_sparsity_out(int);
-int {{ model.name }}_expl_vde_adj_n_in();
-int {{ model.name }}_expl_vde_adj_n_out();
+int {{ model.name }}_expl_vde_adj_n_in(void);
+int {{ model.name }}_expl_vde_adj_n_out(void);
 
 {%- if hessian_approx == "EXACT" %}
 int {{ model.name }}_expl_ode_hess(const real_t** arg, real_t** res, int* iw, real_t* w, void *mem);
 int {{ model.name }}_expl_ode_hess_work(int *, int *, int *, int *);
 const int *{{ model.name }}_expl_ode_hess_sparsity_in(int);
 const int *{{ model.name }}_expl_ode_hess_sparsity_out(int);
-int {{ model.name }}_expl_ode_hess_n_in();
-int {{ model.name }}_expl_ode_hess_n_out();
+int {{ model.name }}_expl_ode_hess_n_in(void);
+int {{ model.name }}_expl_ode_hess_n_out(void);
 {%- endif %}
 
 {% elif solver_options.integrator_type == "DISCRETE" %}
@@ -173,23 +173,23 @@ int {{ model.name }}_dyn_disc_phi_fun(const real_t** arg, real_t** res, int* iw,
 int {{ model.name }}_dyn_disc_phi_fun_work(int *, int *, int *, int *);
 const int *{{ model.name }}_dyn_disc_phi_fun_sparsity_in(int);
 const int *{{ model.name }}_dyn_disc_phi_fun_sparsity_out(int);
-int {{ model.name }}_dyn_disc_phi_fun_n_in();
-int {{ model.name }}_dyn_disc_phi_fun_n_out();
+int {{ model.name }}_dyn_disc_phi_fun_n_in(void);
+int {{ model.name }}_dyn_disc_phi_fun_n_out(void);
 
 int {{ model.name }}_dyn_disc_phi_fun_jac(const real_t** arg, real_t** res, int* iw, real_t* w, void *mem);
 int {{ model.name }}_dyn_disc_phi_fun_jac_work(int *, int *, int *, int *);
 const int *{{ model.name }}_dyn_disc_phi_fun_jac_sparsity_in(int);
 const int *{{ model.name }}_dyn_disc_phi_fun_jac_sparsity_out(int);
-int {{ model.name }}_dyn_disc_phi_fun_jac_n_in();
-int {{ model.name }}_dyn_disc_phi_fun_jac_n_out();
+int {{ model.name }}_dyn_disc_phi_fun_jac_n_in(void);
+int {{ model.name }}_dyn_disc_phi_fun_jac_n_out(void);
 
 {%- if hessian_approx == "EXACT" %}
 int {{ model.name }}_dyn_disc_phi_fun_jac_hess(const real_t** arg, real_t** res, int* iw, real_t* w, void *mem);
 int {{ model.name }}_dyn_disc_phi_fun_jac_hess_work(int *, int *, int *, int *);
 const int *{{ model.name }}_dyn_disc_phi_fun_jac_hess_sparsity_in(int);
 const int *{{ model.name }}_dyn_disc_phi_fun_jac_hess_sparsity_out(int);
-int {{ model.name }}_dyn_disc_phi_fun_jac_hess_n_in();
-int {{ model.name }}_dyn_disc_phi_fun_jac_hess_n_out();
+int {{ model.name }}_dyn_disc_phi_fun_jac_hess_n_in(void);
+int {{ model.name }}_dyn_disc_phi_fun_jac_hess_n_out(void);
 {%- endif %}
 {% else %}
   {%- if hessian_approx == "EXACT" %}

--- a/interfaces/acados_template/acados_template/c_templates_tera/phi_constraint.in.h
+++ b/interfaces/acados_template/acados_template/c_templates_tera/phi_constraint.in.h
@@ -44,8 +44,8 @@ int {{ model.name }}_phi_constraint(const real_t** arg, real_t** res, int* iw, r
 int {{ model.name }}_phi_constraint_work(int *, int *, int *, int *);
 const int *{{ model.name }}_phi_constraint_sparsity_in(int);
 const int *{{ model.name }}_phi_constraint_sparsity_out(int);
-int {{ model.name }}_phi_constraint_n_in();
-int {{ model.name }}_phi_constraint_n_out();
+int {{ model.name }}_phi_constraint_n_in(void);
+int {{ model.name }}_phi_constraint_n_out(void);
 {% endif %}
 
 #ifdef __cplusplus

--- a/interfaces/acados_template/acados_template/c_templates_tera/phi_e_constraint.in.h
+++ b/interfaces/acados_template/acados_template/c_templates_tera/phi_e_constraint.in.h
@@ -10,8 +10,8 @@ int {{ model.name }}_phi_e_constraint(const real_t** arg, real_t** res, int* iw,
 int {{ model.name }}_phi_e_constraint_work(int *, int *, int *, int *);
 const int *{{ model.name }}_phi_e_constraint_sparsity_in(int);
 const int *{{ model.name }}_phi_e_constraint_sparsity_out(int);
-int {{ model.name }}_phi_e_constraint_n_in();
-int {{ model.name }}_phi_e_constraint_n_out();
+int {{ model.name }}_phi_e_constraint_n_in(void);
+int {{ model.name }}_phi_e_constraint_n_out(void);
 {% endif %}
 
 #ifdef __cplusplus


### PR DESCRIPTION
Hello,

```void foo(void)``` and ```void foo()``` are not the same in plain C. This causes the compile to emit warnings resp. errors depending on the context (e.g. ```-Werror -Wstrict-prototypes```). This PR addresses the issue.