### PR TITLE
acados_sim, option "compile_interface": Fixed value "auto" not working correctly on windows

### DIFF
--- a/interfaces/acados_matlab_octave/acados_sim.m
+++ b/interfaces/acados_matlab_octave/acados_sim.m
@@ -78,12 +78,11 @@ classdef acados_sim < handle
                 compile_interface = false;
             elseif strcmp(obj.opts_struct.compile_interface, 'auto')
                 if is_octave()
-                    compile_interface = ~exist( fullfile(obj.opts_struct.output_dir,...
-                        '/sim_create.mex'), 'file');
+                    extension = '.mex';
                 else
-                    compile_interface = ~exist( fullfile(obj.opts_struct.output_dir,...
-                        '/sim_create.mexa64'), 'file');
+                    extension = ['.' mexext];
                 end
+                compile_interface = ~exist(fullfile(obj.opts_struct.output_dir, ['/sim_create', extension]), 'file');
             else
                 obj.model_struct.cost_type
                 error('acados_sim: field compile_interface is , supported values are: true, false, auto');


### PR DESCRIPTION
Hello everyone,

in "acados_sim.m", the code was looking for a file with extension "mexa64" to check whether compilation is necessary, but on windows the extension name should be "mexw64". The Matlab function "mexext" returns the correct extension.