### PR TITLE
Defines in a header file such that they are known at compile time

### DIFF
--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -71,36 +71,36 @@
 
 #include "acados_solver_{{ model.name }}.h"
 
-#define NX     {{ dims.nx }}
-#define NZ     {{ dims.nz }}
-#define NU     {{ dims.nu }}
-#define NP     {{ dims.np }}
-#define NBX    {{ dims.nbx }}
-#define NBX0   {{ dims.nbx_0 }}
-#define NBU    {{ dims.nbu }}
-#define NSBX   {{ dims.nsbx }}
-#define NSBU   {{ dims.nsbu }}
-#define NSH    {{ dims.nsh }}
-#define NSG    {{ dims.nsg }}
-#define NSPHI  {{ dims.nsphi }}
-#define NSHN   {{ dims.nsh_e }}
-#define NSGN   {{ dims.nsg_e }}
-#define NSPHIN {{ dims.nsphi_e }}
-#define NSBXN  {{ dims.nsbx_e }}
-#define NS     {{ dims.ns }}
-#define NSN    {{ dims.ns_e }}
-#define NG     {{ dims.ng }}
-#define NBXN   {{ dims.nbx_e }}
-#define NGN    {{ dims.ng_e }}
-#define NY0    {{ dims.ny_0 }}
-#define NY     {{ dims.ny }}
-#define NYN    {{ dims.ny_e }}
-#define N      {{ dims.N }}
-#define NH     {{ dims.nh }}
-#define NPHI   {{ dims.nphi }}
-#define NHN    {{ dims.nh_e }}
-#define NPHIN  {{ dims.nphi_e }}
-#define NR     {{ dims.nr }}
+#define NX     ACADOS_NX
+#define NZ     ACADOS_NZ
+#define NU     ACADOS_NU
+#define NP     ACADOS_NP
+#define NBX    ACADOS_NBX
+#define NBX0   ACADOS_NBX0
+#define NBU    ACADOS_NBU
+#define NSBX   ACADOS_NSBX
+#define NSBU   ACADOS_NSBU
+#define NSH    ACADOS_NSH
+#define NSG    ACADOS_NSG
+#define NSPHI  ACADOS_NSPHI
+#define NSHN   ACADOS_NSHN
+#define NSGN   ACADOS_NSGN
+#define NSPHIN ACADOS_NSPHIN
+#define NSBXN  ACADOS_NSBXN
+#define NS     ACADOS_NS
+#define NSN    ACADOS_NSN
+#define NG     ACADOS_NG
+#define NBXN   ACADOS_NBXN
+#define NGN    ACADOS_NGN
+#define NY0    ACADOS_NY0
+#define NY     ACADOS_NY
+#define NYN    ACADOS_NYN
+#define N      ACADOS_N
+#define NH     ACADOS_NH
+#define NPHI   ACADOS_NPHI
+#define NHN    ACADOS_NHN
+#define NPHIN  ACADOS_NPHIN
+#define NR     ACADOS_NR
 
 
 // ** solver data **

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.h
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.h
@@ -37,6 +37,37 @@
 #include "acados_c/ocp_nlp_interface.h"
 #include "acados_c/external_function_interface.h"
 
+#define ACADOS_NX     {{ dims.nx }}
+#define ACADOS_NZ     {{ dims.nz }}
+#define ACADOS_NU     {{ dims.nu }}
+#define ACADOS_NP     {{ dims.np }}
+#define ACADOS_NBX    {{ dims.nbx }}
+#define ACADOS_NBX0   {{ dims.nbx_0 }}
+#define ACADOS_NBU    {{ dims.nbu }}
+#define ACADOS_NSBX   {{ dims.nsbx }}
+#define ACADOS_NSBU   {{ dims.nsbu }}
+#define ACADOS_NSH    {{ dims.nsh }}
+#define ACADOS_NSG    {{ dims.nsg }}
+#define ACADOS_NSPHI  {{ dims.nsphi }}
+#define ACADOS_NSHN   {{ dims.nsh_e }}
+#define ACADOS_NSGN   {{ dims.nsg_e }}
+#define ACADOS_NSPHIN {{ dims.nsphi_e }}
+#define ACADOS_NSBXN  {{ dims.nsbx_e }}
+#define ACADOS_NS     {{ dims.ns }}
+#define ACADOS_NSN    {{ dims.ns_e }}
+#define ACADOS_NG     {{ dims.ng }}
+#define ACADOS_NBXN   {{ dims.nbx_e }}
+#define ACADOS_NGN    {{ dims.ng_e }}
+#define ACADOS_NY0    {{ dims.ny_0 }}
+#define ACADOS_NY     {{ dims.ny }}
+#define ACADOS_NYN    {{ dims.ny_e }}
+#define ACADOS_N      {{ dims.N }}
+#define ACADOS_NH     {{ dims.nh }}
+#define ACADOS_NPHI   {{ dims.nphi }}
+#define ACADOS_NHN    {{ dims.nh_e }}
+#define ACADOS_NPHIN  {{ dims.nphi_e }}
+#define ACADOS_NR     {{ dims.nr }}
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
If I try to add the `c_generated_code` folder from a python project to a C++ project, the dimensions of the problem are not known at compile time, which was the case with ACADO (`acado_common.h`). The only way was to include the `acados_solver_<project>.c`, which is rather ugly. This tries to fix that, but not sure if this is the preferred way. Feel free to suggest changes!