### PR TITLE
acados_template improvements

### DIFF
--- a/examples/acados_python/getting_started/common/utils.py
+++ b/examples/acados_python/getting_started/common/utils.py
@@ -36,7 +36,7 @@ import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 
-def plot_pendulum(shooting_nodes, u_max, U, X_true, X_est=None, Y_measured=None, latexify=False):
+def plot_pendulum(shooting_nodes, u_max, U, X_true, X_est=None, Y_measured=None, latexify=False, plt_show=True, X_true_label=None):
     """
     Params:
         shooting_nodes: time values of the discretization
@@ -77,7 +77,11 @@ def plot_pendulum(shooting_nodes, u_max, U, X_true, X_est=None, Y_measured=None,
         t_mhe = np.linspace(N_mhe * Ts, Tf, N_sim-N_mhe)
 
     plt.subplot(nx+1, 1, 1)
-    plt.step(t, np.append([U[0]], U), color='r')
+    line, = plt.step(t, np.append([U[0]], U))
+    if X_true_label is not None:
+        line.set_label(X_true_label)
+    else:
+        line.set_color('r')
     plt.title('closed-loop simulation')
     plt.ylabel('$u$')
     plt.xlabel('$t$')
@@ -90,7 +94,9 @@ def plot_pendulum(shooting_nodes, u_max, U, X_true, X_est=None, Y_measured=None,
 
     for i in range(nx):
         plt.subplot(nx+1, 1, i+2)
-        plt.plot(t, X_true[:,i], label='true')
+        line, = plt.plot(t, X_true[:, i], label='true')
+        if X_true_label is not None:
+            line.set_label(X_true_label)
 
         if WITH_ESTIMATION:
             plt.plot(t_mhe, X_est[:, i], '--', label='estimated')
@@ -104,5 +110,5 @@ def plot_pendulum(shooting_nodes, u_max, U, X_true, X_est=None, Y_measured=None,
     plt.subplots_adjust(left=None, bottom=None, right=None, top=None, hspace=0.4)
 
     # avoid plotting when running on Travis
-    if os.environ.get('ACADOS_ON_TRAVIS') is None:
+    if os.environ.get('ACADOS_ON_TRAVIS') is None and plt_show:
         plt.show()

--- a/examples/acados_python/getting_started/ocp/minimal_example_ocp_reuse_code.py
+++ b/examples/acados_python/getting_started/ocp/minimal_example_ocp_reuse_code.py
@@ -1,0 +1,208 @@
+# Minimal example showing how to reuse the exported c-code with
+# different time-steps.
+#
+# There are two use-cases demonstrated here. One use-case is to change
+# the length of the time-stamp vector (this results in a different
+# N). Another use-case is to change the final time but keep the number
+# of shooting nodes identical. Reusing the exported code with variing
+# N can be useful especially in a c-only application where the process
+# of code-generation should only be done once.
+#
+# This example is an extension of the 'minimal_example_ocp.py' example.
+
+#
+# Copyright 2021 Markus Schwienbacher, Gianluca Frison, Dimitris Kouzoupis,
+# Robin Verschueren, Andrea Zanelli, Niels van Duijkeren, Jonathan Frey,
+# Tommaso Sartor, Branimir Novoselnik, Rien Quirynen, Rezart Qelibari,
+# Dang Doan, Jonas Koenemann, Yutao Chen, Tobias Schöls, Jonas Schlagenhauf,
+# Moritz Diehl
+#
+# This file is part of acados.
+#
+# The 2-Clause BSD License
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.;
+#
+import os
+import sys
+
+sys.path.insert(0, '../common')
+
+from acados_template import AcadosOcp, AcadosOcpSolver
+from pendulum_model import export_pendulum_ode_model
+import numpy as np
+import scipy.linalg
+from utils import plot_pendulum
+
+print('This example demonstrates 2 use-cases for reuse of the code export.')
+
+# create ocp object to formulate the OCP
+ocp = AcadosOcp()
+
+# set model
+model = export_pendulum_ode_model()
+ocp.model = model
+
+nx = model.x.size()[0]
+nu = model.u.size()[0]
+ny = nx + nu
+ny_e = nx
+
+# define the different options for the use-case demonstration
+N0 = 20  # original number of shooting nodes
+N12 = 15  # change the number of shooting nodes for use-cases 1 and 2
+Tf_01 = 1.0  # original final time and for use-case 1
+Tf_2 = Tf_01 * 0.7  # change final time for use-case 2 (but keep N identical)
+
+# set dimensions
+ocp.dims.N = N0
+
+# set cost
+Q = 2 * np.diag([1e3, 1e3, 1e-2, 1e-2])
+R = 2 * np.diag([1e-2])
+
+ocp.cost.W_e = Q
+ocp.cost.W = scipy.linalg.block_diag(Q, R)
+
+ocp.cost.cost_type = 'LINEAR_LS'
+ocp.cost.cost_type_e = 'LINEAR_LS'
+
+ocp.cost.Vx = np.zeros((ny, nx))
+ocp.cost.Vx[:nx, :nx] = np.eye(nx)
+
+Vu = np.zeros((ny, nu))
+Vu[4, 0] = 1.0
+ocp.cost.Vu = Vu
+
+ocp.cost.Vx_e = np.eye(nx)
+
+ocp.cost.yref = np.zeros((ny,))
+ocp.cost.yref_e = np.zeros((ny_e,))
+
+# set constraints
+Fmax = 80
+ocp.constraints.lbu = np.array([-Fmax])
+ocp.constraints.ubu = np.array([+Fmax])
+ocp.constraints.idxbu = np.array([0])
+
+ocp.constraints.x0 = np.array([0.0, np.pi, 0.0, 0.0])
+
+# set options
+ocp.solver_options.qp_solver = 'PARTIAL_CONDENSING_HPIPM'  # FULL_CONDENSING_QPOASES
+# PARTIAL_CONDENSING_HPIPM, FULL_CONDENSING_QPOASES, FULL_CONDENSING_HPIPM,
+# PARTIAL_CONDENSING_QPDUNES, PARTIAL_CONDENSING_OSQP
+ocp.solver_options.hessian_approx = 'GAUSS_NEWTON'
+ocp.solver_options.integrator_type = 'ERK'
+# ocp.solver_options.print_level = 1
+ocp.solver_options.nlp_solver_type = 'SQP'  # SQP_RTI, SQP
+
+# set prediction horizon
+ocp.solver_options.tf = Tf_01
+
+print(80*'-')
+print('generate code and compile...')
+ocp_solver = AcadosOcpSolver(ocp, json_file='acados_ocp.json')
+
+# --------------------------------------------------------------------------------
+# 0) solve the problem defined here (original from code export), analog to 'minimal_example_ocp.py'
+
+simX0 = np.ndarray((N0 + 1, nx))
+simU0 = np.ndarray((N0, nu))
+
+print(80*'-')
+print(f'solve original code with N = {N0} and Tf = {Tf_01} s:')
+status = ocp_solver.solve()
+
+if status != 0:
+    ocp_solver.print_statistics()  # encapsulates: stat = ocp_solver.get_stats("statistics")
+    raise Exception('acados returned status {}. Exiting.'.format(status))
+
+# get solution
+for i in range(N0):
+    simX0[i, :] = ocp_solver.get(i, "x")
+    simU0[i, :] = ocp_solver.get(i, "u")
+simX0[N0, :] = ocp_solver.get(N0, "x")
+
+ocp_solver.print_statistics()  # encapsulates: stat = ocp_solver.get_stats("statistics")
+
+# plot but don't halt
+plot_pendulum(np.linspace(0, Tf_01, N0 + 1), Fmax, simU0, simX0, latexify=False, plt_show=False, X_true_label=f'original: N={N0}, Tf={Tf_01}')
+
+# --------------------------------------------------------------------------------
+# 1) now reuse the code but set a new time-steps vector, with a new number of elements
+dt1 = Tf_01 / N12
+
+new_time_steps1 = np.tile(dt1, (N12,))  # Matlab's equivalent to repmat
+time1 = np.hstack([0, np.cumsum(new_time_steps1)])
+
+simX1 = np.ndarray((N12 + 1, nx))
+simU1 = np.ndarray((N12, nu))
+
+ocp_solver.set_new_time_steps(new_time_steps1)
+print(80*'-')
+print(f'solve use-case 1 with N = {N12} (instead of {N0}) and Tf = {Tf_01} s:')
+status = ocp_solver.solve()
+
+if status != 0:
+    ocp_solver.print_statistics()  # encapsulates: stat = ocp_solver.get_stats("statistics")
+    raise Exception('acados returned status {}. Exiting.'.format(status))
+
+# get solution
+for i in range(N12):
+    simX1[i, :] = ocp_solver.get(i, "x")
+    simU1[i, :] = ocp_solver.get(i, "u")
+simX1[N12, :] = ocp_solver.get(N12, "x")
+
+ocp_solver.print_statistics()  # encapsulates: stat = ocp_solver.get_stats("statistics")
+
+plot_pendulum(time1, Fmax, simU1, simX1, latexify=False, plt_show=False, X_true_label=f'use-case 1: N={N12}')
+
+# --------------------------------------------------------------------------------
+# 2) reuse the code again, set a new time-steps vector, only with a different final time
+dt2 = Tf_2 / N12
+
+new_time_steps2 = np.tile(dt2, (N12,))  # Matlab's equivalent to repmat
+time2 = np.hstack([0, np.cumsum(new_time_steps2)])
+
+simX2 = np.ndarray((N12 + 1, nx))
+simU2 = np.ndarray((N12, nu))
+
+ocp_solver.set_new_time_steps(new_time_steps2)
+print(80*'-')
+print(f'solve use-case 2 with N = {N12} and Tf = {Tf_2} s (instead of {Tf_01} s):')
+status = ocp_solver.solve()
+
+if status != 0:
+    ocp_solver.print_statistics()  # encapsulates: stat = ocp_solver.get_stats("statistics")
+    raise Exception('acados returned status {}. Exiting.'.format(status))
+
+# get solution
+for i in range(N12):
+    simX2[i, :] = ocp_solver.get(i, "x")
+    simU2[i, :] = ocp_solver.get(i, "u")
+simX2[N12, :] = ocp_solver.get(N12, "x")
+
+ocp_solver.print_statistics()  # encapsulates: stat = ocp_solver.get_stats("statistics")
+
+plot_pendulum(time2, Fmax, simU2, simX2, latexify=False, plt_show=True, X_true_label=f'use-case 2: Tf={Tf_2} s')
+

--- a/interfaces/CMakeLists.txt
+++ b/interfaces/CMakeLists.txt
@@ -141,6 +141,9 @@ add_test(NAME python_test_ocp
 add_test(NAME python_pendulum_ocp_example
         COMMAND "${CMAKE_COMMAND}" -E chdir ${PROJECT_SOURCE_DIR}/examples/acados_python/getting_started/ocp
         python minimal_example_ocp.py)
+add_test(NAME python_pendulum_ocp_example_reuse_code
+        COMMAND "${CMAKE_COMMAND}" -E chdir ${PROJECT_SOURCE_DIR}/examples/acados_python/getting_started/ocp
+        python minimal_example_ocp_reuse_code.py)
 add_test(NAME python_nonuniform_discretization_ocp_example
         COMMAND "${CMAKE_COMMAND}" -E chdir ${PROJECT_SOURCE_DIR}/examples/acados_python/getting_started/ocp
         python nonuniform_discretization_example.py)

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -831,6 +831,10 @@ class AcadosOcpSolver:
         assert getattr(self.shared_lib, f"{model.name}_acados_create")(self.capsule)==0
         self.solver_created = True
 
+        # create solver with another number of stages
+        getattr(self.shared_lib, f"{model.name}_acados_create_w_stages").argtypes = [c_void_p, c_int, c_void_p]
+        getattr(self.shared_lib, f"{model.name}_acados_create_w_stages").restype = c_int
+
         # get pointers solver
         getattr(self.shared_lib, f"{model.name}_acados_get_nlp_opts").argtypes = [c_void_p]
         getattr(self.shared_lib, f"{model.name}_acados_get_nlp_opts").restype = c_void_p

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -431,9 +431,15 @@ def make_ocp_dims_consistent(acados_ocp):
         if np.shape(opts.shooting_nodes)[0] != dims.N+1:
             raise Exception('inconsistent dimension N, regarding shooting_nodes.')
 
-        time_steps = np.zeros((dims.N,))
-        for i in range(dims.N):
-            time_steps[i] = opts.shooting_nodes[i+1] - opts.shooting_nodes[i]
+        time_steps = opts.shooting_nodes[1:] - opts.shooting_nodes[0:-1]
+        # identify constant time-steps: due to numerical reasons the content of time_steps might vary a bit
+        delta_time_steps = time_steps[1:] - time_steps[0:-1]
+        avg_time_steps = np.average(time_steps)
+        # criterion for constant time-step detection: the min/max difference in values normalized by the average
+        check_const_time_step = np.max(delta_time_steps)-np.min(delta_time_steps) / avg_time_steps
+        # if the criterion is small, we have a constant time-step
+        if check_const_time_step < 1e-9:
+            time_steps[:] = avg_time_steps  # if we have a constant time-step: apply the average time-step
         opts.time_steps = time_steps
 
     elif (not is_empty(opts.time_steps)) and (not is_empty(opts.shooting_nodes)):

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -831,10 +831,6 @@ class AcadosOcpSolver:
         assert getattr(self.shared_lib, f"{model.name}_acados_create")(self.capsule)==0
         self.solver_created = True
 
-        # create solver with another number of stages
-        getattr(self.shared_lib, f"{model.name}_acados_create_w_stages").argtypes = [c_void_p, c_int, c_void_p]
-        getattr(self.shared_lib, f"{model.name}_acados_create_w_stages").restype = c_int
-
         # get pointers solver
         getattr(self.shared_lib, f"{model.name}_acados_get_nlp_opts").argtypes = [c_void_p]
         getattr(self.shared_lib, f"{model.name}_acados_get_nlp_opts").restype = c_void_p

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -839,6 +839,7 @@ class AcadosOcpSolver:
         # get pointers solver
         self.__get_pointers_solver()
 
+
     def __get_pointers_solver(self):
         """
         Private function to get the pointers for solver
@@ -869,6 +870,7 @@ class AcadosOcpSolver:
         getattr(self.shared_lib, f"{model.name}_acados_get_nlp_solver").restype = c_void_p
         self.nlp_solver = getattr(self.shared_lib, f"{model.name}_acados_get_nlp_solver")(self.capsule)
 
+
     def solve(self):
         """
         Solve the ocp with current input.
@@ -879,6 +881,7 @@ class AcadosOcpSolver:
         getattr(self.shared_lib, f"{model.name}_acados_solve").restype = c_int
         status = getattr(self.shared_lib, f"{model.name}_acados_solve")(self.capsule)
         return status
+
 
     def set_new_time_steps(self, new_time_steps):
         """
@@ -911,12 +914,12 @@ class AcadosOcpSolver:
         else:  # recreate the solver with the new time steps
             self.solver_created = False
 
-            # 1) delete old memory (analog to __del__)
+            # delete old memory (analog to __del__)
             getattr(self.shared_lib, f"{model.name}_acados_free").argtypes = [c_void_p]
             getattr(self.shared_lib, f"{model.name}_acados_free").restype = c_int
             getattr(self.shared_lib, f"{model.name}_acados_free")(self.capsule)
 
-            # 3) rebuild memory with new time steps
+            # store N and new time steps
             self.N = self.acados_ocp.dims.N = N
             self.acados_ocp.solver_options.time_steps = new_time_steps
             self.acados_ocp.solver_options.Tsim = self.acados_ocp.solver_options.time_steps[0]
@@ -930,6 +933,7 @@ class AcadosOcpSolver:
 
             # get pointers solver
             self.__get_pointers_solver()
+
 
     def get(self, stage_, field_):
         """

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_sim_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_sim_solver.in.c
@@ -78,9 +78,10 @@ int {{ model.name }}_acados_sim_solver_free_capsule(sim_solver_capsule * capsule
 int {{ model.name }}_acados_sim_create(sim_solver_capsule * capsule)
 {
     // initialize
-    int nx = {{ dims.nx }};
-    int nu = {{ dims.nu }};
-    int nz = {{ dims.nz }};
+    const int nx = {{ model.name | upper }}_NX;
+    const int nu = {{ model.name | upper }}_NU;
+    const int nz = {{ model.name | upper }}_NZ;
+    const int np = {{ model.name | upper }}_NP;
     bool tmp_bool;
 
     {#// double Tsim = {{ solver_options.tf / dims.N }};#}
@@ -98,7 +99,7 @@ int {{ model.name }}_acados_sim_create(sim_solver_capsule * capsule)
     capsule->sim_impl_dae_fun->casadi_sparsity_out = &{{ model.name }}_impl_dae_fun_sparsity_out;
     capsule->sim_impl_dae_fun->casadi_n_in = &{{ model.name }}_impl_dae_fun_n_in;
     capsule->sim_impl_dae_fun->casadi_n_out = &{{ model.name }}_impl_dae_fun_n_out;
-    external_function_param_casadi_create(capsule->sim_impl_dae_fun, {{ dims.np }});
+    external_function_param_casadi_create(capsule->sim_impl_dae_fun, np);
 
     capsule->sim_impl_dae_fun_jac_x_xdot_z->casadi_fun = &{{ model.name }}_impl_dae_fun_jac_x_xdot_z;
     capsule->sim_impl_dae_fun_jac_x_xdot_z->casadi_work = &{{ model.name }}_impl_dae_fun_jac_x_xdot_z_work;
@@ -106,7 +107,7 @@ int {{ model.name }}_acados_sim_create(sim_solver_capsule * capsule)
     capsule->sim_impl_dae_fun_jac_x_xdot_z->casadi_sparsity_out = &{{ model.name }}_impl_dae_fun_jac_x_xdot_z_sparsity_out;
     capsule->sim_impl_dae_fun_jac_x_xdot_z->casadi_n_in = &{{ model.name }}_impl_dae_fun_jac_x_xdot_z_n_in;
     capsule->sim_impl_dae_fun_jac_x_xdot_z->casadi_n_out = &{{ model.name }}_impl_dae_fun_jac_x_xdot_z_n_out;
-    external_function_param_casadi_create(capsule->sim_impl_dae_fun_jac_x_xdot_z, {{ dims.np }});
+    external_function_param_casadi_create(capsule->sim_impl_dae_fun_jac_x_xdot_z, np);
 
     // external_function_param_casadi impl_dae_jac_x_xdot_u_z;
     capsule->sim_impl_dae_jac_x_xdot_u_z->casadi_fun = &{{ model.name }}_impl_dae_jac_x_xdot_u_z;
@@ -115,7 +116,7 @@ int {{ model.name }}_acados_sim_create(sim_solver_capsule * capsule)
     capsule->sim_impl_dae_jac_x_xdot_u_z->casadi_sparsity_out = &{{ model.name }}_impl_dae_jac_x_xdot_u_z_sparsity_out;
     capsule->sim_impl_dae_jac_x_xdot_u_z->casadi_n_in = &{{ model.name }}_impl_dae_jac_x_xdot_u_z_n_in;
     capsule->sim_impl_dae_jac_x_xdot_u_z->casadi_n_out = &{{ model.name }}_impl_dae_jac_x_xdot_u_z_n_out;
-    external_function_param_casadi_create(capsule->sim_impl_dae_jac_x_xdot_u_z, {{ dims.np }});
+    external_function_param_casadi_create(capsule->sim_impl_dae_jac_x_xdot_u_z, np);
 
 {%- if hessian_approx == "EXACT" %}
     capsule->sim_impl_dae_hess = (external_function_param_casadi *) malloc(sizeof(external_function_param_casadi));
@@ -126,7 +127,7 @@ int {{ model.name }}_acados_sim_create(sim_solver_capsule * capsule)
     capsule->sim_impl_dae_hess->casadi_sparsity_out = &{{ model.name }}_impl_dae_hess_sparsity_out;
     capsule->sim_impl_dae_hess->casadi_n_in = &{{ model.name }}_impl_dae_hess_n_in;
     capsule->sim_impl_dae_hess->casadi_n_out = &{{ model.name }}_impl_dae_hess_n_out;
-    external_function_param_casadi_create(capsule->sim_impl_dae_hess, {{ dims.np }});
+    external_function_param_casadi_create(capsule->sim_impl_dae_hess, np);
 {%- endif %}
 
     {% elif solver_options.integrator_type == "ERK" %}
@@ -140,7 +141,7 @@ int {{ model.name }}_acados_sim_create(sim_solver_capsule * capsule)
     capsule->sim_forw_vde_casadi->casadi_sparsity_in = &{{ model.name }}_expl_vde_forw_sparsity_in;
     capsule->sim_forw_vde_casadi->casadi_sparsity_out = &{{ model.name }}_expl_vde_forw_sparsity_out;
     capsule->sim_forw_vde_casadi->casadi_work = &{{ model.name }}_expl_vde_forw_work;
-    external_function_param_casadi_create(capsule->sim_forw_vde_casadi, {{ dims.np }});
+    external_function_param_casadi_create(capsule->sim_forw_vde_casadi, np);
 
     capsule->sim_expl_ode_fun_casadi->casadi_fun = &{{ model.name }}_expl_ode_fun;
     capsule->sim_expl_ode_fun_casadi->casadi_n_in = &{{ model.name }}_expl_ode_fun_n_in;
@@ -148,7 +149,7 @@ int {{ model.name }}_acados_sim_create(sim_solver_capsule * capsule)
     capsule->sim_expl_ode_fun_casadi->casadi_sparsity_in = &{{ model.name }}_expl_ode_fun_sparsity_in;
     capsule->sim_expl_ode_fun_casadi->casadi_sparsity_out = &{{ model.name }}_expl_ode_fun_sparsity_out;
     capsule->sim_expl_ode_fun_casadi->casadi_work = &{{ model.name }}_expl_ode_fun_work;
-    external_function_param_casadi_create(capsule->sim_expl_ode_fun_casadi, {{ dims.np }});
+    external_function_param_casadi_create(capsule->sim_expl_ode_fun_casadi, np);
 
 {%- if hessian_approx == "EXACT" %}
     capsule->sim_expl_ode_hess = (external_function_param_casadi *) malloc(sizeof(external_function_param_casadi));
@@ -159,7 +160,7 @@ int {{ model.name }}_acados_sim_create(sim_solver_capsule * capsule)
     capsule->sim_expl_ode_hess->casadi_sparsity_out = &{{ model.name }}_expl_ode_hess_sparsity_out;
     capsule->sim_expl_ode_hess->casadi_n_in = &{{ model.name }}_expl_ode_hess_n_in;
     capsule->sim_expl_ode_hess->casadi_n_out = &{{ model.name }}_expl_ode_hess_n_out;
-    external_function_param_casadi_create(capsule->sim_expl_ode_hess, {{ dims.np }});
+    external_function_param_casadi_create(capsule->sim_expl_ode_hess, np);
 {%- endif %}
 
     {% elif solver_options.integrator_type == "GNSF" -%}
@@ -175,7 +176,7 @@ int {{ model.name }}_acados_sim_create(sim_solver_capsule * capsule)
     capsule->sim_gnsf_phi_fun->casadi_sparsity_in = &{{ model.name }}_gnsf_phi_fun_sparsity_in;
     capsule->sim_gnsf_phi_fun->casadi_sparsity_out = &{{ model.name }}_gnsf_phi_fun_sparsity_out;
     capsule->sim_gnsf_phi_fun->casadi_work = &{{ model.name }}_gnsf_phi_fun_work;
-    external_function_param_casadi_create(capsule->sim_gnsf_phi_fun, {{ dims.np }});
+    external_function_param_casadi_create(capsule->sim_gnsf_phi_fun, np);
 
     capsule->sim_gnsf_phi_fun_jac_y->casadi_fun = &{{ model.name }}_gnsf_phi_fun_jac_y;
     capsule->sim_gnsf_phi_fun_jac_y->casadi_n_in = &{{ model.name }}_gnsf_phi_fun_jac_y_n_in;
@@ -183,7 +184,7 @@ int {{ model.name }}_acados_sim_create(sim_solver_capsule * capsule)
     capsule->sim_gnsf_phi_fun_jac_y->casadi_sparsity_in = &{{ model.name }}_gnsf_phi_fun_jac_y_sparsity_in;
     capsule->sim_gnsf_phi_fun_jac_y->casadi_sparsity_out = &{{ model.name }}_gnsf_phi_fun_jac_y_sparsity_out;
     capsule->sim_gnsf_phi_fun_jac_y->casadi_work = &{{ model.name }}_gnsf_phi_fun_jac_y_work;
-    external_function_param_casadi_create(capsule->sim_gnsf_phi_fun_jac_y, {{ dims.np }});
+    external_function_param_casadi_create(capsule->sim_gnsf_phi_fun_jac_y, np);
 
     capsule->sim_gnsf_phi_jac_y_uhat->casadi_fun = &{{ model.name }}_gnsf_phi_jac_y_uhat;
     capsule->sim_gnsf_phi_jac_y_uhat->casadi_n_in = &{{ model.name }}_gnsf_phi_jac_y_uhat_n_in;
@@ -191,7 +192,7 @@ int {{ model.name }}_acados_sim_create(sim_solver_capsule * capsule)
     capsule->sim_gnsf_phi_jac_y_uhat->casadi_sparsity_in = &{{ model.name }}_gnsf_phi_jac_y_uhat_sparsity_in;
     capsule->sim_gnsf_phi_jac_y_uhat->casadi_sparsity_out = &{{ model.name }}_gnsf_phi_jac_y_uhat_sparsity_out;
     capsule->sim_gnsf_phi_jac_y_uhat->casadi_work = &{{ model.name }}_gnsf_phi_jac_y_uhat_work;
-    external_function_param_casadi_create(capsule->sim_gnsf_phi_jac_y_uhat, {{ dims.np }});
+    external_function_param_casadi_create(capsule->sim_gnsf_phi_jac_y_uhat, np);
 
     capsule->sim_gnsf_f_lo_jac_x1_x1dot_u_z->casadi_fun = &{{ model.name }}_gnsf_f_lo_fun_jac_x1k1uz;
     capsule->sim_gnsf_f_lo_jac_x1_x1dot_u_z->casadi_n_in = &{{ model.name }}_gnsf_f_lo_fun_jac_x1k1uz_n_in;
@@ -199,7 +200,7 @@ int {{ model.name }}_acados_sim_create(sim_solver_capsule * capsule)
     capsule->sim_gnsf_f_lo_jac_x1_x1dot_u_z->casadi_sparsity_in = &{{ model.name }}_gnsf_f_lo_fun_jac_x1k1uz_sparsity_in;
     capsule->sim_gnsf_f_lo_jac_x1_x1dot_u_z->casadi_sparsity_out = &{{ model.name }}_gnsf_f_lo_fun_jac_x1k1uz_sparsity_out;
     capsule->sim_gnsf_f_lo_jac_x1_x1dot_u_z->casadi_work = &{{ model.name }}_gnsf_f_lo_fun_jac_x1k1uz_work;
-    external_function_param_casadi_create(capsule->sim_gnsf_f_lo_jac_x1_x1dot_u_z, {{ dims.np }});
+    external_function_param_casadi_create(capsule->sim_gnsf_f_lo_jac_x1_x1dot_u_z, np);
 
     capsule->sim_gnsf_get_matrices_fun->casadi_fun = &{{ model.name }}_gnsf_get_matrices_fun;
     capsule->sim_gnsf_get_matrices_fun->casadi_n_in = &{{ model.name }}_gnsf_get_matrices_fun_n_in;
@@ -207,7 +208,7 @@ int {{ model.name }}_acados_sim_create(sim_solver_capsule * capsule)
     capsule->sim_gnsf_get_matrices_fun->casadi_sparsity_in = &{{ model.name }}_gnsf_get_matrices_fun_sparsity_in;
     capsule->sim_gnsf_get_matrices_fun->casadi_sparsity_out = &{{ model.name }}_gnsf_get_matrices_fun_sparsity_out;
     capsule->sim_gnsf_get_matrices_fun->casadi_work = &{{ model.name }}_gnsf_get_matrices_fun_work;
-    external_function_param_casadi_create(capsule->sim_gnsf_get_matrices_fun, {{ dims.np }});
+    external_function_param_casadi_create(capsule->sim_gnsf_get_matrices_fun, np);
     {% endif %}
 
     // sim plan & config
@@ -323,14 +324,14 @@ int {{ model.name }}_acados_sim_create(sim_solver_capsule * capsule)
 
 {% if dims.np > 0 %}
     /* initialize parameter values */
-    double* p = calloc({{ dims.np }}, sizeof(double));
+    double* p = calloc(np, sizeof(double));
     {% for item in parameter_values %}
         {%- if item != 0 %}
     p[{{ loop.index0 }}] = {{ item }};
         {%- endif %}
     {%- endfor %}
 
-    {{ model.name }}_acados_sim_update_params(capsule, p, {{ dims.np }});
+    {{ model.name }}_acados_sim_update_params(capsule, p, np);
     free(p);
 {% endif %}{# if dims.np #}
 
@@ -420,7 +421,7 @@ int {{ model.name }}_acados_sim_free(sim_solver_capsule *capsule)
 int {{ model.name }}_acados_sim_update_params(sim_solver_capsule *capsule, double *p, int np)
 {
     int status = 0;
-    int casadi_np = {{ dims.np }};
+    int casadi_np = {{ model.name | upper }}_NP;
 
     if (casadi_np != np) {
         printf("{{ model.name }}_acados_sim_update_params: trying to set %i parameters for external functions."

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_sim_solver.in.h
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_sim_solver.in.h
@@ -41,32 +41,6 @@
 #define {{ model.name | upper }}_NZ     {{ dims.nz }}
 #define {{ model.name | upper }}_NU     {{ dims.nu }}
 #define {{ model.name | upper }}_NP     {{ dims.np }}
-#define {{ model.name | upper }}_NBX    {{ dims.nbx }}
-#define {{ model.name | upper }}_NBX0   {{ dims.nbx_0 }}
-#define {{ model.name | upper }}_NBU    {{ dims.nbu }}
-#define {{ model.name | upper }}_NSBX   {{ dims.nsbx }}
-#define {{ model.name | upper }}_NSBU   {{ dims.nsbu }}
-#define {{ model.name | upper }}_NSH    {{ dims.nsh }}
-#define {{ model.name | upper }}_NSG    {{ dims.nsg }}
-#define {{ model.name | upper }}_NSPHI  {{ dims.nsphi }}
-#define {{ model.name | upper }}_NSHN   {{ dims.nsh_e }}
-#define {{ model.name | upper }}_NSGN   {{ dims.nsg_e }}
-#define {{ model.name | upper }}_NSPHIN {{ dims.nsphi_e }}
-#define {{ model.name | upper }}_NSBXN  {{ dims.nsbx_e }}
-#define {{ model.name | upper }}_NS     {{ dims.ns }}
-#define {{ model.name | upper }}_NSN    {{ dims.ns_e }}
-#define {{ model.name | upper }}_NG     {{ dims.ng }}
-#define {{ model.name | upper }}_NBXN   {{ dims.nbx_e }}
-#define {{ model.name | upper }}_NGN    {{ dims.ng_e }}
-#define {{ model.name | upper }}_NY0    {{ dims.ny_0 }}
-#define {{ model.name | upper }}_NY     {{ dims.ny }}
-#define {{ model.name | upper }}_NYN    {{ dims.ny_e }}
-#define {{ model.name | upper }}_N      {{ dims.N }}
-#define {{ model.name | upper }}_NH     {{ dims.nh }}
-#define {{ model.name | upper }}_NPHI   {{ dims.nphi }}
-#define {{ model.name | upper }}_NHN    {{ dims.nh_e }}
-#define {{ model.name | upper }}_NPHIN  {{ dims.nphi_e }}
-#define {{ model.name | upper }}_NR     {{ dims.nr }}
 
 #ifdef __cplusplus
 extern "C" {

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_sim_solver.in.h
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_sim_solver.in.h
@@ -37,6 +37,37 @@
 #include "acados_c/sim_interface.h"
 #include "acados_c/external_function_interface.h"
 
+#define {{ model.name | upper }}_NX     {{ dims.nx }}
+#define {{ model.name | upper }}_NZ     {{ dims.nz }}
+#define {{ model.name | upper }}_NU     {{ dims.nu }}
+#define {{ model.name | upper }}_NP     {{ dims.np }}
+#define {{ model.name | upper }}_NBX    {{ dims.nbx }}
+#define {{ model.name | upper }}_NBX0   {{ dims.nbx_0 }}
+#define {{ model.name | upper }}_NBU    {{ dims.nbu }}
+#define {{ model.name | upper }}_NSBX   {{ dims.nsbx }}
+#define {{ model.name | upper }}_NSBU   {{ dims.nsbu }}
+#define {{ model.name | upper }}_NSH    {{ dims.nsh }}
+#define {{ model.name | upper }}_NSG    {{ dims.nsg }}
+#define {{ model.name | upper }}_NSPHI  {{ dims.nsphi }}
+#define {{ model.name | upper }}_NSHN   {{ dims.nsh_e }}
+#define {{ model.name | upper }}_NSGN   {{ dims.nsg_e }}
+#define {{ model.name | upper }}_NSPHIN {{ dims.nsphi_e }}
+#define {{ model.name | upper }}_NSBXN  {{ dims.nsbx_e }}
+#define {{ model.name | upper }}_NS     {{ dims.ns }}
+#define {{ model.name | upper }}_NSN    {{ dims.ns_e }}
+#define {{ model.name | upper }}_NG     {{ dims.ng }}
+#define {{ model.name | upper }}_NBXN   {{ dims.nbx_e }}
+#define {{ model.name | upper }}_NGN    {{ dims.ng_e }}
+#define {{ model.name | upper }}_NY0    {{ dims.ny_0 }}
+#define {{ model.name | upper }}_NY     {{ dims.ny }}
+#define {{ model.name | upper }}_NYN    {{ dims.ny_e }}
+#define {{ model.name | upper }}_N      {{ dims.N }}
+#define {{ model.name | upper }}_NH     {{ dims.nh }}
+#define {{ model.name | upper }}_NPHI   {{ dims.nphi }}
+#define {{ model.name | upper }}_NHN    {{ dims.nh_e }}
+#define {{ model.name | upper }}_NPHIN  {{ dims.nphi_e }}
+#define {{ model.name | upper }}_NR     {{ dims.nr }}
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -131,9 +131,11 @@ int {{ model.name }}_acados_create({{ model.name }}_solver_capsule * capsule)
 int {{ model.name }}_acados_update_time_steps({{ model.name }}_solver_capsule * capsule, int N, double* new_time_steps)
 {
     if (N != capsule->nlp_solver_plan->N) {
-        fprintf(stderr, "%s: given number of time steps (= %d) differs from the currently allocated number of " \
-            "time steps (= %d)! Please recreate with new discretization and provide a new vector of time_stamps!\n", \
-            __FUNCTION__, N, capsule->nlp_solver_plan->N);
+        fprintf(stderr, "{{ model.name }}_acados_update_time_steps: given number of time steps (= %d) " \
+            "differs from the currently allocated number of " \
+            "time steps (= %d)!\n" \
+            "Please recreate with new discretization and provide a new vector of time_stamps!\n", \
+            N, capsule->nlp_solver_plan->N);
         return 1;
     }
 
@@ -153,10 +155,11 @@ int {{ model.name }}_acados_create_with_discretization({{ model.name }}_solver_c
 {
     int status = 0;
     // If N does not match the number of shooting intervals used for code generation, new_time_steps must be given.
-    if(N != {{ model.name | upper }}_N && !new_time_steps) {
-        fprintf(stderr, "%s: new_time_steps is NULL but the number of shooting intervals (= %d) differs from the number of " \
+    if (N != {{ model.name | upper }}_N && !new_time_steps) {
+        fprintf(stderr, "{{ model.name }}_acados_create_with_discretization: new_time_steps is NULL ", \
+            "but the number of shooting intervals (= %d) differs from the number of " \
             "shooting intervals (= %d) during code generation! Please provide a new vector of time_stamps!\n", \
-             __FUNCTION__, N, {{ model.name | upper }}_N);
+             N, {{ model.name | upper }}_N);
         return 1;
     }
 

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -128,15 +128,35 @@ int {{ model.name }}_acados_create({{ model.name }}_solver_capsule * capsule)
     return {{ model.name }}_acados_create_with_discretization(capsule, N_shooting_intervals, new_time_steps);
 }
 
+int {{ model.name }}_acados_update_time_steps({{ model.name }}_solver_capsule * capsule, int N, double* new_time_steps)
+{
+    if (N != capsule->nlp_solver_plan->N) {
+        fprintf(stderr, "%s: given number of time steps (= %d) differs from the currently allocated number of " \
+            "time steps (= %d)! Please recreate with new discretization and provide a new vector of time_stamps!\n", \
+            __FUNCTION__, N, capsule->nlp_solver_plan->N);
+        return 1;
+    }
+
+    ocp_nlp_config * nlp_config = capsule->nlp_config;
+    ocp_nlp_dims * nlp_dims = capsule->nlp_dims;
+    ocp_nlp_in * nlp_in = capsule->nlp_in;
+
+    for (int i = 0; i < N; i++)
+    {
+        ocp_nlp_in_set(nlp_config, nlp_dims, nlp_in, i, "Ts", &new_time_steps[i]);
+        ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, i, "scaling", &new_time_steps[i]);
+    }
+    return 0;
+}
 
 int {{ model.name }}_acados_create_with_discretization({{ model.name }}_solver_capsule * capsule, int N, double* new_time_steps)
 {
     int status = 0;
     // If N does not match the number of shooting intervals used for code generation, new_time_steps must be given.
     if(N != {{ model.name | upper }}_N && !new_time_steps) {
-        fprintf(stderr, "new_time_steps is NULL but the number of shooting intervals (= %d) differs from the number of " \
+        fprintf(stderr, "%s: new_time_steps is NULL but the number of shooting intervals (= %d) differs from the number of " \
             "shooting intervals (= %d) during code generation! Please provide a new vector of time_stamps!\n", \
-             N, {{ model.name | upper }}_N);
+             __FUNCTION__, N, {{ model.name | upper }}_N);
         return 1;
     }
 
@@ -910,13 +930,8 @@ int {{ model.name }}_acados_create_with_discretization({{ model.name }}_solver_c
         {%- endif %}
     {%- endfor %}
 
-    if(new_time_steps)
-    {
-        for (int i = 0; i < N; i++)
-        {
-            ocp_nlp_in_set(nlp_config, nlp_dims, nlp_in, i, "Ts", &new_time_steps[i]);
-            ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, i, "scaling", &new_time_steps[i]);
-        }
+    if (new_time_steps) {
+        {{ model.name }}_acados_update_time_steps(capsule, N, new_time_steps);
     } else {
     {%- if all_equal == true -%}
         // all time_steps are identical
@@ -932,11 +947,7 @@ int {{ model.name }}_acados_create_with_discretization({{ model.name }}_solver_c
         {%- for j in range(end=dims.N) %}
         time_steps[{{ j }}] = {{ solver_options.time_steps[j] }};
         {%- endfor %}
-        for (int i = 0; i < N; i++)
-        {
-            ocp_nlp_in_set(nlp_config, nlp_dims, nlp_in, i, "Ts", &time_steps[i]);
-            ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, i, "scaling", &time_steps[i]);
-        }
+        {{ model.name }}_acados_update_time_steps(capsule, N, time_steps);
         free(time_steps);
     {%- endif %}
     }
@@ -2148,7 +2159,8 @@ int {{ model.name }}_acados_update_params({{ model.name }}_solver_capsule * caps
     }
 
 {%- if dims.np > 0 %}
-    if (stage < {{ dims.N }} && stage >= 0)
+    const int N = capsule->nlp_solver_plan->N;
+    if (stage < N && stage >= 0)
     {
     {%- if solver_options.integrator_type == "IRK" %}
         capsule->impl_dae_fun[stage].set_param(capsule->impl_dae_fun+stage, p);
@@ -2262,6 +2274,8 @@ int {{ model.name }}_acados_solve({{ model.name }}_solver_capsule * capsule)
 
 int {{ model.name }}_acados_free({{ model.name }}_solver_capsule * capsule)
 {
+    // before destroying, keep some info
+    const int N = capsule->nlp_solver_plan->N;
     // free memory
     ocp_nlp_solver_opts_destroy(capsule->nlp_opts);
     ocp_nlp_in_destroy(capsule->nlp_in);
@@ -2274,7 +2288,7 @@ int {{ model.name }}_acados_free({{ model.name }}_solver_capsule * capsule)
     /* free external function */
     // dynamics
 {%- if solver_options.integrator_type == "IRK" %}
-    for (int i = 0; i < {{ dims.N }}; i++)
+    for (int i = 0; i < N; i++)
     {
         external_function_param_casadi_free(&capsule->impl_dae_fun[i]);
         external_function_param_casadi_free(&capsule->impl_dae_fun_jac_x_xdot_z[i]);
@@ -2291,7 +2305,7 @@ int {{ model.name }}_acados_free({{ model.name }}_solver_capsule * capsule)
     {%- endif %}
 
 {%- elif solver_options.integrator_type == "LIFTED_IRK" %}
-    for (int i = 0; i < {{ dims.N }}; i++)
+    for (int i = 0; i < N; i++)
     {
         external_function_param_casadi_free(&capsule->impl_dae_fun[i]);
         external_function_param_casadi_free(&capsule->impl_dae_fun_jac_x_xdot_u[i]);
@@ -2300,7 +2314,7 @@ int {{ model.name }}_acados_free({{ model.name }}_solver_capsule * capsule)
     free(capsule->impl_dae_fun_jac_x_xdot_u);
 
 {%- elif solver_options.integrator_type == "ERK" %}
-    for (int i = 0; i < {{ dims.N }}; i++)
+    for (int i = 0; i < N; i++)
     {
         external_function_param_casadi_free(&capsule->forw_vde_casadi[i]);
         external_function_param_casadi_free(&capsule->expl_ode_fun[i]);
@@ -2315,7 +2329,7 @@ int {{ model.name }}_acados_free({{ model.name }}_solver_capsule * capsule)
     {%- endif %}
 
 {%- elif solver_options.integrator_type == "GNSF" %}
-    for (int i = 0; i < {{ dims.N }}; i++)
+    for (int i = 0; i < N; i++)
     {
         external_function_param_casadi_free(&capsule->gnsf_phi_fun[i]);
         external_function_param_casadi_free(&capsule->gnsf_phi_fun_jac_y[i]);
@@ -2329,7 +2343,7 @@ int {{ model.name }}_acados_free({{ model.name }}_solver_capsule * capsule)
     free(capsule->gnsf_f_lo_jac_x1_x1dot_u_z);
     free(capsule->gnsf_get_matrices_fun);
 {%- elif solver_options.integrator_type == "DISCRETE" %}
-    for (int i = 0; i < {{ dims.N }}; i++)
+    for (int i = 0; i < N; i++)
     {
         external_function_param_{{ model.dyn_ext_fun_type }}_free(&capsule->discr_dyn_phi_fun[i]);
         external_function_param_{{ model.dyn_ext_fun_type }}_free(&capsule->discr_dyn_phi_fun_jac_ut_xt[i]);
@@ -2356,7 +2370,7 @@ int {{ model.name }}_acados_free({{ model.name }}_solver_capsule * capsule)
     external_function_param_{{ cost.cost_ext_fun_type_0 }}_free(&capsule->ext_cost_0_fun_jac_hess);
 {%- endif %}
 {%- if cost.cost_type == "NONLINEAR_LS" %}
-    for (int i = 0; i < {{ dims.N }} - 1; i++)
+    for (int i = 0; i < N - 1; i++)
     {
         external_function_param_casadi_free(&capsule->cost_y_fun[i]);
         external_function_param_casadi_free(&capsule->cost_y_fun_jac_ut_xt[i]);
@@ -2366,7 +2380,7 @@ int {{ model.name }}_acados_free({{ model.name }}_solver_capsule * capsule)
     free(capsule->cost_y_fun_jac_ut_xt);
     free(capsule->cost_y_hess);
 {%- elif cost.cost_type == "EXTERNAL" %}
-    for (int i = 0; i < {{ dims.N }} - 1; i++)
+    for (int i = 0; i < N - 1; i++)
     {
         external_function_param_{{ cost.cost_ext_fun_type }}_free(&capsule->ext_cost_fun[i]);
         external_function_param_{{ cost.cost_ext_fun_type }}_free(&capsule->ext_cost_fun_jac[i]);
@@ -2388,13 +2402,13 @@ int {{ model.name }}_acados_free({{ model.name }}_solver_capsule * capsule)
 
     // constraints
 {%- if constraints.constr_type == "BGH" and dims.nh > 0 %}
-    for (int i = 0; i < {{ dims.N }}; i++)
+    for (int i = 0; i < N; i++)
     {
         external_function_param_casadi_free(&capsule->nl_constr_h_fun_jac[i]);
         external_function_param_casadi_free(&capsule->nl_constr_h_fun[i]);
     }
   {%- if solver_options.hessian_approx == "EXACT" %}
-    for (int i = 0; i < {{ dims.N }}; i++)
+    for (int i = 0; i < N; i++)
     {
         external_function_param_casadi_free(&capsule->nl_constr_h_fun_jac_hess[i]);
     }
@@ -2406,7 +2420,7 @@ int {{ model.name }}_acados_free({{ model.name }}_solver_capsule * capsule)
   {%- endif %}
 
 {%- elif constraints.constr_type == "BGP" and dims.nphi > 0 %}
-    for (int i = 0; i < {{ dims.N }}; i++)
+    for (int i = 0; i < N; i++)
     {
         external_function_param_casadi_free(&capsule->phi_constraint[i]);
     }

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -926,7 +926,7 @@ int {{ model.name }}_acados_create_w_stages(nlp_solver_capsule * capsule, int N,
     if(const_time_step != NULL)
     {
         for(int i=0; i<N; i++)
-            time_steps[i] = const_dt;
+            time_steps[i] = *const_time_step;
     } else {
     {%- for j in range(end=dims.N) %}
         time_steps[{{ j }}] = {{ solver_options.time_steps[j] }};

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.h
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.h
@@ -145,11 +145,11 @@ int {{ model.name }}_acados_free_capsule(nlp_solver_capsule *capsule);
 
 int {{ model.name }}_acados_create(nlp_solver_capsule * capsule);
 /**
- * More generic acados_create function, since the number of stages usually is independent of the model and its
- * constraints. If the number of stages does not match the one from code-export at least a constant step_time must be
- * given to be filled in. If const_step_time=NULL, the code-exported version is used internally.
+ * Generic version of {{ model.name }}_acados_create which allows to use a different number of shooting intervals than
+ * the number used for code generation. If new_time_steps=NULL and n_time_steps matches the number used for code
+ * generation, the time-steps from code generation is used.
  */
-int {{ model.name }}_acados_create_w_stages(nlp_solver_capsule * capsule, int n_stages, double* const_step_time);
+int {{ model.name }}_acados_create_with_discretization(nlp_solver_capsule * capsule, int n_time_steps, double* new_time_steps);
 int {{ model.name }}_acados_update_params(nlp_solver_capsule * capsule, int stage, double *value, int np);
 int {{ model.name }}_acados_solve(nlp_solver_capsule * capsule);
 int {{ model.name }}_acados_free(nlp_solver_capsule * capsule);

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.h
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.h
@@ -144,6 +144,12 @@ nlp_solver_capsule * {{ model.name }}_acados_create_capsule(void);
 int {{ model.name }}_acados_free_capsule(nlp_solver_capsule *capsule);
 
 int {{ model.name }}_acados_create(nlp_solver_capsule * capsule);
+/**
+ * More generic acados_create function, since the number of stages usually is independent of the model and its
+ * constraints. If the number of stages does not match the one from code-export at least a constant step_time must be
+ * given to be filled in. If const_step_time=NULL, the code-exported version is used internally.
+ */
+int {{ model.name }}_acados_create_w_stages(nlp_solver_capsule * capsule, int n_stages, double* const_step_time);
 int {{ model.name }}_acados_update_params(nlp_solver_capsule * capsule, int stage, double *value, int np);
 int {{ model.name }}_acados_solve(nlp_solver_capsule * capsule);
 int {{ model.name }}_acados_free(nlp_solver_capsule * capsule);

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.h
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.h
@@ -181,6 +181,11 @@ int {{ model.name }}_acados_create({{ model.name }}_solver_capsule * capsule);
  * generation, the time-steps from code generation is used.
  */
 int {{ model.name }}_acados_create_with_discretization({{ model.name }}_solver_capsule * capsule, int n_time_steps, double* new_time_steps);
+/**
+ * Update the time step vector. Number N must be identical to the currently set number of shooting nodes in the
+ * nlp_solver_plan. Returns 0 if no error occurred and a otherwise a value other than 0.
+ */
+int {{ model.name }}_acados_update_time_steps({{ model.name }}_solver_capsule * capsule, int N, double* new_time_steps);
 int {{ model.name }}_acados_update_params({{ model.name }}_solver_capsule * capsule, int stage, double *value, int np);
 int {{ model.name }}_acados_solve({{ model.name }}_solver_capsule * capsule);
 int {{ model.name }}_acados_free({{ model.name }}_solver_capsule * capsule);

--- a/interfaces/acados_template/acados_template/c_templates_tera/main.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/main.in.c
@@ -73,14 +73,15 @@
 #define NR     {{ model.name | upper }}_NR
 
 
-int main(int argc, char** argv)
+int main()
 {
     nlp_solver_capsule *acados_ocp_capsule = {{ model.name }}_acados_create_capsule();
 
-    // there is an opportunity to change the number of stages in C without new code-export
+    // there is an opportunity to change the number of shooting intervals in C without new code generation
     int N = {{ model.name | upper }}_N;
-    double const_time_steps = {{ solver_options.time_steps[0] }};
-    int status = {{ model.name }}_acados_create_w_stages(acados_ocp_capsule, N, &const_time_steps);
+    // allocate the array and fill it accordingly
+    double* new_time_steps = NULL;
+    int status = {{ model.name }}_acados_create_with_discretization(acados_ocp_capsule, N, new_time_steps);
 
     if (status)
     {
@@ -145,7 +146,7 @@ int main(int argc, char** argv)
     double elapsed_time;
     int sqp_iter;
 
-    double xtraj[NX * N+1];
+    double xtraj[NX * (N+1)];
     double utraj[NU * N];
 
 

--- a/interfaces/acados_template/acados_template/c_templates_tera/main.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/main.in.c
@@ -42,12 +42,45 @@
 #include "acados_c/external_function_interface.h"
 #include "acados_solver_{{ model.name }}.h"
 
+#define NX     {{ model.name | upper }}_NX
+#define NZ     {{ model.name | upper }}_NZ
+#define NU     {{ model.name | upper }}_NU
+#define NP     {{ model.name | upper }}_NP
+#define NBX    {{ model.name | upper }}_NBX
+#define NBX0   {{ model.name | upper }}_NBX0
+#define NBU    {{ model.name | upper }}_NBU
+#define NSBX   {{ model.name | upper }}_NSBX
+#define NSBU   {{ model.name | upper }}_NSBU
+#define NSH    {{ model.name | upper }}_NSH
+#define NSG    {{ model.name | upper }}_NSG
+#define NSPHI  {{ model.name | upper }}_NSPHI
+#define NSHN   {{ model.name | upper }}_NSHN
+#define NSGN   {{ model.name | upper }}_NSGN
+#define NSPHIN {{ model.name | upper }}_NSPHIN
+#define NSBXN  {{ model.name | upper }}_NSBXN
+#define NS     {{ model.name | upper }}_NS
+#define NSN    {{ model.name | upper }}_NSN
+#define NG     {{ model.name | upper }}_NG
+#define NBXN   {{ model.name | upper }}_NBXN
+#define NGN    {{ model.name | upper }}_NGN
+#define NY0    {{ model.name | upper }}_NY0
+#define NY     {{ model.name | upper }}_NY
+#define NYN    {{ model.name | upper }}_NYN
+#define NH     {{ model.name | upper }}_NH
+#define NPHI   {{ model.name | upper }}_NPHI
+#define NHN    {{ model.name | upper }}_NHN
+#define NPHIN  {{ model.name | upper }}_NPHIN
+#define NR     {{ model.name | upper }}_NR
 
-int main()
+
+int main(int argc, char** argv)
 {
-
     nlp_solver_capsule *acados_ocp_capsule = {{ model.name }}_acados_create_capsule();
-    int status = {{ model.name }}_acados_create(acados_ocp_capsule);
+
+    // there is an opportunity to change the number of stages in C without new code-export
+    int N = {{ model.name | upper }}_N;
+    double const_time_steps = {{ solver_options.time_steps[0] }};
+    int status = {{ model.name }}_acados_create_w_stages(acados_ocp_capsule, N, &const_time_steps);
 
     if (status)
     {
@@ -63,13 +96,13 @@ int main()
     void *nlp_opts = {{ model.name }}_acados_get_nlp_opts(acados_ocp_capsule);
 
     // initial condition
-    int idxbx0[{{ dims.nbx_0 }}];
+    int idxbx0[NBX0];
     {%- for i in range(end=dims.nbx_0) %}
     idxbx0[{{ i }}] = {{ constraints.idxbx_0[i] }};
     {%- endfor %}
 
-    double lbx0[{{ dims.nbx_0 }}];
-    double ubx0[{{ dims.nbx_0 }}];
+    double lbx0[NBX0];
+    double ubx0[NBX0];
     {%- for i in range(end=dims.nbx_0) %}
     lbx0[{{ i }}] = {{ constraints.lbx_0[i] }};
     ubx0[{{ i }}] = {{ constraints.ubx_0[i] }};
@@ -80,13 +113,13 @@ int main()
     ocp_nlp_constraints_model_set(nlp_config, nlp_dims, nlp_in, 0, "ubx", ubx0);
 
     // initialization for state values
-    double x_init[{{ dims.nx }}];
+    double x_init[NX];
     {%- for i in range(end=dims.nx) %}
     x_init[{{ i }}] = 0.0;
     {%- endfor %}
 
     // initial value for control input
-    double u0[{{ dims.nu }}];
+    double u0[NU];
     {%- for i in range(end=dims.nu) %}
     u0[{{ i }}] = 0.0;
     {%- endfor %}
@@ -94,14 +127,14 @@ int main()
 
   {%- if dims.np > 0 %}
     // set parameters
-    double p[{{ dims.np }}];
-    {% for item in parameter_values %}
+    double p[NP];
+    {%- for item in parameter_values %}
     p[{{ loop.index0 }}] = {{ item }};
-    {% endfor %}
+    {%- endfor %}
 
-    for (int ii = 0; ii <= {{ dims.N }}; ii++)
+    for (int ii = 0; ii <= N; ii++)
     {
-        {{ model.name }}_acados_update_params(acados_ocp_capsule, ii, p, {{ dims.np }});
+        {{ model.name }}_acados_update_params(acados_ocp_capsule, ii, p, NP);
     }
   {% endif %}{# if np > 0 #}
 
@@ -112,8 +145,8 @@ int main()
     double elapsed_time;
     int sqp_iter;
 
-    double xtraj[{{ dims.nx }} * ({{ dims.N }}+1)];
-    double utraj[{{ dims.nu }} * ({{ dims.N }})];
+    double xtraj[NX * N+1];
+    double utraj[NU * N];
 
 
     // solve ocp in loop
@@ -135,14 +168,14 @@ int main()
 
     /* print solution and statistics */
     for (int ii = 0; ii <= nlp_dims->N; ii++)
-        ocp_nlp_out_get(nlp_config, nlp_dims, nlp_out, ii, "x", &xtraj[ii*{{ dims.nx }}]);
+        ocp_nlp_out_get(nlp_config, nlp_dims, nlp_out, ii, "x", &xtraj[ii*NX]);
     for (int ii = 0; ii < nlp_dims->N; ii++)
-        ocp_nlp_out_get(nlp_config, nlp_dims, nlp_out, ii, "u", &utraj[ii*{{ dims.nu }}]);
+        ocp_nlp_out_get(nlp_config, nlp_dims, nlp_out, ii, "u", &utraj[ii*NU]);
 
     printf("\n--- xtraj ---\n");
-    d_print_exp_tran_mat( {{ dims.nx }}, {{ dims.N }}+1, xtraj, {{ dims.nx }} );
+    d_print_exp_tran_mat( NX, N+1, xtraj, NX);
     printf("\n--- utraj ---\n");
-    d_print_exp_tran_mat( {{ dims.nu }}, {{ dims.N }}, utraj, {{ dims.nu }} );
+    d_print_exp_tran_mat( NU, N, utraj, NU );
     // ocp_nlp_out_print(nlp_solver->dims, nlp_out);
 
     printf("\nsolved ocp %d times, solution printed above\n\n", NTIMINGS);

--- a/interfaces/acados_template/acados_template/c_templates_tera/main_sim.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/main_sim.in.c
@@ -72,7 +72,7 @@
 #define NR     {{ model.name | upper }}_NR
 
 
-int main(int argc, char** argv)
+int main()
 {
     int status = 0;
     sim_solver_capsule *capsule = {{ model.name }}_acados_sim_solver_create_capsule();

--- a/interfaces/acados_template/acados_template/c_templates_tera/main_sim.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/main_sim.in.c
@@ -41,8 +41,38 @@
 #include "acados_c/sim_interface.h"
 #include "acados_sim_solver_{{ model.name }}.h"
 
+#define NX     {{ model.name | upper }}_NX
+#define NZ     {{ model.name | upper }}_NZ
+#define NU     {{ model.name | upper }}_NU
+#define NP     {{ model.name | upper }}_NP
+#define NBX    {{ model.name | upper }}_NBX
+#define NBX0   {{ model.name | upper }}_NBX0
+#define NBU    {{ model.name | upper }}_NBU
+#define NSBX   {{ model.name | upper }}_NSBX
+#define NSBU   {{ model.name | upper }}_NSBU
+#define NSH    {{ model.name | upper }}_NSH
+#define NSG    {{ model.name | upper }}_NSG
+#define NSPHI  {{ model.name | upper }}_NSPHI
+#define NSHN   {{ model.name | upper }}_NSHN
+#define NSGN   {{ model.name | upper }}_NSGN
+#define NSPHIN {{ model.name | upper }}_NSPHIN
+#define NSBXN  {{ model.name | upper }}_NSBXN
+#define NS     {{ model.name | upper }}_NS
+#define NSN    {{ model.name | upper }}_NSN
+#define NG     {{ model.name | upper }}_NG
+#define NBXN   {{ model.name | upper }}_NBXN
+#define NGN    {{ model.name | upper }}_NGN
+#define NY0    {{ model.name | upper }}_NY0
+#define NY     {{ model.name | upper }}_NY
+#define NYN    {{ model.name | upper }}_NYN
+#define NH     {{ model.name | upper }}_NH
+#define NPHI   {{ model.name | upper }}_NPHI
+#define NHN    {{ model.name | upper }}_NHN
+#define NPHIN  {{ model.name | upper }}_NPHIN
+#define NR     {{ model.name | upper }}_NR
 
-int main()
+
+int main(int argc, char** argv)
 {
     int status = 0;
     sim_solver_capsule *capsule = {{ model.name }}_acados_sim_solver_create_capsule();
@@ -60,7 +90,7 @@ int main()
     void *acados_sim_dims = {{ model.name }}_acados_get_sim_dims(capsule);
 
     // initial condition
-    double x_current[{{ dims.nx }}];
+    double x_current[NX];
     {%- for i in range(end=dims.nx) %}
     x_current[{{ i }}] = 0.0;
     {%- endfor %}
@@ -78,19 +108,19 @@ int main()
 
 
     // initial value for control input
-    double u0[{{ dims.nu }}];
+    double u0[NU];
     {%- for i in range(end=dims.nu) %}
     u0[{{ i }}] = 0.0;
     {%- endfor %}
 
   {%- if dims.np > 0 %}
     // set parameters
-    double p[{{ dims.np }}];
-    {% for item in parameter_values %}
+    double p[NP];
+    {%- for item in parameter_values %}
     p[{{ loop.index0 }}] = {{ item }};
-    {% endfor %}
+    {%- endfor %}
 
-    {{ model.name }}_acados_sim_update_params(capsule, p, {{ dims.np }});
+    {{ model.name }}_acados_sim_update_params(capsule, p, NP);
   {% endif %}{# if np > 0 #}
 
     int n_sim_steps = 3;
@@ -110,7 +140,7 @@ int main()
                acados_sim_out, "x", x_current);
         
         printf("\nx_current, %d\n", ii);
-        for (int jj = 0; jj < {{ dims.nx }}; jj++)
+        for (int jj = 0; jj < NX; jj++)
         {
             printf("%e\n", x_current[jj]);
         }

--- a/interfaces/acados_template/acados_template/c_templates_tera/main_sim.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/main_sim.in.c
@@ -45,31 +45,6 @@
 #define NZ     {{ model.name | upper }}_NZ
 #define NU     {{ model.name | upper }}_NU
 #define NP     {{ model.name | upper }}_NP
-#define NBX    {{ model.name | upper }}_NBX
-#define NBX0   {{ model.name | upper }}_NBX0
-#define NBU    {{ model.name | upper }}_NBU
-#define NSBX   {{ model.name | upper }}_NSBX
-#define NSBU   {{ model.name | upper }}_NSBU
-#define NSH    {{ model.name | upper }}_NSH
-#define NSG    {{ model.name | upper }}_NSG
-#define NSPHI  {{ model.name | upper }}_NSPHI
-#define NSHN   {{ model.name | upper }}_NSHN
-#define NSGN   {{ model.name | upper }}_NSGN
-#define NSPHIN {{ model.name | upper }}_NSPHIN
-#define NSBXN  {{ model.name | upper }}_NSBXN
-#define NS     {{ model.name | upper }}_NS
-#define NSN    {{ model.name | upper }}_NSN
-#define NG     {{ model.name | upper }}_NG
-#define NBXN   {{ model.name | upper }}_NBXN
-#define NGN    {{ model.name | upper }}_NGN
-#define NY0    {{ model.name | upper }}_NY0
-#define NY     {{ model.name | upper }}_NY
-#define NYN    {{ model.name | upper }}_NYN
-#define NH     {{ model.name | upper }}_NH
-#define NPHI   {{ model.name | upper }}_NPHI
-#define NHN    {{ model.name | upper }}_NHN
-#define NPHIN  {{ model.name | upper }}_NPHIN
-#define NR     {{ model.name | upper }}_NR
 
 
 int main()


### PR DESCRIPTION
This PR adds some improvements to the exported code

1. help to identify constant time-steps with numerical differences (improves reliability when distinguishing code paths in template)
2. ocp & main: help reuse exported code, since the model is independent of the number of shooting nodes
3. sim & main: use dimension defines and help with code readability (use parameters instead of numbers in code)
4. example minimal_example_ocp_reuse_code.py added to ctest