### PR TITLE
Add collocation_type option

### DIFF
--- a/acados/sim/sim_collocation_utils.c
+++ b/acados/sim/sim_collocation_utils.c
@@ -246,7 +246,75 @@ void gauss_legendre_nodes(int ns, double *nodes, void *work)
     return;
 }
 
+// looks up Gauss-Radau IIA nodes (c) for Butcher tableau of size ns
+void gauss_radau_iia_nodes(int ns, double *nodes, void *work)
+{
+    // Radau nodes can be calculated as zeros of polynomial, see:
+    // Encyclopedia of Applied and Computational Mathematics
+    // Full entry, version of August 2, 2011
+    // Radau methods
+    // Ernst Hairer 1 , Gerhard Wanner 1
+    // case 1:
+    //     nodes[0] = 1.0;
+    //     break;
+    // case 2:
+    //     nodes[0] = 1.0 / 3;
+    //     nodes[1] = 1.0;
+    //     break;
+    // case 3:
+    //     nodes[0] = (4 - sqrt(6.0)) / 10;
+    //     nodes[1] = (4 + sqrt(6.0)) / 10;
+    //     nodes[2] = 1.0;
+    //     break;
 
+    /* hard code: Radau nodes, as done in CasADi */
+    https://github.com/casadi/casadi/issues/673
+
+    if (ns < 1 || ns > 9)
+    {
+        printf("\n\nerror: gauss_radau_iia_nodes only available for num_stages = 1,...,9; got %d.\n", ns);
+        exit(1);
+    }
+    // Radau collocation points
+    const long double radau_points1[] =
+        { 1.00000000000000000000 };
+    const long double radau_points2[] =
+        { 0.33333333333333337034, 1.00000000000000000000 };
+    const long double radau_points3[] =
+        { 0.15505102572168222297, 0.64494897427831787695,
+        1.00000000000000000000 };
+    const long double radau_points4[] =
+        { 0.08858795951270420632, 0.40946686444073465694,
+        0.78765946176084700170, 1.00000000000000000000 };
+    const long double radau_points5[] =
+        { 0.05710419611451822419, 0.27684301363812369168,
+        0.58359043236891683382, 0.86024013565621926247, 1.00000000000000000000 };
+    const long double radau_points6[] =
+        { 0.03980985705146905529, 0.19801341787360787761,
+        0.43797481024738621480, 0.69546427335363603106, 0.90146491420117347282,
+        1.00000000000000000000 };
+    const long double radau_points7[] =
+        { 0.02931642715978521885, 0.14807859966848435640,
+        0.33698469028115418666, 0.55867151877155019069, 0.76923386203005450490,
+        0.92694567131974103802, 1.00000000000000000000 };
+    const long double radau_points8[] =
+        { 0.02247938643871305597, 0.11467905316090415413,
+        0.26578982278458951338, 0.45284637366944457959, 0.64737528288683043876,
+        0.81975930826310761113, 0.94373743946307731001, 1.00000000000000000000 };
+    const long double radau_points9[] =
+        { 0.01777991514736393386, 0.09132360789979432347,
+        0.21430847939563035798, 0.37193216458327238438, 0.54518668480342658000,
+        0.71317524285556954666, 0.85563374295785443735, 0.95536604471003006012,
+        1.00000000000000000000 };
+    const long double* radau_points[] =
+        { radau_points1, radau_points2, radau_points3, radau_points4, radau_points5,
+            radau_points6, radau_points7, radau_points8, radau_points9};
+
+    for (int i = 0; i < ns; i++)
+    {
+        nodes[i] = radau_points[ns-1][i];
+    }
+}
 
 acados_size_t gauss_simplified_work_calculate_size(int ns)
 {
@@ -456,8 +524,7 @@ void calculate_butcher_tableau(int ns, sim_collocation_type collocation_type, do
             gauss_legendre_nodes(ns, c_vec, work);
             break;
         case GAUSS_RADAU_IIA:
-            // TODO
-            gauss_legendre_nodes(ns, c_vec, work);
+            gauss_radau_iia_nodes(ns, c_vec, work);
             break;
         default:
             printf("\nerror: calculate_butcher_tableau: unsupported collocation_typre\n");

--- a/acados/sim/sim_collocation_utils.c
+++ b/acados/sim/sim_collocation_utils.c
@@ -268,7 +268,7 @@ void gauss_radau_iia_nodes(int ns, double *nodes, void *work)
     //     break;
 
     /* hard code: Radau nodes, as done in CasADi */
-    https://github.com/casadi/casadi/issues/673
+    // https://github.com/casadi/casadi/issues/673
 
     if (ns < 1 || ns > 9)
     {
@@ -316,132 +316,132 @@ void gauss_radau_iia_nodes(int ns, double *nodes, void *work)
     }
 }
 
-acados_size_t gauss_simplified_work_calculate_size(int ns)
-{
-    acados_size_t size = 0;
+// acados_size_t gauss_simplified_work_calculate_size(int ns)
+// {
+//     acados_size_t size = 0;
 
-    size += 1 * 2 * ns * sizeof(double);   // D
-    size += 3 * ns * ns * sizeof(double);  // T, T_inv, lu_work
+//     size += 1 * 2 * ns * sizeof(double);   // D
+//     size += 3 * ns * ns * sizeof(double);  // T, T_inv, lu_work
 
-    size += 1 * ns * sizeof(int);  // perm
+//     size += 1 * ns * sizeof(int);  // perm
 
-    return size;
-}
+//     return size;
+// }
 
 
-// TODO(all): understand how this works and leave a comment!
-void gauss_simplified(int ns, Newton_scheme *scheme, void *work)
-{
-    char *c_ptr = work;
+// // TODO(all): understand how this works and leave a comment!
+// void gauss_simplified(int ns, Newton_scheme *scheme, void *work)
+// {
+//     char *c_ptr = work;
 
-    // D
-    double *D = (double *) c_ptr;
-    c_ptr += 2 * ns * sizeof(double);
-    // T
-    double *T = (double *) c_ptr;
-    c_ptr += ns * ns * sizeof(double);
-    // T_inv
-    double *T_inv = (double *) c_ptr;
-    c_ptr += ns * ns * sizeof(double);
-    // lu_work
-    double *lu_work = (double *) c_ptr;
-    c_ptr += ns * ns * sizeof(double);
-    // perm
-    int *perm = (int *) c_ptr;
-    c_ptr += ns * sizeof(int);
+//     // D
+//     double *D = (double *) c_ptr;
+//     c_ptr += 2 * ns * sizeof(double);
+//     // T
+//     double *T = (double *) c_ptr;
+//     c_ptr += ns * ns * sizeof(double);
+//     // T_inv
+//     double *T_inv = (double *) c_ptr;
+//     c_ptr += ns * ns * sizeof(double);
+//     // lu_work
+//     double *lu_work = (double *) c_ptr;
+//     c_ptr += ns * ns * sizeof(double);
+//     // perm
+//     int *perm = (int *) c_ptr;
+//     c_ptr += ns * sizeof(int);
 
-    assert((char *) work + gauss_simplified_work_calculate_size(ns) >= c_ptr);
+//     assert((char *) work + gauss_simplified_work_calculate_size(ns) >= c_ptr);
 
-    char simplified[MAX_STR_LEN];
+//     char simplified[MAX_STR_LEN];
 
-    snprintf(simplified, sizeof(simplified), "simplified/GL%d_simpl_%s.txt", 2 * ns, "D");
-    read_matrix(simplified, D, ns, 2);
+//     snprintf(simplified, sizeof(simplified), "simplified/GL%d_simpl_%s.txt", 2 * ns, "D");
+//     read_matrix(simplified, D, ns, 2);
 
-    snprintf(simplified, sizeof(simplified), "simplified/GL%d_simpl_%s.txt", 2 * ns, "T");
-    read_matrix(simplified, T, ns, ns);
+//     snprintf(simplified, sizeof(simplified), "simplified/GL%d_simpl_%s.txt", 2 * ns, "T");
+//     read_matrix(simplified, T, ns, ns);
 
-    scheme->single = false;
-    scheme->low_tria = 0;
-    for (int i = 0; i < ns; i++)
-    {
-        scheme->eig[i] = D[i];
-    }
-    for (int i = 0; i < ns * ns; i++)
-    {
-        scheme->transf2[i] = T[i];
-    }
-    // transf1_T:
-    for (int i = 0; i < ns; i++)
-    {
-        if ((i + 1) < ns)
-        {  // complex conjugate pair of eigenvalues
-            for (int i1 = i; i1 < i + 2; i1++)
-            {
-                for (int i2 = 0; i2 < ns; i2++)
-                {
-                    scheme->transf1_T[i2 * ns + i1] = 0.0;
-                    for (int i3 = 0; i3 < 2; i3++)
-                    {
-                        scheme->transf1_T[i2 * ns + i1] +=
-                            D[(i1 - i) * ns + (i + i3)] * T[(i + i3) * ns + i2];
-                    }
-                }
-            }
-            i++;
-        }
-        else
-        {  // real eigenvalue
-            for (int i2 = 0; i2 < ns; i2++)
-            {
-                scheme->transf1_T[i2 * ns + i] = D[i] * T[i * ns + i2];
-            }
-        }
-    }
+//     scheme->single = false;
+//     scheme->low_tria = 0;
+//     for (int i = 0; i < ns; i++)
+//     {
+//         scheme->eig[i] = D[i];
+//     }
+//     for (int i = 0; i < ns * ns; i++)
+//     {
+//         scheme->transf2[i] = T[i];
+//     }
+//     // transf1_T:
+//     for (int i = 0; i < ns; i++)
+//     {
+//         if ((i + 1) < ns)
+//         {  // complex conjugate pair of eigenvalues
+//             for (int i1 = i; i1 < i + 2; i1++)
+//             {
+//                 for (int i2 = 0; i2 < ns; i2++)
+//                 {
+//                     scheme->transf1_T[i2 * ns + i1] = 0.0;
+//                     for (int i3 = 0; i3 < 2; i3++)
+//                     {
+//                         scheme->transf1_T[i2 * ns + i1] +=
+//                             D[(i1 - i) * ns + (i + i3)] * T[(i + i3) * ns + i2];
+//                     }
+//                 }
+//             }
+//             i++;
+//         }
+//         else
+//         {  // real eigenvalue
+//             for (int i2 = 0; i2 < ns; i2++)
+//             {
+//                 scheme->transf1_T[i2 * ns + i] = D[i] * T[i * ns + i2];
+//             }
+//         }
+//     }
 
-    for (int i = 0; i < ns; i++)
-    {
-        T_inv[i * (ns + 1)] = 1.0;
-    }
+//     for (int i = 0; i < ns; i++)
+//     {
+//         T_inv[i * (ns + 1)] = 1.0;
+//     }
 
-    lu_system_solve(T, T_inv, perm, ns, ns, lu_work);
+//     lu_system_solve(T, T_inv, perm, ns, ns, lu_work);
 
-    // transf1:
-    for (int i = 0; i < ns; i++)
-    {
-        if ((i + 1) < ns)
-        {  // complex conjugate pair of eigenvalues
-            for (int i1 = i; i1 < i + 2; i1++)
-            {
-                for (int i2 = 0; i2 < ns; i2++)
-                {
-                    scheme->transf1[i2 * ns + i1] = 0.0;
-                    for (int i3 = 0; i3 < 2; i3++)
-                    {
-                        scheme->transf1[i2 * ns + i1] += D[i3 * ns + i1] * T_inv[i2 * ns + i + i3];
-                    }
-                }
-            }
-            i++;
-        }
-        else
-        {  // real eigenvalue
-            for (int i2 = 0; i2 < ns; i2++)
-            {
-                scheme->transf1[i2 * ns + i] = D[i] * T_inv[i2 * ns + i];
-            }
-        }
-    }
-    // transf2_T:
-    for (int i = 0; i < ns; i++)
-    {
-        for (int i2 = 0; i2 < ns; i2++)
-        {
-            scheme->transf2_T[i2 * ns + i] = T_inv[i * ns + i2];
-        }
-    }
+//     // transf1:
+//     for (int i = 0; i < ns; i++)
+//     {
+//         if ((i + 1) < ns)
+//         {  // complex conjugate pair of eigenvalues
+//             for (int i1 = i; i1 < i + 2; i1++)
+//             {
+//                 for (int i2 = 0; i2 < ns; i2++)
+//                 {
+//                     scheme->transf1[i2 * ns + i1] = 0.0;
+//                     for (int i3 = 0; i3 < 2; i3++)
+//                     {
+//                         scheme->transf1[i2 * ns + i1] += D[i3 * ns + i1] * T_inv[i2 * ns + i + i3];
+//                     }
+//                 }
+//             }
+//             i++;
+//         }
+//         else
+//         {  // real eigenvalue
+//             for (int i2 = 0; i2 < ns; i2++)
+//             {
+//                 scheme->transf1[i2 * ns + i] = D[i] * T_inv[i2 * ns + i];
+//             }
+//         }
+//     }
+//     // transf2_T:
+//     for (int i = 0; i < ns; i++)
+//     {
+//         for (int i2 = 0; i2 < ns; i2++)
+//         {
+//             scheme->transf2_T[i2 * ns + i] = T_inv[i * ns + i2];
+//         }
+//     }
 
-    return;
-}
+//     return;
+// }
 
 
 

--- a/acados/sim/sim_collocation_utils.c
+++ b/acados/sim/sim_collocation_utils.c
@@ -155,7 +155,7 @@ static double lu_system_solve(double *A, double *b, int *perm, int dim, int dim_
 
 
 
-acados_size_t gauss_legendre_nodes_work_calculate_size(int ns)
+static acados_size_t gauss_legendre_nodes_work_calculate_size(int ns)
 {
     int N = ns - 1;
     int N1 = N + 1;
@@ -171,7 +171,7 @@ acados_size_t gauss_legendre_nodes_work_calculate_size(int ns)
 
 
 // calculates Gauss-Legendre nodes (c) for Butcher tableau of size ns
-void gauss_legendre_nodes(int ns, double *nodes, void *work)
+static void gauss_legendre_nodes(int ns, double *nodes, void *work)
 {
     int N = ns - 1;
     int N1 = N + 1;
@@ -247,7 +247,7 @@ void gauss_legendre_nodes(int ns, double *nodes, void *work)
 }
 
 // looks up Gauss-Radau IIA nodes (c) for Butcher tableau of size ns
-void gauss_radau_iia_nodes(int ns, double *nodes, void *work)
+static void gauss_radau_iia_nodes(int ns, double *nodes, void *work)
 {
     // Radau nodes can be calculated as zeros of polynomial, see:
     // Encyclopedia of Applied and Computational Mathematics
@@ -450,10 +450,11 @@ acados_size_t butcher_tableau_work_calculate_size(int ns)
     acados_size_t size = 0;
 
     size += 3 * ns * ns * sizeof(double);  // can_vm, rhs, lu_work
-
     size += 1 * ns * sizeof(int);  // perm
 
-    return size;
+    acados_size_t size_legendre = gauss_legendre_nodes_work_calculate_size(ns);
+
+    return size > size_legendre ? size : size_legendre;
 }
 
 

--- a/acados/sim/sim_collocation_utils.h
+++ b/acados/sim/sim_collocation_utils.h
@@ -76,9 +76,9 @@ typedef enum
 
 
 //
-acados_size_t gauss_legendre_nodes_work_calculate_size(int ns);
+// acados_size_t gauss_legendre_nodes_work_calculate_size(int ns);
 //
-void gauss_legendre_nodes(int ns, double *nodes, void *raw_memory);
+// void gauss_legendre_nodes(int ns, double *nodes, void *raw_memory);
 //
 // acados_size_t gauss_simplified_work_calculate_size(int ns);
 // //
@@ -86,7 +86,7 @@ void gauss_legendre_nodes(int ns, double *nodes, void *raw_memory);
 //
 acados_size_t butcher_tableau_work_calculate_size(int ns);
 //
-void calculate_butcher_tableau_from_nodes(int ns, double *nodes, double *b, double *A, void *work);
+// void calculate_butcher_tableau_from_nodes(int ns, double *nodes, double *b, double *A, void *work);
 //
 void calculate_butcher_tableau(int ns, sim_collocation_type collocation_type, double *c_vec,
                                double *b_vec, double *A_mat, void *work);

--- a/acados/sim/sim_collocation_utils.h
+++ b/acados/sim/sim_collocation_utils.h
@@ -68,19 +68,28 @@ typedef struct
 } Newton_scheme;
 
 
+typedef enum
+{
+    GAUSS_LEGENDRE,
+    GAUSS_RADAU_IIA,
+} sim_collocation_type;
+
 
 //
-acados_size_t gauss_nodes_work_calculate_size(int ns);
+acados_size_t gauss_legendre_nodes_work_calculate_size(int ns);
 //
-void gauss_nodes(int ns, double *nodes, void *raw_memory);
+void gauss_legendre_nodes(int ns, double *nodes, void *raw_memory);
 //
 acados_size_t gauss_simplified_work_calculate_size(int ns);
 //
 void gauss_simplified(int ns, Newton_scheme *scheme, void *work);
 //
-acados_size_t butcher_table_work_calculate_size(int ns);
+acados_size_t butcher_tableau_work_calculate_size(int ns);
 //
-void butcher_table(int ns, double *nodes, double *b, double *A, void *work);
+void calculate_butcher_tableau_from_nodes(int ns, double *nodes, double *b, double *A, void *work);
+//
+void calculate_butcher_tableau(int ns, sim_collocation_type collocation_type, double *c_vec,
+                               double *b_vec, double *A_mat, void *work);
 
 
 

--- a/acados/sim/sim_collocation_utils.h
+++ b/acados/sim/sim_collocation_utils.h
@@ -43,29 +43,29 @@ extern "C" {
 
 
 
-enum Newton_type_collocation
-{
-    exact = 0,
-    simplified_in,
-    simplified_inis
-};
+// enum Newton_type_collocation
+// {
+//     exact = 0,
+//     simplified_in,
+//     simplified_inis
+// };
 
 
 
-typedef struct
-{
-    enum Newton_type_collocation type;
-    double *eig;
-    double *low_tria;
-    bool single;
-    bool freeze;
+// typedef struct
+// {
+//     enum Newton_type_collocation type;
+//     double *eig;
+//     double *low_tria;
+//     bool single;
+//     bool freeze;
 
-    double *transf1;
-    double *transf2;
+//     double *transf1;
+//     double *transf2;
 
-    double *transf1_T;
-    double *transf2_T;
-} Newton_scheme;
+//     double *transf1_T;
+//     double *transf2_T;
+// } Newton_scheme;
 
 
 typedef enum
@@ -80,9 +80,9 @@ acados_size_t gauss_legendre_nodes_work_calculate_size(int ns);
 //
 void gauss_legendre_nodes(int ns, double *nodes, void *raw_memory);
 //
-acados_size_t gauss_simplified_work_calculate_size(int ns);
-//
-void gauss_simplified(int ns, Newton_scheme *scheme, void *work);
+// acados_size_t gauss_simplified_work_calculate_size(int ns);
+// //
+// void gauss_simplified(int ns, Newton_scheme *scheme, void *work);
 //
 acados_size_t butcher_tableau_work_calculate_size(int ns);
 //

--- a/acados/sim/sim_common.c
+++ b/acados/sim/sim_common.c
@@ -474,6 +474,11 @@ void sim_opts_set_(sim_opts *opts, const char *field, void *value)
         bool *sens_algebraic = (bool *) value;
         opts->sens_algebraic = *sens_algebraic;
     }
+    else if (!strcmp(field, "collocation_type"))
+    {
+        sim_collocation_type *collocation_type = (sim_collocation_type *) value;
+        opts->collocation_type = *collocation_type;
+    }
     else
     {
         printf("\nerror: field %s not available in sim_opts_set\n", field);

--- a/acados/sim/sim_common.h
+++ b/acados/sim/sim_common.h
@@ -147,7 +147,7 @@ typedef struct
     // && jac_reuse=false
     int newton_iter;
     bool jac_reuse;
-    Newton_scheme *scheme;
+    // Newton_scheme *scheme;
 
     // workspace
     void *work;

--- a/acados/sim/sim_common.h
+++ b/acados/sim/sim_common.h
@@ -141,6 +141,7 @@ typedef struct
     bool output_z;        // 1 -- if zn should be computed
     bool sens_algebraic;  // 1 -- if S_algebraic should be computed
     bool exact_z_output;  // 1 -- if z, S_algebraic should be computed exactly, extra Newton iterations
+    sim_collocation_type collocation_type;
 
     // for explicit integrators: newton_iter == 0 && scheme == NULL
     // && jac_reuse=false

--- a/acados/sim/sim_erk_integrator.c
+++ b/acados/sim/sim_erk_integrator.c
@@ -226,7 +226,7 @@ void *sim_erk_opts_assign(void *config_, void *dims, void *raw_memory)
     assert((char *) raw_memory + sim_erk_opts_calculate_size(config_, dims) >= c_ptr);
 
     opts->newton_iter = 0;
-    opts->scheme = NULL;
+    // opts->scheme = NULL;
     opts->jac_reuse = false;
 
     return (void *) opts;

--- a/acados/sim/sim_gnsf.c
+++ b/acados/sim/sim_gnsf.c
@@ -261,16 +261,14 @@ acados_size_t sim_gnsf_opts_calculate_size(void *config_, void *dims)
     size += ns_max * sizeof(double);           // b_vec
     size += ns_max * sizeof(double);           // c_vec
 
-    size_t tmp0 = gauss_legendre_nodes_work_calculate_size(ns_max);
-    size_t tmp1 = butcher_tableau_work_calculate_size(ns_max);
-    acados_size_t work_size = tmp0 > tmp1 ? tmp0 : tmp1;
-    size += work_size;  // work
+    size += butcher_tableau_work_calculate_size(ns_max);
 
     make_int_multiple_of(8, &size);
     size += 1 * 8;
 
     return size;
 }
+
 
 void *sim_gnsf_opts_assign(void *config_, void *dims, void *raw_memory)
 {
@@ -288,11 +286,8 @@ void *sim_gnsf_opts_assign(void *config_, void *dims, void *raw_memory)
     assign_and_advance_double(ns_max, &opts->c_vec, &c_ptr);
 
     // work
-    acados_size_t tmp0 = gauss_legendre_nodes_work_calculate_size(ns_max);
-    acados_size_t tmp1 = butcher_tableau_work_calculate_size(ns_max);
-    acados_size_t work_size = tmp0 > tmp1 ? tmp0 : tmp1;
     opts->work = c_ptr;
-    c_ptr += work_size;
+    c_ptr += butcher_tableau_work_calculate_size(ns_max);;
 
     assert((char *) raw_memory + sim_gnsf_opts_calculate_size(config_, dims) >= c_ptr);
 

--- a/acados/sim/sim_gnsf.c
+++ b/acados/sim/sim_gnsf.c
@@ -308,7 +308,7 @@ void sim_gnsf_opts_initialize_default(void *config_, void *dims_, void *opts_)
 
     // default options
     opts->newton_iter = 3;
-    opts->scheme = NULL;
+    // opts->scheme = NULL;
     opts->num_steps = 2;
     opts->num_forw_sens = dims->nx + dims->nu;
     opts->sens_forw = true;

--- a/acados/sim/sim_gnsf.c
+++ b/acados/sim/sim_gnsf.c
@@ -261,8 +261,8 @@ acados_size_t sim_gnsf_opts_calculate_size(void *config_, void *dims)
     size += ns_max * sizeof(double);           // b_vec
     size += ns_max * sizeof(double);           // c_vec
 
-    size_t tmp0 = gauss_nodes_work_calculate_size(ns_max);
-    size_t tmp1 = butcher_table_work_calculate_size(ns_max);
+    size_t tmp0 = gauss_legendre_nodes_work_calculate_size(ns_max);
+    size_t tmp1 = butcher_tableau_work_calculate_size(ns_max);
     acados_size_t work_size = tmp0 > tmp1 ? tmp0 : tmp1;
     size += work_size;  // work
 
@@ -288,8 +288,8 @@ void *sim_gnsf_opts_assign(void *config_, void *dims, void *raw_memory)
     assign_and_advance_double(ns_max, &opts->c_vec, &c_ptr);
 
     // work
-    acados_size_t tmp0 = gauss_nodes_work_calculate_size(ns_max);
-    acados_size_t tmp1 = butcher_table_work_calculate_size(ns_max);
+    acados_size_t tmp0 = gauss_legendre_nodes_work_calculate_size(ns_max);
+    acados_size_t tmp1 = butcher_tableau_work_calculate_size(ns_max);
     acados_size_t work_size = tmp0 > tmp1 ? tmp0 : tmp1;
     opts->work = c_ptr;
     c_ptr += work_size;
@@ -299,24 +299,12 @@ void *sim_gnsf_opts_assign(void *config_, void *dims, void *raw_memory)
     return (void *) opts;
 }
 
+
+
 void sim_gnsf_opts_initialize_default(void *config_, void *dims_, void *opts_)
 {
     sim_gnsf_dims *dims = (sim_gnsf_dims *) dims_;
     sim_opts *opts = opts_;
-
-    opts->ns = 3;  // GL 3
-    int ns = opts->ns;
-
-    assert(ns <= NS_MAX && "ns > NS_MAX!");
-
-    // set tableau size
-    opts->tableau_size = opts->ns;
-
-    // gauss collocation nodes
-    gauss_nodes(ns, opts->c_vec, opts->work);
-
-    // butcher tableau
-    butcher_table(ns, opts->c_vec, opts->b_vec, opts->A_mat, opts->work);
 
     // default options
     opts->newton_iter = 3;
@@ -328,6 +316,15 @@ void sim_gnsf_opts_initialize_default(void *config_, void *dims_, void *opts_)
     opts->sens_hess = false;
     opts->jac_reuse = true;
     opts->exact_z_output = false;
+    opts->ns = 3;
+    opts->collocation_type = GAUSS_LEGENDRE;
+
+    assert(opts->ns <= NS_MAX && "ns > NS_MAX!");
+
+    // butcher tableau
+    calculate_butcher_tableau(opts->ns, opts->collocation_type, opts->c_vec, opts->b_vec, opts->A_mat, opts->work);
+    // for consistency check
+    opts->tableau_size = opts->ns;
 
     // TODO(oj): check if constr h or cost depend on z, turn on in this case only.
     if (dims->nz > 0)
@@ -350,18 +347,11 @@ void sim_gnsf_opts_update(void *config_, void *dims, void *opts_)
 {
     sim_opts *opts = opts_;
 
-    int ns = opts->ns;
+    assert(opts->ns <= NS_MAX && "ns > NS_MAX!");
 
-    assert(ns <= NS_MAX && "ns > NS_MAX!");
+    calculate_butcher_tableau(opts->ns, opts->collocation_type, opts->c_vec, opts->b_vec, opts->A_mat, opts->work);
 
-    // set tableau size
     opts->tableau_size = opts->ns;
-
-    // gauss collocation nodes
-    gauss_nodes(ns, opts->c_vec, opts->work);
-
-    // butcher tableau
-    butcher_table(ns, opts->c_vec, opts->b_vec, opts->A_mat, opts->work);
 
     return;
 }

--- a/acados/sim/sim_irk_integrator.c
+++ b/acados/sim/sim_irk_integrator.c
@@ -267,7 +267,7 @@ void sim_irk_opts_initialize_default(void *config_, void *dims_, void *opts_)
 
     // default options
     opts->newton_iter = 3;
-    opts->scheme = NULL;
+    // opts->scheme = NULL;
     opts->num_steps = 2;
     opts->num_forw_sens = dims->nx + dims->nu;
     opts->sens_forw = true;

--- a/acados/sim/sim_irk_integrator.c
+++ b/acados/sim/sim_irk_integrator.c
@@ -220,8 +220,8 @@ acados_size_t sim_irk_opts_calculate_size(void *config_, void *dims)
     size += ns_max * sizeof(double);           // b_vec
     size += ns_max * sizeof(double);           // c_vec
 
-    acados_size_t tmp0 = gauss_nodes_work_calculate_size(ns_max);
-    acados_size_t tmp1 = butcher_table_work_calculate_size(ns_max);
+    acados_size_t tmp0 = gauss_legendre_nodes_work_calculate_size(ns_max);
+    acados_size_t tmp1 = butcher_tableau_work_calculate_size(ns_max);
     acados_size_t work_size = tmp0 > tmp1 ? tmp0 : tmp1;
     size += work_size;  // work
 
@@ -247,8 +247,8 @@ void *sim_irk_opts_assign(void *config_, void *dims, void *raw_memory)
     assign_and_advance_double(ns_max, &opts->c_vec, &c_ptr);
 
     // work
-    acados_size_t tmp0 = gauss_nodes_work_calculate_size(ns_max);
-    acados_size_t tmp1 = butcher_table_work_calculate_size(ns_max);
+    acados_size_t tmp0 = gauss_legendre_nodes_work_calculate_size(ns_max);
+    acados_size_t tmp1 = butcher_tableau_work_calculate_size(ns_max);
     acados_size_t work_size = tmp0 > tmp1 ? tmp0 : tmp1;
     opts->work = c_ptr;
     c_ptr += work_size;
@@ -258,24 +258,12 @@ void *sim_irk_opts_assign(void *config_, void *dims, void *raw_memory)
     return (void *) opts;
 }
 
+
+
 void sim_irk_opts_initialize_default(void *config_, void *dims_, void *opts_)
 {
     sim_irk_dims *dims = (sim_irk_dims *) dims_;
     sim_opts *opts = opts_;
-
-    opts->ns = 3;  // GL 3
-    int ns = opts->ns;
-
-    assert(ns <= NS_MAX && "ns > NS_MAX!");
-
-    // set tableau size
-    opts->tableau_size = opts->ns;
-
-    // gauss collocation nodes
-    gauss_nodes(ns, opts->c_vec, opts->work);
-
-    // butcher tableau
-    butcher_table(ns, opts->c_vec, opts->b_vec, opts->A_mat, opts->work);
 
     // default options
     opts->newton_iter = 3;
@@ -287,6 +275,15 @@ void sim_irk_opts_initialize_default(void *config_, void *dims_, void *opts_)
     opts->sens_hess = false;
     opts->jac_reuse = true;
     opts->exact_z_output = false;
+    opts->ns = 3;
+    opts->collocation_type = GAUSS_LEGENDRE;
+
+    assert(opts->ns <= NS_MAX && "ns > NS_MAX!");
+
+    // butcher tableau
+    calculate_butcher_tableau(opts->ns, opts->collocation_type, opts->c_vec, opts->b_vec, opts->A_mat, opts->work);
+    // for consistency check
+    opts->tableau_size = opts->ns;
 
     // TODO(oj): check if constr h or cost depend on z, turn on in this case only.
     if (dims->nz > 0)
@@ -309,18 +306,11 @@ void sim_irk_opts_update(void *config_, void *dims, void *opts_)
 {
     sim_opts *opts = opts_;
 
-    int ns = opts->ns;
+    assert(opts->ns <= NS_MAX && "ns > NS_MAX!");
 
-    assert(ns <= NS_MAX && "ns > NS_MAX!");
+    calculate_butcher_tableau(opts->ns, opts->collocation_type, opts->c_vec, opts->b_vec, opts->A_mat, opts->work);
 
-    // set tableau size
     opts->tableau_size = opts->ns;
-
-    // gauss collocation nodes
-    gauss_nodes(ns, opts->c_vec, opts->work);
-
-    // butcher tableau
-    butcher_table(ns, opts->c_vec, opts->b_vec, opts->A_mat, opts->work);
 
     return;
 }

--- a/acados/sim/sim_irk_integrator.c
+++ b/acados/sim/sim_irk_integrator.c
@@ -312,6 +312,21 @@ void sim_irk_opts_update(void *config_, void *dims, void *opts_)
 
     opts->tableau_size = opts->ns;
 
+    // for debugging: print butcher tableau
+    // printf("Butcher tableau\n");
+    // printf("\nc_vec:\n");
+    // for (int i = 0; i < opts->ns; i++)
+    // {
+    //     printf("%f\t", opts->c_vec[i]);
+    // }
+    // printf("\nb_vec:\n");
+    // for (int i = 0; i < opts->ns; i++)
+    // {
+    //     printf("%f\t", opts->b_vec[i]);
+    // }
+    // printf("\nA_mat:\n");
+    // d_print_mat(opts->ns, opts->ns, opts->A_mat, opts->ns);
+
     return;
 }
 

--- a/acados/sim/sim_irk_integrator.c
+++ b/acados/sim/sim_irk_integrator.c
@@ -220,10 +220,7 @@ acados_size_t sim_irk_opts_calculate_size(void *config_, void *dims)
     size += ns_max * sizeof(double);           // b_vec
     size += ns_max * sizeof(double);           // c_vec
 
-    acados_size_t tmp0 = gauss_legendre_nodes_work_calculate_size(ns_max);
-    acados_size_t tmp1 = butcher_tableau_work_calculate_size(ns_max);
-    acados_size_t work_size = tmp0 > tmp1 ? tmp0 : tmp1;
-    size += work_size;  // work
+    size += butcher_tableau_work_calculate_size(ns_max);
 
     make_int_multiple_of(8, &size);
     size += 1 * 8;
@@ -247,11 +244,8 @@ void *sim_irk_opts_assign(void *config_, void *dims, void *raw_memory)
     assign_and_advance_double(ns_max, &opts->c_vec, &c_ptr);
 
     // work
-    acados_size_t tmp0 = gauss_legendre_nodes_work_calculate_size(ns_max);
-    acados_size_t tmp1 = butcher_tableau_work_calculate_size(ns_max);
-    acados_size_t work_size = tmp0 > tmp1 ? tmp0 : tmp1;
     opts->work = c_ptr;
-    c_ptr += work_size;
+    c_ptr += butcher_tableau_work_calculate_size(ns_max);
 
     assert((char *) raw_memory + sim_irk_opts_calculate_size(config_, dims) >= c_ptr);
 

--- a/acados/sim/sim_lifted_irk_integrator.c
+++ b/acados/sim/sim_lifted_irk_integrator.c
@@ -200,8 +200,8 @@ acados_size_t sim_lifted_irk_opts_calculate_size(void *config_, void *dims)
     size += ns_max * sizeof(double);           // b_vec
     size += ns_max * sizeof(double);           // c_vec
 
-    acados_size_t tmp0 = gauss_nodes_work_calculate_size(ns_max);
-    acados_size_t tmp1 = butcher_table_work_calculate_size(ns_max);
+    acados_size_t tmp0 = gauss_legendre_nodes_work_calculate_size(ns_max);
+    acados_size_t tmp1 = butcher_tableau_work_calculate_size(ns_max);
     acados_size_t work_size = tmp0 > tmp1 ? tmp0 : tmp1;
     size += work_size;  // work
 
@@ -229,8 +229,8 @@ void *sim_lifted_irk_opts_assign(void *config_, void *dims, void *raw_memory)
     assign_and_advance_double(ns_max, &opts->c_vec, &c_ptr);
 
     // work
-    acados_size_t tmp0 = gauss_nodes_work_calculate_size(ns_max);
-    acados_size_t tmp1 = butcher_table_work_calculate_size(ns_max);
+    acados_size_t tmp0 = gauss_legendre_nodes_work_calculate_size(ns_max);
+    acados_size_t tmp1 = butcher_tableau_work_calculate_size(ns_max);
     acados_size_t work_size = tmp0 > tmp1 ? tmp0 : tmp1;
     opts->work = c_ptr;
     c_ptr += work_size;
@@ -247,34 +247,38 @@ void sim_lifted_irk_opts_initialize_default(void *config_, void *dims_, void *op
     sim_opts *opts = opts_;
     sim_lifted_irk_dims *dims = (sim_lifted_irk_dims *) dims_;
 
-    int nx = dims->nx;
-    int nu = dims->nu;
-    opts->ns = 3;  // GL 3
-    int ns = opts->ns;
-
-    assert(ns <= NS_MAX && "ns > NS_MAX!");
-
-    // set tableau size
-    opts->tableau_size = opts->ns;
-
-    // gauss collocation nodes
-    gauss_nodes(ns, opts->c_vec, opts->work);
-
-    // butcher tableau
-    butcher_table(ns, opts->c_vec, opts->b_vec, opts->A_mat, opts->work);
-
     // default options
-    opts->newton_iter = 1;
+    opts->newton_iter = 3;
     opts->scheme = NULL;
-    opts->num_steps = 1;
-    opts->num_forw_sens = nx + nu;
+    opts->num_steps = 2;
+    opts->num_forw_sens = dims->nx + dims->nu;
     opts->sens_forw = true;
     opts->sens_adj = false;
     opts->sens_hess = false;
-    opts->jac_reuse = false;
+    opts->jac_reuse = true;
+    opts->exact_z_output = false;
+    opts->ns = 3;
+    opts->collocation_type = GAUSS_LEGENDRE;
 
-    opts->output_z = false;
-    opts->sens_algebraic = false;
+    assert(opts->ns <= NS_MAX && "ns > NS_MAX!");
+
+    // butcher tableau
+    calculate_butcher_tableau(opts->ns, opts->collocation_type, opts->c_vec, opts->b_vec, opts->A_mat, opts->work);
+    // for consistency check
+    opts->tableau_size = opts->ns;
+
+    // TODO(oj): check if constr h or cost depend on z, turn on in this case only.
+    if (dims->nz > 0)
+    {
+        opts->output_z = true;
+        opts->sens_algebraic = true;
+    }
+    else
+    {
+        opts->output_z = false;
+        opts->sens_algebraic = false;
+    }
+
     return;
 }
 
@@ -284,18 +288,11 @@ void sim_lifted_irk_opts_update(void *config_, void *dims, void *opts_)
 {
     sim_opts *opts = opts_;
 
-    int ns = opts->ns;
+    assert(opts->ns <= NS_MAX && "ns > NS_MAX!");
 
-    assert(ns <= NS_MAX && "ns > NS_MAX!");
+    calculate_butcher_tableau(opts->ns, opts->collocation_type, opts->c_vec, opts->b_vec, opts->A_mat, opts->work);
 
-    // set tableau size
     opts->tableau_size = opts->ns;
-
-    // gauss collocation nodes
-    gauss_nodes(ns, opts->c_vec, opts->work);
-
-    // butcher tableau
-    butcher_table(ns, opts->c_vec, opts->b_vec, opts->A_mat, opts->work);
 
     return;
 }

--- a/acados/sim/sim_lifted_irk_integrator.c
+++ b/acados/sim/sim_lifted_irk_integrator.c
@@ -200,10 +200,7 @@ acados_size_t sim_lifted_irk_opts_calculate_size(void *config_, void *dims)
     size += ns_max * sizeof(double);           // b_vec
     size += ns_max * sizeof(double);           // c_vec
 
-    acados_size_t tmp0 = gauss_legendre_nodes_work_calculate_size(ns_max);
-    acados_size_t tmp1 = butcher_tableau_work_calculate_size(ns_max);
-    acados_size_t work_size = tmp0 > tmp1 ? tmp0 : tmp1;
-    size += work_size;  // work
+    size += butcher_tableau_work_calculate_size(ns_max);
 
     make_int_multiple_of(8, &size);
     size += 1 * 8;
@@ -229,11 +226,8 @@ void *sim_lifted_irk_opts_assign(void *config_, void *dims, void *raw_memory)
     assign_and_advance_double(ns_max, &opts->c_vec, &c_ptr);
 
     // work
-    acados_size_t tmp0 = gauss_legendre_nodes_work_calculate_size(ns_max);
-    acados_size_t tmp1 = butcher_tableau_work_calculate_size(ns_max);
-    acados_size_t work_size = tmp0 > tmp1 ? tmp0 : tmp1;
     opts->work = c_ptr;
-    c_ptr += work_size;
+    c_ptr += butcher_tableau_work_calculate_size(ns_max);
 
     assert((char *) raw_memory + sim_lifted_irk_opts_calculate_size(config_, dims) >= c_ptr);
 

--- a/acados/sim/sim_lifted_irk_integrator.c
+++ b/acados/sim/sim_lifted_irk_integrator.c
@@ -249,7 +249,7 @@ void sim_lifted_irk_opts_initialize_default(void *config_, void *dims_, void *op
 
     // default options
     opts->newton_iter = 3;
-    opts->scheme = NULL;
+    // opts->scheme = NULL;
     opts->num_steps = 2;
     opts->num_forw_sens = dims->nx + dims->nu;
     opts->sens_forw = true;

--- a/examples/acados_matlab_octave/test/test_template_pendulum_ocp.m
+++ b/examples/acados_matlab_octave/test/test_template_pendulum_ocp.m
@@ -48,7 +48,7 @@ qp_solver = 'partial_condensing_hpipm';
     % full_condensing_hpipm, partial_condensing_hpipm, full_condensing_qpoases
 qp_solver_cond_N = 5; % for partial condensing
 % integrator type
-sim_method = 'erk'; % erk, irk, irk_gnsf
+sim_method = 'irk'; % erk, irk, irk_gnsf
 
 %% model dynamics
 model = pendulum_on_cart_model;
@@ -109,6 +109,7 @@ ocp_opts.set('nlp_solver', nlp_solver);
 ocp_opts.set('sim_method', sim_method);
 ocp_opts.set('qp_solver', qp_solver);
 ocp_opts.set('qp_solver_cond_N', qp_solver_cond_N);
+ocp_opts.set('collocation_type', 'gauss_radau_iia');
 % ... see ocp_opts.opts_struct to see what other fields can be set
 
 %% create ocp solver

--- a/examples/acados_python/getting_started/sim/minimal_example_sim.py
+++ b/examples/acados_python/getting_started/sim/minimal_example_sim.py
@@ -57,10 +57,10 @@ N = 200
 sim.solver_options.T = Tf
 # set options
 sim.solver_options.integrator_type = 'IRK'
-sim.solver_options.num_stages = 4
+sim.solver_options.num_stages = 3
 sim.solver_options.num_steps = 3
 sim.solver_options.newton_iter = 3 # for implicit integrator
-
+sim.solver_options.collocation_type = "GAUSS_RADAU_IIA"
 
 # create
 acados_integrator = AcadosSimSolver(sim)

--- a/interfaces/acados_c/sim_interface.h
+++ b/interfaces/acados_c/sim_interface.h
@@ -45,11 +45,11 @@ extern "C" {
 
 typedef enum
 {
-	ERK,
-	IRK,
-	GNSF,
-	LIFTED_IRK,
-	INVALID_SIM_SOLVER,
+    ERK,
+    IRK,
+    GNSF,
+    LIFTED_IRK,
+    INVALID_SIM_SOLVER,
 } sim_solver_t;
 
 

--- a/interfaces/acados_matlab_octave/acados_ocp_opts.m
+++ b/interfaces/acados_matlab_octave/acados_ocp_opts.m
@@ -80,6 +80,7 @@ classdef acados_ocp_opts < handle
             obj.opts_struct.warm_start_first_qp = 0;
                     % 0 no warm start in first sqp iter - 1 warm start even in first sqp iter
             obj.opts_struct.sim_method = 'irk'; % erk; irk; irk_gnsf
+            obj.opts_struct.collocation_type = 'gauss_legendre';
             obj.opts_struct.sim_method_num_stages = 4;
             obj.opts_struct.sim_method_num_steps = 1;
             obj.opts_struct.sim_method_newton_iter = 3;
@@ -176,6 +177,8 @@ classdef acados_ocp_opts < handle
                 obj.opts_struct.qp_solver_warm_start = value;
             elseif (strcmp(field, 'sim_method'))
                 obj.opts_struct.sim_method = value;
+            elseif (strcmp(field, 'collocation_type'))
+                obj.opts_struct.collocation_type = value;
             elseif (strcmp(field, 'sim_method_num_stages'))
                 obj.opts_struct.sim_method_num_stages = value;
             elseif (strcmp(field, 'sim_method_num_steps'))

--- a/interfaces/acados_matlab_octave/acados_sim_opts.m
+++ b/interfaces/acados_matlab_octave/acados_sim_opts.m
@@ -50,6 +50,7 @@ classdef acados_sim_opts < handle
             obj.opts_struct.codgen_model = 'true';
             obj.opts_struct.compile_model = 'true';
             obj.opts_struct.method = 'irk';
+            obj.opts_struct.collocation_type = 'gauss_legendre'
             obj.opts_struct.num_stages = 4;
             obj.opts_struct.num_steps = 1;
             obj.opts_struct.newton_iter = 3;
@@ -100,6 +101,8 @@ classdef acados_sim_opts < handle
                 obj.opts_struct.gnsf_detect_struct = value;
             elseif (strcmp(field, 'output_dir'))
                 obj.opts_struct.output_dir = value;
+            elseif (strcmp(field, 'collocation_type'))
+                obj.opts_struct.collocation_type = value;
             elseif (strcmp(field, 'compile_mex'))
                 disp(['Option compile_mex is not supported anymore,'...
                     'please use compile_interface instead or dont set the option.', ...

--- a/interfaces/acados_matlab_octave/acados_template_mex/+acados_template_mex/ocp_nlp_solver_options_json.m
+++ b/interfaces/acados_matlab_octave/acados_template_mex/+acados_template_mex/ocp_nlp_solver_options_json.m
@@ -70,6 +70,7 @@ classdef ocp_nlp_solver_options_json < handle
         alpha_min
         alpha_reduction
         globalization
+        collocation_type
 
     end
     methods
@@ -77,6 +78,7 @@ classdef ocp_nlp_solver_options_json < handle
             obj.qp_solver       = 'PARTIAL_CONDENSING_HPIPM';
             obj.hessian_approx  = 'GAUSS_NEWTON';
             obj.integrator_type = 'ERK';
+            obj.collocation_type = 'GAUSS_LEGENDRE';
             obj.tf = [];
             obj.Tsim = [];
             obj.nlp_solver_type = 'SQP_RTI';

--- a/interfaces/acados_matlab_octave/ocp_create.c
+++ b/interfaces/acados_matlab_octave/ocp_create.c
@@ -958,6 +958,26 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 
     if (strcmp(dyn_type, "discrete"))
     {
+        // collocation_type
+        char *collocation_type = mxArrayToString( mxGetField( matlab_opts, 0, "collocation_type" ) );
+        sim_collocation_type collo_type;
+        if (!strcmp(collocation_type, "gauss_legendre"))
+        {
+            collo_type = GAUSS_LEGENDRE;
+        }
+        else if (!strcmp(collocation_type, "gauss_radau_iia"))
+        {
+            collo_type = GAUSS_RADAU_IIA;
+        }
+        else
+        {
+            MEX_FIELD_VALUE_NOT_SUPPORTED_SUGGEST(fun_name, "collocation_type", collocation_type, "gauss_legendre, gauss_radau_iia");
+        }
+        for (int ii=0; ii<N; ii++)
+        {
+            ocp_nlp_solver_opts_set_at_stage(config, opts, ii, "dynamics_collocation_type", &collo_type);
+        }
+
         // sim_method_num_stages
         sprintf(matlab_field_name, "sim_method_num_stages");
         const mxArray *matlab_array;

--- a/interfaces/acados_matlab_octave/set_up_acados_ocp_nlp_json.m
+++ b/interfaces/acados_matlab_octave/set_up_acados_ocp_nlp_json.m
@@ -52,6 +52,8 @@ function ocp_json = set_up_acados_ocp_nlp_json(obj, simulink_opts)
     ocp_json.solver_options.qp_solver = upper(obj.opts_struct.qp_solver);
     ocp_json.solver_options.integrator_type = upper(obj.opts_struct.sim_method);
     ocp_json.solver_options.nlp_solver_type = upper(obj.opts_struct.nlp_solver);
+    ocp_json.solver_options.collocation_type = upper(obj.opts_struct.collocation_type);
+
     if strcmp(obj.opts_struct.sim_method, 'irk_gnsf')
         ocp_json.solver_options.integrator_type = 'GNSF';
     end

--- a/interfaces/acados_matlab_octave/sim_create.c
+++ b/interfaces/acados_matlab_octave/sim_create.c
@@ -215,6 +215,21 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         jac_reuse = true;
     }
 
+    char *collocation_type = mxArrayToString( mxGetField( matlab_opts, 0, "collocation_type" ) );
+    sim_collocation_type collo_type;
+    if (!strcmp(collocation_type, "gauss_legendre"))
+    {
+        collo_type = GAUSS_LEGENDRE;
+    }
+    else if (!strcmp(collocation_type, "gauss_radau_iia"))
+    {
+        collo_type = GAUSS_RADAU_IIA;
+    }
+    else
+    {
+        MEX_FIELD_VALUE_NOT_SUPPORTED_SUGGEST(fun_name, "collocation_type", collocation_type, "gauss_legendre, gauss_radau_iia");
+    }
+
     sim_opts_set(config, opts, "num_stages", &num_stages);
     sim_opts_set(config, opts, "num_steps", &num_steps);
     sim_opts_set(config, opts, "newton_iter", &newton_iter);
@@ -223,6 +238,8 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     sim_opts_set(config, opts, "sens_hess", &sens_hess);
     sim_opts_set(config, opts, "sens_algebraic", &sens_algebraic);
     sim_opts_set(config, opts, "jac_reuse", &jac_reuse);
+    sim_opts_set(config, opts, "collocation_type", &collo_type);
+
 
 
     /* in */

--- a/interfaces/acados_template/acados_template/acados_layout.json
+++ b/interfaces/acados_template/acados_template/acados_layout.json
@@ -666,6 +666,9 @@
         "nlp_solver_type": [
             "str"
         ],
+        "collocation_type": [
+            "str"
+        ],
         "globalization": [
             "str"
         ],

--- a/interfaces/acados_template/acados_template/acados_ocp.py
+++ b/interfaces/acados_template/acados_template/acados_ocp.py
@@ -2120,6 +2120,7 @@ class AcadosOcpOptions:
         self.__globalization = 'FIXED_STEP'
         self.__nlp_solver_step_length = 1.0                   # fixed Newton step length
         self.__levenberg_marquardt = 0.0
+        self.__collocation_type = 'GAUSS_LEGENDRE'
         self.__sim_method_num_stages  = 4                     # number of stages in the integrator
         self.__sim_method_num_steps   = 1                     # number of steps in the integrator
         self.__sim_method_newton_iter = 3                     # number of Newton iterations in simulation method
@@ -2194,6 +2195,15 @@ class AcadosOcpOptions:
         .. note:: preliminary implementation.
         """
         return self.__globalization
+
+    @property
+    def collocation_type(self):
+        """Collocation type: relevant for implicit integrators
+        -- string in {GAUSS_RADAU_IIA, GAUSS_LEGENDRE}.
+
+        Default: GAUSS_LEGENDRE
+        """
+        return self.__collocation_type
 
     @property
     def regularize_method(self):
@@ -2480,6 +2490,15 @@ class AcadosOcpOptions:
         else:
             raise Exception('Invalid regularize_method value. Possible values are:\n\n' \
                     + ',\n'.join(regularize_methods) + '.\n\nYou have: ' + regularize_method + '.\n\nExiting.')
+
+    @collocation_type.setter
+    def collocation_type(self, collocation_type):
+        collocation_types = ('GAUSS_RADAU_IIA', 'GAUSS_LEGENDRE')
+        if collocation_type in collocation_types:
+            self.__collocation_type = collocation_type
+        else:
+            raise Exception('Invalid collocation_type value. Possible values are:\n\n' \
+                    + ',\n'.join(collocation_types) + '.\n\nYou have: ' + collocation_type + '.\n\nExiting.')
 
     @hessian_approx.setter
     def hessian_approx(self, hessian_approx):

--- a/interfaces/acados_template/acados_template/acados_sim.py
+++ b/interfaces/acados_template/acados_template/acados_sim.py
@@ -106,6 +106,7 @@ class AcadosSimOpts:
     """
     def __init__(self):
         self.__integrator_type = 'ERK'
+        self.__collocation_type = 'GAUSS_LEGENDRE'
         self.__Tsim = None
         # ints
         self.__sim_method_num_stages = 1
@@ -174,6 +175,15 @@ class AcadosSimOpts:
         """Time horizon"""
         return self.__Tsim
 
+    @property
+    def collocation_type(self):
+        """Collocation type: relevant for implicit integrators
+        -- string in {GAUSS_RADAU_IIA, GAUSS_LEGENDRE}
+
+        Default: GAUSS_LEGENDRE
+        """
+        return self.__collocation_type
+
     @integrator_type.setter
     def integrator_type(self, integrator_type):
         integrator_types = ('ERK', 'IRK', 'GNSF')
@@ -182,6 +192,15 @@ class AcadosSimOpts:
         else:
             raise Exception('Invalid integrator_type value. Possible values are:\n\n' \
                     + ',\n'.join(integrator_types) + '.\n\nYou have: ' + integrator_type + '.\n\nExiting.')
+
+    @collocation_type.setter
+    def collocation_type(self, collocation_type):
+        collocation_types = ('GAUSS_RADAU_IIA', 'GAUSS_LEGENDRE')
+        if collocation_type in collocation_types:
+            self.__collocation_type = collocation_type
+        else:
+            raise Exception('Invalid collocation_type value. Possible values are:\n\n' \
+                    + ',\n'.join(collocation_types) + '.\n\nYou have: ' + collocation_type + '.\n\nExiting.')
 
     @T.setter
     def T(self, T):

--- a/interfaces/acados_template/acados_template/acados_sim_layout.json
+++ b/interfaces/acados_template/acados_template/acados_sim_layout.json
@@ -28,6 +28,9 @@
         "integrator_type": [
             "str"
         ],
+        "collocation_type": [
+            "str"
+        ],
         "Tsim": [
             "float"
         ],

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_sim_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_sim_solver.in.c
@@ -243,6 +243,8 @@ int {{ model.name }}_acados_sim_create(sim_solver_capsule * capsule)
     capsule->acados_sim_opts = {{ model.name }}_sim_opts;
     int tmp_int = {{ solver_options.sim_method_newton_iter }};
     sim_opts_set({{ model.name }}_sim_config, {{ model.name }}_sim_opts, "newton_iter", &tmp_int);
+    sim_collocation_type collocation_type = {{ solver_options.collocation_type }};
+    sim_opts_set({{ model.name }}_sim_config, {{ model.name }}_sim_opts, "collocation_type", &collocation_type);
 
 {% if problem_class == "SIM" %}
     tmp_int = {{ solver_options.sim_method_num_stages }};

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -1879,6 +1879,11 @@ int {{ model.name }}_acados_create({{ model.name }}_solver_capsule * capsule)
 
 {%- if solver_options.integrator_type != "DISCRETE" %}
 
+    // set collocation type (relevant for implicit integrators)
+    sim_collocation_type collocation_type = {{ solver_options.collocation_type }};
+    for (int i = 0; i < N; i++)
+        ocp_nlp_solver_opts_set_at_stage(nlp_config, capsule->nlp_opts, i, "dynamics_collocation_type", &collocation_type);
+
     // set up sim_method_num_steps
     {%- set all_equal = true %}
     {%- set val = solver_options.sim_method_num_steps[0] %}


### PR DESCRIPTION
- supports `GAUSS_LEGENDRE` and `GAUSS_RADAU_IIA` to use corresponding Butcher tableaus in implicit integrators
- clean up collocation utils