### PR TITLE
cython interface

### DIFF
--- a/examples/acados_python/cython/example.py
+++ b/examples/acados_python/cython/example.py
@@ -1,0 +1,218 @@
+#
+# Copyright 2019 Gianluca Frison, Dimitris Kouzoupis, Robin Verschueren,
+# Andrea Zanelli, Niels van Duijkeren, Jonathan Frey, Tommaso Sartor,
+# Branimir Novoselnik, Rien Quirynen, Rezart Qelibari, Dang Doan,
+# Jonas Koenemann, Yutao Chen, Tobias Schöls, Jonas Schlagenhauf, Moritz Diehl
+#
+# This file is part of acados.
+#
+# The 2-Clause BSD License
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.;
+#
+
+import matplotlib.pyplot as plt
+
+from acados_template import AcadosOcp, AcadosOcpSolver, AcadosModel, AcadosSimSolver, AcadosSim
+import numpy as np
+from casadi import SX, vertcat
+import pickle
+
+# (very) simple crane model
+beta = 0.001
+k = 0.9
+a_max = 10
+dt_max = 2.0
+
+# states
+p1 = SX.sym('p1')
+v1 = SX.sym('v1')
+p2 = SX.sym('p2')
+v2 = SX.sym('v2')
+
+x = vertcat(p1, v1, p2, v2)
+
+# controls
+a = SX.sym('a')
+dt = SX.sym('dt')
+
+u = vertcat(a, dt)
+
+f_expl = dt*vertcat(v1, a, v2, -beta*v2-k*(p2 - p1))
+
+model = AcadosModel()
+
+model.f_expl_expr = f_expl
+model.x = x
+model.u = u
+model.name = 'crane_time_opt'
+
+# create ocp object to formulate the OCP
+
+x0 = np.array([2.0, 0.0, 2.0, 0.0])
+xf = np.array([0.0, 0.0, 0.0, 0.0])
+
+ocp = AcadosOcp()
+ocp.model = model
+
+# N - maximum number of bangs
+N = 7
+Tf = N
+nx = model.x.size()[0]
+nu = model.u.size()[0]
+ny = nx + nu
+ny_e = nx
+
+# set dimensions
+ocp.dims.N = N
+
+# set cost
+ocp.cost.cost_type = 'EXTERNAL'
+ocp.cost.cost_type_e = 'EXTERNAL'
+
+ocp.model.cost_expr_ext_cost = dt
+ocp.model.cost_expr_ext_cost_e = 0
+
+ocp.constraints.lbu = np.array([-a_max, 0.0])
+ocp.constraints.ubu = np.array([+a_max, dt_max])
+ocp.constraints.idxbu = np.array([0, 1])
+
+ocp.constraints.x0 = x0
+ocp.constraints.lbx_e = xf
+ocp.constraints.ubx_e = xf
+ocp.constraints.idxbx_e = np.array([0, 1, 2, 3])
+
+# set prediction horizon
+ocp.solver_options.tf = Tf
+
+# set options
+ocp.solver_options.qp_solver = 'FULL_CONDENSING_QPOASES'#'PARTIAL_CONDENSING_HPIPM' # FULL_CONDENSING_QPOASES
+ocp.solver_options.integrator_type = 'ERK'
+ocp.solver_options.print_level = 3
+ocp.solver_options.nlp_solver_type = 'SQP' # SQP_RTI, SQP
+ocp.solver_options.globalization = 'MERIT_BACKTRACKING'
+ocp.solver_options.nlp_solver_max_iter = 5000
+ocp.solver_options.nlp_solver_tol_stat = 1e-6
+ocp.solver_options.levenberg_marquardt = 0.1
+ocp.solver_options.sim_method_num_steps = 15
+ocp.solver_options.qp_solver_iter_max = 100
+
+ocp_solver = AcadosOcpSolver.generate(ocp, json_file = 'acados_ocp.json')
+
+for i, tau in enumerate(np.linspace(0, 1, N)):
+    ocp_solver.set(i, 'x', (1-tau)*x0 + tau*xf)
+    ocp_solver.set(i, 'u', np.array([0.1, 0.5]))
+
+simX = np.zeros((N+1, nx))
+simU = np.zeros((N, nu))
+
+status = ocp_solver.solve()
+
+if status != 0:
+    ocp_solver.print_statistics()
+    raise Exception('acados returned status {}. Exiting.'.format(status))
+
+# get solution
+for i in range(N):
+    simX[i,:] = ocp_solver.get(i, "x")
+    simU[i,:] = ocp_solver.get(i, "u")
+simX[N,:] = ocp_solver.get(N, "x")
+
+dts = simU[:, 1]
+
+# simulate on finer grid
+sim = AcadosSim()
+
+# set model
+sim.model = model
+
+# set options
+sim.solver_options.integrator_type = 'ERK'
+sim.solver_options.num_stages = 4
+sim.solver_options.num_steps = 3
+sim.solver_options.T = 1.0 # dummy value
+
+dt_approx = 0.0005
+
+dts_fine = np.zeros((N,))
+Ns_fine = np.zeros((N,), dtype='int16')
+
+# compute number of simulation steps for bang interval + dt_fine
+for i in range(N):
+    N_approx = max(int(dts[i]/dt_approx), 1)
+    dts_fine[i] = dts[i]/N_approx
+    Ns_fine[i] = int(round(dts[i]/dts_fine[i]))
+
+N_fine = int(np.sum(Ns_fine))
+
+simU_fine = np.zeros((N_fine, nu))
+ts_fine = np.zeros((N_fine+1, ))
+simX_fine = np.zeros((N_fine+1, nx))
+simX_fine[0, :] = x0
+
+acados_integrator = AcadosSimSolver(sim)
+
+k = 0
+for i in range(N):
+    u = simU[i, 0]
+    acados_integrator.set("u", np.hstack((u, np.ones(1, ))))
+
+    # set simulation time
+    acados_integrator.set("T", dts_fine[i])
+
+    for j in range(Ns_fine[i]):
+        acados_integrator.set("x", simX_fine[k,:])
+        status = acados_integrator.solve()
+        if status != 0:
+            raise Exception('acados returned status {}. Exiting.'.format(status))
+
+        simX_fine[k+1,:] = acados_integrator.get("x")
+        simU_fine[k, :] = u
+        ts_fine[k+1] = ts_fine[k] + dts_fine[i]
+
+        k += 1
+
+# visualize
+plt.figure()
+
+ts = np.hstack((np.zeros((1, )), np.cumsum(dts)))
+state_labels = ['p1', 'v1', 'p2', 'v2']
+
+for i,l in enumerate(state_labels):
+    plt.subplot(5, 1, i+1)
+
+    plt.plot(ts_fine, simX_fine[:, i], label='time optimal solution')
+    plt.grid(True)
+    plt.ylabel(l)
+    if i ==0:
+        plt.legend(loc=1)
+
+plt.subplot(5, 1, 5)
+plt.step(ts_fine, np.hstack((simU_fine[:, 0], simU_fine[-1, 0])), '-', where='post')
+plt.grid(True)
+plt.ylabel('a')
+plt.xlabel('t')
+
+plt.show()
+
+# import pdb; pdb.set_trace()

--- a/interfaces/acados_c/ocp_nlp_interface.h
+++ b/interfaces/acados_c/ocp_nlp_interface.h
@@ -293,6 +293,8 @@ void ocp_nlp_constraint_dims_get_from_attr(ocp_nlp_config *config, ocp_nlp_dims 
 void ocp_nlp_cost_dims_get_from_attr(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_out *out,
         int stage, const char *field, int *dims_out);
 
+void ocp_nlp_dynamics_dims_get_from_attr(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_out *out,
+        int stage, const char *field, int *dims_out);
 
 /* opts */
 
@@ -367,6 +369,8 @@ int ocp_nlp_precompute(ocp_nlp_solver *solver, ocp_nlp_in *nlp_in, ocp_nlp_out *
 /// \param nlp_out The output struct.
 void ocp_nlp_eval_cost(ocp_nlp_solver *solver, ocp_nlp_in *nlp_in, ocp_nlp_out *nlp_out);
 
+//
+void ocp_nlp_eval_residuals(ocp_nlp_solver *solver, ocp_nlp_in *nlp_in, ocp_nlp_out *nlp_out);
 
 //
 void ocp_nlp_eval_param_sens(ocp_nlp_solver *solver, char *field, int stage, int index, ocp_nlp_out *sens_nlp_out);

--- a/interfaces/acados_template/acados_template/.gitignore
+++ b/interfaces/acados_template/acados_template/.gitignore
@@ -1,1 +1,6 @@
 __pycache__/
+
+# Cython intermediates
+*_pyx.c
+*_pyx.o
+*_pyx.so

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -786,9 +786,7 @@ class AcadosOcpSolver:
         model = acados_ocp.model
 
         if simulink_opts is None:
-            json_path = os.path.dirname(os.path.realpath(__file__))
-            with open(json_path + '/simulink_default_opts.json', 'r') as f:
-                simulink_opts = json.load(f)
+            simulink_opts = get_simulink_default_opts()
 
         # make dims consistent
         make_ocp_dims_consistent(acados_ocp)

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -654,7 +654,7 @@ def ocp_render_templates(acados_ocp, json_file):
     render_template(in_file, out_file, template_dir, json_path)
 
     in_file = 'acados_solver.in.pxd'
-    out_file = f'acados_solver_{name}.pxd'
+    out_file = f'acados_solver.pxd'
     render_template(in_file, out_file, template_dir, json_path)
 
     in_file = 'Makefile.in'

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -784,6 +784,14 @@ class AcadosOcpSolver:
 
     @classmethod
     def generate(cls, acados_ocp, json_file='acados_ocp_nlp.json', simulink_opts=None, build=True):
+        """
+        Generate
+
+            :param acados_ocp: type AcadosOcp - description of the OCP for acados
+            :param json_file: name for the json file used to render the templated code - default: acados_ocp_nlp.json
+            :param simulink_opts: Options to configure Simulink S-function blocks, mainly to activate possible Inputs and Outputs
+            :param build: whether to build the generated C code, return initialized AcadosOcpSolver instance - default: True
+        """
         model = acados_ocp.model
 
         if simulink_opts is None:
@@ -823,7 +831,7 @@ class AcadosOcpSolver:
             importlib.invalidate_caches()
             acados_ocp_solver_pyx = importlib.import_module(f'{code_export_dir}.acados_ocp_solver_pyx')
             AcadosOcpSolverFast = getattr(acados_ocp_solver_pyx, 'AcadosOcpSolverFast')
-            return AcadosOcpSolverFast(acados_ocp.model.name, acados_ocp.dims.N, code_export_dir)
+            return AcadosOcpSolverFast(acados_ocp.model.name, acados_ocp.dims.N)
 
     def __init__(self, model_name, N, code_export_dir):
         self.model_name = model_name

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -434,15 +434,19 @@ def make_ocp_dims_consistent(acados_ocp):
         if np.shape(opts.shooting_nodes)[0] != dims.N+1:
             raise Exception('inconsistent dimension N, regarding shooting_nodes.')
 
-        time_steps = opts.shooting_nodes[1:] - opts.shooting_nodes[0:-1]
-        # identify constant time-steps: due to numerical reasons the content of time_steps might vary a bit
-        delta_time_steps = time_steps[1:] - time_steps[0:-1]
-        avg_time_steps = np.average(time_steps)
-        # criterion for constant time-step detection: the min/max difference in values normalized by the average
-        check_const_time_step = np.max(delta_time_steps)-np.min(delta_time_steps) / avg_time_steps
-        # if the criterion is small, we have a constant time-step
-        if check_const_time_step < 1e-9:
-            time_steps[:] = avg_time_steps  # if we have a constant time-step: apply the average time-step
+        # time_steps = opts.shooting_nodes[1:] - opts.shooting_nodes[0:-1]
+        # # identify constant time-steps: due to numerical reasons the content of time_steps might vary a bit
+        # delta_time_steps = time_steps[1:] - time_steps[0:-1]
+        # avg_time_steps = np.average(time_steps)
+        # # criterion for constant time-step detection: the min/max difference in values normalized by the average
+        # check_const_time_step = np.max(delta_time_steps)-np.min(delta_time_steps) / avg_time_steps
+        # # if the criterion is small, we have a constant time-step
+        # if check_const_time_step < 1e-9:
+        #     time_steps[:] = avg_time_steps  # if we have a constant time-step: apply the average time-step
+        time_steps = np.zeros((dims.N,))
+        for i in range(dims.N):
+            time_steps[i] = opts.shooting_nodes[i+1] - opts.shooting_nodes[i] # TODO use commented code above
+
         opts.time_steps = time_steps
 
     elif (not is_empty(opts.time_steps)) and (not is_empty(opts.shooting_nodes)):

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -774,13 +774,12 @@ class AcadosOcpSolver:
         dlclose.argtypes = [c_void_p]
 
     @classmethod
-    def generate(cls, acados_ocp, json_file='acados_ocp_nlp.json', simulink_opts=None, build=True, json_path=None):
+    def generate(cls, acados_ocp, json_file='acados_ocp_nlp.json', simulink_opts=None, build=True):
         model = acados_ocp.model
 
         if simulink_opts is None:
-            if json_path is None:
-              acados_path = get_acados_path()
-              json_path = os.path.join(acados_path, 'interfaces/acados_template/acados_template')
+            acados_path = get_acados_path()
+            json_path = os.path.join(acados_path, 'interfaces/acados_template/acados_template')
             with open(json_path + '/simulink_default_opts.json', 'r') as f:
                 simulink_opts = json.load(f)
 

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -32,11 +32,13 @@
 # POSSIBILITY OF SUCH DAMAGE.;
 #
 
-import sys, os, json
+import sys
+import os
+import json
 import numpy as np
 from datetime import datetime
-
-from ctypes import *
+import ctypes
+from ctypes import POINTER, cast, CDLL, c_void_p, c_char_p, c_double, c_int, c_int64, byref
 
 from copy import deepcopy
 
@@ -88,7 +90,7 @@ def make_ocp_dims_consistent(acados_ocp):
         raise Exception('inconsistent dimension np, regarding model.p and parameter_values.' + \
             f'\nGot np = {dims.np}, acados_ocp.parameter_values.shape = {acados_ocp.parameter_values.shape[0]}\n')
 
-    ## cost
+    # cost
     # initial stage - if not set, copy fields from path constraints
     if cost.cost_type_0 is None:
         cost.cost_type_0 = cost.cost_type
@@ -163,7 +165,7 @@ def make_ocp_dims_consistent(acados_ocp):
     if cost.cost_type_e == 'LINEAR_LS':
         ny_e = cost.W_e.shape[0]
         if cost.Vx_e.shape[0] != ny_e:
-            raise Exception('inconsistent dimension ny_e: regarding W_e, cost_y_expr_e.'  + \
+            raise Exception('inconsistent dimension ny_e: regarding W_e, cost_y_expr_e.' + \
                 f'\nGot W_e[{cost.W_e.shape}], Vx_e[{cost.Vx_e.shape}]')
         if cost.Vx_e.shape[1] != dims.nx and ny_e != 0:
             raise Exception('inconsistent dimension: Vx_e should have nx columns.')
@@ -196,12 +198,12 @@ def make_ocp_dims_consistent(acados_ocp):
         dims.nbx_0 = constraints.lbx_0.size
 
     if all(constraints.lbx_0 == constraints.ubx_0) and dims.nbx_0 == dims.nx \
-        and dims.nbxe_0 == None \
+        and dims.nbxe_0 is None \
         and (constraints.idxbxe_0.shape == constraints.idxbx_0.shape)\
-        and all(constraints.idxbxe_0 == constraints.idxbx_0):
+            and all(constraints.idxbxe_0 == constraints.idxbx_0):
         # case: x0 was set: nbx0 are all equlities.
         dims.nbxe_0 = dims.nbx_0
-    elif dims.nbxe_0 == None:
+    elif dims.nbxe_0 is None:
         # case: x0 was not set -> dont assume nbx0 to be equality constraints.
         dims.nbxe_0 = 0
 
@@ -506,7 +508,8 @@ def ocp_formulation_json_dump(acados_ocp, simulink_opts, json_file='acados_ocp_n
 
     for acados_struct, v in ocp_layout.items():
         # skip non dict attributes
-        if not isinstance(v, dict): continue
+        if not isinstance(v, dict):
+            continue
         #  setattr(ocp_nlp, acados_struct, dict(getattr(acados_ocp, acados_struct).__dict__))
         # Copy ocp object attributes dictionaries
         ocp_nlp_dict[acados_struct]=dict(getattr(acados_ocp, acados_struct).__dict__)
@@ -546,10 +549,11 @@ def ocp_formulation_json_load(json_file='acados_ocp_nlp.json'):
     # load class dict
     acados_ocp.__dict__ = ocp_nlp_dict
 
-    # laod class attributes dict, dims, constraints, etc
-    for acados_struct, v  in ocp_layout.items():
+    # load class attributes dict, dims, constraints, etc
+    for acados_struct, v in ocp_layout.items():
         # skip non dict attributes
-        if not isinstance(v, dict): continue
+        if not isinstance(v, dict):
+            continue
         acados_attribute = getattr(acados_ocp, acados_struct)
         acados_attribute.__dict__ = ocp_nlp_dict[acados_struct]
         setattr(acados_ocp, acados_struct, acados_attribute)
@@ -681,7 +685,7 @@ def ocp_render_templates(acados_ocp, json_file):
         # constraints on outer function
         template_dir = os.path.join(code_export_dir, name + '_constraints')
         in_file = 'phi_constraint.in.h'
-        out_file =  f'{name}_phi_constraint.h'
+        out_file = f'{name}_phi_constraint.h'
         render_template(in_file, out_file, template_dir, json_path)
 
     # terminal constraints on convex over nonlinear function
@@ -689,7 +693,7 @@ def ocp_render_templates(acados_ocp, json_file):
         # terminal constraints on outer function
         template_dir = os.path.join(code_export_dir, name + '_constraints')
         in_file = 'phi_e_constraint.in.h'
-        out_file =  f'{name}_phi_e_constraint.h'
+        out_file = f'{name}_phi_e_constraint.h'
         render_template(in_file, out_file, template_dir, json_path)
 
     # nonlinear constraints
@@ -760,24 +764,25 @@ class AcadosOcpSolver:
         :param acados_ocp: type AcadosOcp - description of the OCP for acados
         :param json_file: name for the json file used to render the templated code - default: acados_ocp_nlp.json
         :param simulink_opts: Options to configure Simulink S-function blocks, mainly to activate possible Inputs and Outputs
-        :param build: Option to disable rendering templates and compiling if previously built - default: True
     """
     if sys.platform=="win32":
         from ctypes import wintypes
-        dlclose = WinDLL('kernel32', use_last_error=True).FreeLibrary  
+        dlclose = ctypes.WinDLL('kernel32', use_last_error=True).FreeLibrary
         dlclose.argtypes = [wintypes.HMODULE]
     else:
         dlclose = CDLL(None).dlclose
         dlclose.argtypes = [c_void_p]
 
-    def __init__(self, acados_ocp, json_file='acados_ocp_nlp.json', simulink_opts=None, build=True):
-
-        self.solver_created = False
-        self.N = acados_ocp.dims.N
+    @classmethod
+    def generate(cls, acados_ocp, json_file='acados_ocp_nlp.json', simulink_opts=None, build=True, json_path=None):
         model = acados_ocp.model
 
-        if simulink_opts == None:
-            simulink_opts = get_simulink_default_opts()
+        if simulink_opts is None:
+            if json_path is None:
+              acados_path = get_acados_path()
+              json_path = os.path.join(acados_path, 'interfaces/acados_template/acados_template')
+            with open(json_path + '/simulink_default_opts.json', 'r') as f:
+                simulink_opts = json.load(f)
 
         # make dims consistent
         make_ocp_dims_consistent(acados_ocp)
@@ -799,30 +804,37 @@ class AcadosOcpSolver:
         ocp_formulation_json_dump(acados_ocp, simulink_opts, json_file)
 
         code_export_dir = acados_ocp.code_export_directory
+        # render templates
+        ocp_render_templates(acados_ocp, json_file)
+
         if build:
-            # render templates
-            ocp_render_templates(acados_ocp, json_file)
+          ## Compile solver
+          cwd=os.getcwd()
+          os.chdir(code_export_dir)
+          os.system('make clean_ocp_shared_lib')
+          os.system('make ocp_shared_lib')
+          os.chdir(cwd)
 
-            ## Compile solver
-            cwd=os.getcwd()
-            os.chdir(code_export_dir)
-            os.system('make clean_ocp_shared_lib')
-            os.system('make ocp_shared_lib')
-            os.chdir(cwd)
+        return cls(model.name, acados_ocp.dims.N, code_export_dir)
 
-        self.shared_lib_name = f'{code_export_dir}/libacados_ocp_solver_{model.name}.so'
+    def __init__(self, model_name, N, code_export_dir):
+        self.model_name = model_name
+        self.N = N
+
+        self.solver_created = False
+        self.shared_lib_name = f'{code_export_dir}/libacados_ocp_solver_{self.model_name}.so'
 
         # get shared_lib
         self.shared_lib = CDLL(self.shared_lib_name)
 
         # create capsule
-        getattr(self.shared_lib, f"{model.name}_acados_create_capsule").restype = c_void_p
-        self.capsule = getattr(self.shared_lib, f"{model.name}_acados_create_capsule")()
+        getattr(self.shared_lib, f"{self.model_name}_acados_create_capsule").restype = c_void_p
+        self.capsule = getattr(self.shared_lib, f"{self.model_name}_acados_create_capsule")()
 
         # create solver
-        getattr(self.shared_lib, f"{model.name}_acados_create").argtypes = [c_void_p]
-        getattr(self.shared_lib, f"{model.name}_acados_create").restype = c_int
-        assert getattr(self.shared_lib, f"{model.name}_acados_create")(self.capsule)==0
+        getattr(self.shared_lib, f"{self.model_name}_acados_create").argtypes = [c_void_p]
+        getattr(self.shared_lib, f"{self.model_name}_acados_create").restype = c_int
+        assert getattr(self.shared_lib, f"{self.model_name}_acados_create")(self.capsule)==0
         self.solver_created = True
 
         self.acados_ocp = acados_ocp
@@ -836,41 +848,38 @@ class AcadosOcpSolver:
         Private function to get the pointers for solver
         """
         # get pointers solver
-        model = self.acados_ocp.model
-        getattr(self.shared_lib, f"{model.name}_acados_get_nlp_opts").argtypes = [c_void_p]
-        getattr(self.shared_lib, f"{model.name}_acados_get_nlp_opts").restype = c_void_p
-        self.nlp_opts = getattr(self.shared_lib, f"{model.name}_acados_get_nlp_opts")(self.capsule)
+        getattr(self.shared_lib, f"{self.model_name}_acados_get_nlp_opts").argtypes = [c_void_p]
+        getattr(self.shared_lib, f"{self.model_name}_acados_get_nlp_opts").restype = c_void_p
+        self.nlp_opts = getattr(self.shared_lib, f"{self.model_name}_acados_get_nlp_opts")(self.capsule)
 
-        getattr(self.shared_lib, f"{model.name}_acados_get_nlp_dims").argtypes = [c_void_p]
-        getattr(self.shared_lib, f"{model.name}_acados_get_nlp_dims").restype = c_void_p
-        self.nlp_dims = getattr(self.shared_lib, f"{model.name}_acados_get_nlp_dims")(self.capsule)
+        getattr(self.shared_lib, f"{self.model_name}_acados_get_nlp_dims").argtypes = [c_void_p]
+        getattr(self.shared_lib, f"{self.model_name}_acados_get_nlp_dims").restype = c_void_p
+        self.nlp_dims = getattr(self.shared_lib, f"{self.model_name}_acados_get_nlp_dims")(self.capsule)
 
-        getattr(self.shared_lib, f"{model.name}_acados_get_nlp_config").argtypes = [c_void_p]
-        getattr(self.shared_lib, f"{model.name}_acados_get_nlp_config").restype = c_void_p
-        self.nlp_config = getattr(self.shared_lib, f"{model.name}_acados_get_nlp_config")(self.capsule)
+        getattr(self.shared_lib, f"{self.model_name}_acados_get_nlp_config").argtypes = [c_void_p]
+        getattr(self.shared_lib, f"{self.model_name}_acados_get_nlp_config").restype = c_void_p
+        self.nlp_config = getattr(self.shared_lib, f"{self.model_name}_acados_get_nlp_config")(self.capsule)
 
-        getattr(self.shared_lib, f"{model.name}_acados_get_nlp_out").argtypes = [c_void_p]
-        getattr(self.shared_lib, f"{model.name}_acados_get_nlp_out").restype = c_void_p
-        self.nlp_out = getattr(self.shared_lib, f"{model.name}_acados_get_nlp_out")(self.capsule)
+        getattr(self.shared_lib, f"{self.model_name}_acados_get_nlp_out").argtypes = [c_void_p]
+        getattr(self.shared_lib, f"{self.model_name}_acados_get_nlp_out").restype = c_void_p
+        self.nlp_out = getattr(self.shared_lib, f"{self.model_name}_acados_get_nlp_out")(self.capsule)
 
-        getattr(self.shared_lib, f"{model.name}_acados_get_nlp_in").argtypes = [c_void_p]
-        getattr(self.shared_lib, f"{model.name}_acados_get_nlp_in").restype = c_void_p
-        self.nlp_in = getattr(self.shared_lib, f"{model.name}_acados_get_nlp_in")(self.capsule)
+        getattr(self.shared_lib, f"{self.model_name}_acados_get_nlp_in").argtypes = [c_void_p]
+        getattr(self.shared_lib, f"{self.model_name}_acados_get_nlp_in").restype = c_void_p
+        self.nlp_in = getattr(self.shared_lib, f"{self.model_name}_acados_get_nlp_in")(self.capsule)
 
-        getattr(self.shared_lib, f"{model.name}_acados_get_nlp_solver").argtypes = [c_void_p]
-        getattr(self.shared_lib, f"{model.name}_acados_get_nlp_solver").restype = c_void_p
-        self.nlp_solver = getattr(self.shared_lib, f"{model.name}_acados_get_nlp_solver")(self.capsule)
-
+        getattr(self.shared_lib, f"{self.model_name}_acados_get_nlp_solver").argtypes = [c_void_p]
+        getattr(self.shared_lib, f"{self.model_name}_acados_get_nlp_solver").restype = c_void_p
+        self.nlp_solver = getattr(self.shared_lib, f"{self.model_name}_acados_get_nlp_solver")(self.capsule)
 
     def solve(self):
         """
         Solve the ocp with current input.
         """
-        model = self.acados_ocp.model
 
-        getattr(self.shared_lib, f"{model.name}_acados_solve").argtypes = [c_void_p]
-        getattr(self.shared_lib, f"{model.name}_acados_solve").restype = c_int
-        status = getattr(self.shared_lib, f"{model.name}_acados_solve")(self.capsule)
+        getattr(self.shared_lib, f"{self.model_name}_acados_solve").argtypes = [c_void_p]
+        getattr(self.shared_lib, f"{self.model_name}_acados_solve").restype = c_int
+        status = getattr(self.shared_lib, f"{self.model_name}_acados_solve")(self.capsule)
         return status
 
 
@@ -899,16 +908,16 @@ class AcadosOcpSolver:
 
         # check if recreation of acados is necessary (no need to recreate acados if sizes are identical)
         if self.acados_ocp.solver_options.time_steps.size == N:
-            getattr(self.shared_lib, f"{model.name}_acados_update_time_steps").argtypes = [c_void_p, c_int, c_void_p]
-            getattr(self.shared_lib, f"{model.name}_acados_update_time_steps").restype = c_int
-            assert getattr(self.shared_lib, f"{model.name}_acados_update_time_steps")(self.capsule, N, new_time_steps_data) == 0
+            getattr(self.shared_lib, f"{self.model_name}_acados_update_time_steps").argtypes = [c_void_p, c_int, c_void_p]
+            getattr(self.shared_lib, f"{self.model_name}_acados_update_time_steps").restype = c_int
+            assert getattr(self.shared_lib, f"{self.model_name}_acados_update_time_steps")(self.capsule, N, new_time_steps_data) == 0
         else:  # recreate the solver with the new time steps
             self.solver_created = False
 
             # delete old memory (analog to __del__)
-            getattr(self.shared_lib, f"{model.name}_acados_free").argtypes = [c_void_p]
-            getattr(self.shared_lib, f"{model.name}_acados_free").restype = c_int
-            getattr(self.shared_lib, f"{model.name}_acados_free")(self.capsule)
+            getattr(self.shared_lib, f"{self.model_name}_acados_free").argtypes = [c_void_p]
+            getattr(self.shared_lib, f"{self.model_name}_acados_free").restype = c_int
+            getattr(self.shared_lib, f"{self.model_name}_acados_free")(self.capsule)
 
             # store N and new time steps
             self.N = self.acados_ocp.dims.N = N
@@ -916,9 +925,9 @@ class AcadosOcpSolver:
             self.acados_ocp.solver_options.Tsim = self.acados_ocp.solver_options.time_steps[0]
 
             # create solver with new time steps
-            getattr(self.shared_lib, f"{model.name}_acados_create_with_discretization").argtypes = [c_void_p, c_int, c_void_p]
-            getattr(self.shared_lib, f"{model.name}_acados_create_with_discretization").restype = c_int
-            assert getattr(self.shared_lib, f"{model.name}_acados_create_with_discretization")(self.capsule, N, new_time_steps_data) == 0
+            getattr(self.shared_lib, f"{self.model_name}_acados_create_with_discretization").argtypes = [c_void_p, c_int, c_void_p]
+            getattr(self.shared_lib, f"{self.model_name}_acados_create_with_discretization").restype = c_int
+            assert getattr(self.shared_lib, f"{self.model_name}_acados_create_with_discretization")(self.capsule, N, new_time_steps_data) == 0
 
             self.solver_created = True
 
@@ -1039,7 +1048,7 @@ class AcadosOcpSolver:
             :param overwrite: if false and filename exists add timestamp to filename
         """
         if filename == '':
-            filename += self.acados_ocp.model.name + '_' + 'iterate' + '.json'
+            filename += self.model_name + '_' + 'iterate' + '.json'
 
         if not overwrite:
             # append timestamp
@@ -1103,8 +1112,7 @@ class AcadosOcpSolver:
                   'qp_iter',  # vector of QP iterations for last SQP call
                   'statistics',  # table with info about last iteration
                   'stat_m',
-                  'stat_n',
-                ]
+                  'stat_n',]
 
         field = field_
         field = field.encode('utf-8')
@@ -1124,7 +1132,7 @@ class AcadosOcpSolver:
             min_size = min([stat_m, sqp_iter+1])
 
             out = np.ascontiguousarray(
-                        np.zeros( (stat_n[0]+1, min_size[0]) ), dtype=np.float64)
+                        np.zeros((stat_n[0]+1, min_size[0])), dtype=np.float64)
             out_data = cast(out.ctypes.data, POINTER(c_double))
 
         elif field_ == 'qp_iter':
@@ -1196,12 +1204,13 @@ class AcadosOcpSolver:
         out_data = cast(out[3].ctypes.data, POINTER(c_double))
         field = "res_comp".encode('utf-8')
         self.shared_lib.ocp_nlp_get(self.nlp_config, self.nlp_solver, field, out_data)
-
         return out.flatten()
 
 
     # Note: this function should not be used anymore, better use cost_set, constraints_set
+
     def set(self, stage_, field_, value_):
+
         """
         Set numerical data inside the solver.
 
@@ -1228,8 +1237,6 @@ class AcadosOcpSolver:
             value_ = np.array([value_])
         value_ = value_.astype(float)
 
-        model = self.acados_ocp.model
-
         field = field_
         field = field.encode('utf-8')
 
@@ -1237,12 +1244,12 @@ class AcadosOcpSolver:
 
         # treat parameters separately
         if field_ == 'p':
-            getattr(self.shared_lib, f"{model.name}_acados_update_params").argtypes = [c_void_p, c_int, POINTER(c_double)]
-            getattr(self.shared_lib, f"{model.name}_acados_update_params").restype = c_int
+            getattr(self.shared_lib, f"{self.model_name}_acados_update_params").argtypes = [c_void_p, c_int, POINTER(c_double)]
+            getattr(self.shared_lib, f"{self.model_name}_acados_update_params").restype = c_int
 
             value_data = cast(value_.ctypes.data, POINTER(c_double))
 
-            assert getattr(self.shared_lib, f"{model.name}_acados_update_params")(self.capsule, stage, value_data, value_.shape[0])==0
+            assert getattr(self.shared_lib, f"{self.model_name}_acados_update_params")(self.capsule, stage, value_data, value_.shape[0])==0
         else:
             if field_ not in constraints_fields + cost_fields + out_fields:
                 raise Exception("AcadosOcpSolver.set(): {} is not a valid argument.\
@@ -1409,7 +1416,7 @@ class AcadosOcpSolver:
                 value_ = np.ravel(value_, order='F')
             else:
                 raise Exception("Unknown api: '{}'".format(api))
-                
+
         if value_shape != tuple(dims):
             raise Exception('AcadosOcpSolver.constraints_set(): mismatching dimension' \
                 ' for field "{}" with dimension {} (you have {})'.format(field_, tuple(dims), value_shape))
@@ -1521,21 +1528,18 @@ class AcadosOcpSolver:
                 [c_void_p, c_void_p, c_char_p, c_void_p]
             self.shared_lib.ocp_nlp_solver_opts_set(self.nlp_config, \
                 self.nlp_opts, field, byref(value_ctypes))
-
         return
 
 
     def __del__(self):
-        model = self.acados_ocp.model
-
         if self.solver_created:
-            getattr(self.shared_lib, f"{model.name}_acados_free").argtypes = [c_void_p]
-            getattr(self.shared_lib, f"{model.name}_acados_free").restype = c_int
-            getattr(self.shared_lib, f"{model.name}_acados_free")(self.capsule)
+            getattr(self.shared_lib, f"{self.model_name}_acados_free").argtypes = [c_void_p]
+            getattr(self.shared_lib, f"{self.model_name}_acados_free").restype = c_int
+            getattr(self.shared_lib, f"{self.model_name}_acados_free")(self.capsule)
 
-            getattr(self.shared_lib, f"{model.name}_acados_free_capsule").argtypes = [c_void_p]
-            getattr(self.shared_lib, f"{model.name}_acados_free_capsule").restype = c_int
-            getattr(self.shared_lib, f"{model.name}_acados_free_capsule")(self.capsule)
+            getattr(self.shared_lib, f"{self.model_name}_acados_free_capsule").argtypes = [c_void_p]
+            getattr(self.shared_lib, f"{self.model_name}_acados_free_capsule").restype = c_int
+            getattr(self.shared_lib, f"{self.model_name}_acados_free_capsule")(self.capsule)
 
             try:
                 self.dlclose(self.shared_lib._handle)

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -778,8 +778,7 @@ class AcadosOcpSolver:
         model = acados_ocp.model
 
         if simulink_opts is None:
-            acados_path = get_acados_path()
-            json_path = os.path.join(acados_path, 'interfaces/acados_template/acados_template')
+            json_path = os.path.dirname(os.path.realpath())
             with open(json_path + '/simulink_default_opts.json', 'r') as f:
                 simulink_opts = json.load(f)
 

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -778,7 +778,7 @@ class AcadosOcpSolver:
         model = acados_ocp.model
 
         if simulink_opts is None:
-            json_path = os.path.dirname(os.path.realpath())
+            json_path = os.path.dirname(os.path.realpath(__file__))
             with open(json_path + '/simulink_default_opts.json', 'r') as f:
                 simulink_opts = json.load(f)
 

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -798,17 +798,17 @@ class AcadosOcpSolver:
         # dump to json
         ocp_formulation_json_dump(acados_ocp, simulink_opts, json_file)
 
+        code_export_dir = acados_ocp.code_export_directory
         if build:
-          # render templates
-          ocp_render_templates(acados_ocp, json_file)
+            # render templates
+            ocp_render_templates(acados_ocp, json_file)
 
-          ## Compile solver
-          code_export_dir = acados_ocp.code_export_directory
-          cwd=os.getcwd()
-          os.chdir(code_export_dir)
-          os.system('make clean_ocp_shared_lib')
-          os.system('make ocp_shared_lib')
-          os.chdir(cwd)
+            ## Compile solver
+            cwd=os.getcwd()
+            os.chdir(code_export_dir)
+            os.system('make clean_ocp_shared_lib')
+            os.system('make ocp_shared_lib')
+            os.chdir(cwd)
 
         self.shared_lib_name = f'{code_export_dir}/libacados_ocp_solver_{model.name}.so'
 

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -821,8 +821,6 @@ class AcadosOcpSolver:
           os.system('make ocp_shared_lib')
           os.chdir(cwd)
 
-        return cls(model.name, acados_ocp.dims.N, code_export_dir)
-
     def __init__(self, model_name, N, code_export_dir):
         self.model_name = model_name
         self.N = N
@@ -884,14 +882,10 @@ class AcadosOcpSolver:
         self.shared_lib.ocp_nlp_constraint_dims_get_from_attr.argtypes = \
             [c_void_p, c_void_p, c_void_p, c_int, c_char_p, POINTER(c_int)]
         self.shared_lib.ocp_nlp_constraint_dims_get_from_attr.restype = c_int
-        self.shared_lib.ocp_nlp_constraints_model_set_slice.argtypes = \
-            [c_void_p, c_void_p, c_void_p, c_int, c_int, c_char_p, c_void_p, c_int]
 
         self.shared_lib.ocp_nlp_cost_dims_get_from_attr.argtypes = \
             [c_void_p, c_void_p, c_void_p, c_int, c_char_p, POINTER(c_int)]
         self.shared_lib.ocp_nlp_cost_dims_get_from_attr.restype = c_int
-        self.shared_lib.ocp_nlp_cost_model_set_slice.argtypes = \
-            [c_void_p, c_void_p, c_void_p, c_int, c_int, c_char_p, c_void_p, c_int]
 
         self.shared_lib.ocp_nlp_constraints_model_set.argtypes = \
             [c_void_p, c_void_p, c_void_p, c_int, c_char_p, c_void_p]

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -1289,6 +1289,7 @@ class AcadosOcpSolver:
             #         [c_void_p, c_void_p, c_int, c_char_p, c_void_p]
             #     self.shared_lib.ocp_nlp_set(self.nlp_config, \
             #         self.nlp_solver, stage, field, value_data_p)
+
         return
 
 

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -653,6 +653,10 @@ def ocp_render_templates(acados_ocp, json_file):
     out_file = f'acados_solver_{name}.h'
     render_template(in_file, out_file, template_dir, json_path)
 
+    in_file = 'acados_solver.in.pxd'
+    out_file = f'acados_solver_{name}.pxd'
+    render_template(in_file, out_file, template_dir, json_path)
+
     in_file = 'Makefile.in'
     out_file = 'Makefile'
     render_template(in_file, out_file, template_dir, json_path)

--- a/interfaces/acados_template/acados_template/acados_ocp_solver_pyx.pyx
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver_pyx.pyx
@@ -292,16 +292,16 @@ cdef class AcadosOcpSolverFast:
         acados_solver_common.ocp_nlp_cost_dims_get_from_attr(self.nlp_config, \
             self.nlp_dims, self.nlp_out, stage, field, &dims[0])
 
-        cdef double[::1] value
+        cdef double[::1,:] value
 
         value_shape = value_.shape
         if len(value_shape) == 1:
             value_shape = (value_shape[0], 0)
-            value = np.asfortranarray(value_)
+            value = np.asfortranarray(value_[None,:])
 
         elif len(value_shape) == 2:
             # Get elements in column major order
-            value = np.ravel(value_, order='F')
+            value = np.asfortranarray(value_)
 
         if value_shape[0] != dims[0] or value_shape[1] != dims[1]:
             raise Exception('AcadosOcpSolver.cost_set(): mismatching dimension', \
@@ -309,7 +309,7 @@ cdef class AcadosOcpSolverFast:
                 field_, tuple(dims), value_shape))
 
         acados_solver_common.ocp_nlp_cost_model_set(self.nlp_config, \
-            self.nlp_dims, self.nlp_in, stage, field, <void *> &value[0])
+            self.nlp_dims, self.nlp_in, stage, field, <void *> &value[0][0])
 
 
     def constraints_set(self, int stage, str field_, value_):
@@ -326,23 +326,23 @@ cdef class AcadosOcpSolverFast:
         acados_solver_common.ocp_nlp_constraint_dims_get_from_attr(self.nlp_config, \
             self.nlp_dims, self.nlp_out, stage, field, &dims[0])
 
-        cdef double[::1] value
+        cdef double[::1,:] value
 
         value_shape = value_.shape
         if len(value_shape) == 1:
             value_shape = (value_shape[0], 0)
-            value = np.asfortranarray(value_)
+            value = np.asfortranarray(value_[None,:])
 
         elif len(value_shape) == 2:
             # Get elements in column major order
-            value = np.ravel(value_, order='F')
+            value = np.asfortranarray(value_)
 
         if value_shape[0] != dims[0] or value_shape[1] != dims[1]:
             raise Exception('AcadosOcpSolver.constraints_set(): mismatching dimension' \
                 ' for field "{}" with dimension {} (you have {})'.format(field_, tuple(dims), value_shape))
 
         acados_solver_common.ocp_nlp_constraints_model_set(self.nlp_config, \
-            self.nlp_dims, self.nlp_in, stage, field, <void *> &value[0])
+            self.nlp_dims, self.nlp_in, stage, field, <void *> &value[0][0])
 
         return
 

--- a/interfaces/acados_template/acados_template/acados_ocp_solver_pyx.pyx
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver_pyx.pyx
@@ -297,7 +297,7 @@ cdef class AcadosOcpSolverFast:
         value_shape = value_.shape
         if len(value_shape) == 1:
             value_shape = (value_shape[0], 0)
-            data_ptr = np.asfortranarray(value_)
+            value = np.asfortranarray(value_)
 
         elif len(value_shape) == 2:
             # Get elements in column major order

--- a/interfaces/acados_template/acados_template/acados_ocp_solver_pyx.pyx
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver_pyx.pyx
@@ -347,16 +347,14 @@ cdef class AcadosOcpSolverFast:
         return
 
 
-    def dynamics_get(self, int stage, field_):
+    def dynamics_get(self, int stage, str field_):
         """
         Get numerical data from the dynamics module of the solver:
 
             :param stage: integer corresponding to shooting node
             :param field: string, e.g. 'A'
         """
-
-        field = field_
-        field = field.encode('utf-8')
+        field = field_.encode('utf-8')
 
         # get dims
         cdef int[2] dims
@@ -371,7 +369,7 @@ cdef class AcadosOcpSolverFast:
         return out
 
 
-    def options_set(self, bytes field_, value_):
+    def options_set(self, str field_, value_):
         """
         Set options of the solver.
 
@@ -383,8 +381,7 @@ cdef class AcadosOcpSolverFast:
         string_fields = ['globalization']
 
         # encode
-        field = field_
-        field = field.encode('utf-8')
+        field = field_.encode('utf-8')
 
         cdef int int_value
         cdef double double_value

--- a/interfaces/acados_template/acados_template/acados_ocp_solver_pyx.pyx
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver_pyx.pyx
@@ -1,0 +1,545 @@
+# cython: language_level=3
+# cython: profile=False
+# distutils: language = c
+
+# -*- coding: future_fstrings -*-
+#
+# Copyright 2019 Gianluca Frison, Dimitris Kouzoupis, Robin Verschueren,
+# Andrea Zanelli, Niels van Duijkeren, Jonathan Frey, Tommaso Sartor,
+# Branimir Novoselnik, Rien Quirynen, Rezart Qelibari, Dang Doan,
+# Jonas Koenemann, Yutao Chen, Tobias Schöls, Jonas Schlagenhauf, Moritz Diehl
+#
+# This file is part of acados.
+#
+# The 2-Clause BSD License
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.;
+#
+
+cimport cython
+
+from libc cimport string
+from libc cimport bool
+
+cimport numpy as np
+from cpython cimport array
+
+cimport acados_solver_common
+cimport acados_solver
+
+import os
+import json
+import numpy as np
+import array
+from datetime import datetime
+
+# from .utils import np_array_to_list
+
+
+cdef class AcadosOcpSolverFast:
+    """
+    Class to interact with the acados ocp solver C object.
+
+        :param acados_ocp: type AcadosOcp - description of the OCP for acados
+        :param json_file: name for the json file used to render the templated code - default: acados_ocp_nlp.json
+        :param simulink_opts: Options to configure Simulink S-function blocks, mainly to activate possible Inputs and Outputs
+    """
+
+    cdef acados_solver.nlp_solver_capsule *capsule
+    cdef void *nlp_opts
+    cdef acados_solver_common.ocp_nlp_dims *nlp_dims
+    cdef acados_solver_common.ocp_nlp_config *nlp_config
+    cdef acados_solver_common.ocp_nlp_out *nlp_out
+    cdef acados_solver_common.ocp_nlp_in *nlp_in
+    cdef acados_solver_common.ocp_nlp_solver *nlp_solver
+
+    cdef str model_name
+    cdef int N
+    cdef bint solver_created
+
+    def __cinit__(self, str model_name, int N, str code_export_dir):
+        self.model_name = model_name
+        self.N = N
+
+        self.solver_created = False
+
+        # create capsule
+        self.capsule = acados_solver.acados_create_capsule()
+
+        # create solver
+        assert acados_solver.acados_create(self.capsule) == 0
+        self.solver_created = True
+
+        # get pointers solver
+        self.nlp_opts = acados_solver.acados_get_nlp_opts(self.capsule)
+        self.nlp_dims = acados_solver.acados_get_nlp_dims(self.capsule)
+        self.nlp_config = acados_solver.acados_get_nlp_config(self.capsule)
+        self.nlp_out = acados_solver.acados_get_nlp_out(self.capsule)
+        self.nlp_in = acados_solver.acados_get_nlp_in(self.capsule)
+        self.nlp_solver = acados_solver.acados_get_nlp_solver(self.capsule)
+
+    def solve(self):
+        """
+        Solve the ocp with current input.
+        """
+
+        status = acados_solver.acados_solve(self.capsule)
+        return status
+
+    def get_slice(self, int start_stage_, int end_stage_, str field_):
+        field = field_.encode('utf-8')
+        dims = acados_solver_common.ocp_nlp_dims_get_from_attr(self.nlp_config, self.nlp_dims, self.nlp_out, start_stage_, field)
+        out = np.ascontiguousarray(np.zeros((end_stage_ - start_stage_, dims)), dtype=np.float64)
+        self.fill_in_slice(start_stage_, end_stage_, field_, out)
+        return out
+
+    def fill_in_slice(self, int start_stage_, int end_stage_, str field_, np.ndarray[np.float64_t, ndim=2, mode='c'] arr_):
+        out_fields = ['x', 'u', 'z', 'pi', 'lam', 't']
+        mem_fields = ['sl', 'su']
+
+        field = field_.encode('utf-8')
+
+        if (field_ not in out_fields + mem_fields):
+            raise Exception('AcadosOcpSolver.get_slice(): {} is an invalid argument.\
+                    \n Possible values are {}. Exiting.'.format(field_, out_fields))
+
+        if start_stage_ >= end_stage_:
+            raise Exception('AcadosOcpSolver.get_slice(): end stage index must be larger than start stage index')
+
+        if start_stage_ < 0 or end_stage_ > self.N + 1:
+            raise Exception('AcadosOcpSolver.get_slice(): stage index must be in [0, N], got: {}.'.format(self.N))
+
+        cdef np.ndarray[np.float64_t, ndim=2, mode='c'] arr = np.ascontiguousarray(arr_, dtype=np.double)
+
+        if (field_ in out_fields):
+            acados_solver_common.ocp_nlp_out_get_slice(self.nlp_config, self.nlp_dims, self.nlp_out, start_stage_, end_stage_,
+                field, <double *> arr.data)
+        elif field_ in mem_fields:
+            raise NotImplementedError()
+        #     acados_solver_common.ocp_nlp_get_at_stage(self.nlp_config, self.nlp_dims, self.nlp_solver, start_stage_, end_stage_,
+        #         field, <double *> arr.data)
+
+    def get(self, stage_, field_):
+        return self.get_slice(stage_, stage_ + 1, field_)[0]
+
+
+    def print_statistics(self):
+        """
+        prints statistics of previous solver run as a table:
+            - iter: iteration number
+            - res_stat: stationarity residual
+            - res_eq: residual wrt equality constraints (dynamics)
+            - res_ineq: residual wrt inequality constraints (constraints)
+            - res_comp: residual wrt complementarity conditions
+            - qp_stat: status of QP solver
+            - qp_iter: number of QP iterations
+            - qp_res_stat: stationarity residual of the last QP solution
+            - qp_res_eq: residual wrt equality constraints (dynamics) of the last QP solution
+            - qp_res_ineq: residual wrt inequality constraints (constraints)  of the last QP solution
+            - qp_res_comp: residual wrt complementarity conditions of the last QP solution
+        """
+        stat = self.get_stats("statistics")
+
+        if self.acados_ocp.solver_options.nlp_solver_type == 'SQP':
+            print('\niter\tres_stat\tres_eq\t\tres_ineq\tres_comp\tqp_stat\tqp_iter')
+            if stat.shape[0]>7:
+                print('\tqp_res_stat\tqp_res_eq\tqp_res_ineq\tqp_res_comp')
+            for jj in range(stat.shape[1]):
+                print('{:d}\t{:e}\t{:e}\t{:e}\t{:e}\t{:d}\t{:d}'.format( \
+                     int(stat[0][jj]), stat[1][jj], stat[2][jj], \
+                     stat[3][jj], stat[4][jj], int(stat[5][jj]), int(stat[6][jj])))
+                if stat.shape[0]>7:
+                    print('\t{:e}\t{:e}\t{:e}\t{:e}'.format( \
+                        stat[7][jj], stat[8][jj], stat[9][jj], stat[10][jj]))
+            print('\n')
+        elif self.acados_ocp.solver_options.nlp_solver_type == 'SQP_RTI':
+            print('\niter\tqp_stat\tqp_iter')
+            if stat.shape[0]>3:
+                print('\tqp_res_stat\tqp_res_eq\tqp_res_ineq\tqp_res_comp')
+            for jj in range(stat.shape[1]):
+                print('{:d}\t{:d}\t{:d}'.format( int(stat[0][jj]), int(stat[1][jj]), int(stat[2][jj])))
+                if stat.shape[0]>3:
+                    print('\t{:e}\t{:e}\t{:e}\t{:e}'.format( \
+                         stat[3][jj], stat[4][jj], stat[5][jj], stat[6][jj]))
+            print('\n')
+
+        return
+
+
+    def store_iterate(self, filename='', overwrite=False):
+        """
+        Stores the current iterate of the ocp solver in a json file.
+
+            :param filename: if not set, use model_name + timestamp + '.json'
+            :param overwrite: if false and filename exists add timestamp to filename
+        """
+        if filename == '':
+            filename += self.model_name + '_' + 'iterate' + '.json'
+
+        if not overwrite:
+            # append timestamp
+            if os.path.isfile(filename):
+                filename = filename[:-5]
+                filename += datetime.utcnow().strftime('%Y-%m-%d-%H:%M:%S.%f') + '.json'
+
+        # get iterate:
+        solution = dict()
+
+        for i in range(self.N+1):
+            solution['x_'+str(i)] = self.get(i,'x')
+            solution['u_'+str(i)] = self.get(i,'u')
+            solution['z_'+str(i)] = self.get(i,'z')
+            solution['lam_'+str(i)] = self.get(i,'lam')
+            solution['t_'+str(i)] = self.get(i, 't')
+            solution['sl_'+str(i)] = self.get(i, 'sl')
+            solution['su_'+str(i)] = self.get(i, 'su')
+        for i in range(self.N):
+            solution['pi_'+str(i)] = self.get(i,'pi')
+
+        # save
+        raise NotImplementedError()
+        # with open(filename, 'w') as f:
+        #     json.dump(solution, f, default=np_array_to_list, indent=4, sort_keys=True)
+        # print("stored current iterate in ", os.path.join(os.getcwd(), filename))
+
+
+    def load_iterate(self, filename):
+        """
+        Loads the iterate stored in json file with filename into the ocp solver.
+        """
+        if not os.path.isfile(filename):
+            raise Exception('load_iterate: failed, file does not exist: ' + os.path.join(os.getcwd(), filename))
+
+        with open(filename, 'r') as f:
+            solution = json.load(f)
+
+        for key in solution.keys():
+            (field, stage) = key.split('_')
+            self.set(int(stage), field, np.array(solution[key]))
+
+
+    def get_stats(self, field_):
+        """
+        Get the information of the last solver call.
+
+            :param field: string in ['statistics', 'time_tot', 'time_lin', 'time_sim', 'time_sim_ad', 'time_sim_la', 'time_qp', 'time_qp_solver_call', 'time_reg', 'sqp_iter']
+        """
+
+        fields = ['time_tot',  # total cpu time previous call
+                  'time_lin',  # cpu time for linearization
+                  'time_sim',  # cpu time for integrator
+                  'time_sim_ad',  # cpu time for integrator contribution of external function calls
+                  'time_sim_la',  # cpu time for integrator contribution of linear algebra
+                  'time_qp',   # cpu time qp solution
+                  'time_qp_solver_call',  # cpu time inside qp solver (without converting the QP)
+                  'time_qp_xcond',
+                  'time_glob',  # cpu time globalization
+                  'time_reg',  # cpu time regularization
+                  'sqp_iter',  # number of SQP iterations
+                  'qp_iter',  # vector of QP iterations for last SQP call
+                  'statistics',  # table with info about last iteration
+                  'stat_m',
+                  'stat_n',]
+
+        field = field_
+        field = field.encode('utf-8')
+        if (field_ not in fields):
+            raise Exception('AcadosOcpSolver.get_stats(): {} is not a valid argument.\
+                    \n Possible values are {}. Exiting.'.format(fields, fields))
+
+        if field_ in ['sqp_iter', 'stat_m', 'stat_n']:
+            out = np.ascontiguousarray(np.zeros((1,)), dtype=np.int64)
+            out_data = out.data
+
+        elif field_ == 'statistics':
+            sqp_iter = self.get_stats("sqp_iter")
+            stat_m = self.get_stats("stat_m")
+            stat_n = self.get_stats("stat_n")
+
+            min_size = min([stat_m, sqp_iter+1])
+
+            out = np.ascontiguousarray(np.zeros((stat_n[0]+1, min_size[0])), dtype=np.float64)
+            out_data = out.data
+
+        elif field_ == 'qp_iter':
+            full_stats = self.get_stats('statistics')
+            if self.acados_ocp.solver_options.nlp_solver_type == 'SQP':
+                out = full_stats[6, :]
+            elif self.acados_ocp.solver_options.nlp_solver_type == 'SQP_RTI':
+                out = full_stats[2, :]
+
+        else:
+            out = np.ascontiguousarray(np.zeros((1,)), dtype=np.float64)
+            out_data = out.data
+
+        if not field_ == 'qp_iter':
+            acados_solver_common.ocp_nlp_get(self.nlp_config, self.nlp_solver, field, <void *> out_data)
+
+        return out
+
+
+    def get_cost(self):
+        """
+        Returns the cost value of the current solution.
+        """
+        # compute cost internally
+        acados_solver_common.ocp_nlp_eval_cost(self.nlp_solver, self.nlp_in, self.nlp_out)
+
+        # create output array
+        out = np.ascontiguousarray(np.zeros((1,)), dtype=np.float64)
+
+        # call getter
+        field = "cost_value".encode('utf-8')
+        acados_solver_common.ocp_nlp_get(self.nlp_config, self.nlp_solver, field, <void *> out.data)
+
+        return out[0]
+
+
+    def get_residuals(self):
+        """
+        Returns an array of the form [res_stat, res_eq, res_ineq, res_comp].
+        """
+        # compute residuals if RTI
+        if self.acados_ocp.solver_options.nlp_solver_type == 'SQP_RTI':
+            acados_solver_common.ocp_nlp_eval_residuals(self.nlp_solver, self.nlp_in, self.nlp_out)
+
+        # create output array
+        out = np.ascontiguousarray(np.zeros((4, 1)), dtype=np.float64)
+
+        # call getters
+        field = "res_stat".encode('utf-8')
+        acados_solver_common.ocp_nlp_get(self.nlp_config, self.nlp_solver, field, <void *> out.data)
+
+        field = "res_eq".encode('utf-8')
+        acados_solver_common.ocp_nlp_get(self.nlp_config, self.nlp_solver, field, <void *> out[1].data)
+
+        field = "res_ineq".encode('utf-8')
+        acados_solver_common.ocp_nlp_get(self.nlp_config, self.nlp_solver, field, <void *> out[2].data)
+
+        field = "res_comp".encode('utf-8')
+        acados_solver_common.ocp_nlp_get(self.nlp_config, self.nlp_solver, field, <void *> out[3].data)
+        return out.flatten()
+
+
+    # Note: this function should not be used anymore, better use cost_set, constraints_set
+
+    def set(self, int stage, str field_, value_):
+
+        """
+        Set numerical data inside the solver.
+
+            :param stage: integer corresponding to shooting node
+            :param field: string in ['x', 'u', 'pi', 'lam', 't', 'p']
+
+            .. note:: regarding lam, t: \n
+                    the inequalities are internally organized in the following order: \n
+                    [ lbu lbx lg lh lphi ubu ubx ug uh uphi; \n
+                      lsbu lsbx lsg lsh lsphi usbu usbx usg ush usphi]
+
+            .. note:: pi: multipliers for dynamics equality constraints \n
+                      lam: multipliers for inequalities \n
+                      t: slack variables corresponding to evaluation of all inequalities (at the solution) \n
+                      sl: slack variables of soft lower inequality constraints \n
+                      su: slack variables of soft upper inequality constraints \n
+        """
+        cost_fields = ['y_ref', 'yref']
+        constraints_fields = ['lbx', 'ubx', 'lbu', 'ubu']
+        out_fields = ['x', 'u', 'pi', 'lam', 't', 'z']
+        mem_fields = ['sl', 'su']
+
+        # cast value_ to avoid conversion issues
+        if isinstance(value_, (float, int)):
+            value_ = np.array([value_])
+        value_ = value_.astype(np.double)
+
+        field = field_
+        field = field.encode('utf-8')
+
+        if field_ not in constraints_fields + cost_fields + out_fields + mem_fields:
+            raise Exception("AcadosOcpSolver.set(): {} is not a valid argument.\
+                \nPossible values are {}. Exiting.".format(field, \
+                constraints_fields + cost_fields + out_fields + ['p']))
+
+        dims = acados_solver_common.ocp_nlp_dims_get_from_attr(self.nlp_config, self.nlp_dims, self.nlp_out, stage, field)
+
+        if value_.shape[0] != dims:
+            msg = 'AcadosOcpSolver.set(): mismatching dimension for field "{}" '.format(field_)
+            msg += 'with dimension {} (you have {})'.format(dims, value_.shape)
+            raise Exception(msg)
+
+        cdef np.ndarray[np.float64_t, ndim=1, mode='c'] value = np.ascontiguousarray(value_, dtype=np.double)
+
+        value_data_p = <void *> value.data
+        if field_ in constraints_fields:
+            acados_solver_common.ocp_nlp_constraints_model_set(self.nlp_config, self.nlp_dims, self.nlp_in, stage, field, value_data_p)
+        elif field_ in cost_fields:
+            acados_solver_common.ocp_nlp_cost_model_set(self.nlp_config, self.nlp_dims, self.nlp_in, stage, field, value_data_p)
+        elif field_ in out_fields:
+            acados_solver_common.ocp_nlp_out_set(self.nlp_config, self.nlp_dims, self.nlp_out, stage, field, value_data_p)
+        elif field_ in mem_fields:
+            acados_solver_common.ocp_nlp_set(self.nlp_config, self.nlp_solver, stage, field, value_data_p)
+        return
+
+
+    def set_param(self, stage_, np.ndarray[np.float64_t, ndim=1] value_):
+        cdef np.ndarray[np.float64_t, ndim=1, mode='c'] value = np.ascontiguousarray(value_, dtype=np.double)
+        acados_solver.acados_update_params(self.capsule, stage_, <double *> value_.data, value_.shape[0])
+
+    def cost_set(self, start_stage_, field_, value_, api='warn'):
+      self.cost_set_slice(start_stage_, start_stage_+1, field_, value_[None], api='warn')
+
+    def cost_set_slice(self, start_stage_, end_stage_, field_, value_, api='warn'):
+        """
+        Set numerical data in the cost module of the solver.
+
+            :param stage: integer corresponding to shooting node
+            :param field: string, e.g. 'yref', 'W', 'ext_cost_num_hess'
+            :param value: of appropriate size
+        """
+        # cast value_ to avoid conversion issues
+        field = field_.encode('utf-8')
+        if len(value_.shape) > 2:
+          dim = value_.shape[1]*value_.shape[2]
+        else:
+          dim = value_.shape[1]
+          value_ = value_[None,:,:]
+
+        cdef np.ndarray[np.float64_t, ndim=3, mode='c'] value = np.ascontiguousarray(value_, dtype=np.double)
+
+        acados_solver_common.ocp_nlp_cost_model_set_slice(self.nlp_config, self.nlp_dims, self.nlp_in, start_stage_, end_stage_,
+            field, <void *> value.data, dim)
+
+
+    def constraints_set(self, start_stage_, field_, value_, api='warn'):
+      self.constraints_set_slice(start_stage_, start_stage_+1, field_, value_[None], api='warn')
+
+
+    def constraints_set_slice(self, start_stage_, end_stage_, field_, value_, api='warn'):
+        """
+        Set numerical data in the constraint module of the solver.
+
+            :param stage: integer corresponding to shooting node
+            :param field: string in ['lbx', 'ubx', 'lbu', 'ubu', 'lg', 'ug', 'lh', 'uh', 'uphi']
+            :param value: of appropriate size
+        """
+
+        field = field_.encode('utf-8')
+        if len(value_.shape) > 2:
+          dim = value_.shape[1]*value_.shape[2]
+        else:
+          dim = value_.shape[1]
+          value_ = value_[None,:,:]
+
+        cdef np.ndarray[np.float64_t, ndim=3, mode='c'] value = np.ascontiguousarray(value_, dtype=np.double)
+
+        acados_solver_common.ocp_nlp_constraints_model_set_slice(self.nlp_config, self.nlp_dims, self.nlp_in, start_stage_, end_stage_,
+            field, <void*> value.data, dim)
+
+
+    def dynamics_get(self, int stage, field_):
+        """
+        Get numerical data from the dynamics module of the solver:
+
+            :param stage: integer corresponding to shooting node
+            :param field: string, e.g. 'A'
+        """
+
+        field = field_
+        field = field.encode('utf-8')
+
+        # get dims
+        cdef int[2] dims
+        acados_solver_common.ocp_nlp_dynamics_dims_get_from_attr(self.nlp_config, self.nlp_dims, self.nlp_out, stage, field, &dims[0])
+
+        # create output data
+        out = np.ascontiguousarray(np.zeros((dims[0]*dims[1],)), dtype=np.float64)
+        out = out.reshape(dims[0], dims[1], order='F')
+
+        # call getter
+        acados_solver_common.ocp_nlp_get_at_stage(self.nlp_config, self.nlp_dims, self.nlp_solver, stage, field, <void *> out.data)
+
+        return out
+
+
+    def options_set(self, bytes field_, value_):
+        """
+        Set options of the solver.
+
+            :param field: string, e.g. 'print_level', 'rti_phase', 'initialize_t_slacks', 'step_length', 'alpha_min', 'alpha_reduction'
+            :param value: of type int, float
+        """
+        int_fields = ['print_level', 'rti_phase', 'initialize_t_slacks']
+        double_fields = ['step_length', 'tol_eq', 'tol_stat', 'tol_ineq', 'tol_comp', 'alpha_min', 'alpha_reduction']
+        string_fields = ['globalization']
+
+        # encode
+        field = field_
+        field = field.encode('utf-8')
+
+        cdef int int_value
+        cdef double double_value
+        cdef unsigned char[:] string_value
+
+        # check field availability and type
+        if field_ in int_fields:
+            if not isinstance(value_, int):
+                raise Exception('solver option {} must be of type int. You have {}.'.format(field_, type(value_)))
+
+            if field_ == 'rti_phase':
+                if value_ < 0 or value_ > 2:
+                    raise Exception('AcadosOcpSolver.solve(): argument \'rti_phase\' can '
+                        'take only values 0, 1, 2 for SQP-RTI-type solvers')
+                if self.acados_ocp.solver_options.nlp_solver_type != 'SQP_RTI' and value_ > 0:
+                    raise Exception('AcadosOcpSolver.solve(): argument \'rti_phase\' can '
+                        'take only value 0 for SQP-type solvers')
+
+            int_value = value_
+            acados_solver_common.ocp_nlp_solver_opts_set(self.nlp_config, self.nlp_opts, field, <void *> &int_value)
+
+        elif field_ in double_fields:
+            if not isinstance(value_, float):
+                raise Exception('solver option {} must be of type float. You have {}.'.format(field_, type(value_)))
+
+            double_value = value_
+            acados_solver_common.ocp_nlp_solver_opts_set(self.nlp_config, self.nlp_opts, field, <void *> &double_value)
+
+        elif field_ in string_fields:
+            if not isinstance(value_, bytes):
+                raise Exception('solver option {} must be of type str. You have {}.'.format(field_, type(value_)))
+
+            string_value = value_.encode('utf-8')
+            acados_solver_common.ocp_nlp_solver_opts_set(self.nlp_config, self.nlp_opts, field, <void *> &string_value[0])
+
+        raise Exception('AcadosOcpSolver.options_set() does not support field {}.'\
+            '\n Possible values are {}.'.format(field_, ', '.join(int_fields + double_fields + string_fields)))
+
+
+    def __del__(self):
+        if self.solver_created:
+            acados_solver.acados_free(self.capsule)
+            acados_solver.acados_free_capsule(self.capsule)
+
+            # try:
+            #     self.dlclose(self.shared_lib._handle)
+            # except:
+            #     pass

--- a/interfaces/acados_template/acados_template/acados_ocp_solver_pyx.pyx
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver_pyx.pyx
@@ -41,10 +41,10 @@ from libc cimport string
 cimport acados_solver_common
 cimport acados_solver
 
+cimport numpy as cnp
+
 import os
-import json
 import numpy as np
-from datetime import datetime
 
 
 cdef class AcadosOcpSolverFast:
@@ -89,45 +89,68 @@ cdef class AcadosOcpSolverFast:
         self.nlp_in = acados_solver.acados_get_nlp_in(self.capsule)
         self.nlp_solver = acados_solver.acados_get_nlp_solver(self.capsule)
 
+
     def solve(self):
         """
         Solve the ocp with current input.
         """
         return acados_solver.acados_solve(self.capsule)
 
-    def get_slice(self, int start_stage_, int end_stage_, str field_):
+
+    def set_new_time_steps(self, new_time_steps):
+        """
+        Set new time steps before solving. Only reload library without code generation but with new time steps.
+
+            :param new_time_steps: vector of new time steps for the solver
+
+            .. note:: This allows for different use-cases: either set a new size of time-steps or a new distribution of
+                      the shooting nodes without changing the number, e.g., to reach a different final time. Both cases
+                      do not require a new code export and compilation.
+        """
+        raise NotImplementedError()
+
+
+    def get(self, int stage, str field_):
+        """
+        Get the last solution of the solver:
+
+            :param stage: integer corresponding to shooting node
+            :param field: string in ['x', 'u', 'z', 'pi', 'lam', 't', 'sl', 'su',]
+
+            .. note:: regarding lam, t: \n
+                    the inequalities are internally organized in the following order: \n
+                    [ lbu lbx lg lh lphi ubu ubx ug uh uphi; \n
+                      lsbu lsbx lsg lsh lsphi usbu usbx usg ush usphi]
+
+            .. note:: pi: multipliers for dynamics equality constraints \n
+                      lam: multipliers for inequalities \n
+                      t: slack variables corresponding to evaluation of all inequalities (at the solution) \n
+                      sl: slack variables of soft lower inequality constraints \n
+                      su: slack variables of soft upper inequality constraints \n
+        """
+
+        out_fields = ['x', 'u', 'z', 'pi', 'lam', 't', 'sl', 'su']
         field = field_.encode('utf-8')
-        dims = acados_solver_common.ocp_nlp_dims_get_from_attr(self.nlp_config, self.nlp_dims, self.nlp_out, start_stage_, field)
-        out = np.zeros((end_stage_ - start_stage_, dims), order='C', dtype=np.float64)
-        self.fill_in_slice(start_stage_, end_stage_, field_, out)
-        return out
 
-    def fill_in_slice(self, int start_stage_, int end_stage_, str field_, double[:,::1] arr):
-        out_fields = ['x', 'u', 'z', 'pi', 'lam', 't']
-        mem_fields = ['sl', 'su']
-
-        field = field_.encode('utf-8')
-
-        if (field_ not in out_fields + mem_fields):
-            raise Exception('AcadosOcpSolver.get_slice(): {} is an invalid argument.\
+        if field_ not in out_fields:
+            raise Exception('AcadosOcpSolver.get(): {} is an invalid argument.\
                     \n Possible values are {}. Exiting.'.format(field_, out_fields))
 
-        if start_stage_ >= end_stage_:
-            raise Exception('AcadosOcpSolver.get_slice(): end stage index must be larger than start stage index')
+        if stage < 0 or stage > self.N:
+            raise Exception('AcadosOcpSolver.get(): stage index must be in [0, N], got: {}.'.format(self.N))
 
-        if start_stage_ < 0 or end_stage_ > self.N + 1:
-            raise Exception('AcadosOcpSolver.get_slice(): stage index must be in [0, N], got: {}.'.format(self.N))
+        if stage == self.N and field_ == 'pi':
+            raise Exception('AcadosOcpSolver.get(): field {} does not exist at final stage {}.'\
+                .format(field_, stage))
 
-        if (field_ in out_fields):
-            acados_solver_common.ocp_nlp_out_get_slice(self.nlp_config, self.nlp_dims, self.nlp_out,
-                start_stage_, end_stage_, field, <double *> &arr[0][0])
-        elif field_ in mem_fields:
-            raise NotImplementedError()
-        #     acados_solver_common.ocp_nlp_get_at_stage(self.nlp_config, self.nlp_dims, self.nlp_solver, start_stage_, end_stage_,
-        #         field, <double *> arr.data)
+        cdef int dims = acados_solver_common.ocp_nlp_dims_get_from_attr(self.nlp_config,
+            self.nlp_dims, self.nlp_out, stage, field)
 
-    def get(self, int stage_, field_):
-        return self.get_slice(stage_, stage_ + 1, field_)[0]
+        cdef cnp.ndarray[cnp.float64_t, ndim=1] out = np.zeros((dims,))
+        acados_solver_common.ocp_nlp_out_get(self.nlp_config, \
+            self.nlp_dims, self.nlp_out, stage, field, <void *> out.data)
+
+        return out
 
 
     def print_statistics(self):
@@ -145,32 +168,7 @@ cdef class AcadosOcpSolverFast:
             - qp_res_ineq: residual wrt inequality constraints (constraints)  of the last QP solution
             - qp_res_comp: residual wrt complementarity conditions of the last QP solution
         """
-        stat = self.get_stats("statistics")
-
-        if self.acados_ocp.solver_options.nlp_solver_type == 'SQP':
-            print('\niter\tres_stat\tres_eq\t\tres_ineq\tres_comp\tqp_stat\tqp_iter')
-            if stat.shape[0]>7:
-                print('\tqp_res_stat\tqp_res_eq\tqp_res_ineq\tqp_res_comp')
-            for jj in range(stat.shape[1]):
-                print('{:d}\t{:e}\t{:e}\t{:e}\t{:e}\t{:d}\t{:d}'.format( \
-                     int(stat[0][jj]), stat[1][jj], stat[2][jj], \
-                     stat[3][jj], stat[4][jj], int(stat[5][jj]), int(stat[6][jj])))
-                if stat.shape[0]>7:
-                    print('\t{:e}\t{:e}\t{:e}\t{:e}'.format( \
-                        stat[7][jj], stat[8][jj], stat[9][jj], stat[10][jj]))
-            print('\n')
-        elif self.acados_ocp.solver_options.nlp_solver_type == 'SQP_RTI':
-            print('\niter\tqp_stat\tqp_iter')
-            if stat.shape[0]>3:
-                print('\tqp_res_stat\tqp_res_eq\tqp_res_ineq\tqp_res_comp')
-            for jj in range(stat.shape[1]):
-                print('{:d}\t{:d}\t{:d}'.format( int(stat[0][jj]), int(stat[1][jj]), int(stat[2][jj])))
-                if stat.shape[0]>3:
-                    print('\t{:e}\t{:e}\t{:e}\t{:e}'.format( \
-                         stat[3][jj], stat[4][jj], stat[5][jj], stat[6][jj]))
-            print('\n')
-
-        return
+        raise NotImplementedError()
 
 
     def store_iterate(self, filename='', overwrite=False):
@@ -180,49 +178,14 @@ cdef class AcadosOcpSolverFast:
             :param filename: if not set, use model_name + timestamp + '.json'
             :param overwrite: if false and filename exists add timestamp to filename
         """
-        if filename == '':
-            filename += self.model_name + '_' + 'iterate' + '.json'
-
-        if not overwrite:
-            # append timestamp
-            if os.path.isfile(filename):
-                filename = filename[:-5]
-                filename += datetime.utcnow().strftime('%Y-%m-%d-%H:%M:%S.%f') + '.json'
-
-        # get iterate:
-        solution = dict()
-
-        for i in range(self.N+1):
-            solution['x_'+str(i)] = self.get(i,'x')
-            solution['u_'+str(i)] = self.get(i,'u')
-            solution['z_'+str(i)] = self.get(i,'z')
-            solution['lam_'+str(i)] = self.get(i,'lam')
-            solution['t_'+str(i)] = self.get(i, 't')
-            solution['sl_'+str(i)] = self.get(i, 'sl')
-            solution['su_'+str(i)] = self.get(i, 'su')
-        for i in range(self.N):
-            solution['pi_'+str(i)] = self.get(i,'pi')
-
-        # save
         raise NotImplementedError()
-        # with open(filename, 'w') as f:
-        #     json.dump(solution, f, default=np_array_to_list, indent=4, sort_keys=True)
-        # print("stored current iterate in ", os.path.join(os.getcwd(), filename))
 
 
     def load_iterate(self, filename):
         """
         Loads the iterate stored in json file with filename into the ocp solver.
         """
-        if not os.path.isfile(filename):
-            raise Exception('load_iterate: failed, file does not exist: ' + os.path.join(os.getcwd(), filename))
-
-        with open(filename, 'r') as f:
-            solution = json.load(f)
-
-        for key in solution.keys():
-            (field, stage) = key.split('_')
-            self.set(int(stage), field, np.array(solution[key]))
+        raise NotImplementedError()
 
 
     def get_stats(self, field_):
@@ -231,58 +194,7 @@ cdef class AcadosOcpSolverFast:
 
             :param field: string in ['statistics', 'time_tot', 'time_lin', 'time_sim', 'time_sim_ad', 'time_sim_la', 'time_qp', 'time_qp_solver_call', 'time_reg', 'sqp_iter']
         """
-
-        fields = ['time_tot',  # total cpu time previous call
-                  'time_lin',  # cpu time for linearization
-                  'time_sim',  # cpu time for integrator
-                  'time_sim_ad',  # cpu time for integrator contribution of external function calls
-                  'time_sim_la',  # cpu time for integrator contribution of linear algebra
-                  'time_qp',   # cpu time qp solution
-                  'time_qp_solver_call',  # cpu time inside qp solver (without converting the QP)
-                  'time_qp_xcond',
-                  'time_glob',  # cpu time globalization
-                  'time_reg',  # cpu time regularization
-                  'sqp_iter',  # number of SQP iterations
-                  'qp_iter',  # vector of QP iterations for last SQP call
-                  'statistics',  # table with info about last iteration
-                  'stat_m',
-                  'stat_n',]
-
-        field = field_
-        field = field.encode('utf-8')
-        if (field_ not in fields):
-            raise Exception('AcadosOcpSolver.get_stats(): {} is not a valid argument.\
-                    \n Possible values are {}. Exiting.'.format(fields, fields))
-
-        if field_ in ['sqp_iter', 'stat_m', 'stat_n']:
-            out = np.zeros((1,), order='C', dtype=np.int64)
-            out_data = out.data
-
-        elif field_ == 'statistics':
-            sqp_iter = self.get_stats("sqp_iter")
-            stat_m = self.get_stats("stat_m")
-            stat_n = self.get_stats("stat_n")
-
-            min_size = min([stat_m, sqp_iter+1])
-
-            out = np.zeros((stat_n[0]+1, min_size[0]), order='C', dtype=np.float64)
-            out_data = out.data
-
-        elif field_ == 'qp_iter':
-            full_stats = self.get_stats('statistics')
-            if self.acados_ocp.solver_options.nlp_solver_type == 'SQP':
-                out = full_stats[6, :]
-            elif self.acados_ocp.solver_options.nlp_solver_type == 'SQP_RTI':
-                out = full_stats[2, :]
-
-        else:
-            out = np.zeros((1,), order='C', dtype=np.float64)
-            out_data = out.data
-
-        if not field_ == 'qp_iter':
-            acados_solver_common.ocp_nlp_get(self.nlp_config, self.nlp_solver, field, <void *> out_data)
-
-        return out
+        raise NotImplementedError()
 
 
     def get_cost(self):
@@ -305,23 +217,10 @@ cdef class AcadosOcpSolverFast:
         """
         Returns an array of the form [res_stat, res_eq, res_ineq, res_comp].
         """
-        # compute residuals if RTI
-        if self.acados_ocp.solver_options.nlp_solver_type == 'SQP_RTI':
-            acados_solver_common.ocp_nlp_eval_residuals(self.nlp_solver, self.nlp_in, self.nlp_out)
-
-        # create output array
-        out = np.zeros((4, 1), order='C', dtype=np.float64)
-
-        # call getters
-        acados_solver_common.ocp_nlp_get(self.nlp_config, self.nlp_solver, "res_stat", <void *> out[0].data)
-        acados_solver_common.ocp_nlp_get(self.nlp_config, self.nlp_solver, "res_eq", <void *> out[1].data)
-        acados_solver_common.ocp_nlp_get(self.nlp_config, self.nlp_solver, "res_ineq", <void *> out[2].data)
-        acados_solver_common.ocp_nlp_get(self.nlp_config, self.nlp_solver, "res_comp", <void *> out[3].data)
-        return out.flatten()
+        raise NotImplementedError()
 
 
     # Note: this function should not be used anymore, better use cost_set, constraints_set
-
     def set(self, int stage, str field_, value_):
 
         """
@@ -343,50 +242,45 @@ cdef class AcadosOcpSolverFast:
         """
         cost_fields = ['y_ref', 'yref']
         constraints_fields = ['lbx', 'ubx', 'lbu', 'ubu']
-        out_fields = ['x', 'u', 'pi', 'lam', 't', 'z']
-        mem_fields = ['sl', 'su']
+        out_fields = ['x', 'u', 'pi', 'lam', 't', 'z', 'sl', 'su']
 
-        # cast value_ to avoid conversion issues
-        if isinstance(value_, (float, int)):
-            value_ = np.array([value_])
-        value_ = value_.astype(np.double)
+        field = field_.encode('utf-8')
 
-        field = field_
-        field = field.encode('utf-8')
+        cdef double[::1] value
 
-        if field_ not in constraints_fields + cost_fields + out_fields + mem_fields:
-            raise Exception("AcadosOcpSolver.set(): {} is not a valid argument.\
-                \nPossible values are {}. Exiting.".format(field, \
-                constraints_fields + cost_fields + out_fields + ['p']))
+        # treat parameters separately
+        if field_ == 'p':
+            value = np.ascontiguousarray(value_, dtype=np.double)
+            assert acados_solver.acados_update_params(self.capsule, stage, <double *> &value[0], value.shape[0]) == 0
+        else:
+            if field_ not in constraints_fields + cost_fields + out_fields:
+                raise Exception("AcadosOcpSolver.set(): {} is not a valid argument.\
+                    \nPossible values are {}. Exiting.".format(field, \
+                    constraints_fields + cost_fields + out_fields + ['p']))
 
-        dims = acados_solver_common.ocp_nlp_dims_get_from_attr(self.nlp_config, self.nlp_dims, self.nlp_out, stage, field)
+            dims = acados_solver_common.ocp_nlp_dims_get_from_attr(self.nlp_config,
+                self.nlp_dims, self.nlp_out, stage, field)
 
-        if value_.shape[0] != dims:
-            msg = 'AcadosOcpSolver.set(): mismatching dimension for field "{}" '.format(field_)
-            msg += 'with dimension {} (you have {})'.format(dims, value_.shape)
-            raise Exception(msg)
+            if value_.shape[0] != dims:
+                msg = 'AcadosOcpSolver.set(): mismatching dimension for field "{}" '.format(field_)
+                msg += 'with dimension {} (you have {})'.format(dims, value_.shape[0])
+                raise Exception(msg)
 
-        cdef double[::1] value = np.ascontiguousarray(value_, dtype=np.double)
+            value = np.ascontiguousarray(value_, dtype=np.double)
+            if field_ in constraints_fields:
+                acados_solver_common.ocp_nlp_constraints_model_set(self.nlp_config,
+                    self.nlp_dims, self.nlp_in, stage, field, <void *> &value[0])
+            elif field_ in cost_fields:
+                acados_solver_common.ocp_nlp_cost_model_set(self.nlp_config,
+                    self.nlp_dims, self.nlp_in, stage, field, <void *> &value[0])
+            elif field_ in out_fields:
+                acados_solver_common.ocp_nlp_out_set(self.nlp_config,
+                    self.nlp_dims, self.nlp_out, stage, field, <void *> &value[0])
 
-        value_data_p = <void *> &value[0]
-        if field_ in constraints_fields:
-            acados_solver_common.ocp_nlp_constraints_model_set(self.nlp_config, self.nlp_dims, self.nlp_in, stage, field, value_data_p)
-        elif field_ in cost_fields:
-            acados_solver_common.ocp_nlp_cost_model_set(self.nlp_config, self.nlp_dims, self.nlp_in, stage, field, value_data_p)
-        elif field_ in out_fields:
-            acados_solver_common.ocp_nlp_out_set(self.nlp_config, self.nlp_dims, self.nlp_out, stage, field, value_data_p)
-        elif field_ in mem_fields:
-            acados_solver_common.ocp_nlp_set(self.nlp_config, self.nlp_solver, stage, field, value_data_p)
         return
 
 
-    def set_param(self, int stage_, double[::1] value):
-        acados_solver.acados_update_params(self.capsule, stage_, <double *> &value[0], value.shape[0])
-
-    def cost_set(self, int start_stage_, field_, value_, api='warn'):
-      self.cost_set_slice(start_stage_, start_stage_+1, field_, value_[None], api='warn')
-
-    def cost_set_slice(self, int start_stage_, int end_stage_, field_, value_, api='warn'):
+    def cost_set(self, int stage, str field_, value_, api='warn'):
         """
         Set numerical data in the cost module of the solver.
 
@@ -395,42 +289,112 @@ cdef class AcadosOcpSolverFast:
             :param value: of appropriate size
         """
         # cast value_ to avoid conversion issues
+        if isinstance(value_, (float, int)):
+            value_ = np.array([value_])
+        value_ = value_.astype(float)
+
         field = field_.encode('utf-8')
-        if len(value_.shape) > 2:
-          dim = value_.shape[1]*value_.shape[2]
-        else:
-          dim = value_.shape[1]
-          value_ = value_[None,:,:]
 
-        cdef double[:,:,::1] value = np.ascontiguousarray(value_, dtype=np.double)
+        cdef int dims[2]
+        acados_solver_common.ocp_nlp_cost_dims_get_from_attr(self.nlp_config, \
+            self.nlp_dims, self.nlp_out, stage, field, &dims[0])
 
-        acados_solver_common.ocp_nlp_cost_model_set_slice(self.nlp_config, self.nlp_dims, self.nlp_in,
-            start_stage_, end_stage_, field, <void *> &value[0][0][0], dim)
+        value_shape = value_.shape
+        if len(value_shape) == 1:
+            value_shape = (value_shape[0], 0)
+            # value_ = np.ravel(value_, order='F')
+
+        elif len(value_shape) == 2:
+            if api=='old':
+                pass
+            elif api=='warn':
+                if not np.all(np.ravel(value_, order='F')==np.ravel(value_, order='K')):
+                    raise Exception("Ambiguity in API detected.\n"
+                                    "Are you making an acados model from scrach? Add api='new' to cost_set and carry on.\n"
+                                    "Are you seeing this error suddenly in previously running code? Read on.\n"
+                                    "  You are relying on a now-fixed bug in cost_set for field '{}'.\n".format(field_) +
+                                    "  acados_template now correctly passes on any matrices to acados in column major format.\n" +
+                                    "  Two options to fix this error: \n" +
+                                    "   * Add api='old' to cost_set to restore old incorrect behaviour\n" +
+                                    "   * Add api='new' to cost_set and remove any unnatural manipulation of the value argument " +
+                                    "such as non-mathematical transposes, reshaping, casting to fortran order, etc... " +
+                                    "If there is no such manipulation, then you have probably been getting an incorrect solution before.")
+                # Get elements in column major order
+                value_ = np.ravel(value_, order='F')
+            elif api=='new':
+                # Get elements in column major order
+                value_ = np.ravel(value_, order='F')
+            else:
+                raise Exception("Unknown api: '{}'".format(api))
+
+        if value_shape[0] != dims[0] or value_shape[1] != dims[1]:
+            raise Exception('AcadosOcpSolver.cost_set(): mismatching dimension', \
+                ' for field "{}" with dimension {} (you have {})'.format( \
+                field_, tuple(dims), value_shape))
+
+        cdef double[::1] value = np.asfortranarray(value_, dtype=np.double)
+        acados_solver_common.ocp_nlp_cost_model_set(self.nlp_config, \
+            self.nlp_dims, self.nlp_in, stage, field, <void *> &value[0])
+
+        return
 
 
-    def constraints_set(self, int start_stage_, field_, value_, api='warn'):
-      self.constraints_set_slice(start_stage_, start_stage_+1, field_, value_[None], api='warn')
-
-
-    def constraints_set_slice(self, int start_stage_, int end_stage_, field_, value_, api='warn'):
+    def constraints_set(self, int stage, str field_, value_, api='warn'):
         """
         Set numerical data in the constraint module of the solver.
 
             :param stage: integer corresponding to shooting node
-            :param field: string in ['lbx', 'ubx', 'lbu', 'ubu', 'lg', 'ug', 'lh', 'uh', 'uphi']
+            :param field: string in ['lbx', 'ubx', 'lbu', 'ubu', 'lg', 'ug', 'lh', 'uh', 'uphi', 'C', 'D']
             :param value: of appropriate size
         """
+        # cast value_ to avoid conversion issues
+        if isinstance(value_, (float, int)):
+            value_ = np.array([value_])
+        value_ = value_.astype(float)
 
         field = field_.encode('utf-8')
-        if len(value_.shape) > 2:
-          dim = value_.shape[1]*value_.shape[2]
-        else:
-          dim = value_.shape[1]
-          value_ = value_[None,:,:]
 
-        cdef double[:,:,::1] value = np.ascontiguousarray(value_, dtype=np.double)
-        acados_solver_common.ocp_nlp_constraints_model_set_slice(self.nlp_config, self.nlp_dims, self.nlp_in,
-            start_stage_, end_stage_, field, <void*> &value[0][0][0], dim)
+        cdef int dims[2]
+        acados_solver_common.ocp_nlp_constraint_dims_get_from_attr(self.nlp_config, \
+            self.nlp_dims, self.nlp_out, stage, field, &dims[0])
+
+        value_shape = value_.shape
+        if len(value_shape) == 1:
+            value_shape = (value_shape[0], 0)
+            # value_ = np.ravel(value_, order='F')
+
+        elif len(value_shape) == 2:
+            if api=='old':
+                pass
+            elif api=='warn':
+                if not np.all(np.ravel(value_, order='F')==np.ravel(value_, order='K')):
+                    raise Exception("Ambiguity in API detected.\n"
+                                    "Are you making an acados model from scrach? Add api='new' to constraints_set and carry on.\n"
+                                    "Are you seeing this error suddenly in previously running code? Read on.\n"
+                                    "  You are relying on a now-fixed bug in constraints_set for field '{}'.\n".format(field_) +
+                                    "  acados_template now correctly passes on any matrices to acados in column major format.\n" +
+                                    "  Two options to fix this error: \n" +
+                                    "   * Add api='old' to constraints_set to restore old incorrect behaviour\n" +
+                                    "   * Add api='new' to constraints_set and remove any unnatural manipulation of the value argument " +
+                                    "such as non-mathematical transposes, reshaping, casting to fortran order, etc... " +
+                                    "If there is no such manipulation, then you have probably been getting an incorrect solution before.")
+                # Get elements in column major order
+                value_ = np.ravel(value_, order='F')
+            elif api=='new':
+                # Get elements in column major order
+                value_ = np.ravel(value_, order='F')
+            else:
+                raise Exception("Unknown api: '{}'".format(api))
+
+        if value_shape[0] != dims[0] or value_shape[1] != dims[1]:
+            raise Exception('AcadosOcpSolver.constraints_set(): mismatching dimension' \
+                ' for field "{}" with dimension {} (you have {})'.format(field_, tuple(dims), value_shape))
+
+        cdef double[::1] value = np.asfortranarray(value_, dtype=np.double)
+        acados_solver_common.ocp_nlp_constraints_model_set(self.nlp_config, \
+            self.nlp_dims, self.nlp_in, stage, field, <void *> &value[0])
+
+        return
 
 
     def dynamics_get(self, int stage, field_):

--- a/interfaces/acados_template/acados_template/acados_ocp_solver_pyx.pyx
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver_pyx.pyx
@@ -51,9 +51,8 @@ cdef class AcadosOcpSolverFast:
     """
     Class to interact with the acados ocp solver C object.
 
-        :param acados_ocp: type AcadosOcp - description of the OCP for acados
-        :param json_file: name for the json file used to render the templated code - default: acados_ocp_nlp.json
-        :param simulink_opts: Options to configure Simulink S-function blocks, mainly to activate possible Inputs and Outputs
+        :param model_name:
+        :param N:
     """
 
     cdef acados_solver.nlp_solver_capsule *capsule
@@ -68,7 +67,7 @@ cdef class AcadosOcpSolverFast:
     cdef int N
     cdef bint solver_created
 
-    def __cinit__(self, str model_name, int N, str code_export_dir):
+    def __cinit__(self, str model_name, int N):
         self.model_name = model_name
         self.N = N
 

--- a/interfaces/acados_template/acados_template/acados_ocp_solver_pyx.pyx
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver_pyx.pyx
@@ -420,7 +420,7 @@ cdef class AcadosOcpSolverFast:
         acados_solver_common.ocp_nlp_dynamics_dims_get_from_attr(self.nlp_config, self.nlp_dims, self.nlp_out, stage, field, &dims[0])
 
         # create output data
-        out = np.zeros((dims[0], dims[1]), order='F', dtype=np.float64)
+        cdef cnp.ndarray[cnp.float64_t, ndim=2] out = np.zeros((dims[0], dims[1]), order='F')
 
         # call getter
         acados_solver_common.ocp_nlp_get_at_stage(self.nlp_config, self.nlp_dims, self.nlp_solver, stage, field, <void *> out.data)

--- a/interfaces/acados_template/acados_template/acados_ocp_solver_pyx.pyx
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver_pyx.pyx
@@ -277,10 +277,8 @@ cdef class AcadosOcpSolverFast:
                 acados_solver_common.ocp_nlp_out_set(self.nlp_config,
                     self.nlp_dims, self.nlp_out, stage, field, <void *> &value[0])
 
-        return
 
-
-    def cost_set(self, int stage, str field_, value_, api='warn'):
+    def cost_set(self, int stage, str field_, value_):
         """
         Set numerical data in the cost module of the solver.
 
@@ -288,58 +286,33 @@ cdef class AcadosOcpSolverFast:
             :param field: string, e.g. 'yref', 'W', 'ext_cost_num_hess'
             :param value: of appropriate size
         """
-        # cast value_ to avoid conversion issues
-        if isinstance(value_, (float, int)):
-            value_ = np.array([value_])
-        value_ = value_.astype(float)
-
         field = field_.encode('utf-8')
 
         cdef int dims[2]
         acados_solver_common.ocp_nlp_cost_dims_get_from_attr(self.nlp_config, \
             self.nlp_dims, self.nlp_out, stage, field, &dims[0])
 
+        cdef double[::1] value
+
         value_shape = value_.shape
         if len(value_shape) == 1:
             value_shape = (value_shape[0], 0)
-            # value_ = np.ravel(value_, order='F')
+            data_ptr = np.asfortranarray(value_)
 
         elif len(value_shape) == 2:
-            if api=='old':
-                pass
-            elif api=='warn':
-                if not np.all(np.ravel(value_, order='F')==np.ravel(value_, order='K')):
-                    raise Exception("Ambiguity in API detected.\n"
-                                    "Are you making an acados model from scrach? Add api='new' to cost_set and carry on.\n"
-                                    "Are you seeing this error suddenly in previously running code? Read on.\n"
-                                    "  You are relying on a now-fixed bug in cost_set for field '{}'.\n".format(field_) +
-                                    "  acados_template now correctly passes on any matrices to acados in column major format.\n" +
-                                    "  Two options to fix this error: \n" +
-                                    "   * Add api='old' to cost_set to restore old incorrect behaviour\n" +
-                                    "   * Add api='new' to cost_set and remove any unnatural manipulation of the value argument " +
-                                    "such as non-mathematical transposes, reshaping, casting to fortran order, etc... " +
-                                    "If there is no such manipulation, then you have probably been getting an incorrect solution before.")
-                # Get elements in column major order
-                value_ = np.ravel(value_, order='F')
-            elif api=='new':
-                # Get elements in column major order
-                value_ = np.ravel(value_, order='F')
-            else:
-                raise Exception("Unknown api: '{}'".format(api))
+            # Get elements in column major order
+            value = np.ravel(value_, order='F')
 
         if value_shape[0] != dims[0] or value_shape[1] != dims[1]:
             raise Exception('AcadosOcpSolver.cost_set(): mismatching dimension', \
                 ' for field "{}" with dimension {} (you have {})'.format( \
                 field_, tuple(dims), value_shape))
 
-        cdef double[::1] value = np.asfortranarray(value_, dtype=np.double)
         acados_solver_common.ocp_nlp_cost_model_set(self.nlp_config, \
             self.nlp_dims, self.nlp_in, stage, field, <void *> &value[0])
 
-        return
 
-
-    def constraints_set(self, int stage, str field_, value_, api='warn'):
+    def constraints_set(self, int stage, str field_, value_):
         """
         Set numerical data in the constraint module of the solver.
 
@@ -347,50 +320,27 @@ cdef class AcadosOcpSolverFast:
             :param field: string in ['lbx', 'ubx', 'lbu', 'ubu', 'lg', 'ug', 'lh', 'uh', 'uphi', 'C', 'D']
             :param value: of appropriate size
         """
-        # cast value_ to avoid conversion issues
-        if isinstance(value_, (float, int)):
-            value_ = np.array([value_])
-        value_ = value_.astype(float)
-
         field = field_.encode('utf-8')
 
         cdef int dims[2]
         acados_solver_common.ocp_nlp_constraint_dims_get_from_attr(self.nlp_config, \
             self.nlp_dims, self.nlp_out, stage, field, &dims[0])
 
+        cdef double[::1] value
+
         value_shape = value_.shape
         if len(value_shape) == 1:
             value_shape = (value_shape[0], 0)
-            # value_ = np.ravel(value_, order='F')
+            value = np.asfortranarray(value_)
 
         elif len(value_shape) == 2:
-            if api=='old':
-                pass
-            elif api=='warn':
-                if not np.all(np.ravel(value_, order='F')==np.ravel(value_, order='K')):
-                    raise Exception("Ambiguity in API detected.\n"
-                                    "Are you making an acados model from scrach? Add api='new' to constraints_set and carry on.\n"
-                                    "Are you seeing this error suddenly in previously running code? Read on.\n"
-                                    "  You are relying on a now-fixed bug in constraints_set for field '{}'.\n".format(field_) +
-                                    "  acados_template now correctly passes on any matrices to acados in column major format.\n" +
-                                    "  Two options to fix this error: \n" +
-                                    "   * Add api='old' to constraints_set to restore old incorrect behaviour\n" +
-                                    "   * Add api='new' to constraints_set and remove any unnatural manipulation of the value argument " +
-                                    "such as non-mathematical transposes, reshaping, casting to fortran order, etc... " +
-                                    "If there is no such manipulation, then you have probably been getting an incorrect solution before.")
-                # Get elements in column major order
-                value_ = np.ravel(value_, order='F')
-            elif api=='new':
-                # Get elements in column major order
-                value_ = np.ravel(value_, order='F')
-            else:
-                raise Exception("Unknown api: '{}'".format(api))
+            # Get elements in column major order
+            value = np.ravel(value_, order='F')
 
         if value_shape[0] != dims[0] or value_shape[1] != dims[1]:
             raise Exception('AcadosOcpSolver.constraints_set(): mismatching dimension' \
                 ' for field "{}" with dimension {} (you have {})'.format(field_, tuple(dims), value_shape))
 
-        cdef double[::1] value = np.asfortranarray(value_, dtype=np.double)
         acados_solver_common.ocp_nlp_constraints_model_set(self.nlp_config, \
             self.nlp_dims, self.nlp_in, stage, field, <void *> &value[0])
 

--- a/interfaces/acados_template/acados_template/acados_ocp_solver_pyx.pyx
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver_pyx.pyx
@@ -169,7 +169,7 @@ cdef class AcadosOcpSolverFast:
             - qp_res_ineq: residual wrt inequality constraints (constraints)  of the last QP solution
             - qp_res_comp: residual wrt complementarity conditions of the last QP solution
         """
-        raise NotImplementedError()
+        acados_solver.acados_print_stats(self.capsule)
 
 
     def store_iterate(self, filename='', overwrite=False):
@@ -212,7 +212,15 @@ cdef class AcadosOcpSolverFast:
         """
         Loads the iterate stored in json file with filename into the ocp solver.
         """
-        raise NotImplementedError()
+        if not os.path.isfile(filename):
+            raise Exception('load_iterate: failed, file does not exist: ' + os.path.join(os.getcwd(), filename))
+
+        with open(filename, 'r') as f:
+            solution = json.load(f)
+
+        for key in solution.keys():
+            (field, stage) = key.split('_')
+            self.set(int(stage), field, np.array(solution[key]))
 
 
     def get_stats(self, field_):
@@ -358,12 +366,11 @@ cdef class AcadosOcpSolverFast:
 
         field = field_.encode('utf-8')
 
-        cdef double[::1] value
+        cdef cnp.ndarray[cnp.float64_t, ndim=1] value = np.ascontiguousarray(value_, dtype=np.float64)
 
         # treat parameters separately
         if field_ == 'p':
-            value = np.ascontiguousarray(value_, dtype=np.double)
-            assert acados_solver.acados_update_params(self.capsule, stage, <double *> &value[0], value.shape[0]) == 0
+            assert acados_solver.acados_update_params(self.capsule, stage, <double *> value.data, value.shape[0]) == 0
         else:
             if field_ not in constraints_fields + cost_fields + out_fields:
                 raise Exception("AcadosOcpSolver.set(): {} is not a valid argument.\
@@ -378,16 +385,15 @@ cdef class AcadosOcpSolverFast:
                 msg += 'with dimension {} (you have {})'.format(dims, value_.shape[0])
                 raise Exception(msg)
 
-            value = np.ascontiguousarray(value_, dtype=np.double)
             if field_ in constraints_fields:
                 acados_solver_common.ocp_nlp_constraints_model_set(self.nlp_config,
-                    self.nlp_dims, self.nlp_in, stage, field, <void *> &value[0])
+                    self.nlp_dims, self.nlp_in, stage, field, <void *> value.data)
             elif field_ in cost_fields:
                 acados_solver_common.ocp_nlp_cost_model_set(self.nlp_config,
-                    self.nlp_dims, self.nlp_in, stage, field, <void *> &value[0])
+                    self.nlp_dims, self.nlp_in, stage, field, <void *> value.data)
             elif field_ in out_fields:
                 acados_solver_common.ocp_nlp_out_set(self.nlp_config,
-                    self.nlp_dims, self.nlp_out, stage, field, <void *> &value[0])
+                    self.nlp_dims, self.nlp_out, stage, field, <void *> value.data)
 
 
     def cost_set(self, int stage, str field_, value_):

--- a/interfaces/acados_template/acados_template/acados_ocp_solver_pyx.pyx
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver_pyx.pyx
@@ -1,7 +1,3 @@
-# cython: language_level=3
-# cython: profile=False
-# distutils: language = c
-
 # -*- coding: future_fstrings -*-
 #
 # Copyright 2019 Gianluca Frison, Dimitris Kouzoupis, Robin Verschueren,
@@ -35,6 +31,9 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.;
 #
+# cython: language_level=3
+# cython: profile=False
+# distutils: language=c
 
 cimport cython
 from libc cimport string

--- a/interfaces/acados_template/acados_template/acados_ocp_solver_pyx.pyx
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver_pyx.pyx
@@ -193,7 +193,67 @@ cdef class AcadosOcpSolverFast:
 
             :param field: string in ['statistics', 'time_tot', 'time_lin', 'time_sim', 'time_sim_ad', 'time_sim_la', 'time_qp', 'time_qp_solver_call', 'time_reg', 'sqp_iter']
         """
-        raise NotImplementedError()
+        fields = ['time_tot',  # total cpu time previous call
+                  'time_lin',  # cpu time for linearization
+                  'time_sim',  # cpu time for integrator
+                  'time_sim_ad',  # cpu time for integrator contribution of external function calls
+                  'time_sim_la',  # cpu time for integrator contribution of linear algebra
+                  'time_qp',   # cpu time qp solution
+                  'time_qp_solver_call',  # cpu time inside qp solver (without converting the QP)
+                  'time_qp_xcond',
+                  'time_glob',  # cpu time globalization
+                  'time_reg',  # cpu time regularization
+                  'sqp_iter',  # number of SQP iterations
+                  'qp_iter',  # vector of QP iterations for last SQP call
+                  'statistics',  # table with info about last iteration
+                  'stat_m',
+                  'stat_n',]
+
+        field = field_
+        field = field.encode('utf-8')
+
+        if (field_ not in fields):
+            raise Exception('AcadosOcpSolver.get_stats(): {} is not a valid argument.\
+                    \n Possible values are {}. Exiting.'.format(fields, fields))
+
+        if field_ in ['sqp_iter', 'stat_m', 'stat_n']:
+            return self.__get_stat_int(field)
+
+        elif field_.startswith('time'):
+            return self.__get_stat_double(field)
+
+        elif field_ == 'statistics':
+            sqp_iter = self.get_stats("sqp_iter")
+            stat_m = self.get_stats("stat_m")
+            stat_n = self.get_stats("stat_n")
+            min_size = min([stat_m, sqp_iter+1])
+            return self.__get_stat_matrix(field, stat_n+1, min_size)
+
+        elif field_ == 'qp_iter':
+            NotImplementedError("TODO! Cython not aware if SQP or SQP_RTI")
+            full_stats = self.get_stats('statistics')
+            if self.acados_ocp.solver_options.nlp_solver_type == 'SQP':
+                out = full_stats[6, :]
+            elif self.acados_ocp.solver_options.nlp_solver_type == 'SQP_RTI':
+                out = full_stats[2, :]
+        else:
+            NotImplementedError("TODO!")
+
+
+    def __get_stat_int(self, field):
+        cdef int out
+        acados_solver_common.ocp_nlp_get(self.nlp_config, self.nlp_solver, field, <void *> &out)
+        return out
+
+    def __get_stat_double(self, field):
+        cdef cnp.ndarray[cnp.float64_t, ndim=1] out = np.zeros((1,))
+        acados_solver_common.ocp_nlp_get(self.nlp_config, self.nlp_solver, field, <void *> out.data)
+        return out
+
+    def __get_stat_matrix(self, field, n, m):
+        cdef cnp.ndarray[cnp.float64_t, ndim=2] out_mat = np.ascontiguousarray(np.zeros((n, m)), dtype=np.float64)
+        acados_solver_common.ocp_nlp_get(self.nlp_config, self.nlp_solver, field, <void *> out_mat.data)
+        return out_mat
 
 
     def get_cost(self):

--- a/interfaces/acados_template/acados_template/acados_ocp_solver_pyx.pyx
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver_pyx.pyx
@@ -416,8 +416,9 @@ cdef class AcadosOcpSolverFast:
             string_value = value_.encode('utf-8')
             acados_solver_common.ocp_nlp_solver_opts_set(self.nlp_config, self.nlp_opts, field, <void *> &string_value[0])
 
-        raise Exception('AcadosOcpSolver.options_set() does not support field {}.'\
-            '\n Possible values are {}.'.format(field_, ', '.join(int_fields + double_fields + string_fields)))
+        else:
+            raise Exception('AcadosOcpSolver.options_set() does not support field {}.'\
+                '\n Possible values are {}.'.format(field_, ', '.join(int_fields + double_fields + string_fields)))
 
 
     def __del__(self):

--- a/interfaces/acados_template/acados_template/acados_ocp_solver_pyx.pyx
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver_pyx.pyx
@@ -44,6 +44,8 @@ cimport acados_solver
 cimport numpy as cnp
 
 import os
+import json
+from datetime import datetime
 import numpy as np
 
 
@@ -177,7 +179,33 @@ cdef class AcadosOcpSolverFast:
             :param filename: if not set, use model_name + timestamp + '.json'
             :param overwrite: if false and filename exists add timestamp to filename
         """
-        raise NotImplementedError()
+        if filename == '':
+            filename += self.model_name + '_' + 'iterate' + '.json'
+
+        if not overwrite:
+            # append timestamp
+            if os.path.isfile(filename):
+                filename = filename[:-5]
+                filename += datetime.utcnow().strftime('%Y-%m-%d-%H:%M:%S.%f') + '.json'
+
+        # get iterate:
+        solution = dict()
+
+        for i in range(self.N+1):
+            solution['x_'+str(i)] = self.get(i,'x')
+            solution['u_'+str(i)] = self.get(i,'u')
+            solution['z_'+str(i)] = self.get(i,'z')
+            solution['lam_'+str(i)] = self.get(i,'lam')
+            solution['t_'+str(i)] = self.get(i, 't')
+            solution['sl_'+str(i)] = self.get(i, 'sl')
+            solution['su_'+str(i)] = self.get(i, 'su')
+        for i in range(self.N):
+            solution['pi_'+str(i)] = self.get(i,'pi')
+
+        # save
+        with open(filename, 'w') as f:
+            json.dump(solution, f, default=lambda x: x.tolist(), indent=4, sort_keys=True)
+        print("stored current iterate in ", os.path.join(os.getcwd(), filename))
 
 
     def load_iterate(self, filename):
@@ -276,7 +304,32 @@ cdef class AcadosOcpSolverFast:
         """
         Returns an array of the form [res_stat, res_eq, res_ineq, res_comp].
         """
-        raise NotImplementedError()
+        # TODO: check if RTI, only eval then
+        # if self.acados_ocp.solver_options.nlp_solver_type == 'SQP_RTI':
+        # compute residuals if RTI
+        acados_solver_common.ocp_nlp_eval_residuals(self.nlp_solver, self.nlp_in, self.nlp_out)
+
+        # create output array
+        cdef cnp.ndarray[cnp.float64_t, ndim=1] out = np.ascontiguousarray(np.zeros((4,), dtype=np.float64))
+        cdef double double_value
+
+        field = "res_stat".encode('utf-8')
+        acados_solver_common.ocp_nlp_get(self.nlp_config, self.nlp_solver, field, <void *> &double_value)
+        out[0] = double_value
+
+        field = "res_eq".encode('utf-8')
+        acados_solver_common.ocp_nlp_get(self.nlp_config, self.nlp_solver, field, <void *> &double_value)
+        out[1] = double_value
+
+        field = "res_ineq".encode('utf-8')
+        acados_solver_common.ocp_nlp_get(self.nlp_config, self.nlp_solver, field, <void *> &double_value)
+        out[2] = double_value
+
+        field = "res_comp".encode('utf-8')
+        acados_solver_common.ocp_nlp_get(self.nlp_config, self.nlp_solver, field, <void *> &double_value)
+        out[3] = double_value
+
+        return out
 
 
     # Note: this function should not be used anymore, better use cost_set, constraints_set

--- a/interfaces/acados_template/acados_template/acados_sim_solver.py
+++ b/interfaces/acados_template/acados_template/acados_sim_solver.py
@@ -200,16 +200,16 @@ class AcadosSimSolver:
             sim_generate_casadi_functions(acados_sim)
             sim_formulation_json_dump(acados_sim, json_file)
 
+        code_export_dir = acados_sim.code_export_directory
         if build:
-          # render templates
-          code_export_dir = acados_sim.code_export_directory
-          sim_render_templates(json_file, model_name, code_export_dir)
+            # render templates
+            sim_render_templates(json_file, model_name, code_export_dir)
 
-          ## Compile solver
-          cwd = os.getcwd()
-          os.chdir(code_export_dir)
-          os.system('make sim_shared_lib')
-          os.chdir(cwd)
+            ## Compile solver
+            cwd = os.getcwd()
+            os.chdir(code_export_dir)
+            os.system('make sim_shared_lib')
+            os.chdir(cwd)
 
         self.sim_struct = acados_sim
         model_name = self.sim_struct.model.name

--- a/interfaces/acados_template/acados_template/acados_solver_common.pxd
+++ b/interfaces/acados_template/acados_template/acados_solver_common.pxd
@@ -1,0 +1,106 @@
+# cython: language_level=3
+# cython: profile=True
+# distutils: language = c
+
+# -*- coding: future_fstrings -*-
+#
+# Copyright 2019 Gianluca Frison, Dimitris Kouzoupis, Robin Verschueren,
+# Andrea Zanelli, Niels van Duijkeren, Jonathan Frey, Tommaso Sartor,
+# Branimir Novoselnik, Rien Quirynen, Rezart Qelibari, Dang Doan,
+# Jonas Koenemann, Yutao Chen, Tobias Schöls, Jonas Schlagenhauf, Moritz Diehl
+#
+# This file is part of acados.
+#
+# The 2-Clause BSD License
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.;
+#
+
+
+cdef extern from "acados/ocp_nlp/ocp_nlp_common.h":
+    ctypedef struct ocp_nlp_config:
+        pass
+
+    ctypedef struct ocp_nlp_dims:
+        pass
+
+    ctypedef struct ocp_nlp_in:
+        pass
+
+    ctypedef struct ocp_nlp_out:
+        pass
+
+
+cdef extern from "acados_c/ocp_nlp_interface.h":
+    ctypedef enum ocp_nlp_solver_t:
+        pass
+
+    ctypedef enum ocp_nlp_cost_t:
+        pass
+
+    ctypedef enum ocp_nlp_dynamics_t:
+        pass
+
+    ctypedef enum ocp_nlp_constraints_t:
+        pass
+
+    ctypedef enum ocp_nlp_reg_t:
+        pass
+
+    ctypedef struct ocp_nlp_plan:
+        pass
+
+    ctypedef struct ocp_nlp_solver:
+        pass
+
+    int ocp_nlp_cost_model_set_slice(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in_,
+        int start_stage, int end_stage, const char *field, void *value, int dim)
+    int ocp_nlp_cost_model_set(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in_,
+        int start_stage, const char *field, void *value)
+    int ocp_nlp_constraints_model_set_slice(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in_,
+        int start_stage, int end_stage, const char *field, void *value, int dim)
+    int ocp_nlp_constraints_model_set(ocp_nlp_config *config, ocp_nlp_dims *dims,
+        ocp_nlp_in *in_, int stage, const char *field, void *value)
+
+    # out
+    void ocp_nlp_out_set(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_out *out,
+        int stage, const char *field, void *value)
+    void ocp_nlp_out_get_slice(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_out *out,
+        int start_stage, int end_stage, const char *field, void *value)
+    void ocp_nlp_get_at_stage(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_solver *solver,
+        int stage, const char *field, void *value)
+    int ocp_nlp_dims_get_from_attr(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_out *out,
+        int stage, const char *field)
+    void ocp_nlp_dynamics_dims_get_from_attr(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_out *out,
+        int stage, const char *field, int *dims_out)
+
+    # opts
+    void ocp_nlp_solver_opts_set(ocp_nlp_config *config, void *opts_, const char *field, void* value)
+
+    # solver
+    void ocp_nlp_eval_residuals(ocp_nlp_solver *solver, ocp_nlp_in *nlp_in, ocp_nlp_out *nlp_out)
+    void ocp_nlp_eval_cost(ocp_nlp_solver *solver, ocp_nlp_in *nlp_in_, ocp_nlp_out *nlp_out)
+
+    # get/set
+    void ocp_nlp_get(ocp_nlp_config *config, ocp_nlp_solver *solver, const char *field, void *return_value_)
+    void ocp_nlp_set(ocp_nlp_config *config, ocp_nlp_solver *solver, int stage, const char *field, void *value)

--- a/interfaces/acados_template/acados_template/acados_solver_common.pxd
+++ b/interfaces/acados_template/acados_template/acados_solver_common.pxd
@@ -1,7 +1,3 @@
-# cython: language_level=3
-# cython: profile=True
-# distutils: language = c
-
 # -*- coding: future_fstrings -*-
 #
 # Copyright 2019 Gianluca Frison, Dimitris Kouzoupis, Robin Verschueren,

--- a/interfaces/acados_template/acados_template/acados_solver_common.pxd
+++ b/interfaces/acados_template/acados_template/acados_solver_common.pxd
@@ -69,24 +69,24 @@ cdef extern from "acados_c/ocp_nlp_interface.h":
     ctypedef struct ocp_nlp_solver:
         pass
 
-    int ocp_nlp_cost_model_set_slice(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in_,
-        int start_stage, int end_stage, const char *field, void *value, int dim)
     int ocp_nlp_cost_model_set(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in_,
         int start_stage, const char *field, void *value)
-    int ocp_nlp_constraints_model_set_slice(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in_,
-        int start_stage, int end_stage, const char *field, void *value, int dim)
     int ocp_nlp_constraints_model_set(ocp_nlp_config *config, ocp_nlp_dims *dims,
         ocp_nlp_in *in_, int stage, const char *field, void *value)
 
     # out
     void ocp_nlp_out_set(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_out *out,
         int stage, const char *field, void *value)
-    void ocp_nlp_out_get_slice(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_out *out,
-        int start_stage, int end_stage, const char *field, void *value)
+    void ocp_nlp_out_get(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_out *out,
+        int stage, const char *field, void *value)
     void ocp_nlp_get_at_stage(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_solver *solver,
         int stage, const char *field, void *value)
     int ocp_nlp_dims_get_from_attr(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_out *out,
         int stage, const char *field)
+    void ocp_nlp_constraint_dims_get_from_attr(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_out *out,
+        int stage, const char *field, int *dims_out)
+    void ocp_nlp_cost_dims_get_from_attr(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_out *out,
+        int stage, const char *field, int *dims_out)
     void ocp_nlp_dynamics_dims_get_from_attr(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_out *out,
         int stage, const char *field, int *dims_out)
 

--- a/interfaces/acados_template/acados_template/c_templates_tera/Makefile.in
+++ b/interfaces/acados_template/acados_template/c_templates_tera/Makefile.in
@@ -279,12 +279,12 @@ all: clean casadi_fun example_sim example
 shared_lib: bundled_shared_lib ocp_shared_lib sim_shared_lib
 {%- endif %}
 
-CASADI_MODEL_SOURCE= 
+CASADI_MODEL_SOURCE=
 {%- if solver_options.integrator_type == "ERK" %}
 CASADI_MODEL_SOURCE+= {{ model.name }}_expl_ode_fun.c
-CASADI_MODEL_SOURCE+= {{ model.name }}_expl_vde_forw.c 
+CASADI_MODEL_SOURCE+= {{ model.name }}_expl_vde_forw.c
 {%- if hessian_approx == "EXACT" %}
-CASADI_MODEL_SOURCE+= {{ model.name }}_expl_ode_hess.c 
+CASADI_MODEL_SOURCE+= {{ model.name }}_expl_ode_hess.c
 {%- endif %}
 {%- elif solver_options.integrator_type == "IRK" %}
 CASADI_MODEL_SOURCE+= {{ model.name }}_impl_dae_fun.c
@@ -453,7 +453,7 @@ ocp_shared_lib: casadi_fun ocp_solver
 	-L $(LIB_PATH) -lacados -lhpipm -lblasfeo \
 	{{ link_libs }} \
 	-lm \
-	
+
 {%- else %}
 
 ocp_shared_lib: casadi_fun ocp_solver
@@ -465,8 +465,33 @@ ocp_shared_lib: casadi_fun ocp_solver
 	-L $(LIB_PATH) -lacados -lhpipm -lblasfeo \
 	{{ link_libs }} \
 	-lm \
-	
+
 {%- endif %}
+
+ocp_cython_c: ocp_shared_lib
+	cython \
+	-o acados_ocp_solver_pyx.c \
+	-I $(INCLUDE_PATH)/../interfaces/acados_template/acados_template \
+	$(INCLUDE_PATH)/../interfaces/acados_template/acados_template/acados_ocp_solver_pyx.pyx \
+
+ocp_cython_o: ocp_cython_c
+	clang $(ACADOS_FLAGS) -c -O2 \
+	-o acados_ocp_solver_pyx.o \
+	-I /usr/include/python3.8 \
+	-I $(INCLUDE_PATH)/blasfeo/include/ \
+	-I $(INCLUDE_PATH)/hpipm/include/ \
+	-I $(INCLUDE_PATH) \
+	acados_ocp_solver_pyx.c \
+
+ocp_cython: ocp_cython_o
+	clang $(ACADOS_FLAGS) -shared \
+	-o acados_ocp_solver_pyx.so \
+	-Wl,-rpath=$(LIB_PATH) \
+	acados_ocp_solver_pyx.o \
+	$(abspath .)/libacados_ocp_solver_{{ model.name }}.so \
+	-L $(LIB_PATH) -lacados -lhpipm -lblasfeo -lqpOASES_e \
+	{{ link_libs }} \
+	-lm \
 
 sim_shared_lib: casadi_fun sim_solver
 	gcc $(ACADOS_FLAGS) -shared -o libacados_sim_solver_{{ model.name }}.so $(SIM_OBJ) $(MODEL_OBJ) -L$(EXTERNAL_DIR) -l$(EXTERNAL_LIB) \

--- a/interfaces/acados_template/acados_template/c_templates_tera/Makefile.in
+++ b/interfaces/acados_template/acados_template/c_templates_tera/Makefile.in
@@ -475,7 +475,7 @@ ocp_cython_c: ocp_shared_lib
 	$(INCLUDE_PATH)/../interfaces/acados_template/acados_template/acados_ocp_solver_pyx.pyx \
 
 ocp_cython_o: ocp_cython_c
-	clang $(ACADOS_FLAGS) -c -O2 \
+	gcc $(ACADOS_FLAGS) -c -O2 \
 	-o acados_ocp_solver_pyx.o \
 	-I /usr/include/python3.8 \
 	-I $(INCLUDE_PATH)/blasfeo/include/ \
@@ -484,7 +484,7 @@ ocp_cython_o: ocp_cython_c
 	acados_ocp_solver_pyx.c \
 
 ocp_cython: ocp_cython_o
-	clang $(ACADOS_FLAGS) -shared \
+	gcc $(ACADOS_FLAGS) -shared \
 	-o acados_ocp_solver_pyx.so \
 	-Wl,-rpath=$(LIB_PATH) \
 	acados_ocp_solver_pyx.o \
@@ -513,6 +513,8 @@ clean_ocp_shared_lib:
 clean_ocp_cython:
 	del \Q libacados_ocp_solver_{{ model.name }}.so 2>nul
 	del \Q acados_solver_{{ model.name }}.o 2>nul
+	del \Q acados_ocp_solver_pyx.so 2>nul
+	del \Q acados_ocp_solver_pyx.o 2>nul
 
 {%- else %}
 
@@ -528,5 +530,7 @@ clean_ocp_shared_lib:
 clean_ocp_cython:
 	rm -f libacados_ocp_solver_{{ model.name }}.so
 	rm -f acados_solver_{{ model.name }}.o
+	rm -f acados_ocp_solver_pyx.so
+	rm -f acados_ocp_solver_pyx.o
 
 {%- endif %}

--- a/interfaces/acados_template/acados_template/c_templates_tera/Makefile.in
+++ b/interfaces/acados_template/acados_template/c_templates_tera/Makefile.in
@@ -510,6 +510,10 @@ clean_ocp_shared_lib:
 	del \Q libacados_ocp_solver_{{ model.name }}.so 2>nul
 	del \Q acados_solver_{{ model.name }}.o 2>nul
 
+clean_ocp_cython:
+	del \Q libacados_ocp_solver_{{ model.name }}.so 2>nul
+	del \Q acados_solver_{{ model.name }}.o 2>nul
+
 {%- else %}
 
 clean:
@@ -518,6 +522,10 @@ clean:
 	rm -f main_{{ model.name }}
 
 clean_ocp_shared_lib:
+	rm -f libacados_ocp_solver_{{ model.name }}.so
+	rm -f acados_solver_{{ model.name }}.o
+
+clean_ocp_cython:
 	rm -f libacados_ocp_solver_{{ model.name }}.so
 	rm -f acados_solver_{{ model.name }}.o
 

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.pxd
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.pxd
@@ -1,7 +1,7 @@
 cimport acados_solver_common
 
 cdef extern from "acados_solver_{{ model.name }}.h":
-    ctypedef struct nlp_solver_capsule:
+    ctypedef struct nlp_solver_capsule "{{ model.name }}_solver_capsule":
         pass
 
     nlp_solver_capsule * acados_create_capsule "{{ model.name }}_acados_create_capsule"()

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.pxd
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.pxd
@@ -1,0 +1,22 @@
+cimport acados_solver_common
+
+cdef extern from "acados_solver_{{ model.name }}.h":
+    ctypedef struct nlp_solver_capsule:
+        pass
+
+    nlp_solver_capsule * acados_create_capsule "{{ model.name }}_acados_create_capsule"()
+    int acados_free_capsule "{{ model.name }}_acados_free_capsule"(nlp_solver_capsule *capsule)
+
+    int acados_create "{{ model.name }}_acados_create"(nlp_solver_capsule * capsule)
+    int acados_update_params "{{ model.name }}_acados_update_params"(nlp_solver_capsule * capsule, int stage, double *value, int np_)
+    int acados_solve "{{ model.name }}_acados_solve"(nlp_solver_capsule * capsule)
+    int acados_free "{{ model.name }}_acados_free"(nlp_solver_capsule * capsule)
+    void acados_print_stats "{{ model.name }}_acados_print_stats"(nlp_solver_capsule * capsule)
+
+    acados_solver_common.ocp_nlp_in *acados_get_nlp_in "{{ model.name }}_acados_get_nlp_in"(nlp_solver_capsule * capsule)
+    acados_solver_common.ocp_nlp_out *acados_get_nlp_out "{{ model.name }}_acados_get_nlp_out"(nlp_solver_capsule * capsule)
+    acados_solver_common.ocp_nlp_solver *acados_get_nlp_solver "{{ model.name }}_acados_get_nlp_solver"(nlp_solver_capsule * capsule)
+    acados_solver_common.ocp_nlp_config *acados_get_nlp_config "{{ model.name }}_acados_get_nlp_config"(nlp_solver_capsule * capsule)
+    void *acados_get_nlp_opts "{{ model.name }}_acados_get_nlp_opts"(nlp_solver_capsule * capsule)
+    acados_solver_common.ocp_nlp_dims *acados_get_nlp_dims "{{ model.name }}_acados_get_nlp_dims"(nlp_solver_capsule * capsule)
+    acados_solver_common.ocp_nlp_plan *acados_get_nlp_plan "{{ model.name }}_acados_get_nlp_plan"(nlp_solver_capsule * capsule)

--- a/interfaces/acados_template/acados_template/utils.py
+++ b/interfaces/acados_template/acados_template/utils.py
@@ -55,8 +55,11 @@ def get_acados_path():
 
 
 def get_python_interface_path():
-    acados_path = get_acados_path()
-    return os.path.join(acados_path, 'interfaces', 'acados_template', 'acados_template')
+    ACADOS_PYTHON_INTERFACE_PATH = os.environ.get('ACADOS_PYTHON_INTERFACE_PATH')
+    if not ACADOS_PYTHON_INTERFACE_PATH:
+        acados_path = get_acados_path()
+        ACADOS_PYTHON_INTERFACE_PATH = os.path.join(acados_path, 'interfaces', 'acados_template', 'acados_template')
+    return ACADOS_PYTHON_INTERFACE_PATH
 
 
 def get_tera_exec_path():
@@ -268,9 +271,9 @@ def acados_class2dict(class_instance):
 
 
 def get_ocp_nlp_layout():
-    current_module = sys.modules[__name__]
-    acados_path = os.path.dirname(current_module.__file__)
-    with open(acados_path + '/acados_layout.json', 'r') as f:
+    python_interface_path = get_python_interface_path()
+    abs_path = os.path.join(python_interface_path, 'acados_layout.json')
+    with open(abs_path, 'r') as f:
         ocp_nlp_layout = json.load(f)
     return ocp_nlp_layout
 

--- a/interfaces/acados_template/acados_template/utils.py
+++ b/interfaces/acados_template/acados_template/utils.py
@@ -268,9 +268,9 @@ def acados_class2dict(class_instance):
 
 
 def get_ocp_nlp_layout():
-    python_interface_path = get_python_interface_path()
-    abs_path = os.path.join(python_interface_path, 'acados_layout.json')
-    with open(abs_path, 'r') as f:
+    current_module = sys.modules[__name__]
+    acados_path = os.path.dirname(current_module.__file__)
+    with open(acados_path + '/acados_layout.json', 'r') as f:
         ocp_nlp_layout = json.load(f)
     return ocp_nlp_layout
 


### PR DESCRIPTION
This is an alternative approach to a fast python interface, instead of using slices (#735) it uses cython. 

A cython interface is created in `acados_ocp_solver_pyx.pyx` with the same API as `acados_ocp_solver.py`. 
Not using ctypes, and compiling the code, this is much faster than the original python interface, and it should be just as safe.

@FreyJo what do you think about this approach?