### PR TITLE
Fix build=false when creating AcadosOcpSolver

### DIFF
--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -9,6 +9,7 @@ We assume you have: git, make, cmake installed on your system.
 Clone acados and its submodules by running:
 ```
 git clone https://github.com/acados/acados.git
+cd acados
 git submodule update --recursive --init
 ```
 

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -796,20 +796,19 @@ class AcadosOcpSolver:
 
         # dump to json
         ocp_formulation_json_dump(acados_ocp, simulink_opts, json_file)
-
+        
         if build:
           # render templates
           ocp_render_templates(acados_ocp, json_file)
 
           ## Compile solver
-          code_export_dir = acados_ocp.code_export_directory
           cwd=os.getcwd()
-          os.chdir(code_export_dir)
+          os.chdir(acados_ocp.code_export_directory)
           os.system('make clean_ocp_shared_lib')
           os.system('make ocp_shared_lib')
           os.chdir(cwd)
 
-        self.shared_lib_name = f'{code_export_dir}/libacados_ocp_solver_{model.name}.so'
+        self.shared_lib_name = f'{acados_ocp.code_export_directory}/libacados_ocp_solver_{model.name}.so'
 
         # get shared_lib
         self.shared_lib = CDLL(self.shared_lib_name)


### PR DESCRIPTION
The export directory was not set when not building. This commits fixes it.