### PR TITLE
Fix OpenMP segfault and qpDUNES print issue

### DIFF
--- a/acados/ocp_nlp/ocp_nlp_common.c
+++ b/acados/ocp_nlp/ocp_nlp_common.c
@@ -59,8 +59,6 @@
 
 acados_size_t ocp_nlp_config_calculate_size(int N)
 {
-    int ii;
-
     acados_size_t size = 0;
 
     // self
@@ -76,17 +74,17 @@ acados_size_t ocp_nlp_config_calculate_size(int N)
     // dynamics
     size += N * sizeof(ocp_nlp_dynamics_config *);
 
-    for (ii = 0; ii < N; ii++) size += ocp_nlp_dynamics_config_calculate_size();
+    for (int i = 0; i < N; i++) size += ocp_nlp_dynamics_config_calculate_size();
 
     // cost
     size += (N + 1) * sizeof(ocp_nlp_cost_config *);
 
-    for (ii = 0; ii <= N; ii++) size += ocp_nlp_cost_config_calculate_size();
+    for (int i = 0; i <= N; i++) size += ocp_nlp_cost_config_calculate_size();
 
     // constraints
     size += (N + 1) * sizeof(ocp_nlp_constraints_config *);
 
-    for (ii = 0; ii <= N; ii++) size += ocp_nlp_constraints_config_calculate_size();
+    for (int i = 0; i <= N; i++) size += ocp_nlp_constraints_config_calculate_size();
 
     return size;
 }
@@ -95,8 +93,6 @@ acados_size_t ocp_nlp_config_calculate_size(int N)
 
 ocp_nlp_config *ocp_nlp_config_assign(int N, void *raw_memory)
 {
-    int ii;
-
     char *c_ptr = (char *) raw_memory;
 
     ocp_nlp_config *config = (ocp_nlp_config *) c_ptr;
@@ -116,9 +112,9 @@ ocp_nlp_config *ocp_nlp_config_assign(int N, void *raw_memory)
     config->dynamics = (ocp_nlp_dynamics_config **) c_ptr;
     c_ptr += N * sizeof(ocp_nlp_dynamics_config *);
 
-    for (ii = 0; ii < N; ii++)
+    for (int i = 0; i < N; i++)
     {
-        config->dynamics[ii] = ocp_nlp_dynamics_config_assign(c_ptr);
+        config->dynamics[i] = ocp_nlp_dynamics_config_assign(c_ptr);
         c_ptr += ocp_nlp_dynamics_config_calculate_size();
     }
 
@@ -126,9 +122,9 @@ ocp_nlp_config *ocp_nlp_config_assign(int N, void *raw_memory)
     config->cost = (ocp_nlp_cost_config **) c_ptr;
     c_ptr += (N + 1) * sizeof(ocp_nlp_cost_config *);
 
-    for (ii = 0; ii <= N; ii++)
+    for (int i = 0; i <= N; i++)
     {
-        config->cost[ii] = ocp_nlp_cost_config_assign(c_ptr);
+        config->cost[i] = ocp_nlp_cost_config_assign(c_ptr);
         c_ptr += ocp_nlp_cost_config_calculate_size();
     }
 
@@ -136,9 +132,9 @@ ocp_nlp_config *ocp_nlp_config_assign(int N, void *raw_memory)
     config->constraints = (ocp_nlp_constraints_config **) c_ptr;
     c_ptr += (N + 1) * sizeof(ocp_nlp_constraints_config *);
 
-    for (ii = 0; ii <= N; ii++)
+    for (int i = 0; i <= N; i++)
     {
-        config->constraints[ii] = ocp_nlp_constraints_config_assign(c_ptr);
+        config->constraints[i] = ocp_nlp_constraints_config_assign(c_ptr);
         c_ptr += ocp_nlp_constraints_config_calculate_size();
     }
 
@@ -189,23 +185,21 @@ acados_size_t ocp_nlp_dims_calculate_size(void *config_)
 
     int N = config->N;
 
-    int ii;
-
     acados_size_t size = 0;
 
     // self
     size += ocp_nlp_dims_calculate_size_self(N);
 
     // dynamics
-    for (ii = 0; ii < N; ii++)
-        size += config->dynamics[ii]->dims_calculate_size(config->dynamics[ii]);
+    for (int i = 0; i < N; i++)
+        size += config->dynamics[i]->dims_calculate_size(config->dynamics[i]);
 
     // cost
-    for (ii = 0; ii <= N; ii++) size += config->cost[ii]->dims_calculate_size(config->cost[ii]);
+    for (int i = 0; i <= N; i++) size += config->cost[i]->dims_calculate_size(config->cost[i]);
 
     // constraints
-    for (ii = 0; ii <= N; ii++)
-        size += config->constraints[ii]->dims_calculate_size(config->constraints[ii]);
+    for (int i = 0; i <= N; i++)
+        size += config->constraints[i]->dims_calculate_size(config->constraints[i]);
 
     // qp solver
     size += config->qp_solver->dims_calculate_size(config->qp_solver, N);
@@ -218,8 +212,6 @@ acados_size_t ocp_nlp_dims_calculate_size(void *config_)
 static ocp_nlp_dims *ocp_nlp_dims_assign_self(int N, void *raw_memory)
 {
     char *c_ptr = (char *) raw_memory;
-
-    int ii;
 
     // initial align
     align_char_to(8, &c_ptr);
@@ -262,13 +254,13 @@ static ocp_nlp_dims *ocp_nlp_dims_assign_self(int N, void *raw_memory)
 
     /* initialize qp_solver dimensions */
 //    dims->qp_solver->N = N;
-//    for (ii = 0; ii <= N; ii++)
+//    for (int i = 0; i <= N; i++)
 //    {
         // TODO(dimitris): values below are needed for reformulation of QP when soft constraints
         //   are not supported. Make this a bit more transparent as it clushes with nbx/nbu above.
-//        dims->qp_solver->nsbx[ii] = 0;
-//        dims->qp_solver->nsbu[ii] = 0;
-//        dims->qp_solver->nsg[ii] = 0;
+//        dims->qp_solver->nsbx[i] = 0;
+//        dims->qp_solver->nsbu[i] = 0;
+//        dims->qp_solver->nsg[i] = 0;
 //    }
 
     // N
@@ -276,23 +268,23 @@ static ocp_nlp_dims *ocp_nlp_dims_assign_self(int N, void *raw_memory)
 
     // initialize dimensions to zero by default
     // nv
-    for(ii=0; ii<=N; ii++)
-        dims->nv[ii] = 0;
+    for(int i=0; i<=N; i++)
+        dims->nv[i] = 0;
     // nx
-    for(ii=0; ii<=N; ii++)
-        dims->nx[ii] = 0;
+    for(int i=0; i<=N; i++)
+        dims->nx[i] = 0;
     // nu
-    for(ii=0; ii<=N; ii++)
-        dims->nu[ii] = 0;
+    for(int i=0; i<=N; i++)
+        dims->nu[i] = 0;
     // ni
-    for(ii=0; ii<=N; ii++)
-        dims->ni[ii] = 0;
+    for(int i=0; i<=N; i++)
+        dims->ni[i] = 0;
     // nz
-    for(ii=0; ii<=N; ii++)
-        dims->nz[ii] = 0;
+    for(int i=0; i<=N; i++)
+        dims->nz[i] = 0;
     // ns
-    for(ii=0; ii<=N; ii++)
-        dims->ns[ii] = 0;
+    for(int i=0; i<=N; i++)
+        dims->ns[i] = 0;
     // TODO initialize dims to zero by default also in modules !!!!!!!
 
     // assert
@@ -309,8 +301,6 @@ ocp_nlp_dims *ocp_nlp_dims_assign(void *config_, void *raw_memory)
 
     int N = config->N;
 
-    int ii;
-
     char *c_ptr = (char *) raw_memory;
 
     // self
@@ -318,25 +308,25 @@ ocp_nlp_dims *ocp_nlp_dims_assign(void *config_, void *raw_memory)
     c_ptr += ocp_nlp_dims_calculate_size_self(N);
 
     // dynamics
-    for (ii = 0; ii < N; ii++)
+    for (int i = 0; i < N; i++)
     {
-        dims->dynamics[ii] = config->dynamics[ii]->dims_assign(config->dynamics[ii], c_ptr);
-        c_ptr += config->dynamics[ii]->dims_calculate_size(config->dynamics[ii]);
+        dims->dynamics[i] = config->dynamics[i]->dims_assign(config->dynamics[i], c_ptr);
+        c_ptr += config->dynamics[i]->dims_calculate_size(config->dynamics[i]);
     }
 
     // cost
-    for (ii = 0; ii <= N; ii++)
+    for (int i = 0; i <= N; i++)
     {
-        dims->cost[ii] = config->cost[ii]->dims_assign(config->cost[ii], c_ptr);
-        c_ptr += config->cost[ii]->dims_calculate_size(config->cost[ii]);
+        dims->cost[i] = config->cost[i]->dims_assign(config->cost[i], c_ptr);
+        c_ptr += config->cost[i]->dims_calculate_size(config->cost[i]);
     }
 
     // constraints
-    for (ii = 0; ii <= N; ii++)
+    for (int i = 0; i <= N; i++)
     {
-        dims->constraints[ii] =
-            config->constraints[ii]->dims_assign(config->constraints[ii], c_ptr);
-        c_ptr += config->constraints[ii]->dims_calculate_size(config->constraints[ii]);
+        dims->constraints[i] =
+            config->constraints[i]->dims_assign(config->constraints[i], c_ptr);
+        c_ptr += config->constraints[i]->dims_calculate_size(config->constraints[i]);
     }
 
     // qp solver
@@ -358,8 +348,6 @@ void ocp_nlp_dims_set_opt_vars(void *config_, void *dims_, const char *field,
     ocp_nlp_config *config = config_;
     ocp_nlp_dims *dims = dims_;
 
-    int ii;
-
     int N = config->N;
     int *int_array = (int *) value_array;
 
@@ -367,12 +355,12 @@ void ocp_nlp_dims_set_opt_vars(void *config_, void *dims_, const char *field,
     if (!strcmp(field, "nx"))
     {
         // opt var
-        for (ii = 0; ii <= N; ii++)
+        for (int i = 0; i <= N; i++)
         {
             // set nx
-            dims->nx[ii] = int_array[ii];
+            dims->nx[i] = int_array[i];
             // update nv
-            dims->nv[ii] = dims->nu[ii] + dims->nx[ii] + 2 * dims->ns[ii];
+            dims->nv[i] = dims->nu[i] + dims->nx[i] + 2 * dims->ns[i];
         }
         // cost
         for (int i = 0; i <= N; i++)
@@ -403,20 +391,20 @@ void ocp_nlp_dims_set_opt_vars(void *config_, void *dims_, const char *field,
             config->qp_solver->dims_set(config->qp_solver, dims->qp_solver, i, "nx", &int_array[i]);
         }
         // regularization
-        for (ii = 0; ii <= N; ii++)
+        for (int i = 0; i <= N; i++)
         {
-            config->regularize->dims_set(config->regularize, dims->regularize, ii, "nx", &int_array[ii]);
+            config->regularize->dims_set(config->regularize, dims->regularize, i, "nx", &int_array[i]);
         }
     }
     else if (!strcmp(field, "nu"))
     {
         // nlp opt var
-        for (int ii = 0; ii <= N; ii++)
+        for (int i = 0; i <= N; i++)
         {
             // set nu
-            dims->nu[ii] = int_array[ii];
+            dims->nu[i] = int_array[i];
             // update nv
-            dims->nv[ii] = dims->nu[ii] + dims->nx[ii] + 2 * dims->ns[ii];
+            dims->nv[i] = dims->nu[i] + dims->nx[i] + 2 * dims->ns[i];
         }
         // cost
         for (int i = 0; i <= N; i++)
@@ -447,18 +435,18 @@ void ocp_nlp_dims_set_opt_vars(void *config_, void *dims_, const char *field,
             config->qp_solver->dims_set(config->qp_solver, dims->qp_solver, i, "nu", &int_array[i]);
         }
         // regularization
-        for (ii = 0; ii <= N; ii++)
+        for (int i = 0; i <= N; i++)
         {
-            config->regularize->dims_set(config->regularize, dims->regularize, ii, "nu", &int_array[ii]);
+            config->regularize->dims_set(config->regularize, dims->regularize, i, "nu", &int_array[i]);
         }
     }
     else if (!strcmp(field, "nz"))
     {
         // nlp opt var
-        for (int ii = 0; ii <= N; ii++)
+        for (int i = 0; i <= N; i++)
         {
             // set nz
-            dims->nz[ii] = int_array[ii];
+            dims->nz[i] = int_array[i];
         }
         // cost
         for (int i = 0; i <= N; i++)
@@ -482,12 +470,12 @@ void ocp_nlp_dims_set_opt_vars(void *config_, void *dims_, const char *field,
     else if (!strcmp(field, "ns"))
     {
         // nlp opt var
-        for (int ii = 0; ii <= N; ii++)
+        for (int i = 0; i <= N; i++)
         {
             // set ns
-            dims->ns[ii] = int_array[ii];
+            dims->ns[i] = int_array[i];
             // update nv
-            dims->nv[ii] = dims->nu[ii] + dims->nx[ii] + 2 * dims->ns[ii];
+            dims->nv[i] = dims->nu[i] + dims->nx[i] + 2 * dims->ns[i];
         }
         // cost
         for (int i = 0; i <= N; i++)
@@ -686,30 +674,28 @@ acados_size_t ocp_nlp_in_calculate_size_self(int N)
 
 acados_size_t ocp_nlp_in_calculate_size(ocp_nlp_config *config, ocp_nlp_dims *dims)
 {
-    int ii;
-
     int N = dims->N;
 
     acados_size_t size = ocp_nlp_in_calculate_size_self(N);
 
     // dynamics
-    for (ii = 0; ii < N; ii++)
+    for (int i = 0; i < N; i++)
     {
         size +=
-            config->dynamics[ii]->model_calculate_size(config->dynamics[ii], dims->dynamics[ii]);
+            config->dynamics[i]->model_calculate_size(config->dynamics[i], dims->dynamics[i]);
     }
 
     // cost
-    for (ii = 0; ii <= N; ii++)
+    for (int i = 0; i <= N; i++)
     {
-        size += config->cost[ii]->model_calculate_size(config->cost[ii], dims->cost[ii]);
+        size += config->cost[i]->model_calculate_size(config->cost[i], dims->cost[i]);
     }
 
     // constraints
-    for (ii = 0; ii <= N; ii++)
+    for (int i = 0; i <= N; i++)
     {
-        size += config->constraints[ii]->model_calculate_size(config->constraints[ii],
-                                                              dims->constraints[ii]);
+        size += config->constraints[i]->model_calculate_size(config->constraints[i],
+                                                              dims->constraints[i]);
     }
 
     size += 8;  // initial align
@@ -757,8 +743,6 @@ ocp_nlp_in *ocp_nlp_in_assign_self(int N, void *raw_memory)
 
 ocp_nlp_in *ocp_nlp_in_assign(ocp_nlp_config *config, ocp_nlp_dims *dims, void *raw_memory)
 {
-    int ii;
-
     int N = dims->N;
 
     char *c_ptr = (char *) raw_memory;
@@ -768,28 +752,28 @@ ocp_nlp_in *ocp_nlp_in_assign(ocp_nlp_config *config, ocp_nlp_dims *dims, void *
     c_ptr += ocp_nlp_in_calculate_size_self(N);
 
     // dynamics
-    for (ii = 0; ii < N; ii++)
+    for (int i = 0; i < N; i++)
     {
-        in->dynamics[ii] =
-            config->dynamics[ii]->model_assign(config->dynamics[ii], dims->dynamics[ii], c_ptr);
+        in->dynamics[i] =
+            config->dynamics[i]->model_assign(config->dynamics[i], dims->dynamics[i], c_ptr);
         c_ptr +=
-            config->dynamics[ii]->model_calculate_size(config->dynamics[ii], dims->dynamics[ii]);
+            config->dynamics[i]->model_calculate_size(config->dynamics[i], dims->dynamics[i]);
     }
 
     // cost
-    for (ii = 0; ii <= N; ii++)
+    for (int i = 0; i <= N; i++)
     {
-        in->cost[ii] = config->cost[ii]->model_assign(config->cost[ii], dims->cost[ii], c_ptr);
-        c_ptr += config->cost[ii]->model_calculate_size(config->cost[ii], dims->cost[ii]);
+        in->cost[i] = config->cost[i]->model_assign(config->cost[i], dims->cost[i], c_ptr);
+        c_ptr += config->cost[i]->model_calculate_size(config->cost[i], dims->cost[i]);
     }
 
     // constraints
-    for (ii = 0; ii <= N; ii++)
+    for (int i = 0; i <= N; i++)
     {
-        in->constraints[ii] = config->constraints[ii]->model_assign(config->constraints[ii],
-                                                                    dims->constraints[ii], c_ptr);
-        c_ptr += config->constraints[ii]->model_calculate_size(config->constraints[ii],
-                                                               dims->constraints[ii]);
+        in->constraints[i] = config->constraints[i]->model_assign(config->constraints[i],
+                                                                    dims->constraints[i], c_ptr);
+        c_ptr += config->constraints[i]->model_calculate_size(config->constraints[i],
+                                                               dims->constraints[i]);
     }
 
     assert((char *) raw_memory + ocp_nlp_in_calculate_size(config, dims) >= c_ptr);
@@ -818,12 +802,12 @@ acados_size_t ocp_nlp_out_calculate_size(ocp_nlp_config *config, ocp_nlp_dims *d
     size += 4 * (N + 1) * sizeof(struct blasfeo_dvec);  // ux, lam, t, z
     size += 1 * N * sizeof(struct blasfeo_dvec);        // pi
 
-    for (int ii = 0; ii < N; ii++)
+    for (int i = 0; i < N; i++)
     {
-        size += 1 * blasfeo_memsize_dvec(nv[ii]);      // ux
-        size += 1 * blasfeo_memsize_dvec(nz[ii]);      // z
-        size += 2 * blasfeo_memsize_dvec(2 * ni[ii]);  // lam, t
-        size += 1 * blasfeo_memsize_dvec(nx[ii + 1]);  // pi
+        size += 1 * blasfeo_memsize_dvec(nv[i]);      // ux
+        size += 1 * blasfeo_memsize_dvec(nz[i]);      // z
+        size += 2 * blasfeo_memsize_dvec(2 * ni[i]);  // lam, t
+        size += 1 * blasfeo_memsize_dvec(nx[i + 1]);  // pi
     }
     size += 1 * blasfeo_memsize_dvec(nv[N]);      // ux
     size += 1 * blasfeo_memsize_dvec(nz[N]);     // z
@@ -842,9 +826,6 @@ acados_size_t ocp_nlp_out_calculate_size(ocp_nlp_config *config, ocp_nlp_dims *d
 
 ocp_nlp_out *ocp_nlp_out_assign(ocp_nlp_config *config, ocp_nlp_dims *dims, void *raw_memory)
 {
-    // loop index
-    int ii;
-
     // extract sizes
     int N = dims->N;
     int *nv = dims->nv;
@@ -881,45 +862,44 @@ ocp_nlp_out *ocp_nlp_out_assign(ocp_nlp_config *config, ocp_nlp_dims *dims, void
 
     // blasfeo_dvec
     // ux
-    for (int ii = 0; ii <= N; ++ii)
+    for (int i = 0; i <= N; ++i)
     {
-        assign_and_advance_blasfeo_dvec_mem(nv[ii], out->ux + ii, &c_ptr);
+        assign_and_advance_blasfeo_dvec_mem(nv[i], out->ux + i, &c_ptr);
     }
     // z
-    for (int ii = 0; ii <= N; ++ii)
+    for (int i = 0; i <= N; ++i)
     {
-        assign_and_advance_blasfeo_dvec_mem(nz[ii], out->z + ii, &c_ptr);
+        assign_and_advance_blasfeo_dvec_mem(nz[i], out->z + i, &c_ptr);
     }
     // pi
-    for (int ii = 0; ii < N; ++ii)
+    for (int i = 0; i < N; ++i)
     {
-        assign_and_advance_blasfeo_dvec_mem(nx[ii + 1], out->pi + ii, &c_ptr);
+        assign_and_advance_blasfeo_dvec_mem(nx[i + 1], out->pi + i, &c_ptr);
     }
     // lam
-    for (int ii = 0; ii <= N; ++ii)
+    for (int i = 0; i <= N; ++i)
     {
-        assign_and_advance_blasfeo_dvec_mem(2 * ni[ii], out->lam + ii, &c_ptr);
+        assign_and_advance_blasfeo_dvec_mem(2 * ni[i], out->lam + i, &c_ptr);
     }
     // t
-    for (int ii = 0; ii <= N; ++ii)
+    for (int i = 0; i <= N; ++i)
     {
-        assign_and_advance_blasfeo_dvec_mem(2 * ni[ii], out->t + ii, &c_ptr);
+        assign_and_advance_blasfeo_dvec_mem(2 * ni[i], out->t + i, &c_ptr);
     }
 
     // zero solution
-    for(ii=0; ii<N; ii++)
+    for(int i=0; i<N; i++)
     {
-        blasfeo_dvecse(nv[ii], 0.0, out->ux+ii, 0);
-        blasfeo_dvecse(nz[ii], 0.0, out->z+ii, 0);
-        blasfeo_dvecse(nx[ii+1], 0.0, out->pi+ii, 0);
-        blasfeo_dvecse(2*ni[ii], 0.0, out->lam+ii, 0);
-        blasfeo_dvecse(2*ni[ii], 0.0, out->t+ii, 0);
+        blasfeo_dvecse(nv[i], 0.0, out->ux+i, 0);
+        blasfeo_dvecse(nz[i], 0.0, out->z+i, 0);
+        blasfeo_dvecse(nx[i+1], 0.0, out->pi+i, 0);
+        blasfeo_dvecse(2*ni[i], 0.0, out->lam+i, 0);
+        blasfeo_dvecse(2*ni[i], 0.0, out->t+i, 0);
     }
-    ii = N;
-    blasfeo_dvecse(nv[ii], 0.0, out->ux+ii, 0);
-    blasfeo_dvecse(nz[ii], 0.0, out->z+ii, 0);
-    blasfeo_dvecse(2*ni[ii], 0.0, out->lam+ii, 0);
-    blasfeo_dvecse(2*ni[ii], 0.0, out->t+ii, 0);
+    blasfeo_dvecse(nv[N], 0.0, out->ux+N, 0);
+    blasfeo_dvecse(nz[N], 0.0, out->z+N, 0);
+    blasfeo_dvecse(2*ni[N], 0.0, out->lam+N, 0);
+    blasfeo_dvecse(2*ni[N], 0.0, out->t+N, 0);
 
     assert((char *) raw_memory + ocp_nlp_out_calculate_size(config, dims) >= c_ptr);
 
@@ -954,23 +934,23 @@ acados_size_t ocp_nlp_opts_calculate_size(void *config_, void *dims_)
 
     // dynamics
     size += N * sizeof(void *);
-    for (int ii = 0; ii < N; ii++)
+    for (int i = 0; i < N; i++)
     {
-        size += dynamics[ii]->opts_calculate_size(dynamics[ii], dims->dynamics[ii]);
+        size += dynamics[i]->opts_calculate_size(dynamics[i], dims->dynamics[i]);
     }
 
     // cost
     size += (N + 1) * sizeof(void *);
-    for (int ii = 0; ii <= N; ii++)
+    for (int i = 0; i <= N; i++)
     {
-        size += cost[ii]->opts_calculate_size(cost[ii], dims->cost[ii]);
+        size += cost[i]->opts_calculate_size(cost[i], dims->cost[i]);
     }
 
     // constraints
     size += (N + 1) * sizeof(void *);
-    for (int ii = 0; ii <= N; ii++)
+    for (int i = 0; i <= N; i++)
     {
-        size += constraints[ii]->opts_calculate_size(constraints[ii], dims->constraints[ii]);
+        size += constraints[i]->opts_calculate_size(constraints[i], dims->constraints[i]);
     }
 
     size += 2*8;  // 2 aligns
@@ -1018,25 +998,25 @@ void *ocp_nlp_opts_assign(void *config_, void *dims_, void *raw_memory)
     c_ptr += config->regularize->opts_calculate_size();
 
     // dynamics
-    for (int ii = 0; ii < N; ii++)
+    for (int i = 0; i < N; i++)
     {
-        opts->dynamics[ii] = dynamics[ii]->opts_assign(dynamics[ii], dims->dynamics[ii], c_ptr);
-        c_ptr += dynamics[ii]->opts_calculate_size(dynamics[ii], dims->dynamics[ii]);
+        opts->dynamics[i] = dynamics[i]->opts_assign(dynamics[i], dims->dynamics[i], c_ptr);
+        c_ptr += dynamics[i]->opts_calculate_size(dynamics[i], dims->dynamics[i]);
     }
 
     // cost
-    for (int ii = 0; ii <= N; ii++)
+    for (int i = 0; i <= N; i++)
     {
-        opts->cost[ii] = cost[ii]->opts_assign(cost[ii], dims->cost[ii], c_ptr);
-        c_ptr += cost[ii]->opts_calculate_size(cost[ii], dims->cost[ii]);
+        opts->cost[i] = cost[i]->opts_assign(cost[i], dims->cost[i], c_ptr);
+        c_ptr += cost[i]->opts_calculate_size(cost[i], dims->cost[i]);
     }
 
     // constraints
-    for (int ii = 0; ii <= N; ii++)
+    for (int i = 0; i <= N; i++)
     {
-        opts->constraints[ii] =
-            constraints[ii]->opts_assign(constraints[ii], dims->constraints[ii], c_ptr);
-        c_ptr += constraints[ii]->opts_calculate_size(constraints[ii], dims->constraints[ii]);
+        opts->constraints[i] =
+            constraints[i]->opts_assign(constraints[i], dims->constraints[i], c_ptr);
+        c_ptr += constraints[i]->opts_calculate_size(constraints[i], dims->constraints[i]);
     }
 
     assert((char *) raw_memory + ocp_nlp_opts_calculate_size(config, dims) >= c_ptr);
@@ -1057,8 +1037,6 @@ void ocp_nlp_opts_initialize_default(void *config_, void *dims_, void *opts_)
     ocp_nlp_cost_config **cost = config->cost;
     ocp_nlp_constraints_config **constraints = config->constraints;
     ocp_nlp_reg_config *regularize = config->regularize;
-
-    int ii;
 
     int N = dims->N;
 
@@ -1088,21 +1066,21 @@ void ocp_nlp_opts_initialize_default(void *config_, void *dims_, void *opts_)
     regularize->opts_initialize_default(regularize, dims->regularize, opts->regularize);
 
     // dynamics
-    for (ii = 0; ii < N; ii++)
+    for (int i = 0; i < N; i++)
     {
-        dynamics[ii]->opts_initialize_default(dynamics[ii], dims->dynamics[ii], opts->dynamics[ii]);
+        dynamics[i]->opts_initialize_default(dynamics[i], dims->dynamics[i], opts->dynamics[i]);
     }
 
     // cost
-    for (ii = 0; ii <= N; ii++)
+    for (int i = 0; i <= N; i++)
     {
-        cost[ii]->opts_initialize_default(cost[ii], dims->cost[ii], opts->cost[ii]);
+        cost[i]->opts_initialize_default(cost[i], dims->cost[i], opts->cost[i]);
     }
 
     // constraints
-    for (ii = 0; ii <= N; ii++)
+    for (int i = 0; i <= N; i++)
     {
-        constraints[ii]->opts_initialize_default(constraints[ii], dims->constraints[ii], opts->constraints[ii]);
+        constraints[i]->opts_initialize_default(constraints[i], dims->constraints[i], opts->constraints[i]);
     }
 
     // globalization
@@ -1111,7 +1089,7 @@ void ocp_nlp_opts_initialize_default(void *config_, void *dims_, void *opts_)
     opts->full_step_dual = 0;
     opts->line_search_use_sufficient_descent = 0;
     opts->globalization_use_SOC = 0;
-    opts->eps_sufficient_descent = 1e-4; // Leineweber1999: MUSCOD-II eps_T = 1e-4 (p.89); Note: eps_T = 0.1 originally proposed by Powell 1978 (Leineweber 1999, p. 53)
+    opts->eps_sufficient_descent = 1e-4; // Leineweber1999: MUSCOD-I eps_T = 1e-4 (p.89); Note: eps_T = 0.1 originally proposed by Powell 1978 (Leineweber 1999, p. 53)
 
     return;
 }
@@ -1129,28 +1107,26 @@ void ocp_nlp_opts_update(void *config_, void *dims_, void *opts_)
     ocp_nlp_cost_config **cost = config->cost;
     ocp_nlp_constraints_config **constraints = config->constraints;
 
-    int ii;
-
     int N = dims->N;
 
     qp_solver->opts_update(qp_solver, dims->qp_solver, opts->qp_solver_opts);
 
     // dynamics
-    for (ii = 0; ii < N; ii++)
+    for (int i = 0; i < N; i++)
     {
-        dynamics[ii]->opts_update(dynamics[ii], dims->dynamics[ii], opts->dynamics[ii]);
+        dynamics[i]->opts_update(dynamics[i], dims->dynamics[i], opts->dynamics[i]);
     }
 
     // cost
-    for (ii = 0; ii <= N; ii++)
+    for (int i = 0; i <= N; i++)
     {
-        cost[ii]->opts_update(cost[ii], dims->cost[ii], opts->cost[ii]);
+        cost[i]->opts_update(cost[i], dims->cost[i], opts->cost[i]);
     }
 
     // constraints
-    for (ii = 0; ii <= N; ii++)
+    for (int i = 0; i <= N; i++)
     {
-        constraints[ii]->opts_update(constraints[ii], dims->constraints[ii], opts->constraints[ii]);
+        constraints[i]->opts_update(constraints[i], dims->constraints[i], opts->constraints[i]);
     }
 
     return;
@@ -1163,8 +1139,6 @@ void ocp_nlp_opts_set(void *config_, void *opts_, const char *field, void* value
     ocp_nlp_opts *opts = (ocp_nlp_opts *) opts_;
     ocp_nlp_config *config = config_;
 
-    int ii;
-
     char module[MAX_STR_LEN];
     char *ptr_module = NULL;
     int module_length = 0;
@@ -1174,8 +1148,8 @@ void ocp_nlp_opts_set(void *config_, void *opts_, const char *field, void* value
     if (char_!=NULL)
     {
         module_length = char_-field;
-        for (ii=0; ii<module_length; ii++)
-            module[ii] = field[ii];
+        for (int i=0; i<module_length; i++)
+            module[i] = field[i];
         module[module_length] = '\0'; // add end of string
         ptr_module = module;
     }
@@ -1260,36 +1234,36 @@ void ocp_nlp_opts_set(void *config_, void *opts_, const char *field, void* value
         {
             int N = config->N;
             // cost
-            for (ii=0; ii<=N; ii++)
-                config->cost[ii]->opts_set(config->cost[ii], opts->cost[ii], "exact_hess", value);
+            for (int i=0; i<=N; i++)
+                config->cost[i]->opts_set(config->cost[i], opts->cost[i], "exact_hess", value);
             // dynamics
-            for (ii=0; ii<N; ii++)
-                config->dynamics[ii]->opts_set(config->dynamics[ii], opts->dynamics[ii],
+            for (int i=0; i<N; i++)
+                config->dynamics[i]->opts_set(config->dynamics[i], opts->dynamics[i],
                                                "compute_hess", value);
             // constraints
-            for (ii=0; ii<=N; ii++)
-                config->constraints[ii]->opts_set(config->constraints[ii], opts->constraints[ii],
+            for (int i=0; i<=N; i++)
+                config->constraints[i]->opts_set(config->constraints[i], opts->constraints[i],
                                                   "compute_hess", value);
         }
         // selectively turn on exact hessian contributions
         else if (!strcmp(field, "exact_hess_cost"))
         {
             int N = config->N;
-            for (ii=0; ii<=N; ii++)
-                config->cost[ii]->opts_set(config->cost[ii], opts->cost[ii], "exact_hess", value);
+            for (int i=0; i<=N; i++)
+                config->cost[i]->opts_set(config->cost[i], opts->cost[i], "exact_hess", value);
         }
         else if (!strcmp(field, "exact_hess_dyn"))
         {
             int N = config->N;
-            for (ii=0; ii<N; ii++)
-                config->dynamics[ii]->opts_set(config->dynamics[ii], opts->dynamics[ii],
+            for (int i=0; i<N; i++)
+                config->dynamics[i]->opts_set(config->dynamics[i], opts->dynamics[i],
                                                "compute_hess", value);
         }
         else if (!strcmp(field, "exact_hess_constr"))
         {
             int N = config->N;
-            for (ii=0; ii<=N; ii++)
-                config->constraints[ii]->opts_set(config->constraints[ii], opts->constraints[ii],
+            for (int i=0; i<=N; i++)
+                config->constraints[i]->opts_set(config->constraints[i], opts->constraints[i],
                                                   "compute_hess", value);
         }
         else if (!strcmp(field, "print_level"))
@@ -1320,8 +1294,6 @@ void ocp_nlp_opts_set_at_stage(void *config_, void *opts_, int stage, const char
     ocp_nlp_opts *opts = (ocp_nlp_opts *) opts_;
     ocp_nlp_config *config = config_;
 
-    int ii;
-
     char module[MAX_STR_LEN];
     char *ptr_module = NULL;
     int module_length = 0;
@@ -1331,8 +1303,8 @@ void ocp_nlp_opts_set_at_stage(void *config_, void *opts_, int stage, const char
     if (char_!=NULL)
     {
         module_length = char_-field;
-        for (ii=0; ii<module_length; ii++)
-            module[ii] = field[ii];
+        for (int i=0; i<module_length; i++)
+            module[i] = field[i];
         module[module_length] = '\0'; // add end of string
         ptr_module = module;
     }
@@ -1402,23 +1374,23 @@ acados_size_t ocp_nlp_memory_calculate_size(ocp_nlp_config *config, ocp_nlp_dims
 
     // dynamics
     size += N * sizeof(void *);
-    for (int ii = 0; ii < N; ii++)
+    for (int i = 0; i < N; i++)
     {
-        size += dynamics[ii]->memory_calculate_size(dynamics[ii], dims->dynamics[ii], opts->dynamics[ii]);
+        size += dynamics[i]->memory_calculate_size(dynamics[i], dims->dynamics[i], opts->dynamics[i]);
     }
 
     // cost
     size += (N + 1) * sizeof(void *);
-    for (int ii = 0; ii <= N; ii++)
+    for (int i = 0; i <= N; i++)
     {
-        size += cost[ii]->memory_calculate_size(cost[ii], dims->cost[ii], opts->cost[ii]);
+        size += cost[i]->memory_calculate_size(cost[i], dims->cost[i], opts->cost[i]);
     }
 
     // constraints
     size += (N + 1) * sizeof(void *);
-    for (int ii = 0; ii <= N; ii++)
+    for (int i = 0; i <= N; i++)
     {
-        size += constraints[ii]->memory_calculate_size(constraints[ii], dims->constraints[ii], opts->constraints[ii]);
+        size += constraints[i]->memory_calculate_size(constraints[i], dims->constraints[i], opts->constraints[i]);
     }
 
     // nlp res
@@ -1430,15 +1402,15 @@ acados_size_t ocp_nlp_memory_calculate_size(ocp_nlp_config *config, ocp_nlp_dims
     size += 6*(N+1)*sizeof(struct blasfeo_dvec);  // cost_grad ineq_fun ineq_adj dyn_adj sim_guess z_alg
     size += 1*N*sizeof(struct blasfeo_dvec);        // dyn_fun
 
-    for (int ii = 0; ii < N; ii++)
+    for (int i = 0; i < N; i++)
     {
-        size += 1*blasfeo_memsize_dmat(nu[ii]+nx[ii], nz[ii]); // dzduxt
-        size += 1*blasfeo_memsize_dvec(nz[ii]); // z_alg
-        size += 2*blasfeo_memsize_dvec(nv[ii]);           // cost_grad ineq_adj
-        size += 1*blasfeo_memsize_dvec(nu[ii] + nx[ii]);  // dyn_adj
-        size += 1*blasfeo_memsize_dvec(nx[ii + 1]);       // dyn_fun
-        size += 1*blasfeo_memsize_dvec(2 * ni[ii]);       // ineq_fun
-        size += 1*blasfeo_memsize_dvec(nx[ii] + nz[ii]); // sim_guess
+        size += 1*blasfeo_memsize_dmat(nu[i]+nx[i], nz[i]); // dzduxt
+        size += 1*blasfeo_memsize_dvec(nz[i]); // z_alg
+        size += 2*blasfeo_memsize_dvec(nv[i]);           // cost_grad ineq_adj
+        size += 1*blasfeo_memsize_dvec(nu[i] + nx[i]);  // dyn_adj
+        size += 1*blasfeo_memsize_dvec(nx[i + 1]);       // dyn_fun
+        size += 1*blasfeo_memsize_dvec(2 * ni[i]);       // ineq_fun
+        size += 1*blasfeo_memsize_dvec(nx[i] + nz[i]); // sim_guess
     }
     size += 1*blasfeo_memsize_dmat(nu[N]+nx[N], nz[N]); // dzduxt
     size += 1*blasfeo_memsize_dvec(nz[N]); // z_alg
@@ -1519,26 +1491,26 @@ ocp_nlp_memory *ocp_nlp_memory_assign(ocp_nlp_config *config, ocp_nlp_dims *dims
                                                        opts->regularize);
 
     // dynamics
-    for (int ii = 0; ii < N; ii++)
+    for (int i = 0; i < N; i++)
     {
-        mem->dynamics[ii] = dynamics[ii]->memory_assign(dynamics[ii], dims->dynamics[ii], opts->dynamics[ii], c_ptr);
-        c_ptr += dynamics[ii]->memory_calculate_size(dynamics[ii], dims->dynamics[ii], opts->dynamics[ii]);
+        mem->dynamics[i] = dynamics[i]->memory_assign(dynamics[i], dims->dynamics[i], opts->dynamics[i], c_ptr);
+        c_ptr += dynamics[i]->memory_calculate_size(dynamics[i], dims->dynamics[i], opts->dynamics[i]);
     }
 
     // cost
-    for (int ii = 0; ii <= N; ii++)
+    for (int i = 0; i <= N; i++)
     {
-        mem->cost[ii] = cost[ii]->memory_assign(cost[ii], dims->cost[ii], opts->cost[ii], c_ptr);
-        c_ptr += cost[ii]->memory_calculate_size(cost[ii], dims->cost[ii], opts->cost[ii]);
+        mem->cost[i] = cost[i]->memory_assign(cost[i], dims->cost[i], opts->cost[i], c_ptr);
+        c_ptr += cost[i]->memory_calculate_size(cost[i], dims->cost[i], opts->cost[i]);
     }
 
     // constraints
-    for (int ii = 0; ii <= N; ii++)
+    for (int i = 0; i <= N; i++)
     {
-        mem->constraints[ii] = constraints[ii]->memory_assign(constraints[ii],
-                                            dims->constraints[ii], opts->constraints[ii], c_ptr);
-        c_ptr += constraints[ii]->memory_calculate_size( constraints[ii], dims->constraints[ii],
-                                                                 opts->constraints[ii]);
+        mem->constraints[i] = constraints[i]->memory_assign(constraints[i],
+                                            dims->constraints[i], opts->constraints[i], c_ptr);
+        c_ptr += constraints[i]->memory_calculate_size( constraints[i], dims->constraints[i],
+                                                                 opts->constraints[i]);
     }
 
     // nlp res
@@ -1568,58 +1540,58 @@ ocp_nlp_memory *ocp_nlp_memory_assign(ocp_nlp_config *config, ocp_nlp_dims *dims
 
     // set_sim_guess
     assign_and_advance_bool(N+1, &mem->set_sim_guess, &c_ptr);
-    for (int ii = 0; ii <= N; ++ii)
+    for (int i = 0; i <= N; ++i)
     {
-        mem->set_sim_guess[ii] = false;
+        mem->set_sim_guess[i] = false;
     }
 
     // blasfeo_mem align
     align_char_to(64, &c_ptr);
 
     // dzduxt
-    for (int ii=0; ii<=N; ii++)
+    for (int i=0; i<=N; i++)
     {
-        assign_and_advance_blasfeo_dmat_mem(nu[ii]+nx[ii], nz[ii], mem->dzduxt+ii, &c_ptr);
+        assign_and_advance_blasfeo_dmat_mem(nu[i]+nx[i], nz[i], mem->dzduxt+i, &c_ptr);
     }
     // z_alg
-    for (int ii=0; ii<=N; ii++)
+    for (int i=0; i<=N; i++)
     {
-        blasfeo_create_dvec(nz[ii], mem->z_alg+ii, c_ptr);
-        c_ptr += blasfeo_memsize_dvec(nz[ii]);
+        blasfeo_create_dvec(nz[i], mem->z_alg+i, c_ptr);
+        c_ptr += blasfeo_memsize_dvec(nz[i]);
     }
 
     // cost_grad
-    for (int ii = 0; ii <= N; ii++)
+    for (int i = 0; i <= N; i++)
     {
-        assign_and_advance_blasfeo_dvec_mem(nv[ii], mem->cost_grad + ii, &c_ptr);
+        assign_and_advance_blasfeo_dvec_mem(nv[i], mem->cost_grad + i, &c_ptr);
     }
     // ineq_fun
-    for (int ii = 0; ii <= N; ii++)
+    for (int i = 0; i <= N; i++)
     {
-        assign_and_advance_blasfeo_dvec_mem(2 * ni[ii], mem->ineq_fun + ii, &c_ptr);
+        assign_and_advance_blasfeo_dvec_mem(2 * ni[i], mem->ineq_fun + i, &c_ptr);
     }
     // ineq_adj
-    for (int ii = 0; ii <= N; ii++)
+    for (int i = 0; i <= N; i++)
     {
-        assign_and_advance_blasfeo_dvec_mem(nv[ii], mem->ineq_adj + ii, &c_ptr);
+        assign_and_advance_blasfeo_dvec_mem(nv[i], mem->ineq_adj + i, &c_ptr);
     }
     // dyn_fun
-    for (int ii = 0; ii < N; ii++)
+    for (int i = 0; i < N; i++)
     {
-        assign_and_advance_blasfeo_dvec_mem(nx[ii + 1], mem->dyn_fun + ii, &c_ptr);
+        assign_and_advance_blasfeo_dvec_mem(nx[i + 1], mem->dyn_fun + i, &c_ptr);
     }
     // dyn_adj
-    for (int ii = 0; ii <= N; ii++)
+    for (int i = 0; i <= N; i++)
     {
-        assign_and_advance_blasfeo_dvec_mem(nu[ii] + nx[ii], mem->dyn_adj + ii, &c_ptr);
+        assign_and_advance_blasfeo_dvec_mem(nu[i] + nx[i], mem->dyn_adj + i, &c_ptr);
     }
     // sim_guess
-    for (int ii = 0; ii <= N; ii++)
+    for (int i = 0; i <= N; i++)
     {
-        assign_and_advance_blasfeo_dvec_mem(nx[ii] + nz[ii], mem->sim_guess + ii, &c_ptr);
+        assign_and_advance_blasfeo_dvec_mem(nx[i] + nz[i], mem->sim_guess + i, &c_ptr);
         // set to 0;
-        blasfeo_dvecse(nx[ii] + nz[ii], 0.0, mem->sim_guess+ii, 0);
-        // printf("sim_guess ii %d: %p\n", ii, mem->sim_guess+ii);
+        blasfeo_dvecse(nx[i] + nz[i], 0.0, mem->sim_guess+i, 0);
+        // printf("sim_guess i %d: %p\n", i, mem->sim_guess+i);
     }
     // printf("created memory %p\n", mem);
 
@@ -1638,8 +1610,6 @@ acados_size_t ocp_nlp_workspace_calculate_size(ocp_nlp_config *config, ocp_nlp_d
     ocp_nlp_dynamics_config **dynamics = config->dynamics;
     ocp_nlp_cost_config **cost = config->cost;
     ocp_nlp_constraints_config **constraints = config->constraints;
-
-    int ii;
 
     int N = dims->N;
     int *nx = dims->nx;
@@ -1662,11 +1632,11 @@ acados_size_t ocp_nlp_workspace_calculate_size(ocp_nlp_config *config, ocp_nlp_d
     int nxu_max = 0;
     int nx_max = 0;
     int ni_max = 0;
-    for (int ii = 0; ii <= N; ii++)
+    for (int i = 0; i <= N; i++)
     {
-        nx_max = nx_max > nx[ii] ? nx_max : nx[ii];
-        nxu_max = nxu_max > (nx[ii]+nu[ii]) ? nxu_max : (nx[ii]+nu[ii]);
-        ni_max = ni_max > ni[ii] ? ni_max : ni[ii];
+        nx_max = nx_max > nx[i] ? nx_max : nx[i];
+        nxu_max = nxu_max > (nx[i]+nu[i]) ? nxu_max : (nx[i]+nu[i]);
+        ni_max = ni_max > ni[i] ? ni_max : ni[i];
     }
     size += 1 * blasfeo_memsize_dvec(nx_max);
     size += 1 * blasfeo_memsize_dvec(nxu_max);
@@ -1691,21 +1661,21 @@ acados_size_t ocp_nlp_workspace_calculate_size(ocp_nlp_config *config, ocp_nlp_d
             opts->qp_solver_opts);
 
         // dynamics
-        for (ii = 0; ii < N; ii++)
+        for (int i = 0; i < N; i++)
         {
-            size += dynamics[ii]->workspace_calculate_size(dynamics[ii], dims->dynamics[ii], opts->dynamics[ii]);
+            size += dynamics[i]->workspace_calculate_size(dynamics[i], dims->dynamics[i], opts->dynamics[i]);
         }
 
         // cost
-        for (ii = 0; ii <= N; ii++)
+        for (int i = 0; i <= N; i++)
         {
-            size += cost[ii]->workspace_calculate_size(cost[ii], dims->cost[ii], opts->cost[ii]);
+            size += cost[i]->workspace_calculate_size(cost[i], dims->cost[i], opts->cost[i]);
         }
 
         // constraints
-        for (ii = 0; ii <= N; ii++)
+        for (int i = 0; i <= N; i++)
         {
-            size += constraints[ii]->workspace_calculate_size(constraints[ii], dims->constraints[ii], opts->constraints[ii]);
+            size += constraints[i]->workspace_calculate_size(constraints[i], dims->constraints[i], opts->constraints[i]);
         }
 
 #else
@@ -1717,23 +1687,23 @@ acados_size_t ocp_nlp_workspace_calculate_size(ocp_nlp_config *config, ocp_nlp_d
         size_tmp = tmp > size_tmp ? tmp : size_tmp;
 
         // dynamics
-        for (ii = 0; ii < N; ii++)
+        for (int i = 0; i < N; i++)
         {
-            tmp = dynamics[ii]->workspace_calculate_size(dynamics[ii], dims->dynamics[ii], opts->dynamics[ii]);
+            tmp = dynamics[i]->workspace_calculate_size(dynamics[i], dims->dynamics[i], opts->dynamics[i]);
             size_tmp = tmp > size_tmp ? tmp : size_tmp;
         }
 
         // cost
-        for (ii = 0; ii <= N; ii++)
+        for (int i = 0; i <= N; i++)
         {
-            tmp = cost[ii]->workspace_calculate_size(cost[ii], dims->cost[ii], opts->cost[ii]);
+            tmp = cost[i]->workspace_calculate_size(cost[i], dims->cost[i], opts->cost[i]);
             size_tmp = tmp > size_tmp ? tmp : size_tmp;
         }
 
         // constraints
-        for (ii = 0; ii <= N; ii++)
+        for (int i = 0; i <= N; i++)
         {
-            tmp = constraints[ii]->workspace_calculate_size(constraints[ii], dims->constraints[ii], opts->constraints[ii]);
+            tmp = constraints[i]->workspace_calculate_size(constraints[i], dims->constraints[i], opts->constraints[i]);
             size_tmp = tmp > size_tmp ? tmp : size_tmp;
         }
 
@@ -1750,21 +1720,21 @@ acados_size_t ocp_nlp_workspace_calculate_size(ocp_nlp_config *config, ocp_nlp_d
             opts->qp_solver_opts);
 
         // dynamics
-        for (ii = 0; ii < N; ii++)
+        for (int i = 0; i < N; i++)
         {
-            size += dynamics[ii]->workspace_calculate_size(dynamics[ii], dims->dynamics[ii], opts->dynamics[ii]);
+            size += dynamics[i]->workspace_calculate_size(dynamics[i], dims->dynamics[i], opts->dynamics[i]);
         }
 
         // cost
-        for (ii = 0; ii <= N; ii++)
+        for (int i = 0; i <= N; i++)
         {
-            size += cost[ii]->workspace_calculate_size(cost[ii], dims->cost[ii], opts->cost[ii]);
+            size += cost[i]->workspace_calculate_size(cost[i], dims->cost[i], opts->cost[i]);
         }
 
         // constraints
-        for (ii = 0; ii <= N; ii++)
+        for (int i = 0; i <= N; i++)
         {
-            size += constraints[ii]->workspace_calculate_size(constraints[ii], dims->constraints[ii], opts->constraints[ii]);
+            size += constraints[i]->workspace_calculate_size(constraints[i], dims->constraints[i], opts->constraints[i]);
         }
 
     }
@@ -1821,11 +1791,11 @@ ocp_nlp_workspace *ocp_nlp_workspace_assign(ocp_nlp_config *config, ocp_nlp_dims
     int nxu_max = 0;
     int nx_max = 0;
     int ni_max = 0;
-    for (int ii = 0; ii <= N; ii++)
+    for (int i = 0; i <= N; i++)
     {
-        nx_max = nx_max > nx[ii] ? nx_max : nx[ii];
-        nxu_max = nxu_max > (nx[ii]+nu[ii]) ? nxu_max : (nx[ii]+nu[ii]);
-        ni_max = ni_max > ni[ii] ? ni_max : ni[ii];
+        nx_max = nx_max > nx[i] ? nx_max : nx[i];
+        nxu_max = nxu_max > (nx[i]+nu[i]) ? nxu_max : (nx[i]+nu[i]);
+        ni_max = ni_max > ni[i] ? ni_max : ni[i];
     }
     assign_and_advance_blasfeo_dvec_mem(nxu_max, &work->tmp_nxu, &c_ptr);
     assign_and_advance_blasfeo_dvec_mem(ni_max, &work->tmp_ni, &c_ptr);
@@ -1841,24 +1811,24 @@ ocp_nlp_workspace *ocp_nlp_workspace_assign(ocp_nlp_config *config, ocp_nlp_dims
         c_ptr += qp_solver->workspace_calculate_size(qp_solver, dims->qp_solver, opts->qp_solver_opts);
 
         // dynamics
-        for (int ii = 0; ii < N; ii++)
+        for (int i = 0; i < N; i++)
         {
-            work->dynamics[ii] = c_ptr;
-            c_ptr += dynamics[ii]->workspace_calculate_size(dynamics[ii], dims->dynamics[ii], opts->dynamics[ii]);
+            work->dynamics[i] = c_ptr;
+            c_ptr += dynamics[i]->workspace_calculate_size(dynamics[i], dims->dynamics[i], opts->dynamics[i]);
         }
 
         // cost
-        for (int ii = 0; ii <= N; ii++)
+        for (int i = 0; i <= N; i++)
         {
-            work->cost[ii] = c_ptr;
-            c_ptr += cost[ii]->workspace_calculate_size(cost[ii], dims->cost[ii], opts->cost[ii]);
+            work->cost[i] = c_ptr;
+            c_ptr += cost[i]->workspace_calculate_size(cost[i], dims->cost[i], opts->cost[i]);
         }
 
         // constraints
-        for (int ii = 0; ii <= N; ii++)
+        for (int i = 0; i <= N; i++)
         {
-            work->constraints[ii] = c_ptr;
-            c_ptr += constraints[ii]->workspace_calculate_size(constraints[ii], dims->constraints[ii], opts->constraints[ii]);
+            work->constraints[i] = c_ptr;
+            c_ptr += constraints[i]->workspace_calculate_size(constraints[i], dims->constraints[i], opts->constraints[i]);
         }
 
 #else
@@ -1872,26 +1842,26 @@ ocp_nlp_workspace *ocp_nlp_workspace_assign(ocp_nlp_config *config, ocp_nlp_dims
         size_tmp = tmp > size_tmp ? tmp : size_tmp;
 
         // dynamics
-        for (int ii = 0; ii < N; ii++)
+        for (int i = 0; i < N; i++)
         {
-            work->dynamics[ii] = c_ptr;
-            tmp = dynamics[ii]->workspace_calculate_size(dynamics[ii], dims->dynamics[ii], opts->dynamics[ii]);
+            work->dynamics[i] = c_ptr;
+            tmp = dynamics[i]->workspace_calculate_size(dynamics[i], dims->dynamics[i], opts->dynamics[i]);
             size_tmp = tmp > size_tmp ? tmp : size_tmp;
         }
 
         // cost
-        for (int ii = 0; ii <= N; ii++)
+        for (int i = 0; i <= N; i++)
         {
-            work->cost[ii] = c_ptr;
-            tmp = cost[ii]->workspace_calculate_size(cost[ii], dims->cost[ii], opts->cost[ii]);
+            work->cost[i] = c_ptr;
+            tmp = cost[i]->workspace_calculate_size(cost[i], dims->cost[i], opts->cost[i]);
             size_tmp = tmp > size_tmp ? tmp : size_tmp;
         }
 
         // constraints
-        for (int ii = 0; ii <= N; ii++)
+        for (int i = 0; i <= N; i++)
         {
-            work->constraints[ii] = c_ptr;
-            tmp = constraints[ii]->workspace_calculate_size(constraints[ii], dims->constraints[ii], opts->constraints[ii]);
+            work->constraints[i] = c_ptr;
+            tmp = constraints[i]->workspace_calculate_size(constraints[i], dims->constraints[i], opts->constraints[i]);
             size_tmp = tmp > size_tmp ? tmp : size_tmp;
         }
 
@@ -1909,24 +1879,24 @@ ocp_nlp_workspace *ocp_nlp_workspace_assign(ocp_nlp_config *config, ocp_nlp_dims
             opts->qp_solver_opts);
 
         // dynamics
-        for (int ii = 0; ii < N; ii++)
+        for (int i = 0; i < N; i++)
         {
-            work->dynamics[ii] = c_ptr;
-            c_ptr += dynamics[ii]->workspace_calculate_size(dynamics[ii], dims->dynamics[ii], opts->dynamics[ii]);
+            work->dynamics[i] = c_ptr;
+            c_ptr += dynamics[i]->workspace_calculate_size(dynamics[i], dims->dynamics[i], opts->dynamics[i]);
         }
 
         // cost
-        for (int ii = 0; ii <= N; ii++)
+        for (int i = 0; i <= N; i++)
         {
-            work->cost[ii] = c_ptr;
-            c_ptr += cost[ii]->workspace_calculate_size(cost[ii], dims->cost[ii], opts->cost[ii]);
+            work->cost[i] = c_ptr;
+            c_ptr += cost[i]->workspace_calculate_size(cost[i], dims->cost[i], opts->cost[i]);
         }
 
         // constraints
-        for (int ii = 0; ii <= N; ii++)
+        for (int i = 0; i <= N; i++)
         {
-            work->constraints[ii] = c_ptr;
-            c_ptr += constraints[ii]->workspace_calculate_size(constraints[ii], dims->constraints[ii], opts->constraints[ii]);
+            work->constraints[i] = c_ptr;
+            c_ptr += constraints[i]->workspace_calculate_size(constraints[i], dims->constraints[i], opts->constraints[i]);
         }
 
     }
@@ -1950,59 +1920,63 @@ void ocp_nlp_alias_memory_to_submodules(ocp_nlp_config *config, ocp_nlp_dims *di
     { // beginning of parallel region
 #endif
 
-    int ii;
     int N = dims->N;
 
     // alias to dynamics_memory
 #if defined(ACADOS_WITH_OPENMP)
     #pragma omp for nowait
 #endif
-    for (ii = 0; ii < N; ii++)
+    for (int i = 0; i < N; i++)
     {
-        config->dynamics[ii]->memory_set_ux_ptr(nlp_out->ux+ii, nlp_mem->dynamics[ii]);
-        config->dynamics[ii]->memory_set_tmp_ux_ptr(nlp_work->tmp_nlp_out->ux+ii, nlp_mem->dynamics[ii]);
-        config->dynamics[ii]->memory_set_ux1_ptr(nlp_out->ux+ii+1, nlp_mem->dynamics[ii]);
-        config->dynamics[ii]->memory_set_tmp_ux1_ptr(nlp_work->tmp_nlp_out->ux+ii+1, nlp_mem->dynamics[ii]);
-        config->dynamics[ii]->memory_set_pi_ptr(nlp_out->pi+ii, nlp_mem->dynamics[ii]);
-        config->dynamics[ii]->memory_set_tmp_pi_ptr(nlp_work->tmp_nlp_out->pi+ii, nlp_mem->dynamics[ii]);
-        config->dynamics[ii]->memory_set_BAbt_ptr(nlp_mem->qp_in->BAbt+ii, nlp_mem->dynamics[ii]);
-        config->dynamics[ii]->memory_set_RSQrq_ptr(nlp_mem->qp_in->RSQrq+ii, nlp_mem->dynamics[ii]);
-        config->dynamics[ii]->memory_set_dzduxt_ptr(nlp_mem->dzduxt+ii, nlp_mem->dynamics[ii]);
-        config->dynamics[ii]->memory_set_sim_guess_ptr(nlp_mem->sim_guess+ii, nlp_mem->set_sim_guess+ii, nlp_mem->dynamics[ii]);
-        config->dynamics[ii]->memory_set_z_alg_ptr(nlp_mem->z_alg+ii, nlp_mem->dynamics[ii]);
+        config->dynamics[i]->memory_set_ux_ptr(nlp_out->ux+i, nlp_mem->dynamics[i]);
+        config->dynamics[i]->memory_set_tmp_ux_ptr(nlp_work->tmp_nlp_out->ux+i, nlp_mem->dynamics[i]);
+        config->dynamics[i]->memory_set_ux1_ptr(nlp_out->ux+i+1, nlp_mem->dynamics[i]);
+        config->dynamics[i]->memory_set_tmp_ux1_ptr(nlp_work->tmp_nlp_out->ux+i+1, nlp_mem->dynamics[i]);
+        config->dynamics[i]->memory_set_pi_ptr(nlp_out->pi+i, nlp_mem->dynamics[i]);
+        config->dynamics[i]->memory_set_tmp_pi_ptr(nlp_work->tmp_nlp_out->pi+i, nlp_mem->dynamics[i]);
+        config->dynamics[i]->memory_set_BAbt_ptr(nlp_mem->qp_in->BAbt+i, nlp_mem->dynamics[i]);
+        config->dynamics[i]->memory_set_RSQrq_ptr(nlp_mem->qp_in->RSQrq+i, nlp_mem->dynamics[i]);
+        config->dynamics[i]->memory_set_dzduxt_ptr(nlp_mem->dzduxt+i, nlp_mem->dynamics[i]);
+        config->dynamics[i]->memory_set_sim_guess_ptr(nlp_mem->sim_guess+i, nlp_mem->set_sim_guess+i, nlp_mem->dynamics[i]);
+        config->dynamics[i]->memory_set_z_alg_ptr(nlp_mem->z_alg+i, nlp_mem->dynamics[i]);
     }
-
+#pragma omp parallel for
+    for (int i = 0; i < N; i++)
+    {
+        i+=1;
+    }
+    
     // alias to cost_memory
 #if defined(ACADOS_WITH_OPENMP)
     #pragma omp for nowait
 #endif
-    for (ii = 0; ii <= N; ii++)
+    for (int i = 0; i <= N; i++)
     {
-        config->cost[ii]->memory_set_ux_ptr(nlp_out->ux+ii, nlp_mem->cost[ii]);
-        config->cost[ii]->memory_set_tmp_ux_ptr(nlp_work->tmp_nlp_out->ux+ii, nlp_mem->cost[ii]);
-        config->cost[ii]->memory_set_z_alg_ptr(nlp_mem->z_alg+ii, nlp_mem->cost[ii]);
-        config->cost[ii]->memory_set_dzdux_tran_ptr(nlp_mem->dzduxt+ii, nlp_mem->cost[ii]);
-        config->cost[ii]->memory_set_RSQrq_ptr(nlp_mem->qp_in->RSQrq+ii, nlp_mem->cost[ii]);
-        config->cost[ii]->memory_set_Z_ptr(nlp_mem->qp_in->Z+ii, nlp_mem->cost[ii]);
+        config->cost[i]->memory_set_ux_ptr(nlp_out->ux+i, nlp_mem->cost[i]);
+        config->cost[i]->memory_set_tmp_ux_ptr(nlp_work->tmp_nlp_out->ux+i, nlp_mem->cost[i]);
+        config->cost[i]->memory_set_z_alg_ptr(nlp_mem->z_alg+i, nlp_mem->cost[i]);
+        config->cost[i]->memory_set_dzdux_tran_ptr(nlp_mem->dzduxt+i, nlp_mem->cost[i]);
+        config->cost[i]->memory_set_RSQrq_ptr(nlp_mem->qp_in->RSQrq+i, nlp_mem->cost[i]);
+        config->cost[i]->memory_set_Z_ptr(nlp_mem->qp_in->Z+i, nlp_mem->cost[i]);
     }
 
     // alias to constraints_memory
 #if defined(ACADOS_WITH_OPENMP)
     #pragma omp for nowait
 #endif
-    for (ii = 0; ii <= N; ii++)
+    for (int i = 0; i <= N; i++)
     {
-        config->constraints[ii]->memory_set_ux_ptr(nlp_out->ux+ii, nlp_mem->constraints[ii]);
-        config->constraints[ii]->memory_set_tmp_ux_ptr(nlp_work->tmp_nlp_out->ux+ii, nlp_mem->constraints[ii]);
-        config->constraints[ii]->memory_set_lam_ptr(nlp_out->lam+ii, nlp_mem->constraints[ii]);
-        config->constraints[ii]->memory_set_tmp_lam_ptr(nlp_work->tmp_nlp_out->lam+ii, nlp_mem->constraints[ii]);
-        config->constraints[ii]->memory_set_z_alg_ptr(nlp_mem->z_alg+ii, nlp_mem->constraints[ii]);
-        config->constraints[ii]->memory_set_dzdux_tran_ptr(nlp_mem->dzduxt+ii, nlp_mem->constraints[ii]);
-        config->constraints[ii]->memory_set_DCt_ptr(nlp_mem->qp_in->DCt+ii, nlp_mem->constraints[ii]);
-        config->constraints[ii]->memory_set_RSQrq_ptr(nlp_mem->qp_in->RSQrq+ii, nlp_mem->constraints[ii]);
-        config->constraints[ii]->memory_set_idxb_ptr(nlp_mem->qp_in->idxb[ii], nlp_mem->constraints[ii]);
-        config->constraints[ii]->memory_set_idxs_rev_ptr(nlp_mem->qp_in->idxs_rev[ii], nlp_mem->constraints[ii]);
-        config->constraints[ii]->memory_set_idxe_ptr(nlp_mem->qp_in->idxe[ii], nlp_mem->constraints[ii]);
+        config->constraints[i]->memory_set_ux_ptr(nlp_out->ux+i, nlp_mem->constraints[i]);
+        config->constraints[i]->memory_set_tmp_ux_ptr(nlp_work->tmp_nlp_out->ux+i, nlp_mem->constraints[i]);
+        config->constraints[i]->memory_set_lam_ptr(nlp_out->lam+i, nlp_mem->constraints[i]);
+        config->constraints[i]->memory_set_tmp_lam_ptr(nlp_work->tmp_nlp_out->lam+i, nlp_mem->constraints[i]);
+        config->constraints[i]->memory_set_z_alg_ptr(nlp_mem->z_alg+i, nlp_mem->constraints[i]);
+        config->constraints[i]->memory_set_dzdux_tran_ptr(nlp_mem->dzduxt+i, nlp_mem->constraints[i]);
+        config->constraints[i]->memory_set_DCt_ptr(nlp_mem->qp_in->DCt+i, nlp_mem->constraints[i]);
+        config->constraints[i]->memory_set_RSQrq_ptr(nlp_mem->qp_in->RSQrq+i, nlp_mem->constraints[i]);
+        config->constraints[i]->memory_set_idxb_ptr(nlp_mem->qp_in->idxb[i], nlp_mem->constraints[i]);
+        config->constraints[i]->memory_set_idxs_rev_ptr(nlp_mem->qp_in->idxs_rev[i], nlp_mem->constraints[i]);
+        config->constraints[i]->memory_set_idxe_ptr(nlp_mem->qp_in->idxe[i], nlp_mem->constraints[i]);
     }
 
     // alias to regularize memory
@@ -2022,10 +1996,10 @@ void ocp_nlp_alias_memory_to_submodules(ocp_nlp_config *config, ocp_nlp_dims *di
 #endif
     // NOTE(oj): this will lead in an error for irk_gnsf, T must be set in precompute;
     //    -> remove here and make sure precompute is called everywhere (e.g. Python interface).
-    for (ii = 0; ii < N; ii++)
+    for (int i = 0; i < N; i++)
     {
-        config->dynamics[ii]->model_set(config->dynamics[ii], dims->dynamics[ii],
-                                         nlp_in->dynamics[ii], "T", nlp_in->Ts+ii);
+        config->dynamics[i]->model_set(config->dynamics[i], dims->dynamics[i],
+                                         nlp_in->dynamics[i], "T", nlp_in->Ts+i);
     }
 
 #if defined(ACADOS_WITH_OPENMP)
@@ -2039,26 +2013,23 @@ void ocp_nlp_alias_memory_to_submodules(ocp_nlp_config *config, ocp_nlp_dims *di
 void ocp_nlp_initialize_qp(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in,
          ocp_nlp_out *out, ocp_nlp_opts *opts, ocp_nlp_memory *mem, ocp_nlp_workspace *work)
 {
-
-    int ii;
-
     int N = dims->N;
 
 #if defined(ACADOS_WITH_OPENMP)
     #pragma omp parallel for
 #endif
-    for (ii = 0; ii <= N; ii++)
+    for (int i = 0; i <= N; i++)
     {
         // cost
-        config->cost[ii]->initialize(config->cost[ii], dims->cost[ii], in->cost[ii],
-                opts->cost[ii], mem->cost[ii], work->cost[ii]);
+        config->cost[i]->initialize(config->cost[i], dims->cost[i], in->cost[i],
+                opts->cost[i], mem->cost[i], work->cost[i]);
         // dynamics
-        if (ii < N)
-            config->dynamics[ii]->initialize(config->dynamics[ii], dims->dynamics[ii],
-                    in->dynamics[ii], opts->dynamics[ii], mem->dynamics[ii], work->dynamics[ii]);
+        if (i < N)
+            config->dynamics[i]->initialize(config->dynamics[i], dims->dynamics[i],
+                    in->dynamics[i], opts->dynamics[i], mem->dynamics[i], work->dynamics[i]);
         // constraints
-        config->constraints[ii]->initialize(config->constraints[ii], dims->constraints[ii],
-                in->constraints[ii], opts->constraints[ii], mem->constraints[ii], work->constraints[ii]);
+        config->constraints[i]->initialize(config->constraints[i], dims->constraints[i],
+                in->constraints[i], opts->constraints[i], mem->constraints[i], work->constraints[i]);
     }
 
     return;
@@ -2068,7 +2039,6 @@ void ocp_nlp_initialize_qp(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_i
 void ocp_nlp_initialize_t_slacks(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in,
          ocp_nlp_out *out, ocp_nlp_opts *opts, ocp_nlp_memory *mem, ocp_nlp_workspace *work)
 {
-    int ii;
     struct blasfeo_dvec *ineq_fun;
     int N = dims->N;
     int *ni = dims->ni;
@@ -2079,18 +2049,18 @@ void ocp_nlp_initialize_t_slacks(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp
 #if defined(ACADOS_WITH_OPENMP)
     #pragma omp parallel for
 #endif
-    for (ii = 0; ii <= N; ii++)
+    for (int i = 0; i <= N; i++)
     {
         // copy out->ux to tmp_nlp_out->ux, since this is used in compute_fun
-        blasfeo_dveccp(nx[ii]+nu[ii]+2*ns[ii], out->ux+ii, 0, work->tmp_nlp_out->ux+ii, 0);
+        blasfeo_dveccp(nx[i]+nu[i]+2*ns[i], out->ux+i, 0, work->tmp_nlp_out->ux+i, 0);
 
         // evaluate inequalities
-        config->constraints[ii]->compute_fun(config->constraints[ii], dims->constraints[ii],
-                                             in->constraints[ii], opts->constraints[ii],
-                                             mem->constraints[ii], work->constraints[ii]);
-        ineq_fun = config->constraints[ii]->memory_get_fun_ptr(mem->constraints[ii]);
+        config->constraints[i]->compute_fun(config->constraints[i], dims->constraints[i],
+                                             in->constraints[i], opts->constraints[i],
+                                             mem->constraints[i], work->constraints[i]);
+        ineq_fun = config->constraints[i]->memory_get_fun_ptr(mem->constraints[i]);
         // t = -ineq_fun
-        blasfeo_dveccpsc(2 * ni[ii], -1.0, ineq_fun, 0, out->t + ii, 0);
+        blasfeo_dveccpsc(2 * ni[i], -1.0, ineq_fun, 0, out->t + i, 0);
     }
 
     return;
@@ -2102,9 +2072,6 @@ void ocp_nlp_approximate_qp_matrices(ocp_nlp_config *config, ocp_nlp_dims *dims,
     ocp_nlp_in *in, ocp_nlp_out *out, ocp_nlp_opts *opts, ocp_nlp_memory *mem,
     ocp_nlp_workspace *work)
 {
-
-    int i;
-
     int N = dims->N;
     int *nv = dims->nv;
     int *nx = dims->nx;
@@ -2116,7 +2083,7 @@ void ocp_nlp_approximate_qp_matrices(ocp_nlp_config *config, ocp_nlp_dims *dims,
 #if defined(ACADOS_WITH_OPENMP)
     #pragma omp parallel for
 #endif
-    for (i = 0; i <= N; i++)
+    for (int i = 0; i <= N; i++)
     {
         // init Hessian to 0 
         blasfeo_dgese(nu[i] + nx[i], nu[i] + nx[i], 0.0, mem->qp_in->RSQrq+i, 0, 0);
@@ -2155,7 +2122,7 @@ void ocp_nlp_approximate_qp_matrices(ocp_nlp_config *config, ocp_nlp_dims *dims,
 #if defined(ACADOS_WITH_OPENMP)
     #pragma omp parallel for
 #endif
-    for (i=0; i <= N; i++)
+    for (int i=0; i <= N; i++)
     {
 
         // nlp mem: cost_grad
@@ -2201,7 +2168,7 @@ void ocp_nlp_approximate_qp_matrices(ocp_nlp_config *config, ocp_nlp_dims *dims,
 
     }
 
-    for (i = 0; i <= N; i++)
+    for (int i = 0; i <= N; i++)
     {
         // TODO(rien) where should the update happen??? move to qp update ???
         // TODO(all): fix and move where appropriate
@@ -2228,8 +2195,6 @@ void ocp_nlp_approximate_qp_vectors_sqp(ocp_nlp_config *config,
     ocp_nlp_dims *dims, ocp_nlp_in *in, ocp_nlp_out *out, ocp_nlp_opts *opts,
     ocp_nlp_memory *mem, ocp_nlp_workspace *work)
 {
-    int i;
-
     int N = dims->N;
     int *nv = dims->nv;
     int *nx = dims->nx;
@@ -2239,7 +2204,7 @@ void ocp_nlp_approximate_qp_vectors_sqp(ocp_nlp_config *config,
 #if defined(ACADOS_WITH_OPENMP)
     #pragma omp parallel for
 #endif
-    for (i = 0; i <= N; i++)
+    for (int i = 0; i <= N; i++)
     {
         // g
         blasfeo_dveccp(nv[i], mem->cost_grad + i, 0, mem->qp_in->rqz + i, 0);
@@ -2464,7 +2429,7 @@ double ocp_nlp_evaluate_merit_fun(ocp_nlp_config *config, ocp_nlp_dims *dims,
                                   ocp_nlp_memory *mem, ocp_nlp_workspace *work)
 {
     /* computes merit function value at iterate: tmp_nlp_out, with weights: work->weight_merit_fun */
-    int i, j;
+    //int j;
 
     int N = dims->N;
     int *nx = dims->nx;
@@ -2476,7 +2441,7 @@ double ocp_nlp_evaluate_merit_fun(ocp_nlp_config *config, ocp_nlp_dims *dims,
 #if defined(ACADOS_WITH_OPENMP)
     #pragma omp parallel for
 #endif
-    for (i=0; i<=N; i++)
+    for (int i=0; i<=N; i++)
     {
         // cost
         config->cost[i]->compute_fun(config->cost[i], dims->cost[i], in->cost[i], opts->cost[i],
@@ -2485,7 +2450,7 @@ double ocp_nlp_evaluate_merit_fun(ocp_nlp_config *config, ocp_nlp_dims *dims,
 #if defined(ACADOS_WITH_OPENMP)
     #pragma omp parallel for
 #endif
-    for (i=0; i<N; i++)
+    for (int i=0; i<N; i++)
     {
         // dynamics
         config->dynamics[i]->compute_fun(config->dynamics[i], dims->dynamics[i], in->dynamics[i],
@@ -2494,7 +2459,7 @@ double ocp_nlp_evaluate_merit_fun(ocp_nlp_config *config, ocp_nlp_dims *dims,
 #if defined(ACADOS_WITH_OPENMP)
     #pragma omp parallel for
 #endif
-    for (i=0; i<=N; i++)
+    for (int i=0; i<=N; i++)
     {
         // constr
         config->constraints[i]->compute_fun(config->constraints[i], dims->constraints[i],
@@ -2507,20 +2472,20 @@ double ocp_nlp_evaluate_merit_fun(ocp_nlp_config *config, ocp_nlp_dims *dims,
     struct blasfeo_dvec *tmp_fun_vec;
 
     double cost_fun = 0.0;
-    for(i=0; i<=N; i++)
+    for(int i=0; i<=N; i++)
     {
         tmp_fun = config->cost[i]->memory_get_fun_ptr(mem->cost[i]);
         cost_fun += *tmp_fun;
     }
 
     double dyn_fun = 0.0;
-    for(i=0; i<N; i++)
+    for(int i=0; i<N; i++)
     {
         tmp_fun_vec = config->dynamics[i]->memory_get_fun_ptr(mem->dynamics[i]);
         // printf("\nMerit: dyn will multiply tmp_fun, weights %d\n", i);
         // blasfeo_print_exp_tran_dvec(nx[i+1], tmp_fun_vec, 0);
         // blasfeo_print_exp_tran_dvec(nx[i+1], work->weight_merit_fun->pi+i, 0);
-        for(j=0; j<nx[i+1]; j++)
+        for(int j=0; j<nx[i+1]; j++)
         {
 //            printf("\n%e %e\n", fabs(BLASFEO_DVECEL(work->weight_merit_fun->pi+i, j)), fabs(BLASFEO_DVECEL(tmp_fun_vec, j)));
             dyn_fun += fabs(BLASFEO_DVECEL(work->weight_merit_fun->pi+i, j)) * fabs(BLASFEO_DVECEL(tmp_fun_vec, j));
@@ -2528,13 +2493,13 @@ double ocp_nlp_evaluate_merit_fun(ocp_nlp_config *config, ocp_nlp_dims *dims,
     }
 
     double constr_fun = 0.0;
-    for(i=0; i<=N; i++)
+    for(int i=0; i<=N; i++)
     {
 //        printf("\ni %d\n", i);
         tmp_fun_vec = config->constraints[i]->memory_get_fun_ptr(mem->constraints[i]);
 //        blasfeo_print_exp_tran_dvec(2*ni[i], tmp_fun_vec, 0);
 //        blasfeo_print_exp_tran_dvec(2*ni[i], work->weight_merit_fun->lam+i, 0);
-        for (j=0; j<2*ni[i]; j++)
+        for (int j=0; j<2*ni[i]; j++)
         {
             tmp = BLASFEO_DVECEL(tmp_fun_vec, j);
             if (tmp > 0.0)
@@ -2748,8 +2713,6 @@ double ocp_nlp_line_search(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_i
 void ocp_nlp_update_variables_sqp(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in,
             ocp_nlp_out *out, ocp_nlp_opts *opts, ocp_nlp_memory *mem, ocp_nlp_workspace *work, double alpha)
 {
-    int i;
-
     int N = dims->N;
     int *nv = dims->nv;
     int *nx = dims->nx;
@@ -2761,7 +2724,7 @@ void ocp_nlp_update_variables_sqp(ocp_nlp_config *config, ocp_nlp_dims *dims, oc
 #if defined(ACADOS_WITH_OPENMP)
     #pragma omp parallel for
 #endif
-    for (i = 0; i <= N; i++)
+    for (int i = 0; i <= N; i++)
     {
         // step in primal variables
         blasfeo_daxpy(nv[i], alpha, mem->qp_out->ux + i, 0, out->ux + i, 0, out->ux + i, 0);
@@ -2820,11 +2783,11 @@ acados_size_t ocp_nlp_res_calculate_size(ocp_nlp_dims *dims)
     size += 3 * (N + 1) * sizeof(struct blasfeo_dvec);  // res_stat res_ineq res_comp
     size += 1 * N * sizeof(struct blasfeo_dvec);        // res_eq
 
-    for (int ii = 0; ii < N; ii++)
+    for (int i = 0; i < N; i++)
     {
-        size += 1 * blasfeo_memsize_dvec(nv[ii]);      // res_stat
-        size += 1 * blasfeo_memsize_dvec(nx[ii + 1]);  // res_eq
-        size += 2 * blasfeo_memsize_dvec(2 * ni[ii]);  // res_ineq res_comp
+        size += 1 * blasfeo_memsize_dvec(nv[i]);      // res_stat
+        size += 1 * blasfeo_memsize_dvec(nx[i + 1]);  // res_eq
+        size += 2 * blasfeo_memsize_dvec(2 * ni[i]);  // res_ineq res_comp
     }
     size += 1 * blasfeo_memsize_dvec(nv[N]);      // res_stat
     size += 2 * blasfeo_memsize_dvec(2 * ni[N]);  // res_ineq res_comp
@@ -2873,24 +2836,24 @@ ocp_nlp_res *ocp_nlp_res_assign(ocp_nlp_dims *dims, void *raw_memory)
     align_char_to(64, &c_ptr);
 
     // res_stat
-    for (int ii = 0; ii <= N; ii++)
+    for (int i = 0; i <= N; i++)
     {
-        assign_and_advance_blasfeo_dvec_mem(nv[ii], res->res_stat + ii, &c_ptr);
+        assign_and_advance_blasfeo_dvec_mem(nv[i], res->res_stat + i, &c_ptr);
     }
     // res_eq
-    for (int ii = 0; ii < N; ii++)
+    for (int i = 0; i < N; i++)
     {
-        assign_and_advance_blasfeo_dvec_mem(nx[ii + 1], res->res_eq + ii, &c_ptr);
+        assign_and_advance_blasfeo_dvec_mem(nx[i + 1], res->res_eq + i, &c_ptr);
     }
     // res_ineq
-    for (int ii = 0; ii <= N; ii++)
+    for (int i = 0; i <= N; i++)
     {
-        assign_and_advance_blasfeo_dvec_mem(2 * ni[ii], res->res_ineq + ii, &c_ptr);
+        assign_and_advance_blasfeo_dvec_mem(2 * ni[i], res->res_ineq + i, &c_ptr);
     }
     // res_comp
-    for (int ii = 0; ii <= N; ii++)
+    for (int i = 0; i <= N; i++)
     {
-        assign_and_advance_blasfeo_dvec_mem(2 * ni[ii], res->res_comp + ii, &c_ptr);
+        assign_and_advance_blasfeo_dvec_mem(2 * ni[i], res->res_comp + i, &c_ptr);
     }
 
     res->memsize = ocp_nlp_res_calculate_size(dims);
@@ -2914,40 +2877,40 @@ void ocp_nlp_res_compute(ocp_nlp_dims *dims, ocp_nlp_in *in, ocp_nlp_out *out, o
 
     // res_stat
     res->inf_norm_res_stat = 0.0;
-    for (int ii = 0; ii <= N; ii++)
+    for (int i = 0; i <= N; i++)
     {
-        blasfeo_daxpy(nv[ii], -1.0, mem->ineq_adj + ii, 0, mem->cost_grad + ii, 0, res->res_stat + ii,
+        blasfeo_daxpy(nv[i], -1.0, mem->ineq_adj + i, 0, mem->cost_grad + i, 0, res->res_stat + i,
                       0);
-        blasfeo_daxpy(nu[ii] + nx[ii], -1.0, mem->dyn_adj + ii, 0, res->res_stat + ii, 0,
-                      res->res_stat + ii, 0);
-        blasfeo_dvecnrm_inf(nv[ii], res->res_stat + ii, 0, &tmp_res);
+        blasfeo_daxpy(nu[i] + nx[i], -1.0, mem->dyn_adj + i, 0, res->res_stat + i, 0,
+                      res->res_stat + i, 0);
+        blasfeo_dvecnrm_inf(nv[i], res->res_stat + i, 0, &tmp_res);
         res->inf_norm_res_stat = tmp_res > res->inf_norm_res_stat ? tmp_res : res->inf_norm_res_stat;
     }
 
     // res_eq
     res->inf_norm_res_eq = 0.0;
-    for (int ii = 0; ii < N; ii++)
+    for (int i = 0; i < N; i++)
     {
-        blasfeo_dveccp(nx[ii + 1], mem->dyn_fun + ii, 0, res->res_eq + ii, 0);
-        blasfeo_dvecnrm_inf(nx[ii + 1], res->res_eq + ii, 0, &tmp_res);
+        blasfeo_dveccp(nx[i + 1], mem->dyn_fun + i, 0, res->res_eq + i, 0);
+        blasfeo_dvecnrm_inf(nx[i + 1], res->res_eq + i, 0, &tmp_res);
         res->inf_norm_res_eq = tmp_res > res->inf_norm_res_eq ? tmp_res : res->inf_norm_res_eq;
     }
 
     // res_ineq
     res->inf_norm_res_ineq = 0.0;
-    for (int ii = 0; ii <= N; ii++)
+    for (int i = 0; i <= N; i++)
     {
-        blasfeo_daxpy(2 * ni[ii], 1.0, out->t + ii, 0, mem->ineq_fun + ii, 0, res->res_ineq + ii, 0);
-        blasfeo_dvecnrm_inf(2 * ni[ii], res->res_ineq + ii, 0, &tmp_res);
+        blasfeo_daxpy(2 * ni[i], 1.0, out->t + i, 0, mem->ineq_fun + i, 0, res->res_ineq + i, 0);
+        blasfeo_dvecnrm_inf(2 * ni[i], res->res_ineq + i, 0, &tmp_res);
         res->inf_norm_res_ineq = tmp_res > res->inf_norm_res_ineq ? tmp_res : res->inf_norm_res_ineq;
     }
 
     // res_comp
     res->inf_norm_res_comp = 0.0;
-    for (int ii = 0; ii <= N; ii++)
+    for (int i = 0; i <= N; i++)
     {
-        blasfeo_dvecmul(2 * ni[ii], out->lam + ii, 0, out->t + ii, 0, res->res_comp + ii, 0);
-        blasfeo_dvecnrm_inf(2 * ni[ii], res->res_comp + ii, 0, &tmp_res);
+        blasfeo_dvecmul(2 * ni[i], out->lam + i, 0, out->t + i, 0, res->res_comp + i, 0);
+        blasfeo_dvecnrm_inf(2 * ni[i], res->res_comp + i, 0, &tmp_res);
         res->inf_norm_res_comp = tmp_res > res->inf_norm_res_comp ? tmp_res : res->inf_norm_res_comp;
     }
 
@@ -2976,18 +2939,18 @@ void ocp_nlp_cost_compute(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in
     double* tmp_cost = NULL;
     double total_cost = 0.0;
 
-    for (int ii = 0; ii <= N; ii++)
+    for (int i = 0; i <= N; i++)
     {
         // set pointers
         // NOTE(oj): the cost compute function takes the tmp_ux_ptr as input,
         //  since it is also used for globalization,
         //  especially with primal variables that are NOT current SQP iterates.
-        config->cost[ii]->memory_set_tmp_ux_ptr(out->ux+ii, mem->cost[ii]);
+        config->cost[i]->memory_set_tmp_ux_ptr(out->ux+i, mem->cost[i]);
 
-        config->cost[ii]->compute_fun(config->cost[ii], dims->cost[ii], in->cost[ii],
-                    opts->cost[ii], mem->cost[ii], work->cost[ii]);
-        tmp_cost = config->cost[ii]->memory_get_fun_ptr(mem->cost[ii]);
-        // printf("cost at stage %d = %e, total = %e\n", ii, *tmp_cost, total_cost);
+        config->cost[i]->compute_fun(config->cost[i], dims->cost[i], in->cost[i],
+                    opts->cost[i], mem->cost[i], work->cost[i]);
+        tmp_cost = config->cost[i]->memory_get_fun_ptr(mem->cost[i]);
+        // printf("cost at stage %d = %e, total = %e\n", i, *tmp_cost, total_cost);
         total_cost += *tmp_cost;
     }
     mem->cost_value = total_cost;


### PR DESCRIPTION
This PR should fix issues #777 and #782.
Explanation: both issues seem to have the same root cause, since `libacados.so` is loaded by the solver. Upon destruction of the solver it seems that also `libacados.so` is unloaded and that causes the issues.
- In #777 `qpDUNES` seems to close `stdout` during destruction.
- In #782 the threads created by `OpenMP` are spin waiting in the background and cause a segmentation fault.

The solution is to load `libacados.so` separately and avoid unloading upon destruction of the solver.

This PR also allows the two tests `main_test.py` (external call to python) and `armijo_test.py` (multiple creations/destructions of solvers in the same python session) under `examples/acados_python/tests` to run correctly.