### PR TITLE
Fixed minor issues in python interface for win

### DIFF
--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -812,7 +812,8 @@ class AcadosOcpSolver:
     """
     if sys.platform=="win32":
         from ctypes import wintypes
-        dlclose = ctypes.WinDLL('kernel32', use_last_error=True).FreeLibrary
+        from ctypes import WinDLL
+        dlclose = WinDLL('kernel32', use_last_error=True).FreeLibrary
         dlclose.argtypes = [wintypes.HMODULE]
     else:
         dlclose = CDLL(None).dlclose

--- a/interfaces/acados_template/acados_template/utils.py
+++ b/interfaces/acados_template/acados_template/utils.py
@@ -49,7 +49,7 @@ def get_acados_path():
         ACADOS_PATH = os.path.realpath(acados_path)
         msg = 'Warning: Did not find environment variable ACADOS_SOURCE_DIR, '
         msg += 'guessed ACADOS_PATH to be {}.\n'.format(ACADOS_PATH)
-        msg += 'Please export ACADOS_SOURCE_DIR to not avoid this warning.'
+        msg += 'Please export ACADOS_SOURCE_DIR to avoid this warning.'
         print(msg)
     return ACADOS_PATH
 
@@ -74,7 +74,7 @@ def get_tera_exec_path():
 platform2tera = {
     "linux": "linux",
     "darwin": "osx",
-    "win32": "window.exe"
+    "win32": "windows"
 }
 
 
@@ -216,7 +216,7 @@ def render_template(in_file, out_file, template_dir, json_path):
     # Windows cmd.exe can not cope with '...', so use "..." instead:
     if os.name == 'nt':
         os_cmd = os_cmd.replace('\'', '\"')
-    
+
     status = os.system(os_cmd)
     if (status != 0):
         raise Exception(f'Rendering of {in_file} failed!\n\nAttempted to execute OS command:\n{os_cmd}\n\nExiting.\n')


### PR DESCRIPTION
Suggestions for docmentation in https://docs.acados.org/python_interface/index.html:

- Step 5: path has changed from /getting_started/minimal_example_ocp.py to /getting_started/ocp/minimal_example_ocp.py
- Step 5: explicitly mention to run the example from _inside_ the folder since it imports 'common' using relative path

I still did not manage to run the example natively on windows (had to switch to WSL which works fine) due to other errors I could not fix. @FreyJo are you aware if this is even supported?

