### PR TITLE
Matlab: add option ext_fun_compile_flags with default `-O2`

### DIFF
--- a/interfaces/acados_matlab_octave/acados_ocp_opts.m
+++ b/interfaces/acados_matlab_octave/acados_ocp_opts.m
@@ -97,7 +97,7 @@ classdef acados_ocp_opts < handle
             obj.opts_struct.exact_hess_dyn = 1;
             obj.opts_struct.exact_hess_cost = 1;
             obj.opts_struct.exact_hess_constr = 1;
-
+            obj.opts_struct.ext_fun_compile_flags = '-O2';
 
             obj.opts_struct.output_dir = fullfile(pwd, 'build');
             if ismac()
@@ -219,6 +219,8 @@ classdef acados_ocp_opts < handle
                 obj.opts_struct.globalization = value;
             elseif (strcmp(field, 'parameter_values'))
                 obj.opts_struct.parameter_values = value;
+            elseif (strcmp(field, 'ext_fun_compile_flags'))
+                obj.opts_struct.ext_fun_compile_flags = value
             elseif (strcmp(field, 'compile_mex'))
                 disp(['Option compile_mex is not supported anymore,'...
                     'please use compile_interface instead or dont set the option.', ...

--- a/interfaces/acados_matlab_octave/acados_sim_opts.m
+++ b/interfaces/acados_matlab_octave/acados_sim_opts.m
@@ -62,6 +62,7 @@ classdef acados_sim_opts < handle
             obj.opts_struct.jac_reuse = 'false';
             obj.opts_struct.gnsf_detect_struct = 'true';
             obj.opts_struct.output_dir = fullfile(pwd, 'build');
+            obj.opts_struct.ext_fun_compile_flags = '-O2';
         end
 
 
@@ -73,6 +74,8 @@ classdef acados_sim_opts < handle
 
             if (strcmp(field, 'compile_interface'))
                 obj.opts_struct.compile_interface = value;
+            elseif (strcmp(field, 'ext_fun_compile_flags'))
+                obj.opts_struct.ext_fun_compile_flags = value
             elseif (strcmp(field, 'codgen_model'))
                 obj.opts_struct.codgen_model = value;
             elseif (strcmp(field, 'compile_model'))

--- a/interfaces/acados_matlab_octave/ocp_generate_casadi_ext_fun.m
+++ b/interfaces/acados_matlab_octave/ocp_generate_casadi_ext_fun.m
@@ -206,6 +206,8 @@ if ~is_octave()
     end
 end
 
+ext_fun_compile_flags = opts_struct.ext_fun_compile_flags;
+
 if use_msvc
     % get env vars for MSVC
     msvc_env = fullfile(mexOpts.Location, 'VC\Auxiliary\Build\vcvars64.bat');
@@ -220,12 +222,6 @@ if use_msvc
 
     % build
     compile_command = sprintf('"%s" & %s', msvc_env, build_cmd);
-    compile_status = system(compile_command);
-    if compile_status ~= 0
-        error('Compilation of model functions failed! %s %s\n%s\n\n', ...
-            'Please check the compile command above and the flags therein closely.',...
-            'Compile command was:', compile_command);
-    end
 else % gcc
     % set includes
     acados_include = ['-I' acados_folder];
@@ -236,14 +232,15 @@ else % gcc
     else
         out_lib = fullfile(opts_struct.output_dir, ['lib', model_name, '.so']);
     end
-    compile_command = ['gcc -O2 -fPIC -shared ', acados_include, ' ', blasfeo_include,...
+    compile_command = ['gcc ', ext_fun_compile_flags, ' -fPIC -shared ', acados_include, ' ', blasfeo_include,...
                        ' ', strjoin(unique(c_files_path), ' '), ' -o ', out_lib];
-    compile_status = system(compile_command);
-    if compile_status ~= 0
-        error('Compilation of model functions failed! %s %s\n%s\n\n', ...
-            'Please check the compile command above and the flags therein closely.',...
-            'Compile command was:', compile_command);
-    end
+end
+
+compile_status = system(compile_command);
+if compile_status ~= 0
+    error('Compilation of model functions failed! %s %s\n%s\n\n', ...
+        'Please check the compile command above and the flags therein closely.',...
+        'Compile command was:', compile_command);
 end
 
 end


### PR DESCRIPTION
this allows to reduce code optimizations conveniently, which is needed for big models