### PR TITLE
Change defaults of qp_solver_ric_alg, qp_solver_cond_ric_alg to 1, i.e. square-root version

### DIFF
--- a/interfaces/acados_matlab_octave/acados_ocp_opts.m
+++ b/interfaces/acados_matlab_octave/acados_ocp_opts.m
@@ -77,8 +77,8 @@ classdef acados_ocp_opts < handle
 
             obj.opts_struct.qp_solver_iter_max = 50;
             % obj.opts_struct.qp_solver_cond_N = 5; % New horizon after partial condensing
-            obj.opts_struct.qp_solver_cond_ric_alg = 0; % 0: dont factorize hessian in the condensing; 1: factorize
-            obj.opts_struct.qp_solver_ric_alg = 0; % HPIPM specific
+            obj.opts_struct.qp_solver_cond_ric_alg = 1; % 0: dont factorize hessian in the condensing; 1: factorize
+            obj.opts_struct.qp_solver_ric_alg = 1; % HPIPM specific
             obj.opts_struct.qp_solver_warm_start = 0;
                     % 0 no warm start; 1 warm start primal variables; 2 warm start primal and dual variables
             obj.opts_struct.warm_start_first_qp = 0;

--- a/interfaces/acados_template/acados_template/acados_ocp.py
+++ b/interfaces/acados_template/acados_template/acados_ocp.py
@@ -2132,8 +2132,8 @@ class AcadosOcpOptions:
         self.__qp_solver_iter_max = 50                        # QP solver max iter
         self.__qp_solver_cond_N = None                        # QP solver: new horizon after partial condensing
         self.__qp_solver_warm_start = 0
-        self.__qp_solver_cond_ric_alg = 0
-        self.__qp_solver_ric_alg = 0
+        self.__qp_solver_cond_ric_alg = 1
+        self.__qp_solver_ric_alg = 1
         self.__nlp_solver_tol_stat = 1e-6                     # NLP solver stationarity tolerance
         self.__nlp_solver_tol_eq   = 1e-6                     # NLP solver equality tolerance
         self.__nlp_solver_tol_ineq = 1e-6                     # NLP solver inequality
@@ -2340,7 +2340,7 @@ class AcadosOcpOptions:
         """
         QP solver: Determines which algorithm is used in HPIPM condensing.
         0: dont factorize hessian in the condensing; 1: factorize.
-        Default: 0
+        Default: 1
         """
         return self.__qp_solver_cond_ric_alg
 
@@ -2360,7 +2360,7 @@ class AcadosOcpOptions:
         [HPIPM paper]: HPIPM: a high-performance quadratic programming framework for model predictive control, Frison and Diehl, 2020
         https://cdn.syscop.de/publications/Frison2020a.pdf
 
-        Default: 0
+        Default: 1
         """
         return self.__qp_solver_ric_alg
 


### PR DESCRIPTION
The square-root version is supposed to be faster, and also better conditioning wise, since the square-root values are closer to 1.

At the last release: The default in C and Python was 1. The default in Matlab was 0.
In 751a8000c1e980c4e312a83cb4c90102bee49e9c I had added support for those options in Python with default as in Matlab. 