### PR TITLE
add flag: ACADOS_DEBUG_SQP_PRINT_QPS_TO_FILE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,7 @@ endif()
 
 option(ACADOS_WITH_OPENMP "OpenMP Parallelization" OFF)
 option(ACADOS_SILENT "No console status output" OFF)
+option(ACADOS_DEBUG_SQP_PRINT_QPS_TO_FILE "Print QP inputs and outputs to file in SQP" OFF)
 
 # Additional targets
 option(ACADOS_UNIT_TESTS "Compile Unit tests" OFF)
@@ -160,6 +161,12 @@ if(ACADOS_SILENT)
     message(STATUS "ACADOS_SILENT is ON")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DACADOS_SILENT")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DACADOS_SILENT")
+endif()
+
+if(ACADOS_DEBUG_SQP_PRINT_QPS_TO_FILE)
+    message(STATUS "ACADOS_DEBUG_SQP_PRINT_QPS_TO_FILE is ON")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DACADOS_DEBUG_SQP_PRINT_QPS_TO_FILE")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DACADOS_DEBUG_SQP_PRINT_QPS_TO_FILE")
 endif()
 
 # uninstall

--- a/acados/ocp_nlp/ocp_nlp_sqp.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp.c
@@ -607,14 +607,16 @@ int ocp_nlp_sqp(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
                                          "warm_start", &tmp_int);
         }
 
-        if (0) // DEBUG printing
+#if defined(ACADOS_DEBUG_SQP_PRINT_QPS_TO_FILE)
+        if (1) // DEBUG printing
         {
             char filename[100];
-            sprintf(filename, "qp_prints/qp_in_%d.txt", sqp_iter);
+            sprintf(filename, "qp_in_%d.txt", sqp_iter);
             FILE *out_file = fopen(filename, "w");
             print_ocp_qp_in_to_file(out_file, qp_in);
             fclose(out_file);
         }
+#endif
         // solve qp
         acados_tic(&timer1);
         qp_status = qp_solver->evaluate(qp_solver, dims->qp_solver, qp_in, qp_out,
@@ -645,14 +647,16 @@ int ocp_nlp_sqp(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
             print_ocp_qp_out(qp_out);
         }
 
-        if (0) // DEBUG printing
+#if defined(ACADOS_DEBUG_SQP_PRINT_QPS_TO_FILE)
+        if (1) // DEBUG printing
         {
             char filename[100];
-            sprintf(filename, "qp_prints/qp_out_%d.txt", sqp_iter);
+            sprintf(filename, "qp_out_%d.txt", sqp_iter);
             FILE *out_file = fopen(filename, "w");
             print_ocp_qp_out_to_file(out_file, qp_out);
             fclose(out_file);
         }
+#endif
 
         // TODO move into QP solver memory ???
         qp_info *qp_info_;
@@ -844,14 +848,17 @@ int ocp_nlp_sqp(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
                     printf("\n\nSQP: SOC ocp_qp_in at iteration %d\n", sqp_iter);
                     print_ocp_qp_in(qp_in);
                 }
-                if (0) // DEBUG printing
+
+#if defined(ACADOS_DEBUG_SQP_PRINT_QPS_TO_FILE)
+                if (1) // DEBUG printing
                 {
                     char filename[100];
-                    sprintf(filename, "qp_prints/qp_in_%d_SOC.txt", sqp_iter);
+                    sprintf(filename, "qp_in_%d_SOC.txt", sqp_iter);
                     FILE *out_file = fopen(filename, "w");
                     print_ocp_qp_in_to_file(out_file, qp_in);
                     fclose(out_file);
                 }
+#endif
 
                 // solve QP
                 // acados_tic(&timer1);
@@ -895,14 +902,16 @@ int ocp_nlp_sqp(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
                     printf("\n\nSQP: SOC ocp_qp_out at iteration %d\n", sqp_iter);
                     print_ocp_qp_out(qp_out);
                 }
-                if (0) // DEBUG printing
+#if defined(ACADOS_DEBUG_SQP_PRINT_QPS_TO_FILE)
+                if (1) // DEBUG printing
                 {
                     char filename[100];
-                    sprintf(filename, "qp_prints/qp_out_%d_SOC.txt", sqp_iter);
+                    sprintf(filename, "qp_out_%d_SOC.txt", sqp_iter);
                     FILE *out_file = fopen(filename, "w");
                     print_ocp_qp_out_to_file(out_file, qp_out);
                     fclose(out_file);
                 }
+#endif
 
                 // exit conditions on QP status
                 if ((qp_status!=ACADOS_SUCCESS) & (qp_status!=ACADOS_MAXITER))


### PR DESCRIPTION
This writes all QP inputs and outputs of the latest SQP call into files called
`qp_in_{{iterate_number}}.txt`,  `qp_out_{{iterate_number}}.txt` in the current working directory.
Previous files with the same name are overwritten.

Could be extended to not overwrite, but should be compatible with Windows, see https://stackoverflow.com/questions/230062/whats-the-best-way-to-check-if-a-file-exists-in-c