### PR TITLE
Add possibility to get QP matrices from Matlab and Python interfaces

### DIFF
--- a/examples/acados_matlab_octave/getting_started/extensive_example_ocp.m
+++ b/examples/acados_matlab_octave/getting_started/extensive_example_ocp.m
@@ -295,6 +295,38 @@ su = ocp.get('su', N);
 % get cost value
 cost_val_ocp = ocp.get_cost();
 
+
+%% get QP matrices:
+% See https://docs.acados.org/problem_formulation
+% either stage wise
+for stage = [0, N-1]
+    % Note loop over field doesnt work because stupid matlab diff between
+    % chars and strings
+    field = 'qp_A';
+    disp(strcat(field, " at stage ", num2str(stage), " = "));
+    ocp.get(field, stage)
+    field = 'qp_B';
+    disp(strcat(field, " at stage ", num2str(stage), " = "));
+    ocp.get(field, stage)
+    field = 'qp_R';
+    disp(strcat(field, " at stage ", num2str(stage), " = "));
+    ocp.get(field, stage)
+    field = 'qp_Q';
+    disp(strcat(field, " at stage ", num2str(stage), " = "));
+    ocp.get(field, stage)
+end
+
+stage = N;
+field = 'qp_Q';
+disp(strcat(field, " at stage ", num2str(stage), " = "));
+ocp.get(field, stage)
+field = 'qp_R';
+disp(strcat(field, " at stage ", num2str(stage), " = "));
+ocp.get(field, stage)
+
+% or for all stages
+qp_Q = ocp.get('qp_Q');
+
 %% Plot trajectories
 figure; hold on;
 States = {'p', 'theta', 'v', 'dtheta'};

--- a/examples/acados_matlab_octave/pendulum_on_cart_model/example_ocp_reg.m
+++ b/examples/acados_matlab_octave/pendulum_on_cart_model/example_ocp_reg.m
@@ -283,7 +283,7 @@ else
         ocp.print('stat');
 
         % check stability of qp
-        qp_A = ocp.get('qp_solver_A');
+        qp_A = ocp.get('qp_A');
         qp_A_eig_max = 0;
         for jj=1:length(qp_A)
             tmp_A = qp_A{jj};

--- a/examples/acados_matlab_octave/pendulum_on_cart_model/example_ocp_reg.m
+++ b/examples/acados_matlab_octave/pendulum_on_cart_model/example_ocp_reg.m
@@ -37,7 +37,7 @@ clear VARIABLES
 % check that env.sh has been run
 env_run = getenv('ENV_RUN');
 if (~strcmp(env_run, 'true'))
-	error('env.sh has not been sourced! Before executing this example, run: source env.sh');
+    error('env.sh has not been sourced! Before executing this example, run: source env.sh');
 end
 
 %% arguments
@@ -93,19 +93,19 @@ nu = model.nu;
 ny = nu+nx; % number of outputs in lagrange term
 ny_e = nx; % number of outputs in mayer term
 if 0
-	nbx = 0;
-	nbu = nu;
-	ng = 0;
-	ng_e = 0;
-	nh = 0;
-	nh_e = 0;
+    nbx = 0;
+    nbu = nu;
+    ng = 0;
+    ng_e = 0;
+    nh = 0;
+    nh_e = 0;
 else
-	nbx = 0;
-	nbu = 0;
-	ng = 0;
-	ng_e = 0;
-	nh = nu;
-	nh_e = 0;
+    nbx = 0;
+    nbu = 0;
+    ng = 0;
+    ng_e = 0;
+    nh = nu;
+    nh_e = 0;
 end
 
 % cost
@@ -143,58 +143,58 @@ ocp_model.set('T', T);
 % symbolics
 ocp_model.set('sym_x', model.sym_x);
 if isfield(model, 'sym_u')
-	ocp_model.set('sym_u', model.sym_u);
+    ocp_model.set('sym_u', model.sym_u);
 end
 if isfield(model, 'sym_xdot')
-	ocp_model.set('sym_xdot', model.sym_xdot);
+    ocp_model.set('sym_xdot', model.sym_xdot);
 end
 % cost
 ocp_model.set('cost_type', cost_type);
 ocp_model.set('cost_type_e', cost_type);
 %if (strcmp(cost_type, 'linear_ls'))
-	ocp_model.set('cost_Vu', Vu);
-	ocp_model.set('cost_Vx', Vx);
-	ocp_model.set('cost_Vx_e', Vx_e);
-	ocp_model.set('cost_W', W);
-	ocp_model.set('cost_W_e', W_e);
-	ocp_model.set('cost_y_ref', yr);
-	ocp_model.set('cost_y_ref_e', yr_e);
+    ocp_model.set('cost_Vu', Vu);
+    ocp_model.set('cost_Vx', Vx);
+    ocp_model.set('cost_Vx_e', Vx_e);
+    ocp_model.set('cost_W', W);
+    ocp_model.set('cost_W_e', W_e);
+    ocp_model.set('cost_y_ref', yr);
+    ocp_model.set('cost_y_ref_e', yr_e);
 %else % if (strcmp(cost_type, 'ext_cost'))
-%	ocp_model.set('cost_expr_ext_cost', model.expr_ext_cost);
-%	ocp_model.set('cost_expr_ext_cost_e', model.expr_ext_cost_e);
+%    ocp_model.set('cost_expr_ext_cost', model.expr_ext_cost);
+%    ocp_model.set('cost_expr_ext_cost_e', model.expr_ext_cost_e);
 %end
 % dynamics
 if (strcmp(sim_method, 'erk'))
-	ocp_model.set('dyn_type', 'explicit');
-	ocp_model.set('dyn_expr_f', model.expr_f_expl);
+    ocp_model.set('dyn_type', 'explicit');
+    ocp_model.set('dyn_expr_f', model.expr_f_expl);
 else % irk irk_gnsf
-	ocp_model.set('dyn_type', 'implicit');
-	ocp_model.set('dyn_expr_f', model.expr_f_impl);
+    ocp_model.set('dyn_type', 'implicit');
+    ocp_model.set('dyn_expr_f', model.expr_f_impl);
 end
 % constraints
 ocp_model.set('constr_x0', x0);
 if (ng>0)
-	ocp_model.set('constr_C', C);
-	ocp_model.set('constr_D', D);
-	ocp_model.set('constr_lg', lg);
-	ocp_model.set('constr_ug', ug);
-	ocp_model.set('constr_C_e', C_e);
-	ocp_model.set('constr_lg_e', lg_e);
-	ocp_model.set('constr_ug_e', ug_e);
+    ocp_model.set('constr_C', C);
+    ocp_model.set('constr_D', D);
+    ocp_model.set('constr_lg', lg);
+    ocp_model.set('constr_ug', ug);
+    ocp_model.set('constr_C_e', C_e);
+    ocp_model.set('constr_lg_e', lg_e);
+    ocp_model.set('constr_ug_e', ug_e);
 elseif (nh>0)
-	ocp_model.set('constr_expr_h', model.expr_h);
-	ocp_model.set('constr_lh', lbu);
-	ocp_model.set('constr_uh', ubu);
-%	ocp_model.set('constr_expr_h_e', model.expr_h_e);
-%	ocp_model.set('constr_lh_e', lh_e);
-%	ocp_model.set('constr_uh_e', uh_e);
+    ocp_model.set('constr_expr_h', model.expr_h);
+    ocp_model.set('constr_lh', lbu);
+    ocp_model.set('constr_uh', ubu);
+%    ocp_model.set('constr_expr_h_e', model.expr_h_e);
+%    ocp_model.set('constr_lh_e', lh_e);
+%    ocp_model.set('constr_uh_e', uh_e);
 else
-%	ocp_model.set('constr_Jbx', Jbx);
-%	ocp_model.set('constr_lbx', lbx);
-%	ocp_model.set('constr_ubx', ubx);
-	ocp_model.set('constr_Jbu', Jbu);
-	ocp_model.set('constr_lbu', lbu);
-	ocp_model.set('constr_ubu', ubu);
+%    ocp_model.set('constr_Jbx', Jbx);
+%    ocp_model.set('constr_lbx', lbx);
+%    ocp_model.set('constr_ubx', ubx);
+    ocp_model.set('constr_Jbu', Jbu);
+    ocp_model.set('constr_lbu', lbu);
+    ocp_model.set('constr_ubu', ubu);
 end
 disp('ocp_model.model_struct')
 disp(ocp_model.model_struct)
@@ -211,16 +211,16 @@ ocp_opts.set('regularize_method', regularize_method);
 ocp_opts.set('nlp_solver_ext_qp_res', nlp_solver_ext_qp_res);
 ocp_opts.set('nlp_solver_step_length', nlp_solver_step_length);
 if (strcmp(nlp_solver, 'sqp'))
-	ocp_opts.set('nlp_solver_max_iter', nlp_solver_max_iter);
-	ocp_opts.set('nlp_solver_tol_stat', nlp_solver_tol_stat);
-	ocp_opts.set('nlp_solver_tol_eq', nlp_solver_tol_eq);
-	ocp_opts.set('nlp_solver_tol_ineq', nlp_solver_tol_ineq);
-	ocp_opts.set('nlp_solver_tol_comp', nlp_solver_tol_comp);
+    ocp_opts.set('nlp_solver_max_iter', nlp_solver_max_iter);
+    ocp_opts.set('nlp_solver_tol_stat', nlp_solver_tol_stat);
+    ocp_opts.set('nlp_solver_tol_eq', nlp_solver_tol_eq);
+    ocp_opts.set('nlp_solver_tol_ineq', nlp_solver_tol_ineq);
+    ocp_opts.set('nlp_solver_tol_comp', nlp_solver_tol_comp);
 end
 ocp_opts.set('qp_solver', qp_solver);
 if (strcmp(qp_solver, 'partial_condensing_hpipm'))
-	ocp_opts.set('qp_solver_cond_N', qp_solver_cond_N);
-	ocp_opts.set('qp_solver_ric_alg', qp_solver_ric_alg);
+    ocp_opts.set('qp_solver_cond_N', qp_solver_cond_N);
+    ocp_opts.set('qp_solver_ric_alg', qp_solver_ric_alg);
 end
 ocp_opts.set('qp_solver_cond_ric_alg', qp_solver_cond_ric_alg);
 ocp_opts.set('qp_solver_warm_start', qp_solver_warm_start);
@@ -229,7 +229,7 @@ ocp_opts.set('sim_method', sim_method);
 ocp_opts.set('sim_method_num_stages', sim_method_num_stages);
 ocp_opts.set('sim_method_num_steps', sim_method_num_steps);
 if (strcmp(sim_method, 'irk_gnsf'))
-	ocp_opts.set('gnsf_detect_struct', gnsf_detect_struct);
+    ocp_opts.set('gnsf_detect_struct', gnsf_detect_struct);
 end
 
 disp('ocp_opts');
@@ -265,77 +265,71 @@ ocp.set('init_u', u_traj_init);
 tic;
 
 if 0
-
-	% solve ocp
-	ocp.solve();
-
+    % solve ocp
+    ocp.solve();
 else
 
-	% do one step at the time
-	ocp.set('nlp_solver_max_iter', 1);
+    % do one step at the time
+    ocp.set('nlp_solver_max_iter', 1);
 
-	for ii=1:nlp_solver_max_iter
+    for ii=1:nlp_solver_max_iter
 
-		disp(['iteration number ', num2str(ii)])
+        disp(['iteration number ', num2str(ii)])
 
-		% solve the system using 1 SQP iteration
-		ocp.solve();
+        % solve the system using 1 SQP iteration
+        ocp.solve();
 
-		% print 1-iteration stat
-		ocp.print('stat');
+        % print 1-iteration stat
+        ocp.print('stat');
 
-		% check stability of qp
-		qp_A = ocp.get('qp_solver_A');
-		qp_A_eig_max = 0;
-		for jj=1:length(qp_A)
-			tmp_A = qp_A{jj};
-			qp_A_eig = eig(tmp_A);
-			tmp = max(abs(qp_A_eig));
-			if tmp>qp_A_eig_max
-				qp_A_eig_max = tmp;
-			end
-		end
-		fprintf('A eig max %e\n', qp_A_eig_max);
+        % check stability of qp
+        qp_A = ocp.get('qp_solver_A');
+        qp_A_eig_max = 0;
+        for jj=1:length(qp_A)
+            tmp_A = qp_A{jj};
+            qp_A_eig = eig(tmp_A);
+            tmp = max(abs(qp_A_eig));
+            if tmp>qp_A_eig_max
+                qp_A_eig_max = tmp;
+            end
+        end
+        fprintf('A eig max %e\n', qp_A_eig_max);
 
-		% compute conditioning number and eigenvalues of hessian of (partial) cond qp
-		qp_cond_H = ocp.get('qp_solver_cond_H');
-		if iscell(qp_cond_H)
+        % compute conditioning number and eigenvalues of hessian of (partial) cond qp
+        qp_cond_H = ocp.get('qp_solver_cond_H');
+        if iscell(qp_cond_H)
 
-			for jj=1:length(qp_cond_H)
+            for jj=1:length(qp_cond_H)
 
-				tmp_H = qp_cond_H{jj};
-				nv = size(tmp_H, 1);
-				% make full
-				for jj=1:nv
-					for ii=jj+1:nv
-						tmp_H(jj,ii) = tmp_H(ii,jj);
-					end
-				end
-				qp_H_cond_num = cond(tmp_H);
-				qp_H_eig = eig(tmp_H);
-    			fprintf('cond H condition number %e min eigenval %e max eigenvalue %e\n', qp_H_cond_num, min(qp_H_eig), max(qp_H_eig));
+                tmp_H = qp_cond_H{jj};
+                nv = size(tmp_H, 1);
+                % make full
+                for jj=1:nv
+                    for ii=jj+1:nv
+                        tmp_H(jj,ii) = tmp_H(ii,jj);
+                    end
+                end
+                qp_H_cond_num = cond(tmp_H);
+                qp_H_eig = eig(tmp_H);
+                fprintf('cond H condition number %e min eigenval %e max eigenvalue %e\n', qp_H_cond_num, min(qp_H_eig), max(qp_H_eig));
 
-			end
+            end
+        else
+            nv = size(qp_cond_H, 1);
+            % make full
+            for jj=1:nv
+                for ii=jj+1:nv
+                    qp_cond_H(jj,ii) = qp_cond_H(ii,jj);
+                end
+            end
+            qp_H_cond_num = cond(qp_cond_H);
+            qp_H_eig = eig(qp_cond_H);
+            fprintf('cond H condition number %e min eigenval %e max eigenvalue %e\n', qp_H_cond_num, min(qp_H_eig), max(qp_H_eig));
 
-		else
+        end
 
-			nv = size(qp_cond_H, 1);
-			% make full
-			for jj=1:nv
-				for ii=jj+1:nv
-					qp_cond_H(jj,ii) = qp_cond_H(ii,jj);
-				end
-			end
-			qp_H_cond_num = cond(qp_cond_H);
-			qp_H_eig = eig(qp_cond_H);
-			fprintf('cond H condition number %e min eigenval %e max eigenvalue %e\n', qp_H_cond_num, min(qp_H_eig), max(qp_H_eig));
-
-		end
-
-		fprintf('\n\n');
-
-	end
-
+        fprintf('\n\n');
+    end
 end
 
 time_ext = toc;
@@ -360,7 +354,7 @@ ocp.print('stat');
 %% figures
 
 for ii=1:N+1
-	x_cur = x(:,ii);
+    x_cur = x(:,ii);
 %visualize;
 end
 
@@ -376,28 +370,28 @@ legend('F');
 
 stat = ocp.get('stat');
 if (strcmp(nlp_solver, 'sqp'))
-	figure;
- 	plot([0: size(stat,1)-1], log10(stat(:,2)), 'r-x');
- 	hold on
- 	plot([0: size(stat,1)-1], log10(stat(:,3)), 'b-x');
- 	plot([0: size(stat,1)-1], log10(stat(:,4)), 'g-x');
- 	plot([0: size(stat,1)-1], log10(stat(:,5)), 'k-x');
-%	semilogy(0: size(stat,1)-1, stat(:,2), 'r-x');
-%	hold on
-%	semilogy(0: size(stat,1)-1, stat(:,3), 'b-x');
-%	semilogy(0: size(stat,1)-1, stat(:,4), 'g-x');
-%	semilogy(0: size(stat,1)-1, stat(:,5), 'k-x');
+    figure;
+     plot([0: size(stat,1)-1], log10(stat(:,2)), 'r-x');
+     hold on
+     plot([0: size(stat,1)-1], log10(stat(:,3)), 'b-x');
+     plot([0: size(stat,1)-1], log10(stat(:,4)), 'g-x');
+     plot([0: size(stat,1)-1], log10(stat(:,5)), 'k-x');
+%    semilogy(0: size(stat,1)-1, stat(:,2), 'r-x');
+%    hold on
+%    semilogy(0: size(stat,1)-1, stat(:,3), 'b-x');
+%    semilogy(0: size(stat,1)-1, stat(:,4), 'g-x');
+%    semilogy(0: size(stat,1)-1, stat(:,5), 'k-x');
     hold off
-	xlabel('iter')
-	ylabel('res')
+    xlabel('iter')
+    ylabel('res')
     legend('res stat', 'res eq', 'res ineq', 'res compl');
 end
 
 
 if status==0
-	fprintf('\nsuccess!\n\n');
+    fprintf('\nsuccess!\n\n');
 else
-	fprintf('\nsolution failed!\n\n');
+    fprintf('\nsolution failed!\n\n');
 end
 
 

--- a/examples/acados_matlab_octave/pendulum_on_cart_model/example_ocp_reg.m
+++ b/examples/acados_matlab_octave/pendulum_on_cart_model/example_ocp_reg.m
@@ -239,11 +239,11 @@ disp(ocp_opts.opts_struct);
 %% acados ocp
 % create ocp
 ocp = acados_ocp(ocp_model, ocp_opts);
-ocp
-disp('ocp.C_ocp');
-disp(ocp.C_ocp);
-disp('ocp.C_ocp_ext_fun');
-disp(ocp.C_ocp_ext_fun);
+% ocp
+% disp('ocp.C_ocp');
+% disp(ocp.C_ocp);
+% disp('ocp.C_ocp_ext_fun');
+% disp(ocp.C_ocp_ext_fun);
 %ocp.model_struct
 
 
@@ -313,12 +313,12 @@ else
 				end
 				qp_H_cond_num = cond(tmp_H);
 				qp_H_eig = eig(tmp_H);
-				fprintf('cond H condition number %e %e %e\n', qp_H_cond_num, min(qp_H_eig), max(qp_H_eig));
+    			fprintf('cond H condition number %e min eigenval %e max eigenvalue %e\n', qp_H_cond_num, min(qp_H_eig), max(qp_H_eig));
 
 			end
 
 		else
-			
+
 			nv = size(qp_cond_H, 1);
 			% make full
 			for jj=1:nv
@@ -328,7 +328,7 @@ else
 			end
 			qp_H_cond_num = cond(qp_cond_H);
 			qp_H_eig = eig(qp_cond_H);
-			fprintf('cond H condition number %e %e %e\n', qp_H_cond_num, min(qp_H_eig), max(qp_H_eig));
+			fprintf('cond H condition number %e min eigenval %e max eigenvalue %e\n', qp_H_cond_num, min(qp_H_eig), max(qp_H_eig));
 
 		end
 
@@ -339,8 +339,6 @@ else
 end
 
 time_ext = toc;
-% TODO: add getter for internal timing
-fprintf(['time for ocp.solve (matlab tic-toc): ', num2str(time_ext), ' s\n'])
 
 % get solution
 u = ocp.get('u');

--- a/examples/acados_matlab_octave/pendulum_on_cart_model/example_ocp_reg.m
+++ b/examples/acados_matlab_octave/pendulum_on_cart_model/example_ocp_reg.m
@@ -196,8 +196,8 @@ else
     ocp_model.set('constr_lbu', lbu);
     ocp_model.set('constr_ubu', ubu);
 end
-disp('ocp_model.model_struct')
-disp(ocp_model.model_struct)
+% disp('ocp_model.model_struct')
+% disp(ocp_model.model_struct)
 
 
 %% acados ocp opts
@@ -232,8 +232,8 @@ if (strcmp(sim_method, 'irk_gnsf'))
     ocp_opts.set('gnsf_detect_struct', gnsf_detect_struct);
 end
 
-disp('ocp_opts');
-disp(ocp_opts.opts_struct);
+% disp('ocp_opts');
+% disp(ocp_opts.opts_struct);
 
 
 %% acados ocp
@@ -329,7 +329,7 @@ else
         end
 
 		% check residuals and terminate if tol is reached
-		residuals = ocp.get("residuals");
+		residuals = ocp.get('residuals');
 		if residuals(1) < nlp_solver_tol_stat && residuals(2) < nlp_solver_tol_eq && residuals(3) < nlp_solver_tol_ineq && residuals(4) < nlp_solver_tol_comp
 			break
 		end
@@ -362,6 +362,7 @@ for ii=1:N+1
 %visualize;
 end
 
+%% plot trajectory
 figure;
 subplot(2,1,1);
 plot(0:N, x);
@@ -372,24 +373,26 @@ plot(0:N-1, u);
 xlim([0 N]);
 legend('F');
 
-stat = ocp.get('stat');
-if (strcmp(nlp_solver, 'sqp'))
-    figure;
-    plot([0: size(stat,1)-1], log10(stat(:,2)), 'r-x');
-    hold on
-    plot([0: size(stat,1)-1], log10(stat(:,3)), 'b-x');
-    plot([0: size(stat,1)-1], log10(stat(:,4)), 'g-x');
-    plot([0: size(stat,1)-1], log10(stat(:,5)), 'k-x');
-%    semilogy(0: size(stat,1)-1, stat(:,2), 'r-x');
-%    hold on
-%    semilogy(0: size(stat,1)-1, stat(:,3), 'b-x');
-%    semilogy(0: size(stat,1)-1, stat(:,4), 'g-x');
-%    semilogy(0: size(stat,1)-1, stat(:,5), 'k-x');
-    hold off
-    xlabel('iter')
-    ylabel('res')
-    legend('res stat', 'res eq', 'res ineq', 'res compl');
-end
+
+%% plot residual
+% stat = ocp.get('stat');
+% if (strcmp(nlp_solver, 'sqp'))
+%     figure;
+%     plot([0: size(stat,1)-1], log10(stat(:,2)), 'r-x');
+%     hold on
+%     plot([0: size(stat,1)-1], log10(stat(:,3)), 'b-x');
+%     plot([0: size(stat,1)-1], log10(stat(:,4)), 'g-x');
+%     plot([0: size(stat,1)-1], log10(stat(:,5)), 'k-x');
+% %    semilogy(0: size(stat,1)-1, stat(:,2), 'r-x');
+% %    hold on
+% %    semilogy(0: size(stat,1)-1, stat(:,3), 'b-x');
+% %    semilogy(0: size(stat,1)-1, stat(:,4), 'g-x');
+% %    semilogy(0: size(stat,1)-1, stat(:,5), 'k-x');
+%     hold off
+%     xlabel('iter')
+%     ylabel('res')
+%     legend('res stat', 'res eq', 'res ineq', 'res compl');
+% end
 
 
 if status==0

--- a/examples/acados_matlab_octave/pendulum_on_cart_model/example_ocp_reg.m
+++ b/examples/acados_matlab_octave/pendulum_on_cart_model/example_ocp_reg.m
@@ -328,7 +328,11 @@ else
 
         end
 
-        fprintf('\n\n');
+		% check residuals and terminate if tol is reached
+		residuals = ocp.get("residuals");
+		if residuals(1) < nlp_solver_tol_stat && residuals(2) < nlp_solver_tol_eq && residuals(3) < nlp_solver_tol_ineq && residuals(4) < nlp_solver_tol_comp
+			break
+		end
     end
 end
 
@@ -371,11 +375,11 @@ legend('F');
 stat = ocp.get('stat');
 if (strcmp(nlp_solver, 'sqp'))
     figure;
-     plot([0: size(stat,1)-1], log10(stat(:,2)), 'r-x');
-     hold on
-     plot([0: size(stat,1)-1], log10(stat(:,3)), 'b-x');
-     plot([0: size(stat,1)-1], log10(stat(:,4)), 'g-x');
-     plot([0: size(stat,1)-1], log10(stat(:,5)), 'k-x');
+    plot([0: size(stat,1)-1], log10(stat(:,2)), 'r-x');
+    hold on
+    plot([0: size(stat,1)-1], log10(stat(:,3)), 'b-x');
+    plot([0: size(stat,1)-1], log10(stat(:,4)), 'g-x');
+    plot([0: size(stat,1)-1], log10(stat(:,5)), 'k-x');
 %    semilogy(0: size(stat,1)-1, stat(:,2), 'r-x');
 %    hold on
 %    semilogy(0: size(stat,1)-1, stat(:,3), 'b-x');

--- a/examples/acados_python/getting_started/ocp/example_sqp_rti_loop.py
+++ b/examples/acados_python/getting_started/ocp/example_sqp_rti_loop.py
@@ -126,11 +126,39 @@ simX[N,:] = ocp_solver.get(N, "x")
 
 ocp_solver.print_statistics() # encapsulates: stat = ocp_solver.get_stats("statistics")
 
-# 
+#
 cost = ocp_solver.get_cost()
 print("cost function value of solution = ", cost)
 
-A = ocp_solver.dynamics_get(0, "A")
-print("forward sensitivities A at stage 0:", A)
+PRINT_QP = True
+if PRINT_QP:
+    for i in range(N):
+        A_qp = ocp_solver.get_from_qp_in(i, "A")
+        print(f"qp: A at stage {i}: {A_qp}")
 
+    for i in range(N):
+        B_qp = ocp_solver.get_from_qp_in(i, "B")
+        print(f"qp: B at stage {i}: {B_qp}")
+
+    for i in range(N+1):
+        Q_qp = ocp_solver.get_from_qp_in(i, "Q")
+        print(f"qp: Q at stage {i}: {Q_qp}")
+
+    for i in range(N+1):
+        R_qp = ocp_solver.get_from_qp_in(i, "R")
+        print(f"qp: R at stage {i}: {R_qp}")
+
+    for i in range(N+1):
+        S_qp = ocp_solver.get_from_qp_in(i, "S")
+        print(f"qp: S at stage {i}: {S_qp}")
+
+    for i in range(N+1):
+        r_qp = ocp_solver.get_from_qp_in(i, "r")
+        print(f"qp: r at stage {i}: {r_qp}")
+
+    for i in range(N+1):
+        q_qp = ocp_solver.get_from_qp_in(i, "q")
+        print(f"qp: q at stage {i}: {q_qp}")
+
+# plot
 plot_pendulum(np.linspace(0, Tf, N+1), Fmax, simU, simX, latexify=False)

--- a/interfaces/acados_c/ocp_nlp_interface.c
+++ b/interfaces/acados_c/ocp_nlp_interface.c
@@ -758,13 +758,28 @@ void ocp_nlp_qp_dims_get_from_attr(ocp_nlp_config *config, ocp_nlp_dims *dims, o
         // config->dynamics[stage]->dims_get(config->dynamics[stage], dims->dynamics[stage],
         //                                   "nx1", &dims_out[0]);
         // dims_out[1] = dims->nx[stage];
-        dims_out[0] = dims->nx[stage];
-        dims_out[1] = dims->nx[stage+1];
+        dims_out[0] = dims->nx[stage+1];
+        dims_out[1] = dims->nx[stage];
     }
     else if (!strcmp(field, "B"))
     {
+        dims_out[0] = dims->nx[stage+1];
+        dims_out[1] = dims->nu[stage];
+    }
+    else if (!strcmp(field, "Q"))
+    {
+        dims_out[0] = dims->nx[stage];
+        dims_out[1] = dims->nx[stage];
+    }
+    else if (!strcmp(field, "R"))
+    {
         dims_out[0] = dims->nu[stage];
-        dims_out[1] = dims->nx[stage+1];
+        dims_out[1] = dims->nu[stage];
+    }
+    else if (!strcmp(field, "S"))
+    {
+        dims_out[0] = dims->nx[stage];
+        dims_out[1] = dims->nu[stage];
     }
     else
     {
@@ -1048,6 +1063,26 @@ void ocp_nlp_get_at_stage(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_so
     {
         double *double_values = value;
         d_ocp_qp_get_A(stage, nlp_mem->qp_in, double_values);
+    }
+    else if (!strcmp(field, "B"))
+    {
+        double *double_values = value;
+        d_ocp_qp_get_B(stage, nlp_mem->qp_in, double_values);
+    }
+    else if (!strcmp(field, "Q"))
+    {
+        double *double_values = value;
+        d_ocp_qp_get_Q(stage, nlp_mem->qp_in, double_values);
+    }
+    else if (!strcmp(field, "R"))
+    {
+        double *double_values = value;
+        d_ocp_qp_get_R(stage, nlp_mem->qp_in, double_values);
+    }
+    else if (!strcmp(field, "S"))
+    {
+        double *double_values = value;
+        d_ocp_qp_get_S(stage, nlp_mem->qp_in, double_values);
     }
     else
     {

--- a/interfaces/acados_c/ocp_nlp_interface.c
+++ b/interfaces/acados_c/ocp_nlp_interface.c
@@ -781,6 +781,16 @@ void ocp_nlp_qp_dims_get_from_attr(ocp_nlp_config *config, ocp_nlp_dims *dims, o
         dims_out[0] = dims->nx[stage];
         dims_out[1] = dims->nu[stage];
     }
+    else if (!strcmp(field, "r"))
+    {
+        dims_out[0] = 1;
+        dims_out[1] = dims->nu[stage];
+    }
+    else if (!strcmp(field, "q"))
+    {
+        dims_out[0] = 1;
+        dims_out[1] = dims->nx[stage];
+    }
     else
     {
         printf("\nerror: ocp_nlp_qp_dims_get_from_attr: field %s not available\n", field);
@@ -1069,6 +1079,11 @@ void ocp_nlp_get_at_stage(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_so
         double *double_values = value;
         d_ocp_qp_get_B(stage, nlp_mem->qp_in, double_values);
     }
+    else if (!strcmp(field, "b"))
+    {
+        double *double_values = value;
+        d_ocp_qp_get_b(stage, nlp_mem->qp_in, double_values);
+    }
     else if (!strcmp(field, "Q"))
     {
         double *double_values = value;
@@ -1083,6 +1098,16 @@ void ocp_nlp_get_at_stage(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_so
     {
         double *double_values = value;
         d_ocp_qp_get_S(stage, nlp_mem->qp_in, double_values);
+    }
+    else if (!strcmp(field, "r"))
+    {
+        double *double_values = value;
+        d_ocp_qp_get_r(stage, nlp_mem->qp_in, double_values);
+    }
+    else if (!strcmp(field, "q"))
+    {
+        double *double_values = value;
+        d_ocp_qp_get_q(stage, nlp_mem->qp_in, double_values);
     }
     else
     {

--- a/interfaces/acados_c/ocp_nlp_interface.c
+++ b/interfaces/acados_c/ocp_nlp_interface.c
@@ -747,7 +747,7 @@ void ocp_nlp_constraint_dims_get_from_attr(ocp_nlp_config *config, ocp_nlp_dims 
 }
 
 
-void ocp_nlp_dynamics_dims_get_from_attr(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_out *out,
+void ocp_nlp_qp_dims_get_from_attr(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_out *out,
         int stage, const char *field, int *dims_out)
 {
     // vectors first
@@ -755,13 +755,20 @@ void ocp_nlp_dynamics_dims_get_from_attr(ocp_nlp_config *config, ocp_nlp_dims *d
     // only matrices here matrices
     if (!strcmp(field, "A"))
     {
-        config->dynamics[stage]->dims_get(config->dynamics[stage], dims->dynamics[stage],
-                                          "nx1", &dims_out[0]);
-        dims_out[1] = dims->nx[stage];
+        // config->dynamics[stage]->dims_get(config->dynamics[stage], dims->dynamics[stage],
+        //                                   "nx1", &dims_out[0]);
+        // dims_out[1] = dims->nx[stage];
+        dims_out[0] = dims->nx[stage];
+        dims_out[1] = dims->nx[stage+1];
+    }
+    else if (!strcmp(field, "B"))
+    {
+        dims_out[0] = dims->nu[stage];
+        dims_out[1] = dims->nx[stage+1];
     }
     else
     {
-        printf("\nerror: ocp_nlp_dynamics_dims_get_from_attr: field %s not available\n", field);
+        printf("\nerror: ocp_nlp_qp_dims_get_from_attr: field %s not available\n", field);
         exit(1);
     }
 }

--- a/interfaces/acados_c/ocp_nlp_interface.h
+++ b/interfaces/acados_c/ocp_nlp_interface.h
@@ -297,7 +297,7 @@ ACADOS_SYMBOL_EXPORT void ocp_nlp_constraint_dims_get_from_attr(ocp_nlp_config *
 ACADOS_SYMBOL_EXPORT void ocp_nlp_cost_dims_get_from_attr(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_out *out,
         int stage, const char *field, int *dims_out);
 
-void ocp_nlp_qp_dims_get_from_attr(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_out *out,
+ACADOS_SYMBOL_EXPORT void ocp_nlp_qp_dims_get_from_attr(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_out *out,
         int stage, const char *field, int *dims_out);
 
 /* opts */

--- a/interfaces/acados_c/ocp_nlp_interface.h
+++ b/interfaces/acados_c/ocp_nlp_interface.h
@@ -297,7 +297,7 @@ ACADOS_SYMBOL_EXPORT void ocp_nlp_constraint_dims_get_from_attr(ocp_nlp_config *
 ACADOS_SYMBOL_EXPORT void ocp_nlp_cost_dims_get_from_attr(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_out *out,
         int stage, const char *field, int *dims_out);
 
-void ocp_nlp_dynamics_dims_get_from_attr(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_out *out,
+void ocp_nlp_qp_dims_get_from_attr(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_out *out,
         int stage, const char *field, int *dims_out);
 
 /* opts */

--- a/interfaces/acados_matlab_octave/ocp_get.c
+++ b/interfaces/acados_matlab_octave/ocp_get.c
@@ -99,7 +99,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
             sprintf(buffer, "\nocp_get: invalid stage index, got %d\n", stage);
             mexErrMsgTxt(buffer);
         }
-        else if (stage == N && strcmp(field, "x") && strcmp(field, "lam") && strcmp(field, "t") && strcmp(field, "sens_x") && strcmp(field, "sl") && strcmp(field, "su") )
+        else if (stage == N && strcmp(field, "x") && strcmp(field, "lam") && strcmp(field, "t") && strcmp(field, "sens_x") && strcmp(field, "sl") && strcmp(field, "su") && strcmp(field, "qp_Q") && strcmp(field, "qp_R") && strcmp(field, "qp_S") && strcmp(field, "qp_q") )
         {
             sprintf(buffer, "\nocp_get: invalid stage index, got stage = %d = N, field = %s, only x, lam, t, slacks available at this stage\n", stage, field);
             mexErrMsgTxt(buffer);
@@ -440,39 +440,38 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 			exit(1);
 		}
 	}
-    else if (!strcmp(field, "qp_A"))
+    else if (!strcmp(field, "qp_A") || !strcmp(field, "qp_B") || !strcmp(field, "qp_Q") ||
+             !strcmp(field, "qp_R") || !strcmp(field, "qp_S") || !strcmp(field, "qp_b") ||
+             !strcmp(field, "qp_q") || !strcmp(field, "qp_r"))
     {
         int out_dims[2];
         if (nrhs==2)
         {
             mxArray *cell_array = mxCreateCellMatrix(N, 1);
             plhs[0] = cell_array;
-
             mxArray *tmp_mat;
 
             for (ii=0; ii<N; ii++)
             {
-                // tmp_mat = mxCreateNumericMatrix(nx[ii+1], nx[ii], mxDOUBLE_CLASS, mxREAL);
-                ocp_nlp_qp_dims_get_from_attr(config, dims, out, ii, "A", out_dims);
+                ocp_nlp_qp_dims_get_from_attr(config, dims, out, ii, &field[3], out_dims);
                 tmp_mat = mxCreateNumericMatrix(out_dims[0], out_dims[1], mxDOUBLE_CLASS, mxREAL);
                 double *mat_ptr = mxGetPr( tmp_mat );
-                ocp_nlp_get_at_stage(config, dims, solver, ii, "A", mat_ptr);
+                ocp_nlp_get_at_stage(config, dims, solver, ii, &field[3], mat_ptr);
                 mxSetCell(cell_array, ii, tmp_mat);
             }
         }
         else if (nrhs==3)
         {
-            ocp_nlp_qp_dims_get_from_attr(config, dims, out, stage, "A", out_dims);
-
+            ocp_nlp_qp_dims_get_from_attr(config, dims, out, stage, &field[3], out_dims);
             plhs[0] = mxCreateNumericMatrix(out_dims[0], out_dims[1], mxDOUBLE_CLASS, mxREAL);
             double *mat_ptr = mxGetPr( plhs[0] );
-            ocp_nlp_get_at_stage(config, dims, solver, stage, "A", mat_ptr);
+            ocp_nlp_get_at_stage(config, dims, solver, stage, &field[3], mat_ptr);
         }
     }
     else
     {
         MEX_FIELD_NOT_SUPPORTED_SUGGEST(fun_name, field,
-             "x, u, z, pi, lam, sl, su, t, sens_x, sens_u, sens_pi, status, sqp_iter, time_tot, time_lin, time_reg, time_qp_sol, stat, qp_solver_cond_H, qp_A");
+             "x, u, z, pi, lam, sl, su, t, sens_x, sens_u, sens_pi, status, sqp_iter, time_tot, time_lin, time_reg, time_qp_sol, stat, qp_solver_cond_H, qp_A, qp_B, qp_Q, qp_R, qp_S, qp_b, qp_q, qp_r");
     }
 
     return;

--- a/interfaces/acados_matlab_octave/ocp_get.c
+++ b/interfaces/acados_matlab_octave/ocp_get.c
@@ -389,57 +389,57 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     }
     else if (!strcmp(field, "qp_solver_cond_H"))
     {
-		void *qp_in_;
+        void *qp_in_;
         ocp_nlp_get(config, solver, "qp_xcond_in", &qp_in_);
-		int solver_type = 0;
-		if (plan->ocp_qp_solver_plan.qp_solver==PARTIAL_CONDENSING_HPIPM)
-			solver_type=1;
-		if (plan->ocp_qp_solver_plan.qp_solver==FULL_CONDENSING_HPIPM)
-			solver_type=2;
+        int solver_type = 0;
+        if (plan->ocp_qp_solver_plan.qp_solver==PARTIAL_CONDENSING_HPIPM)
+            solver_type=1;
+        if (plan->ocp_qp_solver_plan.qp_solver==FULL_CONDENSING_HPIPM)
+            solver_type=2;
 #if defined(ACADOS_WITH_QPOASES)
-		if (plan->ocp_qp_solver_plan.qp_solver==FULL_CONDENSING_QPOASES)
-			solver_type=2;
+        if (plan->ocp_qp_solver_plan.qp_solver==FULL_CONDENSING_QPOASES)
+            solver_type=2;
 #endif
 #if defined(ACADOS_WITH_DAQP)
-		if (plan->ocp_qp_solver_plan.qp_solver==FULL_CONDENSING_DAQP)
-			solver_type=2;
+        if (plan->ocp_qp_solver_plan.qp_solver==FULL_CONDENSING_DAQP)
+            solver_type=2;
 #endif
-		// ocp solver (not dense)
-		if(solver_type==1)
-		{
-			ocp_qp_in *qp_in = qp_in_;
-			int *nu = qp_in->dim->nu;
-			int *nx = qp_in->dim->nx;
+        // ocp solver (not dense)
+        if(solver_type==1)
+        {
+            ocp_qp_in *qp_in = qp_in_;
+            int *nu = qp_in->dim->nu;
+            int *nx = qp_in->dim->nx;
 
-			mxArray *cell_array = mxCreateCellMatrix(N+1, 1);
-			plhs[0] = cell_array;
+            mxArray *cell_array = mxCreateCellMatrix(N+1, 1);
+            plhs[0] = cell_array;
 
-			mxArray *tmp_mat;
+            mxArray *tmp_mat;
 
-			for (ii=0; ii<=N; ii++)
-			{
-				tmp_mat = mxCreateNumericMatrix(nu[ii]+nx[ii], nu[ii]+nx[ii], mxDOUBLE_CLASS, mxREAL);
-				double *mat_ptr = mxGetPr( tmp_mat );
-				blasfeo_unpack_dmat(nu[ii]+nx[ii], nu[ii]+nx[ii], qp_in->RSQrq+ii, 0, 0, mat_ptr, nu[ii]+nx[ii]);
+            for (ii=0; ii<=N; ii++)
+            {
+                tmp_mat = mxCreateNumericMatrix(nu[ii]+nx[ii], nu[ii]+nx[ii], mxDOUBLE_CLASS, mxREAL);
+                double *mat_ptr = mxGetPr( tmp_mat );
+                blasfeo_unpack_dmat(nu[ii]+nx[ii], nu[ii]+nx[ii], qp_in->RSQrq+ii, 0, 0, mat_ptr, nu[ii]+nx[ii]);
 
-				mxSetCell(cell_array, ii, tmp_mat);
-			}
-		}
-		// dense solver
-		else if(solver_type==2)
-		{
-			dense_qp_in *qp_in = qp_in_;
-			int nv = qp_in->dim->nv;
-			plhs[0] = mxCreateNumericMatrix(nv, nv, mxDOUBLE_CLASS, mxREAL);
-			double *mat_ptr = mxGetPr( plhs[0] );
-			blasfeo_unpack_dmat(nv, nv, qp_in->Hv, 0, 0, mat_ptr, nv);
-		}
-		else
-		{
-			mexPrintf("\nerror: ocp_get: qp_solver_cond_H: unsupported solver\n");
-			exit(1);
-		}
-	}
+                mxSetCell(cell_array, ii, tmp_mat);
+            }
+        }
+        // dense solver
+        else if(solver_type==2)
+        {
+            dense_qp_in *qp_in = qp_in_;
+            int nv = qp_in->dim->nv;
+            plhs[0] = mxCreateNumericMatrix(nv, nv, mxDOUBLE_CLASS, mxREAL);
+            double *mat_ptr = mxGetPr( plhs[0] );
+            blasfeo_unpack_dmat(nv, nv, qp_in->Hv, 0, 0, mat_ptr, nv);
+        }
+        else
+        {
+            mexPrintf("\nerror: ocp_get: qp_solver_cond_H: unsupported solver\n");
+            exit(1);
+        }
+    }
     else if (!strcmp(field, "qp_A") || !strcmp(field, "qp_B") || !strcmp(field, "qp_Q") ||
              !strcmp(field, "qp_R") || !strcmp(field, "qp_S") || !strcmp(field, "qp_b") ||
              !strcmp(field, "qp_q") || !strcmp(field, "qp_r"))

--- a/interfaces/acados_matlab_octave/ocp_get.c
+++ b/interfaces/acados_matlab_octave/ocp_get.c
@@ -70,6 +70,9 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     // solver
     ptr = (long long *) mxGetData( mxGetField( C_ocp, 0, "solver" ) );
     ocp_nlp_solver *solver = (ocp_nlp_solver *) ptr[0];
+    // in
+    ptr = (long long *) mxGetData( mxGetField( prhs[0], 0, "in" ) );
+    ocp_nlp_in *in = (ocp_nlp_in *) ptr[0];
     // sens_out
     ptr = (long long *) mxGetData( mxGetField( C_ocp, 0, "sens_out" ) );
     ocp_nlp_out *sens_out = (ocp_nlp_out *) ptr[0];
@@ -372,6 +375,17 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
             for (jj=0; jj<stat_n; jj++)
                 mat_ptr[ii+(jj+1)*min_size] = stat[jj+ii*stat_n];
         }
+    }
+    else if (!strcmp(field, "residuals"))
+    {
+        if (plan->nlp_solver == SQP_RTI)
+            ocp_nlp_eval_residuals(solver, in, out);
+        plhs[0] = mxCreateNumericMatrix(4, 1, mxDOUBLE_CLASS, mxREAL);
+        double *mat_ptr = mxGetPr( plhs[0] );
+        ocp_nlp_get(config, solver, "res_stat", &mat_ptr[0]);
+        ocp_nlp_get(config, solver, "res_eq", &mat_ptr[1]);
+        ocp_nlp_get(config, solver, "res_ineq", &mat_ptr[2]);
+        ocp_nlp_get(config, solver, "res_comp", &mat_ptr[3]);
     }
     else if (!strcmp(field, "qp_solver_cond_H"))
     {

--- a/interfaces/acados_matlab_octave/ocp_get.c
+++ b/interfaces/acados_matlab_octave/ocp_get.c
@@ -440,7 +440,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 			exit(1);
 		}
 	}
-    else if (!strcmp(field, "qp_solver_A"))
+    else if (!strcmp(field, "qp_A"))
     {
         int out_dims[2];
         if (nrhs==2)
@@ -472,7 +472,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     else
     {
         MEX_FIELD_NOT_SUPPORTED_SUGGEST(fun_name, field,
-             "x, u, z, pi, lam, sl, su, t, sens_x, sens_u, sens_pi, status, sqp_iter, time_tot, time_lin, time_reg, time_qp_sol, stat, qp_solver_cond_H, qp_solver_A");
+             "x, u, z, pi, lam, sl, su, t, sens_x, sens_u, sens_pi, status, sqp_iter, time_tot, time_lin, time_reg, time_qp_sol, stat, qp_solver_cond_H, qp_A");
     }
 
     return;

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -1453,6 +1453,12 @@ class AcadosOcpSolver:
     def get_residuals(self, recompute=False):
         """
         Returns an array of the form [res_stat, res_eq, res_ineq, res_comp].
+        This residual has to be computed for SQP_RTI solver, since it is not available by default.
+
+        - res_stat: stationarity residual
+        - res_eq: residual wrt equality constraints (dynamics)
+        - res_ineq: residual wrt inequality constraints (constraints)
+        - res_comp: residual wrt complementarity conditions
         """
         # compute residuals if RTI
         if self.solver_options['nlp_solver_type'] == 'SQP_RTI' or recompute:

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -1705,27 +1705,26 @@ class AcadosOcpSolver:
         return
 
 
-    def dynamics_get(self, stage_, field_):
+    def get_from_qp_in(self, stage_, field_):
         """
-        Get numerical data from the dynamics module of the solver:
+        Get numerical data from the current QP.
 
             :param stage: integer corresponding to shooting node
             :param field: string, e.g., 'A'
         """
 
-        field = field_
-        field = field.encode('utf-8')
+        field = field_.encode('utf-8')
         stage = c_int(stage_)
 
         # get dims
-        self.shared_lib.ocp_nlp_dynamics_dims_get_from_attr.argtypes = \
+        self.shared_lib.ocp_nlp_qp_dims_get_from_attr.argtypes = \
             [c_void_p, c_void_p, c_void_p, c_int, c_char_p, POINTER(c_int)]
-        self.shared_lib.ocp_nlp_dynamics_dims_get_from_attr.restype = c_int
+        self.shared_lib.ocp_nlp_qp_dims_get_from_attr.restype = c_int
 
         dims = np.ascontiguousarray(np.zeros((2,)), dtype=np.intc)
         dims_data = cast(dims.ctypes.data, POINTER(c_int))
 
-        self.shared_lib.ocp_nlp_dynamics_dims_get_from_attr(self.nlp_config, \
+        self.shared_lib.ocp_nlp_qp_dims_get_from_attr(self.nlp_config, \
             self.nlp_dims, self.nlp_out, stage_, field, dims_data)
 
         # create output data

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -1710,7 +1710,7 @@ class AcadosOcpSolver:
         Get numerical data from the current QP.
 
             :param stage: integer corresponding to shooting node
-            :param field: string, e.g., 'A'
+            :param field: string in ['A', 'B', 'Q', 'R', 'S', 'b', 'q', 'r']
         """
 
         field = field_.encode('utf-8')

--- a/interfaces/acados_template/acados_template/acados_ocp_solver_pyx.pyx
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver_pyx.pyx
@@ -627,7 +627,7 @@ cdef class AcadosOcpSolverCython:
         return
 
 
-    def dynamics_get(self, int stage, str field_):
+    def get_from_qp_in(self, int stage, str field_):
         """
         Get numerical data from the dynamics module of the solver:
 
@@ -638,7 +638,7 @@ cdef class AcadosOcpSolverCython:
 
         # get dims
         cdef int[2] dims
-        acados_solver_common.ocp_nlp_dynamics_dims_get_from_attr(self.nlp_config, self.nlp_dims, self.nlp_out, stage, field, &dims[0])
+        acados_solver_common.ocp_nlp_qp_dims_get_from_attr(self.nlp_config, self.nlp_dims, self.nlp_out, stage, field, &dims[0])
 
         # create output data
         cdef cnp.ndarray[cnp.float64_t, ndim=2] out = np.zeros((dims[0], dims[1]), order='F')

--- a/interfaces/acados_template/acados_template/acados_solver_common.pxd
+++ b/interfaces/acados_template/acados_template/acados_solver_common.pxd
@@ -87,7 +87,7 @@ cdef extern from "acados_c/ocp_nlp_interface.h":
         int stage, const char *field, int *dims_out)
     void ocp_nlp_cost_dims_get_from_attr(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_out *out,
         int stage, const char *field, int *dims_out)
-    void ocp_nlp_dynamics_dims_get_from_attr(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_out *out,
+    void ocp_nlp_qp_dims_get_from_attr(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_out *out,
         int stage, const char *field, int *dims_out)
 
     # opts


### PR DESCRIPTION
Two breaking changes, of not widely used functionality:

Python / C:
[BREAKING: rename dynamics_get -> get_from_qp_in](https://github.com/acados/acados/commit/41a599971a9ec96e1cf02ade3b6f61507be548b4)

Matlab:
[BREAKING: Matlab: change 'qp_solver_A' to 'qp_A'](https://github.com/acados/acados/commit/1c4256f152657b40dc7fc13e66d79e40ca06ada4)