### PR TITLE
Work on core for speedups

### DIFF
--- a/acados/ocp_nlp/ocp_nlp_common.c
+++ b/acados/ocp_nlp/ocp_nlp_common.c
@@ -1881,7 +1881,6 @@ ocp_nlp_workspace *ocp_nlp_workspace_assign(ocp_nlp_config *config, ocp_nlp_dims
     }
     else
     {
-
         // qp solver
         work->qp_work = (void *) c_ptr;
         c_ptr += qp_solver->workspace_calculate_size(qp_solver, dims->qp_solver,
@@ -1910,7 +1909,7 @@ ocp_nlp_workspace *ocp_nlp_workspace_assign(ocp_nlp_config *config, ocp_nlp_dims
 
     }
 
-    assert((char *) work + ocp_nlp_workspace_calculate_size(config, dims, opts) >= c_ptr);
+    assert((char *) work + mem->workspace_size >= c_ptr);
 
     return work;
 }

--- a/acados/ocp_nlp/ocp_nlp_common.c
+++ b/acados/ocp_nlp/ocp_nlp_common.c
@@ -1953,6 +1953,7 @@ void ocp_nlp_alias_memory_to_submodules(ocp_nlp_config *config, ocp_nlp_dims *di
         config->dynamics[i]->memory_set_RSQrq_ptr(nlp_mem->qp_in->RSQrq+i, nlp_mem->dynamics[i]);
         config->dynamics[i]->memory_set_dzduxt_ptr(nlp_mem->dzduxt+i, nlp_mem->dynamics[i]);
         config->dynamics[i]->memory_set_sim_guess_ptr(nlp_mem->sim_guess+i, nlp_mem->set_sim_guess+i, nlp_mem->dynamics[i]);
+        // NOTE: no z at terminal stage, since dynamics modules dont compute it.
         config->dynamics[i]->memory_set_z_alg_ptr(nlp_mem->z_alg+i, nlp_mem->dynamics[i]);
     }
 

--- a/acados/ocp_nlp/ocp_nlp_common.h
+++ b/acados/ocp_nlp/ocp_nlp_common.h
@@ -354,6 +354,7 @@ typedef struct ocp_nlp_memory
 
     bool *set_sim_guess; // indicate if there is new explicitly provided guess for integration variables
     struct blasfeo_dvec *sim_guess;
+    acados_size_t workspace_size;
 
 } ocp_nlp_memory;
 

--- a/acados/ocp_nlp/ocp_nlp_constraints_bgh.c
+++ b/acados/ocp_nlp/ocp_nlp_constraints_bgh.c
@@ -1192,12 +1192,18 @@ acados_size_t ocp_nlp_constraints_bgh_workspace_calculate_size(void *config_, vo
 
     size += sizeof(ocp_nlp_constraints_bgh_workspace);
 
-    size += 1 * blasfeo_memsize_dmat(nu+nx, nu+nx); // tmp_nv_nv
-    size += 1 * blasfeo_memsize_dmat(nz, nh);       // tmp_nz_nh
-    size += 1 * blasfeo_memsize_dmat(nz, nx+nu);       // tmp_nz_nv
-    size += 1 * blasfeo_memsize_dmat(nx+nu, nh);    // tmp_nv_nh
-    size += 1 * blasfeo_memsize_dmat(nz, nz);    // hess_z
-    size += 1 * blasfeo_memsize_dvec(nh);           // tmp_nh
+    if (nz > 0)
+    {
+        size += 1 * blasfeo_memsize_dmat(nz, nh);       // tmp_nz_nh
+        size += 1 * blasfeo_memsize_dmat(nz, nz);    // hess_z
+        size += 1 * blasfeo_memsize_dmat(nz, nx+nu);       // tmp_nz_nv
+    }
+    if (nh > 0)
+    {
+        size += 1 * blasfeo_memsize_dmat(nu+nx, nu+nx); // tmp_nv_nv
+        size += 1 * blasfeo_memsize_dmat(nx+nu, nh);    // tmp_nv_nh
+        size += 1 * blasfeo_memsize_dvec(nh);           // tmp_nh
+    }
     size += 1 * blasfeo_memsize_dvec(nb+ng+nh+ns);  // tmp_ni
 
     size += 1 * 64;                                 // blasfeo_mem align
@@ -1227,23 +1233,24 @@ static void ocp_nlp_constraints_bgh_cast_workspace(void *config_, void *dims_, v
     // blasfeo_mem align
     align_char_to(64, &c_ptr);
 
-    // tmp_nv_nv
-    assign_and_advance_blasfeo_dmat_mem(nu+nx, nu+nx, &work->tmp_nv_nv, &c_ptr);
-
-    // tmp_nz_nh
-    assign_and_advance_blasfeo_dmat_mem(nz, nh, &work->tmp_nz_nh, &c_ptr);
-
-    // tmp_nv_nh
-    assign_and_advance_blasfeo_dmat_mem(nx + nu, nh, &work->tmp_nv_nh, &c_ptr);
-
-    // hess_z
-    assign_and_advance_blasfeo_dmat_mem(nz, nz, &work->hess_z, &c_ptr);
-
-    // tmp_nz_nv
-    assign_and_advance_blasfeo_dmat_mem(nz, nx+nu, &work->tmp_nz_nv, &c_ptr);
-
-    // tmp_nh
-    assign_and_advance_blasfeo_dvec_mem(nh, &work->tmp_nh, &c_ptr);
+    if (nz > 0)
+    {
+        // tmp_nz_nh
+        assign_and_advance_blasfeo_dmat_mem(nz, nh, &work->tmp_nz_nh, &c_ptr);
+        // hess_z
+        assign_and_advance_blasfeo_dmat_mem(nz, nz, &work->hess_z, &c_ptr);
+        // tmp_nz_nv
+        assign_and_advance_blasfeo_dmat_mem(nz, nx+nu, &work->tmp_nz_nv, &c_ptr);
+    }
+    if (nh > 0)
+    {
+        // tmp_nv_nv
+        assign_and_advance_blasfeo_dmat_mem(nu+nx, nu+nx, &work->tmp_nv_nv, &c_ptr);
+        // tmp_nv_nh
+        assign_and_advance_blasfeo_dmat_mem(nx + nu, nh, &work->tmp_nv_nh, &c_ptr);
+        // tmp_nh
+        assign_and_advance_blasfeo_dvec_mem(nh, &work->tmp_nh, &c_ptr);
+    }
 
     // tmp_ni
     assign_and_advance_blasfeo_dvec_mem(nb+ng+nh+ns, &work->tmp_ni, &c_ptr);

--- a/acados/ocp_nlp/ocp_nlp_dynamics_cont.c
+++ b/acados/ocp_nlp/ocp_nlp_dynamics_cont.c
@@ -650,8 +650,8 @@ static void ocp_nlp_dynamics_cont_cast_workspace(void *config_, void *dims_, voi
     int nu = dims->nu;
 
     // sim in
-    work->sim_in = sim_in_assign(config->sim_solver, dims->sim, c_ptr);
-    c_ptr += sim_in_calculate_size(config->sim_solver, dims->sim);
+    sim_in_assign_and_advance(config->sim_solver, dims->sim, &work->sim_in, &c_ptr);
+
     // sim out
     work->sim_out = sim_out_assign(config->sim_solver, dims->sim, c_ptr);
     c_ptr += sim_out_calculate_size(config->sim_solver, dims->sim);

--- a/acados/ocp_nlp/ocp_nlp_dynamics_cont.c
+++ b/acados/ocp_nlp/ocp_nlp_dynamics_cont.c
@@ -635,8 +635,9 @@ acados_size_t ocp_nlp_dynamics_cont_workspace_calculate_size(void *config_, void
 
 
 static void ocp_nlp_dynamics_cont_cast_workspace(void *config_, void *dims_, void *opts_,
-                                                 void *work_)
+                                                 void *work_, void *mem_)
 {
+    ocp_nlp_dynamics_cont_memory *mem = mem_;
     ocp_nlp_dynamics_config *config = config_;
     ocp_nlp_dynamics_cont_dims *dims = dims_;
     ocp_nlp_dynamics_cont_opts *opts = opts_;
@@ -665,7 +666,7 @@ static void ocp_nlp_dynamics_cont_cast_workspace(void *config_, void *dims_, voi
     // hess
     assign_and_advance_blasfeo_dmat_mem(nu+nx, nu+nx, &work->hess, &c_ptr);
 
-    assert((char *) work + ocp_nlp_dynamics_cont_workspace_calculate_size(config, dims, opts) >= c_ptr);
+    assert((char *) work + mem->workspace_size >= c_ptr);
 
     return;
 }
@@ -764,7 +765,7 @@ void ocp_nlp_dynamics_cont_initialize(void *config_, void *dims_, void *model_, 
 
 void ocp_nlp_dynamics_cont_update_qp_matrices(void *config_, void *dims_, void *model_, void *opts_, void *mem_, void *work_)
 {
-    ocp_nlp_dynamics_cont_cast_workspace(config_, dims_, opts_, work_);
+    ocp_nlp_dynamics_cont_cast_workspace(config_, dims_, opts_, work_, mem_);
 
     ocp_nlp_dynamics_config *config = config_;
     ocp_nlp_dynamics_cont_dims *dims = dims_;
@@ -896,7 +897,7 @@ void ocp_nlp_dynamics_cont_update_qp_matrices(void *config_, void *dims_, void *
 
 void ocp_nlp_dynamics_cont_compute_fun(void *config_, void *dims_, void *model_, void *opts_, void *mem_, void *work_)
 {
-    ocp_nlp_dynamics_cont_cast_workspace(config_, dims_, opts_, work_);
+    ocp_nlp_dynamics_cont_cast_workspace(config_, dims_, opts_, work_, mem_);
 
     ocp_nlp_dynamics_config *config = config_;
     ocp_nlp_dynamics_cont_dims *dims = dims_;
@@ -968,13 +969,14 @@ void ocp_nlp_dynamics_cont_compute_fun(void *config_, void *dims_, void *model_,
 int ocp_nlp_dynamics_cont_precompute(void *config_, void *dims_, void *model_, void *opts_,
                                         void *mem_, void *work_)
 {
-    ocp_nlp_dynamics_cont_cast_workspace(config_, dims_, opts_, work_);
-
+    ocp_nlp_dynamics_cont_memory *mem = mem_;
     ocp_nlp_dynamics_config *config = config_;
+    mem->workspace_size = ocp_nlp_dynamics_cont_workspace_calculate_size(config, dims_, opts_);
+    ocp_nlp_dynamics_cont_cast_workspace(config_, dims_, opts_, work_, mem_);
+
     // ocp_nlp_dynamics_cont_dims *dims = dims_;
     ocp_nlp_dynamics_cont_opts *opts = opts_;
     ocp_nlp_dynamics_cont_workspace *work = work_;
-    ocp_nlp_dynamics_cont_memory *mem = mem_;
     ocp_nlp_dynamics_cont_model *model = model_;
     work->sim_in->model = model->sim_model;
     work->sim_in->T = model->T;
@@ -982,7 +984,7 @@ int ocp_nlp_dynamics_cont_precompute(void *config_, void *dims_, void *model_, v
     // call integrator
     int status = config->sim_solver->precompute(config->sim_solver, work->sim_in, work->sim_out,
                                    opts->sim_solver, mem->sim_solver, work->sim_solver);
-    
+
     config->sim_solver->memory_set_to_zero(config->sim_solver, work->sim_in->dims,
                                     opts->sim_solver, mem->sim_solver, "guesses");
 

--- a/acados/ocp_nlp/ocp_nlp_dynamics_cont.h
+++ b/acados/ocp_nlp/ocp_nlp_dynamics_cont.h
@@ -121,6 +121,8 @@ typedef struct
     // struct blasfeo_dvec *z;             // pointer to (input) z in nlp_out at current stage
     struct blasfeo_dmat *dzduxt;        // pointer to dzdux transposed
     void *sim_solver;                   // sim solver memory
+    acados_size_t workspace_size;
+
 } ocp_nlp_dynamics_cont_memory;
 
 //

--- a/acados/ocp_nlp/ocp_nlp_sqp.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp.c
@@ -498,7 +498,6 @@ int ocp_nlp_sqp(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
     // set number of threads
     omp_set_num_threads(opts->nlp_opts->num_threads);
 #endif
-    ocp_nlp_alias_memory_to_submodules(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work);
 
     //
     if (opts->initialize_t_slacks > 0)

--- a/acados/ocp_nlp/ocp_nlp_sqp.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp.c
@@ -468,7 +468,7 @@ int ocp_nlp_sqp(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
     ocp_nlp_res *nlp_res = nlp_mem->nlp_res;
 
     ocp_nlp_sqp_workspace *work = work_;
-    ocp_nlp_sqp_cast_workspace(config, dims, opts, mem, work);
+    // ocp_nlp_sqp_cast_workspace(config, dims, opts, mem, work);
     ocp_nlp_workspace *nlp_work = work->nlp_work;
 
     ocp_qp_in *qp_in = nlp_mem->qp_in;
@@ -1039,7 +1039,7 @@ void ocp_nlp_sqp_eval_param_sens(void *config_, void *dims_, void *opts_, void *
     ocp_nlp_out *sens_nlp_out = sens_nlp_out_;
 
     ocp_nlp_sqp_workspace *work = work_;
-    ocp_nlp_sqp_cast_workspace(config, dims, opts, mem, work);
+    // ocp_nlp_sqp_cast_workspace(config, dims, opts, mem, work);
     ocp_nlp_workspace *nlp_work = work->nlp_work;
 
     d_ocp_qp_copy_all(nlp_mem->qp_in, work->tmp_qp_in);

--- a/acados/ocp_nlp/ocp_nlp_sqp.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp.c
@@ -1016,6 +1016,8 @@ int ocp_nlp_sqp_precompute(void *config_, void *dims_, void *nlp_in_, void *nlp_
     ocp_nlp_out *nlp_out = nlp_out_;
     ocp_nlp_memory *nlp_mem = mem->nlp_mem;
 
+    nlp_mem->workspace_size = ocp_nlp_workspace_calculate_size(config, dims, opts->nlp_opts);
+
     ocp_nlp_sqp_workspace *work = work_;
     ocp_nlp_sqp_cast_workspace(config, dims, opts, mem, work);
     ocp_nlp_workspace *nlp_work = work->nlp_work;

--- a/acados/ocp_nlp/ocp_nlp_sqp_rti.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp_rti.c
@@ -444,8 +444,6 @@ static void ocp_nlp_sqp_rti_preparation_step(ocp_nlp_config *config, ocp_nlp_dim
     omp_set_num_threads(opts->nlp_opts->num_threads);
 #endif
 
-    ocp_nlp_alias_memory_to_submodules(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work);
-
     // initialize QP
     ocp_nlp_initialize_submodules(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work);
 

--- a/acados/ocp_nlp/ocp_nlp_sqp_rti.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp_rti.c
@@ -680,6 +680,8 @@ int ocp_nlp_sqp_rti_precompute(void *config_, void *dims_, void *nlp_in_,
     ocp_nlp_out *nlp_out = nlp_out_;
     ocp_nlp_memory *nlp_mem = mem->nlp_mem;
 
+    nlp_mem->workspace_size = ocp_nlp_workspace_calculate_size(config, dims, opts->nlp_opts);
+
     ocp_nlp_sqp_rti_workspace *work = work_;
     ocp_nlp_sqp_rti_cast_workspace(config, dims, opts, mem, work);
     ocp_nlp_workspace *nlp_work = work->nlp_work;

--- a/acados/ocp_nlp/ocp_nlp_sqp_rti.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp_rti.c
@@ -620,7 +620,7 @@ int ocp_nlp_sqp_rti(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
     ocp_nlp_in *nlp_in = nlp_in_;
     ocp_nlp_out *nlp_out = nlp_out_;
     ocp_nlp_sqp_rti_workspace *work = work_;
-    ocp_nlp_sqp_rti_cast_workspace(config, dims, opts, mem, work);
+    // ocp_nlp_sqp_rti_cast_workspace(config, dims, opts, mem, work);
 
     int rti_phase = opts->rti_phase;
 
@@ -704,7 +704,7 @@ void ocp_nlp_sqp_rti_eval_param_sens(void *config_, void *dims_, void *opts_,
     ocp_nlp_out *sens_nlp_out = sens_nlp_out_;
 
     ocp_nlp_sqp_rti_workspace *work = work_;
-    ocp_nlp_sqp_rti_cast_workspace(config, dims, opts, mem, work);
+    // ocp_nlp_sqp_rti_cast_workspace(config, dims, opts, mem, work);
     ocp_nlp_workspace *nlp_work = work->nlp_work;
 
     d_ocp_qp_copy_all(nlp_mem->qp_in, work->tmp_qp_in);

--- a/acados/ocp_qp/ocp_qp_xcond_solver.c
+++ b/acados/ocp_qp/ocp_qp_xcond_solver.c
@@ -300,7 +300,7 @@ acados_size_t ocp_qp_xcond_solver_memory_calculate_size(void *config_, ocp_qp_xc
     acados_size_t size = 0;
     size += sizeof(ocp_qp_xcond_solver_memory);
 
-    // set up dimesions of partially condensed qp
+    // set up dimensions of partially condensed qp
     void *xcond_qp_dims;
     xcond->dims_get(xcond, dims->xcond_dims, "xcond_dims", &xcond_qp_dims);
 
@@ -324,7 +324,7 @@ void *ocp_qp_xcond_solver_memory_assign(void *config_, ocp_qp_xcond_solver_dims 
 
     char *c_ptr = (char *) raw_memory;
 
-    // set up dimesions of partially condensed qp
+    // set up dimensions of partially condensed qp
     void *xcond_qp_dims;
     xcond->dims_get(xcond, dims->xcond_dims, "xcond_dims", &xcond_qp_dims);
 
@@ -442,7 +442,7 @@ acados_size_t ocp_qp_xcond_solver_workspace_calculate_size(void *config_, ocp_qp
 //    size += xcond->workspace_calculate_size(dims->orig_dims, opts->xcond_opts);
     size += xcond->workspace_calculate_size(dims->xcond_dims, opts->xcond_opts);
 
-    // set up dimesions of condensed qp
+    // set up dimensions of condensed qp
     void *xcond_qp_dims;
     xcond->dims_get(xcond, dims->xcond_dims, "xcond_dims", &xcond_qp_dims);
 
@@ -462,7 +462,6 @@ static void cast_workspace(void *config_, ocp_qp_xcond_solver_dims *dims,
     qp_solver_config *qp_solver = config->qp_solver;
     ocp_qp_xcond_config *xcond = config->xcond;
 
-    // set up dimesions of  condensed qp
     void *xcond_qp_dims;
     xcond->dims_get(xcond, dims->xcond_dims, "xcond_dims", &xcond_qp_dims);
 

--- a/acados/sim/sim_common.h
+++ b/acados/sim/sim_common.h
@@ -205,6 +205,8 @@ acados_size_t sim_in_calculate_size(void *config, void *dims);
 //
 sim_in *sim_in_assign(void *config, void *dims, void *raw_memory);
 //
+void sim_in_assign_and_advance(void *config, void *dims, sim_in **sim_in_p, char **c_ptr);
+//
 int sim_in_set_(void *config_, void *dims_, sim_in *in, const char *field, void *value);
 
 /* out */

--- a/acados/sim/sim_erk_integrator.c
+++ b/acados/sim/sim_erk_integrator.c
@@ -440,10 +440,11 @@ acados_size_t sim_erk_workspace_calculate_size(void *config_, void *dims_, void 
 
 
 
-static void *sim_erk_cast_workspace(void *config_, void *dims_, void *opts_, void *raw_memory)
+static void *sim_erk_cast_workspace(void *config_, void *dims_, void *opts_, void *raw_memory, void *mem_)
 {
     sim_opts *opts = opts_;
     sim_erk_dims *dims = (sim_erk_dims *) dims_;
+    sim_erk_memory *mem = mem_;
 
     int ns = opts->ns;
 
@@ -478,7 +479,6 @@ static void *sim_erk_cast_workspace(void *config_, void *dims_, void *opts_, voi
         //assign_and_advance_double((num_steps + 1) * nX, &workspace->out_forw_traj, &c_ptr);
         work->out_forw_traj = d_ptr;
         d_ptr += (num_steps+1)*nX;
-        
     }
     else
     {
@@ -518,7 +518,7 @@ static void *sim_erk_cast_workspace(void *config_, void *dims_, void *opts_, voi
     // update c_ptr
     c_ptr = (char *) d_ptr;
 
-    assert((char *) raw_memory + sim_erk_workspace_calculate_size(config_, dims, opts_) >= c_ptr);
+    assert((char *) raw_memory + mem->workspace_size >= c_ptr);
 
     return (void *) work;
 }
@@ -530,6 +530,8 @@ static void *sim_erk_cast_workspace(void *config_, void *dims_, void *opts_, voi
 int sim_erk_precompute(void *config_, sim_in *in, sim_out *out, void *opts_, void *mem_,
                        void *work_)
 {
+    sim_erk_memory *mem = mem_;
+    mem->workspace_size = sim_erk_workspace_calculate_size(config_, in->dims, opts_);
     return ACADOS_SUCCESS;
 }
 
@@ -555,7 +557,7 @@ int sim_erk(void *config_, sim_in *in, sim_out *out, void *opts_, void *mem_, vo
     void *dims_ = in->dims;
     sim_erk_dims *dims = (sim_erk_dims *) dims_;
 
-    sim_erk_workspace *work = sim_erk_cast_workspace(config, dims, opts, work_);
+    sim_erk_workspace *work = sim_erk_cast_workspace(config, dims, opts, work_, mem_);
 
     int i, j, s, istep;
     double a = 0, b = 0;  // temp values of A_mat and b_vec

--- a/acados/sim/sim_erk_integrator.c
+++ b/acados/sim/sim_erk_integrator.c
@@ -623,7 +623,8 @@ int sim_erk(void *config_, sim_in *in, sim_out *out, void *opts_, void *mem_, vo
     ext_fun_arg_t expl_vde_type_out[3];
     void *expl_vde_out[3];
 
-    int nx_squared = nx * nx;
+    int nx_squared_plus_nx = nx * nx + nx;
+    int nx_times_nu = nx * nu;
 
     if (opts->sens_forw)
     {  // simulation + forward sensitivities
@@ -632,9 +633,9 @@ int sim_erk(void *config_, sim_in *in, sim_out *out, void *opts_, void *mem_, vo
         expl_vde_type_in[1] = COLMAJ;
         expl_vde_in[1] = rhs_forw_in + nx;  // Sx: nx*nx
         expl_vde_type_in[2] = COLMAJ;
-        expl_vde_in[2] = rhs_forw_in + nx + nx_squared;  // Su: nx*nu
+        expl_vde_in[2] = rhs_forw_in + nx_squared_plus_nx;  // Su: nx*nu
         expl_vde_type_in[3] = COLMAJ;
-        expl_vde_in[3] = rhs_forw_in + nx + nx_squared + nx * nu;  // u: nu
+        expl_vde_in[3] = rhs_forw_in + nx_squared_plus_nx + nx_times_nu;  // u: nu
 
         expl_vde_type_out[0] = COLMAJ;
         expl_vde_type_out[1] = COLMAJ;
@@ -697,7 +698,7 @@ int sim_erk(void *config_, sim_in *in, sim_out *out, void *opts_, void *mem_, vo
                 // forward VDE evaluation
                 expl_vde_out[0] = K_traj + s * nX;  // fun: nx
                 expl_vde_out[1] = K_traj + s * nX + nx;  // Sx: nx*nx
-                expl_vde_out[2] = K_traj + s * nX + nx + nx_squared;  // Su: nx*nu
+                expl_vde_out[2] = K_traj + s * nX + nx_squared_plus_nx;  // Su: nx*nu
                 model->expl_vde_for->evaluate(model->expl_vde_for, expl_vde_type_in, expl_vde_in,
                                               expl_vde_type_out, expl_vde_out);
             }
@@ -825,11 +826,11 @@ int sim_erk(void *config_, sim_in *in, sim_out *out, void *opts_, void *mem_, vo
                     ext_fun_type_in[1] = COLMAJ;
                     ext_fun_in[1] = rhs_adj_in + nx;  // Sx: nx*nx
                     ext_fun_type_in[2] = COLMAJ;
-                    ext_fun_in[2] = rhs_adj_in + nx + nx_squared;  // Su: nx*nu
+                    ext_fun_in[2] = rhs_adj_in + nx_squared_plus_nx;  // Su: nx*nu
                     ext_fun_type_in[3] = COLMAJ;
-                    ext_fun_in[3] = rhs_adj_in + nx + nx_squared + nx * nu;  // lam: nx
+                    ext_fun_in[3] = rhs_adj_in + nx_squared_plus_nx + nx_times_nu;  // lam: nx
                     ext_fun_type_in[4] = COLMAJ;
-                    ext_fun_in[4] = rhs_adj_in + nx + nx_squared + nx * nu + nx;  // u: nu
+                    ext_fun_in[4] = rhs_adj_in + nx_squared_plus_nx + nx_times_nu + nx;  // u: nu
 
                     ext_fun_type_out[0] = COLMAJ;
                     ext_fun_out[0] = adj_traj + s * nAdj + 0;  // adj: nx+nu

--- a/acados/sim/sim_erk_integrator.c
+++ b/acados/sim/sim_erk_integrator.c
@@ -737,8 +737,6 @@ int sim_erk(void *config_, sim_in *in, sim_out *out, void *opts_, void *mem_, vo
                 adj_tmp[nx + nu + i] = 0.0;
         }
 
-        //        printf("\nnForw=%d nAdj=%d\n", nForw, nAdj);
-
         for (i = 0; i < nu; i++)
             rhs_adj_in[nForw + nx + i] = u[i];
 
@@ -783,20 +781,12 @@ int sim_erk(void *config_, sim_in *in, sim_out *out, void *opts_, void *mem_, vo
                     }
                 }
 
-                // TODO(oj): fix this whole file or write from scratch, not really readable :/
                 acados_tic(&timer_ad);
                 if (!opts->sens_hess)
                 {
                     ext_fun_type_in[0] = COLMAJ;
                     ext_fun_in[0] = rhs_adj_in + 0;  // x: nx
-//                    ext_fun_type_in[1] = COLMAJ;
-//                    ext_fun_in[1] = rhs_adj_in + nx;  // Sx: nx*nx
-//                    ext_fun_type_in[2] = COLMAJ;
-//                    ext_fun_in[2] = rhs_adj_in + nx + nx * nx;  // Su: nx*nu
-//                    ext_fun_type_in[3] = COLMAJ;
-//                    ext_fun_in[3] = rhs_adj_in + nx + nx * nx + nx * nu;  // lam: nx
-//                    ext_fun_type_in[4] = COLMAJ;
-//                    ext_fun_in[4] = rhs_adj_in + nx + nx * nx + nx * nu + nx;  // u: nu
+
                     ext_fun_type_in[1] = COLMAJ;
                     ext_fun_in[1] = rhs_adj_in + nx;  // lam: nx
                     ext_fun_type_in[2] = COLMAJ;
@@ -804,8 +794,6 @@ int sim_erk(void *config_, sim_in *in, sim_out *out, void *opts_, void *mem_, vo
 
                     ext_fun_type_out[0] = COLMAJ;
                     ext_fun_out[0] = adj_traj + s * nAdj + 0;  // adj: nx+nu
-//                    ext_fun_type_out[1] = COLMAJ;
-//                    ext_fun_out[1] = adj_traj + s * nAdj + nx + nu;  // hess: (nx+nu)*(nx+nu)
 
                     if (model->expl_vde_adj == 0)
                     {
@@ -834,20 +822,8 @@ int sim_erk(void *config_, sim_in *in, sim_out *out, void *opts_, void *mem_, vo
                     ext_fun_type_out[1] = COLMAJ;
                     ext_fun_out[1] = adj_traj + s * nAdj + nx + nu;  // hess: (nx+nu)*(nx+nu)
 
-//printf("\nin\n");
-//d_print_mat(1, nx, ext_fun_in[0], 1);
-//d_print_mat(nx, nx, ext_fun_in[1], nx);
-//d_print_mat(nx, nu, ext_fun_in[2], nx);
-//d_print_mat(1, nx, ext_fun_in[3], 1);
-//d_print_mat(1, nu, ext_fun_in[4], 1);
-
                     model->expl_ode_hes->evaluate(model->expl_ode_hes, ext_fun_type_in, ext_fun_in,
                             ext_fun_type_out, ext_fun_out);
-
-//printf("\nout\n");
-//d_print_mat(1, nx+nu, ext_fun_out[0], 1);
-//d_print_mat(1, (nx+nu)*(nu+nx+1)/2, ext_fun_out[1], nu+nx);
-
                 }
                 timing_ad += acados_toc(&timer_ad);
             }
@@ -872,8 +848,8 @@ int sim_erk(void *config_, sim_in *in, sim_out *out, void *opts_, void *mem_, vo
                 for (int i = j; i < nx + nu; i++)
                 {
                     S_hess_out[i + (nf) *j] = adj_tmp[nx + nu + count_upper];
-                    S_hess_out[j + (nf) *i] = adj_tmp[nx + nu + count_upper];
                     // copy to upper part
+                    S_hess_out[j + (nf) *i] = adj_tmp[nx + nu + count_upper];
                     count_upper++;
                 }
             }
@@ -889,8 +865,7 @@ int sim_erk(void *config_, sim_in *in, sim_out *out, void *opts_, void *mem_, vo
     mem->time_ad = out->info->ADtime;
     mem->time_la = out->info->LAtime;
 
-    // return
-    return 0;  // success
+    return 0;
 }
 
 

--- a/acados/sim/sim_erk_integrator.h
+++ b/acados/sim/sim_erk_integrator.h
@@ -68,19 +68,19 @@ typedef struct
 
 typedef struct
 {
-	// memory
-	double time_sim;
-	double time_ad;
-	double time_la;
+    // memory
+    double time_sim;
+    double time_ad;
+    double time_la;
+    acados_size_t workspace_size;
 
-	// workspace structs
 } sim_erk_memory;
 
 
 
 typedef struct
 {
-	// workspace mem
+    // workspace mem
     double *rhs_forw_in;  // x + S + p
 
     double *K_traj;         // (stages*nX) or (steps*stages*nX) for adj

--- a/acados/utils/external_function_generic.c
+++ b/acados/utils/external_function_generic.c
@@ -192,6 +192,8 @@ static int casadi_nnz(const int *sparsity)
 
 static int casadi_is_dense(const int *sparsity)
 {
+    // returns true if casadi sparsity goes through all elements of the matrix as it would for a dense matrix;
+    // otherwise false.
     int idx, jj;
     if (sparsity != NULL)
     {

--- a/acados/utils/external_function_generic.h
+++ b/acados/utils/external_function_generic.h
@@ -142,6 +142,8 @@ typedef struct
     int *iw;
     int *args_size;     // size of args[i]
     int *res_size;      // size of res[i]
+    int *args_dense;    // indicates if args[i] is dense
+    int *res_dense;     // indicates if res[i] is dense
     int args_num;       // number of args arrays
     int args_size_tot;  // total size of args arrays
     int res_num;        // number of res arrays
@@ -200,6 +202,8 @@ typedef struct
     int *iw;
     int *args_size;     // size of args[i]
     int *res_size;      // size of res[i]
+    int *args_dense;    // indicates if args[i] is dense
+    int *res_dense;     // indicates if res[i] is dense
     int args_num;       // number of args arrays
     int args_size_tot;  // total size of args arrays
     int res_num;        // number of res arrays

--- a/examples/c/simple_dae_example.c
+++ b/examples/c/simple_dae_example.c
@@ -395,6 +395,7 @@ int main() {
     }
 
 	ocp_nlp_solver *solver = ocp_nlp_solver_create(config, dims, nlp_opts);
+    ocp_nlp_precompute(solver, nlp_in, nlp_out);
 
 	// NLP solution
     acados_timer timer;

--- a/test/ocp_nlp/test_chain.cpp
+++ b/test/ocp_nlp/test_chain.cpp
@@ -1415,12 +1415,14 @@ void setup_and_solve_nlp(int NN,
     ocp_nlp_out *nlp_out = ocp_nlp_out_create(config, dims);
 
     ocp_nlp_solver *solver = ocp_nlp_solver_create(config, dims, nlp_opts);
+    int status;
+    status = ocp_nlp_precompute(solver, nlp_in, nlp_out);
+
 
     /************************************************
     * sqp solve
     ************************************************/
 
-    int status;
 
     // warm start output initial guess of
     // solution


### PR DESCRIPTION
- **Cast highest level workspace (SQP/SQP-RTI) only in precompute for more speed**:
This still allows to reuse workspace across modules. This can only break if one tries to reuse the acados workspace memory from outside.
- **Add CasADi sparsity detection** that is called when creating an external function.
The CasADi sparsity struct in the generated functions contains an `int` which always say inputs are sparse, often this is not the case. Thus, we check now for speed!
- Added `sim_in_assign_and_advance`, this can be called to avoid calling `calculate_size` twice. Doing this everywhere is rather tedious and does not save very much.
- **Breaking**: precompute is now required!

On a small benchmark of an RTI with ERK and the cartpole this gives me >20% speedup, from 78μs to 62μs.