### PR TITLE
Matlab remove os path dependency

### DIFF
--- a/interfaces/acados_matlab_octave/ocp_generate_casadi_ext_fun.m
+++ b/interfaces/acados_matlab_octave/ocp_generate_casadi_ext_fun.m
@@ -197,8 +197,8 @@ if (strcmp(model_struct.dyn_type, 'discrete') && strcmp(model_struct.dyn_ext_fun
     c_files_path{end+1} = model_struct.dyn_generic_source;
 end
 
-%Store the current PATH environment variable value
-origEnvPath=getenv('PATH');
+% Store the current PATH environment variable value
+origEnvPath = getenv('PATH');
 
 % check compiler
 use_msvc = false;
@@ -207,11 +207,10 @@ if ~is_octave()
     if contains(mexOpts.ShortName, 'MSVC')
         use_msvc = true;
     else
-        %Read the mex C compiler configuration and extract the location
+        % Get mex C compiler configuration and extract the location
         pathToCompilerLocation = mexOpts.Location;
-        %Modify the environment PATH varuable for this Matlab session such that 
-        %the mex C compiler takes priority ensuring calls to gcc uses the
-        %configured mex compiler
+        % Set environment PATH variable for this Matlab session such that
+        % configured mex C compiler is prioritized
         setenv('PATH', [fullfile(pathToCompilerLocation,'bin') ';' origEnvPath]);
     end
 end
@@ -246,14 +245,13 @@ else % gcc
                        ' ', strjoin(unique(c_files_path), ' '), ' -o ', out_lib];
 end
 
-%Store the PATH environment variable used during compile for error reporting
-envPath=getenv('PATH');
+% Store the PATH environment variable used during compilation for error reporting
+envPath = getenv('PATH');
 
 compile_status = system(compile_command);
 
-%Reset the environment path variable to its original value
-%This is done before potentially raising an error to ensure that the path
-%environment variable is clean
+% Reset the environment PATH variable to its original value before potentially
+% raising an error to ensure that the path environment variable is clean
 setenv('PATH',origEnvPath);
 
 if compile_status ~= 0

--- a/interfaces/acados_matlab_octave/ocp_generate_casadi_ext_fun.m
+++ b/interfaces/acados_matlab_octave/ocp_generate_casadi_ext_fun.m
@@ -230,7 +230,7 @@ else % gcc
     cCompilerConfig = mex.getCompilerConfigurations('C');
     pathToCompilerLocation = cCompilerConfig.Location;
     %Modify the environment PATH varuable for this Matlab session such that 
-    %the mex C compiler takes periority ensuring calls to gcc uses the
+    %the mex C compiler takes priority ensuring calls to gcc uses the
     %configured mex compiler
     setenv('PATH', [fullfile(pathToCompilerLocation,'bin') ';' origEnvPath]);
     % set includes

--- a/interfaces/acados_matlab_octave/ocp_generate_casadi_ext_fun.m
+++ b/interfaces/acados_matlab_octave/ocp_generate_casadi_ext_fun.m
@@ -146,11 +146,11 @@ if (strcmp(opts_struct.codgen_model, 'true') && ...
     ((strcmp(model_struct.cost_ext_fun_type, 'casadi') && strcmp(model_struct.cost_type, 'ext_cost')) || ...
     (strcmp(model_struct.cost_ext_fun_type_e, 'casadi') && strcmp(model_struct.cost_type_e, 'ext_cost')) || ...
     (strcmp(model_struct.cost_ext_fun_type_0, 'casadi') && strcmp(model_struct.cost_type_0, 'ext_cost'))))
-    % generate c for function and derivatives using casadi    
-    generate_c_code_ext_cost(model_struct, opts_struct);    
+    % generate c for function and derivatives using casadi
+    generate_c_code_ext_cost(model_struct, opts_struct);
 end
-% external cost sources list 
-if (strcmp(model_struct.cost_type, 'ext_cost') && strcmp(model_struct.cost_ext_fun_type, 'casadi') && isfield(model_struct, 'cost_expr_ext_cost'))       
+% external cost sources list
+if (strcmp(model_struct.cost_type, 'ext_cost') && strcmp(model_struct.cost_ext_fun_type, 'casadi') && isfield(model_struct, 'cost_expr_ext_cost'))
     c_files{end+1} = [model_name, '_cost_ext_cost_fun.c'];
     c_files{end+1} = [model_name, '_cost_ext_cost_fun_jac.c'];
     c_files{end+1} = [model_name, '_cost_ext_cost_fun_jac_hess.c'];
@@ -158,12 +158,12 @@ end
 if (strcmp(model_struct.cost_type_e, 'ext_cost') && strcmp(model_struct.cost_ext_fun_type_e, 'casadi') && isfield(model_struct, 'cost_expr_ext_cost_e'))
     c_files{end+1} = [model_name, '_cost_ext_cost_e_fun.c'];
     c_files{end+1} = [model_name, '_cost_ext_cost_e_fun_jac.c'];
-    c_files{end+1} = [model_name, '_cost_ext_cost_e_fun_jac_hess.c'];    
+    c_files{end+1} = [model_name, '_cost_ext_cost_e_fun_jac_hess.c'];
 end
 if (strcmp(model_struct.cost_type_0, 'ext_cost') && strcmp(model_struct.cost_ext_fun_type_0, 'casadi') && isfield(model_struct, 'cost_expr_ext_cost_0'))
     c_files{end+1} = [model_name, '_cost_ext_cost_0_fun.c'];
     c_files{end+1} = [model_name, '_cost_ext_cost_0_fun_jac.c'];
-    c_files{end+1} = [model_name, '_cost_ext_cost_0_fun_jac_hess.c'];    
+    c_files{end+1} = [model_name, '_cost_ext_cost_0_fun_jac_hess.c'];
 end
 
 if (strcmp(opts_struct.codgen_model, 'true'))
@@ -180,15 +180,15 @@ end
 % generic external cost
 if (strcmp(model_struct.cost_type, 'ext_cost') && strcmp(model_struct.cost_ext_fun_type, 'generic') &&...
     isfield(model_struct, 'cost_source_ext_cost') && isfield(model_struct, 'cost_function_ext_cost'))
-    c_files_path{end+1} = model_struct.cost_source_ext_cost;        
+    c_files_path{end+1} = model_struct.cost_source_ext_cost;
 end
 if (strcmp(model_struct.cost_type_e, 'ext_cost') && strcmp(model_struct.cost_ext_fun_type_e, 'generic') &&...
     isfield(model_struct, 'cost_source_ext_cost_e') && isfield(model_struct, 'cost_function_ext_cost_e'))
-    c_files_path{end+1} = model_struct.cost_source_ext_cost_e;        
+    c_files_path{end+1} = model_struct.cost_source_ext_cost_e;
 end
 if (strcmp(model_struct.cost_type_0, 'ext_cost') && strcmp(model_struct.cost_ext_fun_type_0, 'generic') &&...
     isfield(model_struct, 'cost_source_ext_cost_0') && isfield(model_struct, 'cost_function_ext_cost_0'))
-    c_files_path{end+1} = model_struct.cost_source_ext_cost_0;        
+    c_files_path{end+1} = model_struct.cost_source_ext_cost_0;
 end
 
 % generic discrete dynamics

--- a/interfaces/acados_matlab_octave/sim_generate_casadi_ext_fun.m
+++ b/interfaces/acados_matlab_octave/sim_generate_casadi_ext_fun.m
@@ -90,8 +90,8 @@ for k=1:length(c_files)
 	c_files_path{k} = fullfile(opts_struct.output_dir, c_files{k});
 end
 
-%Store the current PATH environment variable value
-origEnvPath=getenv('PATH');
+% Store the current PATH environment variable value
+origEnvPath = getenv('PATH');
 
 % check compiler
 use_msvc = false;
@@ -100,11 +100,10 @@ if ~is_octave()
     if contains(mexOpts.ShortName, 'MSVC')
         use_msvc = true;
     else
-        %Read the mex C compiler configuration and extract the location
+        % Get mex C compiler configuration and extract the location
         pathToCompilerLocation = mexOpts.Location;
-        %Modify the environment PATH varuable for this Matlab session such that 
-        %the mex C compiler takes priority ensuring calls to gcc uses the
-        %configured mex compiler
+        % Set environment PATH variable for this Matlab session such that
+        % configured mex C compiler is prioritized
         setenv('PATH', [fullfile(pathToCompilerLocation,'bin') ';' origEnvPath]);
     end
 end
@@ -131,14 +130,13 @@ else % gcc
     compile_command = ['gcc ', ext_fun_compile_flags, ' -fPIC -shared ', strjoin(unique(c_files_path), ' '), ' -o ', out_lib];
 end
 
-%Store the PATH environment variable used during compile for error reporting
-envPath=getenv('PATH');
+% Store the PATH environment variable used during compilation for error reporting
+envPath = getenv('PATH');
 
 compile_status = system(compile_command);
 
-%Reset the environment path variable to its original value
-%This is done before potentially raising an error to ensure that the path
-%environment variable is clean
+% Reset the environment PATH variable to its original value before potentially
+% raising an error to ensure that the path environment variable is clean
 setenv('PATH',origEnvPath);
 
 if compile_status ~= 0


### PR DESCRIPTION
When generating a Simulink s-function a number of c-files are compiled using the mex compilation setup and these are linked with a library containing the casadi_ext_fun. The compilation of this library does not use mex compilation, but is rather a system call directly to the compiler. For this to work it is required that the compiler used by mex is added to the OS PATH environment variable.

As we need to have another (incompatible) version of gcc in our OS PATH environment variable acados will use this incompatible gcc version to compile the cadasdi_ext_fun library and the linking will subsequently fail.