### PR TITLE
Automate matlab install

### DIFF
--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -111,8 +111,7 @@ acados_install_windows()
 
 This will build acados with the standard options and install the external dependencies; casadi and terra renderer
 
-The `acados_install_windows(acados_root_folder,CMakeConfigString)` script can take two optional parameters:
-- acados_root_folder: Specify the path to the acados root manually
+The `acados_install_windows(CMakeConfigString)` script can take an optional argument:
 - CMake configuration string: Configuration options for CMake. The default is `-DBUILD_SHARED_LIBS=OFF -DACADOS_WITH_OSQP=OFF`
 
 ### Build acados manually (minGW)

--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -102,10 +102,22 @@ git submodule update --recursive --init
 - Add this path to your environment variable PATH, using the Windows GUI. To open the GUI press Windows key and type "env".
 - Install mingw from MATLAB add-ons manager.
 - Locate this mingw installation. The default location is `C:\ProgramData\MATLAB\SupportPackages\R2018a\3P.instrset\mingw_w64.instrset`.
-- Add the subfolders `bin` and `x86_64-w64-mingw32\bin` of the above mentioned mingw installation to your environment variable PATH.
 
+### Automatic build of acados (minGW)
+Run the following in Matlab in the folder `<acados_root_folder>/interfaces/acados_matlab_octave`:
+```
+acados_install_windows()
+```
 
-### Build acados (minGW)
+This will build acados with the standard options and install the external dependencies; casadi and terra renderer
+
+The `acados_install_windows(acados_root_folder,CMakeConfigString)` script can take two optional parameters:
+- acados_root_folder: Specify the path to the acados root manually
+- CMake configuration string: Configuration options for CMake. The default is `-DBUILD_SHARED_LIBS=OFF -DACADOS_WITH_OSQP=OFF`
+
+### Build acados manually (minGW)
+If the automated install procedure does not work acados can be built manually using these steps.
+
 Run the following from a powershell in the `<acados_root_folder>`:
 ```
 $ACADOS_INSTALL_DIR=$(pwd)

--- a/interfaces/acados_matlab_octave/acados_env_variables_windows.m
+++ b/interfaces/acados_matlab_octave/acados_env_variables_windows.m
@@ -32,9 +32,9 @@
 %
 
 
-example_dir = fileparts(which('acados_env_variables_windows'));
+interface_dir = fileparts(which('acados_env_variables_windows'));
 
-acados_dir = fullfile(example_dir, '..', '..');
+acados_dir = fullfile(interface_dir, '..', '..');
 casadi_dir = fullfile(acados_dir, 'external', 'casadi-matlab');
 matlab_interface_dir = fullfile(acados_dir, 'interfaces', 'acados_matlab_octave');
 mex_template_dir = fullfile(matlab_interface_dir, 'acados_template_mex');

--- a/interfaces/acados_matlab_octave/acados_install.m
+++ b/interfaces/acados_matlab_octave/acados_install.m
@@ -1,0 +1,92 @@
+function acados_install(acadosPath)
+arguments
+    acadosPath=pwd; %If path is not supplied, assume acados path is current directory
+end
+
+    acadosBuildPath=fullfile(acadosPath,'build');
+
+    %% Acados installation instructions:
+    % Add the subfolders bin and x86_64-w64-mingw32\bin of the above mentioned mingw installation to your environment variable PATH.
+
+    %Store the current PATH environment variable value
+    origEnvPath=getenv('PATH');
+    %Read the mex C compiler configuration and extract the location
+    cCompilerConfig = mex.getCompilerConfigurations('C');
+    pathToCompilerLocation = cCompilerConfig.Location;
+    %Modify the environment PATH varuable for this Matlab session such that 
+    %the mex C compiler takes priority ensuring calls to gcc uses the
+    %configured mex compiler
+    setenv('PATH', [fullfile(pathToCompilerLocation,'bin') ';' origEnvPath]);
+
+    %% Acados installation instructions:
+    % $ACADOS_INSTALL_DIR=$(pwd)
+    % mkdir -p build
+    % cd build
+
+    setenv('ACADOS_INSTALL_DIR',acadosPath);
+    mkdir(acadosBuildPath);
+    cd(acadosBuildPath);
+
+    %% Acados installation instructions:
+    % cmake.exe -G "MinGW Makefiles" -DACADOS_INSTALL_DIR="$ACADOS_INSTALL_DIR" -DBUILD_SHARED_LIBS=OFF -DACADOS_WITH_OSQP=ON ..
+    % # useful options to add above:
+    % # -DACADOS_WITH_QPOASES=ON/OFF -DACADOS_WITH_OSQP=ON/OFF -DACADOS_WITH_QPDUNES=ON/OFF ..
+    % # -DBLASFEO_TARGET=GENERIC -DHPIPM_TARGET=GENERIC
+    % # NOTE: check the output of cmake: -- Installation directory: should be <acados_root_folder>,
+    % #     if this is not the case, set -DACADOS_INSTALL_DIR=<acados_root_folder> explicitly above.
+
+    %Command slightly modified to work with CMD instead of PowerShell
+    cmake_cmd = 'cmake.exe -G "MinGW Makefiles" -DACADOS_INSTALL_DIR=%ACADOS_INSTALL_DIR% -DBUILD_SHARED_LIBS=OFF -DACADOS_WITH_OSQP=OFF ..';
+
+    status=system(cmake_cmd);
+    if (status~=0)
+        error('cmake command failed: %s',cmake_cmd);
+    end
+
+    %% Acados installation instructions:
+    % mingw32-make.exe -j4
+    % mingw32-make.exe install
+
+
+    compile_command='mingw32-make.exe -j4';
+    status = system(compile_command);
+    if status ~= 0
+        %Store the PATH environment variable used during compile for error reporting
+        envPath=getenv('PATH');
+        setenv('PATH',origEnvPath);
+        error('Compilation of acados failed %s\n%s\n%s\n%s\n\n', ...
+            'Compile command was:', compile_command, ...
+            'Environment path was: ', envPath);
+    end
+
+    install_command='mingw32-make.exe install';
+    status = system(install_command);
+    if status ~= 0
+        %Store the PATH environment variable used during compile for error reporting
+        envPath=getenv('PATH');
+        setenv('PATH',origEnvPath);
+        error('Installation of acados failed %s\n%s\n%s\n%s\n\n', ...
+            'Install command was:', install_command, ...
+            'Environment path was: ', envPath);
+    end
+    
+    %Restore path to original
+    setenv('PATH',origEnvPath);
+    
+    %% Install is not complete - download casadi
+    addpath(fullfile(acadosPath,'interfaces\acados_matlab_octave'));
+    run('acados_env_variables_windows');
+    check_acados_requirements(true);
+    
+    %%Install is still not complete - install the renderer 
+    acados_root_dir = getenv('ACADOS_INSTALL_DIR');
+ 
+    %% check if t_renderer is available -> download if not
+    t_renderer_location = fullfile(acados_root_dir,'bin','t_renderer.exe');
+
+
+    if ~exist( t_renderer_location, 'file' )
+        acados_template_mex.set_up_t_renderer( t_renderer_location )
+    end
+    
+end

--- a/interfaces/acados_matlab_octave/acados_install_windows.m
+++ b/interfaces/acados_matlab_octave/acados_install_windows.m
@@ -1,27 +1,25 @@
 function acados_install_windows(varargin)
-% acados_install_windows([AcadosPath],[CmakeConfigString])
+% acados_install_windows([CmakeConfigString])
 % Install script for acados on windows
-% AcadosPath - path to the root of the acados repository [Default='PATHOFTHISFILE\..\..']
 % CmakeConfigString - config string for the CMAKE command [Default='-DBUILD_SHARED_LIBS=OFF -DACADOS_WITH_OSQP=OFF']
+
 
     switch(nargin)
         case 0
-            fullPath = mfilename('fullpath');
-            % Extract path for this file
-            [folderPath,~,~]=fileparts(fullPath);
-            % Remove the two top directories to get the acados path
-            [folderPath,~,~]=fileparts(folderPath);
-            [acadosPath,~,~]=fileparts(folderPath);
             cmakeConfigString='-DBUILD_SHARED_LIBS=OFF -DACADOS_WITH_OSQP=OFF';
         case 1
-            acadosPath=varargin{1};
-            cmakeConfigString='-DBUILD_SHARED_LIBS=OFF -DACADOS_WITH_OSQP=OFF';
-        case 2
-            acadosPath=varargin{1};
-            cmakeConfigString=varargin{2};
+            cmakeConfigString=varargin{1};
         otherwise 
-            error('function called with %d parameters, was expecting max 2',nargin);
-    end
+            error('function called with %d parameters, was expecting max 1',nargin);
+    end    
+
+    % Derive the path for the acados root
+    fullPath = mfilename('fullpath');
+    % Extract path for this file
+    [folderPath,~,~]=fileparts(fullPath);
+    % Remove the two top directories to get the acados path
+    [folderPath,~,~]=fileparts(folderPath);
+    [acadosPath,~,~]=fileparts(folderPath);
 
     acadosBuildPath=fullfile(acadosPath,'build');
 

--- a/interfaces/acados_matlab_octave/acados_install_windows.m
+++ b/interfaces/acados_matlab_octave/acados_install_windows.m
@@ -1,13 +1,12 @@
 function acados_install_windows(varargin)
 
-    %The first variable parameter determines whether to force install
     switch(nargin)
         case 0
-            acadosPath=pwd; 
+            acadosPath=pwd;
         case 1
             acadosPath=varargin{1};
-        otherwise 
-            error('function called with %d parameters, was expecting max 1',nargin);
+        otherwise
+            error('function called with %d parameters, was expecting max 1', nargin);
     end
 
     acadosBuildPath=fullfile(acadosPath,'build');
@@ -15,24 +14,23 @@ function acados_install_windows(varargin)
     %% Acados installation instructions:
     % Add the subfolders bin and x86_64-w64-mingw32\bin of the above mentioned mingw installation to your environment variable PATH.
     fprintf('Setting up environment PATH variable\n');
-    
-    %Store the current PATH environment variable value
+
+    % Store the current PATH environment variable value
     origEnvPath=getenv('PATH');
-    %Read the mex C compiler configuration and extract the location
+    % Read the mex C compiler configuration and extract the location
     cCompilerConfig = mex.getCompilerConfigurations('C');
     pathToCompilerLocation = cCompilerConfig.Location;
-    %Modify the environment PATH varuable for this Matlab session such that 
-    %the mex C compiler takes priority ensuring calls to gcc uses the
-    %configured mex compiler
+    % Modify the environment PATH variable for this Matlab session such that
+    % the mex C compiler takes priority ensuring calls to gcc uses the
+    % configured mex compiler
     setenv('PATH', [fullfile(pathToCompilerLocation,'bin') ';' origEnvPath]);
 
     %% Acados installation instructions:
     % $ACADOS_INSTALL_DIR=$(pwd)
     % mkdir -p build
     % cd build
-    fprintf('Creating build dir in %s\n',acadosBuildPath);
-    
-    setenv('ACADOS_INSTALL_DIR',acadosPath);
+    fprintf('Creating build dir in %s\n', acadosBuildPath);
+    setenv('ACADOS_INSTALL_DIR', acadosPath);
     mkdir(acadosBuildPath);
     cd(acadosBuildPath);
 
@@ -44,13 +42,12 @@ function acados_install_windows(varargin)
     % # NOTE: check the output of cmake: -- Installation directory: should be <acados_root_folder>,
     % #     if this is not the case, set -DACADOS_INSTALL_DIR=<acados_root_folder> explicitly above.
     fprintf('Executing cmake configuration\n');
-    
-    %Command slightly modified to work with CMD instead of PowerShell
+    % Command slightly modified to work with CMD instead of PowerShell
     cmake_cmd = 'cmake.exe -G "MinGW Makefiles" -DACADOS_INSTALL_DIR=%ACADOS_INSTALL_DIR% -DBUILD_SHARED_LIBS=OFF -DACADOS_WITH_OSQP=OFF ..';
 
     status=system(cmake_cmd);
     if (status~=0)
-        error('cmake command failed: %s',cmake_cmd);
+        error('cmake command failed. Command was:\n%s\n', cmake_cmd);
     end
 
     %% Acados installation instructions:
@@ -79,26 +76,25 @@ function acados_install_windows(varargin)
             'Install command was:', install_command, ...
             'Environment path was: ', envPath);
     end
-    
-    %Restore path to original
+
+    % Restore path to original
     setenv('PATH',origEnvPath);
-    
-    %% Install is not complete - download casadi
+
+    %% Download external dependencies
+    % casadi
     fprintf('Downloading casadi\n');
-    addpath(fullfile(acadosPath,'interfaces\acados_matlab_octave'));
+    addpath(fullfile(acadosPath,'interfaces', 'acados_matlab_octave'));
     run('acados_env_variables_windows');
     check_acados_requirements(true);
-    
-    %%Install is still not complete - install the renderer 
+
+    %% renderer
     fprintf('Install the template renderer\n');
     acados_root_dir = getenv('ACADOS_INSTALL_DIR');
- 
     %% check if t_renderer is available -> download if not
-    t_renderer_location = fullfile(acados_root_dir,'bin','t_renderer.exe');
-
+    t_renderer_location = fullfile(acados_root_dir, 'bin', 't_renderer.exe');
 
     if ~exist( t_renderer_location, 'file' )
         acados_template_mex.set_up_t_renderer( t_renderer_location )
     end
-    
+
 end

--- a/interfaces/acados_matlab_octave/acados_install_windows.m
+++ b/interfaces/acados_matlab_octave/acados_install_windows.m
@@ -1,12 +1,26 @@
 function acados_install_windows(varargin)
+% acados_install_windows([AcadosPath],[CmakeConfigString])
+% Install script for acados on windows
+% AcadosPath - path to the root of the acados repository [Default='PATHOFTHISFILE\..\..']
+% CmakeConfigString - config string for the CMAKE command [Default='-DBUILD_SHARED_LIBS=OFF -DACADOS_WITH_OSQP=OFF']
 
     switch(nargin)
         case 0
-            acadosPath=pwd;
+            fullPath = mfilename('fullpath');
+            % Extract path for this file
+            [folderPath,~,~]=fileparts(fullPath);
+            % Remove the two top directories to get the acados path
+            [folderPath,~,~]=fileparts(folderPath);
+            [acadosPath,~,~]=fileparts(folderPath);
+            cmakeConfigString='-DBUILD_SHARED_LIBS=OFF -DACADOS_WITH_OSQP=OFF';
         case 1
             acadosPath=varargin{1};
-        otherwise
-            error('function called with %d parameters, was expecting max 1', nargin);
+            cmakeConfigString='-DBUILD_SHARED_LIBS=OFF -DACADOS_WITH_OSQP=OFF';
+        case 2
+            acadosPath=varargin{1};
+            cmakeConfigString=varargin{2};
+        otherwise 
+            error('function called with %d parameters, was expecting max 2',nargin);
     end
 
     acadosBuildPath=fullfile(acadosPath,'build');
@@ -43,7 +57,7 @@ function acados_install_windows(varargin)
     % #     if this is not the case, set -DACADOS_INSTALL_DIR=<acados_root_folder> explicitly above.
     fprintf('Executing cmake configuration\n');
     % Command slightly modified to work with CMD instead of PowerShell
-    cmake_cmd = 'cmake.exe -G "MinGW Makefiles" -DACADOS_INSTALL_DIR=%ACADOS_INSTALL_DIR% -DBUILD_SHARED_LIBS=OFF -DACADOS_WITH_OSQP=OFF ..';
+    cmake_cmd = sprintf('cmake.exe -G "MinGW Makefiles" -DACADOS_INSTALL_DIR=%%ACADOS_INSTALL_DIR%% %s ..',cmakeConfigString);
 
     status=system(cmake_cmd);
     if (status~=0)

--- a/interfaces/acados_matlab_octave/acados_install_windows.m
+++ b/interfaces/acados_matlab_octave/acados_install_windows.m
@@ -1,7 +1,14 @@
-function acados_install(acadosPath)
-arguments
-    acadosPath=pwd; %If path is not supplied, assume acados path is current directory
-end
+function acados_install_windows(varargin)
+
+    %The first variable parameter determines whether to force install
+    switch(nargin)
+        case 0
+            acadosPath=pwd; 
+        case 1
+            acadosPath=varargin{1};
+        otherwise 
+            error('function called with %d parameters, was expecting max 1',nargin);
+    end
 
     acadosBuildPath=fullfile(acadosPath,'build');
 

--- a/interfaces/acados_matlab_octave/acados_install_windows.m
+++ b/interfaces/acados_matlab_octave/acados_install_windows.m
@@ -14,7 +14,8 @@ function acados_install_windows(varargin)
 
     %% Acados installation instructions:
     % Add the subfolders bin and x86_64-w64-mingw32\bin of the above mentioned mingw installation to your environment variable PATH.
-
+    fprintf('Setting up environment PATH variable\n');
+    
     %Store the current PATH environment variable value
     origEnvPath=getenv('PATH');
     %Read the mex C compiler configuration and extract the location
@@ -29,7 +30,8 @@ function acados_install_windows(varargin)
     % $ACADOS_INSTALL_DIR=$(pwd)
     % mkdir -p build
     % cd build
-
+    fprintf('Creating build dir in %s\n',acadosBuildPath);
+    
     setenv('ACADOS_INSTALL_DIR',acadosPath);
     mkdir(acadosBuildPath);
     cd(acadosBuildPath);
@@ -41,7 +43,8 @@ function acados_install_windows(varargin)
     % # -DBLASFEO_TARGET=GENERIC -DHPIPM_TARGET=GENERIC
     % # NOTE: check the output of cmake: -- Installation directory: should be <acados_root_folder>,
     % #     if this is not the case, set -DACADOS_INSTALL_DIR=<acados_root_folder> explicitly above.
-
+    fprintf('Executing cmake configuration\n');
+    
     %Command slightly modified to work with CMD instead of PowerShell
     cmake_cmd = 'cmake.exe -G "MinGW Makefiles" -DACADOS_INSTALL_DIR=%ACADOS_INSTALL_DIR% -DBUILD_SHARED_LIBS=OFF -DACADOS_WITH_OSQP=OFF ..';
 
@@ -53,7 +56,7 @@ function acados_install_windows(varargin)
     %% Acados installation instructions:
     % mingw32-make.exe -j4
     % mingw32-make.exe install
-
+    fprintf('Compiling and installing using minGW\n');
 
     compile_command='mingw32-make.exe -j4';
     status = system(compile_command);
@@ -81,11 +84,13 @@ function acados_install_windows(varargin)
     setenv('PATH',origEnvPath);
     
     %% Install is not complete - download casadi
+    fprintf('Downloading casadi\n');
     addpath(fullfile(acadosPath,'interfaces\acados_matlab_octave'));
     run('acados_env_variables_windows');
     check_acados_requirements(true);
     
     %%Install is still not complete - install the renderer 
+    fprintf('Install the template renderer\n');
     acados_root_dir = getenv('ACADOS_INSTALL_DIR');
  
     %% check if t_renderer is available -> download if not

--- a/interfaces/acados_matlab_octave/acados_template_mex/+acados_template_mex/render_acados_templates.m
+++ b/interfaces/acados_matlab_octave/acados_template_mex/+acados_template_mex/render_acados_templates.m
@@ -45,7 +45,7 @@ function render_acados_templates(acados_ocp_nlp_json_file)
     end
 
     if ~exist( t_renderer_location, 'file' )
-        set_up_t_renderer( t_renderer_location )
+        acados_template_mex.set_up_t_renderer( t_renderer_location )
     end
 
     %% load json data
@@ -216,44 +216,3 @@ function render_file( json_fullfile, template_dir, template_file, out_file, ...
     end
 end
 
-
-function set_up_t_renderer( t_renderer_location )
-    message = ['\nDear acados user, we could not find t_renderer binaries,',...
-        '\n which are needed to export templated C code from ',...
-        'Matlab.\n Press any key to proceed setting up the t_renderer automatically.',...
-        '\n Press "n" or "N" to exit, if you wish to set up t_renderer yourself.\n',...
-        '\n https://github.com/acados/tera_renderer/releases'];
-
-    In = input(message,'s');
-
-    if strcmpi( In, 'n')
-        error('Please set up t_renderer yourself and try again');
-    else
-        t_renderer_version = 'v0.0.34';
-        if ismac()
-            suffix = '-osx';
-        elseif isunix()
-            suffix = '-linux';
-        elseif ispc()
-            suffix = '-windows';
-        end
-        acados_root_dir = getenv('ACADOS_INSTALL_DIR');
-
-        tera_url = ['https://github.com/acados/tera_renderer/releases/download/', ...
-                t_renderer_version '/t_renderer-', t_renderer_version, suffix];
-        destination = fullfile(acados_root_dir, 'bin');
-        tmp_file = websave(destination, tera_url);
-
-        if ~exist(destination, 'dir')
-            [~,~] = mkdir(destination);
-        end
-
-        movefile(tmp_file, t_renderer_location);
-
-        if isunix()
-            % make executable
-            system(['chmod a+x ', t_renderer_location]);
-        end
-        fprintf('\nSuccessfully set up t_renderer\n')
-    end
-end

--- a/interfaces/acados_matlab_octave/acados_template_mex/+acados_template_mex/set_up_t_renderer.m
+++ b/interfaces/acados_matlab_octave/acados_template_mex/+acados_template_mex/set_up_t_renderer.m
@@ -1,0 +1,44 @@
+function set_up_t_renderer(t_renderer_location,force)
+arguments
+    t_renderer_location
+    force=true
+end
+    message = ['\nDear acados user, we could not find t_renderer binaries,',...
+        '\n which are needed to export templated C code from ',...
+        'Matlab.\n Press any key to proceed setting up the t_renderer automatically.',...
+        '\n Press "n" or "N" to exit, if you wish to set up t_renderer yourself.\n',...
+        '\n https://github.com/acados/tera_renderer/releases'];
+    
+    if(~force)
+        In = input(message,'s');
+        if strcmpi( In, 'n')
+            error('Please set up t_renderer yourself and try again');
+        end
+    end
+	t_renderer_version = 'v0.0.34';
+	if ismac()
+		suffix = '-osx';
+	elseif isunix()
+		suffix = '-linux';
+	elseif ispc()
+		suffix = '-windows';
+	end
+	acados_root_dir = getenv('ACADOS_INSTALL_DIR');
+
+	tera_url = ['https://github.com/acados/tera_renderer/releases/download/', ...
+			t_renderer_version '/t_renderer-', t_renderer_version, suffix];
+	destination = fullfile(acados_root_dir, 'bin');
+	tmp_file = websave(destination, tera_url);
+
+	if ~exist(destination, 'dir')
+		[~,~] = mkdir(destination);
+	end
+
+	movefile(tmp_file, t_renderer_location);
+
+	if isunix()
+		% make executable
+		system(['chmod a+x ', t_renderer_location]);
+	end
+	fprintf('\nSuccessfully set up t_renderer\n')
+end

--- a/interfaces/acados_matlab_octave/acados_template_mex/+acados_template_mex/set_up_t_renderer.m
+++ b/interfaces/acados_matlab_octave/acados_template_mex/+acados_template_mex/set_up_t_renderer.m
@@ -1,44 +1,56 @@
-function set_up_t_renderer(t_renderer_location,force)
-arguments
-    t_renderer_location
-    force=true
-end
+function set_up_t_renderer(t_renderer_location,varargin)
+% set_up_t_renderer(t_renderer_location,[force])
+% If force is not provided it is default set to true
+
+    %The first variable parameter determines whether to force install
+    switch(nargin)
+        case 1
+            force=true;
+        case 2
+            force=varargin{1};
+        otherwise
+            error('function called with %d parameters, was expecting max 2',nargin);       
+    end
+
+
     message = ['\nDear acados user, we could not find t_renderer binaries,',...
         '\n which are needed to export templated C code from ',...
         'Matlab.\n Press any key to proceed setting up the t_renderer automatically.',...
         '\n Press "n" or "N" to exit, if you wish to set up t_renderer yourself.\n',...
         '\n https://github.com/acados/tera_renderer/releases'];
-    
+
     if(~force)
         In = input(message,'s');
         if strcmpi( In, 'n')
             error('Please set up t_renderer yourself and try again');
         end
     end
-	t_renderer_version = 'v0.0.34';
-	if ismac()
-		suffix = '-osx';
-	elseif isunix()
-		suffix = '-linux';
-	elseif ispc()
-		suffix = '-windows';
-	end
-	acados_root_dir = getenv('ACADOS_INSTALL_DIR');
 
-	tera_url = ['https://github.com/acados/tera_renderer/releases/download/', ...
-			t_renderer_version '/t_renderer-', t_renderer_version, suffix];
-	destination = fullfile(acados_root_dir, 'bin');
-	tmp_file = websave(destination, tera_url);
+    t_renderer_version = 'v0.0.34';
+    if ismac()
+        suffix = '-osx';
+    elseif isunix()
+        suffix = '-linux';
+    elseif ispc()
+        suffix = '-windows';
+    end
+    acados_root_dir = getenv('ACADOS_INSTALL_DIR');
 
-	if ~exist(destination, 'dir')
-		[~,~] = mkdir(destination);
-	end
+    tera_url = ['https://github.com/acados/tera_renderer/releases/download/', ...
+            t_renderer_version '/t_renderer-', t_renderer_version, suffix];
+    destination = fullfile(acados_root_dir, 'bin');
+    tmp_file = websave(destination, tera_url);
 
-	movefile(tmp_file, t_renderer_location);
+    if ~exist(destination, 'dir')
+        [~,~] = mkdir(destination);
+    end
 
-	if isunix()
-		% make executable
-		system(['chmod a+x ', t_renderer_location]);
-	end
-	fprintf('\nSuccessfully set up t_renderer\n')
+    movefile(tmp_file, t_renderer_location);
+
+    if isunix()
+        % make executable
+        system(['chmod a+x ', t_renderer_location]);
+    end
+    fprintf('\nSuccessfully set up t_renderer\n')
+
 end

--- a/interfaces/acados_matlab_octave/check_acados_requirements.m
+++ b/interfaces/acados_matlab_octave/check_acados_requirements.m
@@ -1,4 +1,7 @@
-function check_acados_requirements()
+function check_acados_requirements(force)
+arguments
+    force=false;
+end
 
     % check environment variables
     env_run = getenv('ENV_RUN');
@@ -13,8 +16,13 @@ function check_acados_requirements()
             ',\n which is needed to run the acados Matlab/Octave examples.',...
             '\n Press any key to proceed setting up the CasADi automatically.',...
             '\n Press "n" or "N" to exit, if you wish to set up CasADi yourself.\n'];
-        In = input(message,'s');
-        if strcmpi( In, 'n')
+        if ~force
+            In = input(message,'s');
+        else
+            In = 'Y';
+        end
+        
+        if strcmpi( In, 'n') 
             error('Please set up CasADi yourself and try again.');
         else
             % download CasADi

--- a/interfaces/acados_matlab_octave/check_acados_requirements.m
+++ b/interfaces/acados_matlab_octave/check_acados_requirements.m
@@ -1,7 +1,17 @@
-function check_acados_requirements(force)
-arguments
-    force=false;
-end
+function check_acados_requirements(varargin)
+% check_acados_requirements([force])
+% If force is not provided it is default set to true
+
+    %The first variable parameter determines whether to force install
+    switch(nargin)
+        case 0
+            force=true;
+        case 1
+            force=varargin{1};
+        otherwise
+            error('function called with %d parameters, was expecting max 1',nargin);       
+    end
+
 
     % check environment variables
     env_run = getenv('ENV_RUN');

--- a/interfaces/acados_matlab_octave/ocp_compile_interface.m
+++ b/interfaces/acados_matlab_octave/ocp_compile_interface.m
@@ -39,12 +39,13 @@ mex_flags = getenv('ACADOS_MEX_FLAGS');
 
 % set paths
 acados_mex_folder = fullfile(acados_folder, 'interfaces', 'acados_matlab_octave');
-acados_include = ['-I', acados_folder];
-acados_interfaces_include = ['-I', fullfile(acados_folder, 'interfaces')];
-external_include = ['-I', fullfile(acados_folder, 'external')];
-blasfeo_include = ['-I', fullfile(acados_folder, 'external', 'blasfeo', 'include')];
-hpipm_include = ['-I', fullfile(acados_folder, 'external', 'hpipm', 'include')];
-acados_lib_path = ['-L', fullfile(acados_folder, 'lib')];
+acados_include = ['-I' fullfile(acados_folder,'include')];
+acados_interfaces_include = ['-I' fullfile(acados_folder, 'interfaces')];
+external_include = ['-I' fullfile(acados_folder, 'external')];
+blasfeo_include = ['-I' fullfile(acados_folder, 'include' , 'blasfeo', 'include')];
+hpipm_include = ['-I' fullfile(acados_folder, 'include' , 'hpipm', 'include')];
+acados_lib_path = ['-L' fullfile(acados_folder, 'lib')];
+
 
 mex_names = { ...
     'ocp_create', ...

--- a/interfaces/acados_matlab_octave/ocp_set_ext_fun.m
+++ b/interfaces/acados_matlab_octave/ocp_set_ext_fun.m
@@ -43,11 +43,11 @@ addpath(fullfile(acados_folder, 'external', 'jsonlab'));
 
 % set paths
 acados_mex_folder = fullfile(acados_folder, 'interfaces', 'acados_matlab_octave');
-acados_include = ['-I' acados_folder];
+acados_include = ['-I' fullfile(acados_folder,'include')];
 acados_interfaces_include = ['-I' fullfile(acados_folder, 'interfaces')];
 external_include = ['-I' fullfile(acados_folder, 'external')];
-blasfeo_include = ['-I' fullfile(acados_folder, 'external' , 'blasfeo', 'include')];
-hpipm_include = ['-I' fullfile(acados_folder, 'external' , 'hpipm', 'include')];
+blasfeo_include = ['-I' fullfile(acados_folder, 'include' , 'blasfeo', 'include')];
+hpipm_include = ['-I' fullfile(acados_folder, 'include' , 'hpipm', 'include')];
 acados_lib_path = ['-L' fullfile(acados_folder, 'lib')];
 acados_matlab_octave_lib_path = ['-L' fullfile(acados_folder, 'interfaces', 'acados_matlab_octave')];
 model_lib_path = ['-L', opts_struct.output_dir];

--- a/interfaces/acados_matlab_octave/sim_set_ext_fun.m
+++ b/interfaces/acados_matlab_octave/sim_set_ext_fun.m
@@ -41,7 +41,7 @@ mex_flags = getenv('ACADOS_MEX_FLAGS');
 
 % set paths
 acados_mex_folder = fullfile(acados_folder, 'interfaces', 'acados_matlab_octave');
-acados_include = ['-I' acados_folder];
+acados_include = ['-I' fullfile(acados_folder,'include')];
 acados_interfaces_include = ['-I' fullfile(acados_folder, 'interfaces')];
 acados_lib_path = ['-L' fullfile(acados_folder, 'lib')];
 acados_matlab_octave_lib_path = ['-L' fullfile(acados_folder, 'interfaces', 'acados_matlab_octave')];


### PR DESCRIPTION
Install script for automating acados installation using Matlab.

Also includes minor changes to enable full installation without user interaction.

Note: A few files were moved from examples to interfaces as they are actually needed to use acados and are thus part of the interface and not an example.

Furthermore, the include directory references were changes to point at the include directory created automatically when installing acados instead of directly from the source. This enables management of the acados install used on an enterprise level where the responsible software engineer can generate an acados package with a specific configuration and share a minimal and compiled acados distribution to the engineers using the solver generation. 