### PR TITLE
Fix: undefined reference to 'ocp_nlp_cost_conl_config_initialize_default'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ OBJS += acados/ocp_nlp/ocp_nlp_cost_common.o
 OBJS += acados/ocp_nlp/ocp_nlp_cost_ls.o
 OBJS += acados/ocp_nlp/ocp_nlp_cost_nls.o
 OBJS += acados/ocp_nlp/ocp_nlp_cost_external.o
+OBJS += acados/ocp_nlp/ocp_nlp_cost_conl.o
 OBJS += acados/ocp_nlp/ocp_nlp_constraints_common.o
 OBJS += acados/ocp_nlp/ocp_nlp_constraints_bgh.o
 OBJS += acados/ocp_nlp/ocp_nlp_constraints_bgp.o


### PR DESCRIPTION
"ocp_nlp_cost_conl.o" added to the root "Makefile" to find the reference to "ocp_nlp_cost_conl_config_initialize_default function" of the "ocp_nlp_cost_conl" files.