### PR TITLE
added verbose option to AcadosOcpSolver build

### DIFF
--- a/examples/acados_python/pendulum_on_cart/ocp/nonuniform_discretization_example.py
+++ b/examples/acados_python/pendulum_on_cart/ocp/nonuniform_discretization_example.py
@@ -144,7 +144,7 @@ def main(discretization='shooting_nodes'):
     json_path = os.path.join(acados_path, 'interfaces/acados_template/acados_template')
     with open(json_path + '/simulink_default_opts.json', 'r') as f:
         simulink_opts = json.load(f)
-    ocp_solver = AcadosOcpSolver(ocp, json_file = 'acados_ocp.json', simulink_opts = simulink_opts)
+    ocp_solver = AcadosOcpSolver(ocp, json_file = 'acados_ocp.json', simulink_opts = simulink_opts, verbose=False)
 
     # ocp_solver = AcadosOcpSolver(ocp, json_file = 'acados_ocp.json')
 

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -865,7 +865,7 @@ class AcadosOcpSolver:
 
 
     @classmethod
-    def build(cls, code_export_dir, with_cython=False, cmake_builder: CMakeBuilder = None, verbose = True):
+    def build(cls, code_export_dir, with_cython=False, cmake_builder: CMakeBuilder = None, verbose: bool = True):
         """
         Builds the code for an acados OCP solver, that has been generated in code_export_dir
             :param code_export_dir: directory in which acados OCP solver has been generated, see generate()
@@ -873,19 +873,20 @@ class AcadosOcpSolver:
             :param cmake_builder: type :py:class:`~acados_template.builders.CMakeBuilder` generate a `CMakeLists.txt` and use
                    the `CMake` pipeline instead of a `Makefile` (`CMake` seems to be the better option in conjunction with
                    `MS Visual Studio`); default: `None`
+            :param verbose: indicating if build command is printed
         """
         code_export_dir = os.path.abspath(code_export_dir)
         cwd = os.getcwd()
         os.chdir(code_export_dir)
         if with_cython:
             call(
-                ['make', 'clean_all'], 
-                stdout=None if verbose else DEVNULL, 
+                ['make', 'clean_all'],
+                stdout=None if verbose else DEVNULL,
                 stderr=None if verbose else STDOUT
             )
             call(
-                ['make', 'ocp_cython'], 
-                stdout=None if verbose else DEVNULL, 
+                ['make', 'ocp_cython'],
+                stdout=None if verbose else DEVNULL,
                 stderr=None if verbose else STDOUT
             )
         else:
@@ -894,12 +895,12 @@ class AcadosOcpSolver:
             else:
                 call(
                     ['make', 'clean_ocp_shared_lib'],
-                    stdout=None if verbose else DEVNULL, 
+                    stdout=None if verbose else DEVNULL,
                     stderr=None if verbose else STDOUT
                 )
                 call(
                     ['make', 'ocp_shared_lib'],
-                    stdout=None if verbose else DEVNULL, 
+                    stdout=None if verbose else DEVNULL,
                     stderr=None if verbose else STDOUT
                 )
         os.chdir(cwd)

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -40,6 +40,8 @@ from datetime import datetime
 import importlib
 import shutil
 
+from subprocess import DEVNULL, call, STDOUT
+
 from ctypes import POINTER, cast, CDLL, c_void_p, c_char_p, c_double, c_int, c_int64, byref
 
 from copy import deepcopy
@@ -863,7 +865,7 @@ class AcadosOcpSolver:
 
 
     @classmethod
-    def build(cls, code_export_dir, with_cython=False, cmake_builder: CMakeBuilder = None):
+    def build(cls, code_export_dir, with_cython=False, cmake_builder: CMakeBuilder = None, verbose = True):
         """
         Builds the code for an acados OCP solver, that has been generated in code_export_dir
             :param code_export_dir: directory in which acados OCP solver has been generated, see generate()
@@ -876,14 +878,30 @@ class AcadosOcpSolver:
         cwd = os.getcwd()
         os.chdir(code_export_dir)
         if with_cython:
-            os.system('make clean_ocp_cython')
-            os.system('make ocp_cython')
+            call(
+                ['make', 'clean_all'], 
+                stdout=None if verbose else DEVNULL, 
+                stderr=None if verbose else STDOUT
+            )
+            call(
+                ['make', 'ocp_cython'], 
+                stdout=None if verbose else DEVNULL, 
+                stderr=None if verbose else STDOUT
+            )
         else:
             if cmake_builder is not None:
                 cmake_builder.exec(code_export_dir)
             else:
-                os.system('make clean_ocp_shared_lib')
-                os.system('make ocp_shared_lib')
+                call(
+                    ['make', 'clean_ocp_shared_lib'],
+                    stdout=None if verbose else DEVNULL, 
+                    stderr=None if verbose else STDOUT
+                )
+                call(
+                    ['make', 'ocp_shared_lib'],
+                    stdout=None if verbose else DEVNULL, 
+                    stderr=None if verbose else STDOUT
+                )
         os.chdir(cwd)
 
 
@@ -911,7 +929,7 @@ class AcadosOcpSolver:
                     acados_ocp_json['dims']['N'])
 
 
-    def __init__(self, acados_ocp: AcadosOcp, json_file='acados_ocp_nlp.json', simulink_opts=None, build=True, generate=True, cmake_builder: CMakeBuilder = None):
+    def __init__(self, acados_ocp: AcadosOcp, json_file='acados_ocp_nlp.json', simulink_opts=None, build=True, generate=True, cmake_builder: CMakeBuilder = None, verbose=True):
 
         self.solver_created = False
         if generate:
@@ -928,7 +946,7 @@ class AcadosOcpSolver:
         code_export_directory = acados_ocp_json['code_export_directory']
 
         if build:
-            self.build(code_export_directory, with_cython=False, cmake_builder=cmake_builder)
+            self.build(code_export_directory, with_cython=False, cmake_builder=cmake_builder, verbose=verbose)
 
         # prepare library loading
         lib_prefix = 'lib'

--- a/interfaces/acados_template/acados_template/acados_sim_solver.py
+++ b/interfaces/acados_template/acados_template/acados_sim_solver.py
@@ -243,19 +243,19 @@ class AcadosSimSolver:
 
 
     @classmethod
-    def build(cls, code_export_dir, with_cython=False, cmake_builder: CMakeBuilder = None, verbose=True):
+    def build(cls, code_export_dir, with_cython=False, cmake_builder: CMakeBuilder = None, verbose: bool = True):
         # Compile solver
         cwd = os.getcwd()
         os.chdir(code_export_dir)
         if with_cython:
             call(
                 ['make', 'clean_sim_cython'],
-                stdout=None if verbose else DEVNULL, 
+                stdout=None if verbose else DEVNULL,
                 stderr=None if verbose else STDOUT
             )
             call(
                 ['make', 'sim_cython'],
-                stdout=None if verbose else DEVNULL, 
+                stdout=None if verbose else DEVNULL,
                 stderr=None if verbose else STDOUT
             )
         else:
@@ -285,7 +285,7 @@ class AcadosSimSolver:
         AcadosSimSolverCython = getattr(acados_sim_solver_pyx, 'AcadosSimSolverCython')
         return AcadosSimSolverCython(acados_sim_json['model']['name'])
 
-    def __init__(self, acados_sim, json_file='acados_sim.json', generate=True, build=True, cmake_builder: CMakeBuilder = None):
+    def __init__(self, acados_sim, json_file='acados_sim.json', generate=True, build=True, cmake_builder: CMakeBuilder = None, verbose: bool = True):
 
         self.solver_created = False
         self.acados_sim = acados_sim
@@ -299,7 +299,7 @@ class AcadosSimSolver:
             self.generate(acados_sim, json_file=json_file, cmake_builder=cmake_builder)
 
         if build:
-            self.build(code_export_dir, cmake_builder=cmake_builder)
+            self.build(code_export_dir, cmake_builder=cmake_builder, verbose=True)
 
         # prepare library loading
         lib_prefix = 'lib'

--- a/interfaces/acados_template/acados_template/acados_sim_solver.py
+++ b/interfaces/acados_template/acados_template/acados_sim_solver.py
@@ -39,6 +39,8 @@ import importlib
 
 import numpy as np
 
+from subprocess import DEVNULL, call, STDOUT
+
 from ctypes import POINTER, cast, CDLL, c_void_p, c_char_p, c_double, c_int, c_bool, byref
 from copy import deepcopy
 
@@ -241,18 +243,30 @@ class AcadosSimSolver:
 
 
     @classmethod
-    def build(cls, code_export_dir, with_cython=False, cmake_builder: CMakeBuilder = None):
+    def build(cls, code_export_dir, with_cython=False, cmake_builder: CMakeBuilder = None, verbose=True):
         # Compile solver
         cwd = os.getcwd()
         os.chdir(code_export_dir)
         if with_cython:
-            os.system('make clean_sim_cython')
-            os.system('make sim_cython')
+            call(
+                ['make', 'clean_sim_cython'],
+                stdout=None if verbose else DEVNULL, 
+                stderr=None if verbose else STDOUT
+            )
+            call(
+                ['make', 'sim_cython'],
+                stdout=None if verbose else DEVNULL, 
+                stderr=None if verbose else STDOUT
+            )
         else:
             if cmake_builder is not None:
-                cmake_builder.exec(code_export_dir)
+                cmake_builder.exec(code_export_dir, verbose=verbose)
             else:
-                os.system('make sim_shared_lib')
+                call(
+                    ['make', 'sim_shared_lib'],
+                    stdout=None if verbose else DEVNULL,
+                    stderr=None if verbose else STDOUT
+                )
         os.chdir(cwd)
 
 

--- a/interfaces/acados_template/acados_template/builders.py
+++ b/interfaces/acados_template/acados_template/builders.py
@@ -34,7 +34,6 @@
 
 import os
 import sys
-from subprocess import call
 from subprocess import DEVNULL, call, STDOUT
 
 
@@ -98,9 +97,9 @@ class CMakeBuilder:
             cmd_str = self.get_cmd1_cmake()
             print(f'call("{cmd_str})"')
             retcode = call(
-                cmd_str, 
-                shell=True, 
-                stdout=None if verbose else DEVNULL, 
+                cmd_str,
+                shell=True,
+                stdout=None if verbose else DEVNULL,
                 stderr=None if verbose else STDOUT
             )
             if retcode != 0:
@@ -110,7 +109,7 @@ class CMakeBuilder:
             retcode = call(
                 cmd_str,
                 shell=True,
-                stdout=None if verbose else DEVNULL, 
+                stdout=None if verbose else DEVNULL,
                 stderr=None if verbose else STDOUT
             )
             if retcode != 0:
@@ -120,7 +119,7 @@ class CMakeBuilder:
             retcode = call(
                 cmd_str,
                 shell=True,
-                stdout=None if verbose else DEVNULL, 
+                stdout=None if verbose else DEVNULL,
                 stderr=None if verbose else STDOUT
             )
             if retcode != 0:

--- a/interfaces/acados_template/acados_template/builders.py
+++ b/interfaces/acados_template/acados_template/builders.py
@@ -35,6 +35,7 @@
 import os
 import sys
 from subprocess import call
+from subprocess import DEVNULL, call, STDOUT
 
 
 class CMakeBuilder:
@@ -78,7 +79,7 @@ class CMakeBuilder:
     def get_cmd3_install(self):
         return f'cmake --install "{self._build_dir}"'
 
-    def exec(self, code_export_directory):
+    def exec(self, code_export_directory, verbose=True):
         """
         Execute the compilation using `CMake` with the given settings.
         :param code_export_directory: must be the absolute path to the directory where the code was exported to
@@ -96,17 +97,32 @@ class CMakeBuilder:
             os.chdir(self._build_dir)
             cmd_str = self.get_cmd1_cmake()
             print(f'call("{cmd_str})"')
-            retcode = call(cmd_str, shell=True)
+            retcode = call(
+                cmd_str, 
+                shell=True, 
+                stdout=None if verbose else DEVNULL, 
+                stderr=None if verbose else STDOUT
+            )
             if retcode != 0:
                 raise RuntimeError(f'CMake command "{cmd_str}" was terminated by signal {retcode}')
             cmd_str = self.get_cmd2_build()
             print(f'call("{cmd_str}")')
-            retcode = call(cmd_str, shell=True)
+            retcode = call(
+                cmd_str,
+                shell=True,
+                stdout=None if verbose else DEVNULL, 
+                stderr=None if verbose else STDOUT
+            )
             if retcode != 0:
                 raise RuntimeError(f'Build command "{cmd_str}" was terminated by signal {retcode}')
             cmd_str = self.get_cmd3_install()
             print(f'call("{cmd_str}")')
-            retcode = call(cmd_str, shell=True)
+            retcode = call(
+                cmd_str,
+                shell=True,
+                stdout=None if verbose else DEVNULL, 
+                stderr=None if verbose else STDOUT
+            )
             if retcode != 0:
                 raise RuntimeError(f'Install command "{cmd_str}" was terminated by signal {retcode}')
         except OSError as e:


### PR DESCRIPTION
This PR answers my own question on the [discourse forum](https://discourse.acados.org/t/disabling-compilation-stdout-output/1019?u=tudoroancea).
It simply adds a verbose argument to some of the functions of the Python interface to disable the compiler output. 
I achieved this by replacing the calls to `os.system()` by calls to `subprocess.call()` which can properly redirect the output to `/dev/null` as indicated in this [StackOverflow answer](https://stackoverflow.com/a/5597017).
I have added this option for the `CMakeBuilder` and `AcadosSimSolver` classes as well, but I may still have missed some parts of the code to change for consistency, please let me know.