### PR TITLE
NLS cost module: Change W_changed flag if cost matrix was changed

### DIFF
--- a/acados/ocp_nlp/ocp_nlp_cost_nls.c
+++ b/acados/ocp_nlp/ocp_nlp_cost_nls.c
@@ -229,7 +229,7 @@ int ocp_nlp_cost_nls_model_set(void *config_, void *dims_, void *model_,
     {
         double *W_col_maj = (double *) value_;
         blasfeo_pack_dmat(ny, ny, W_col_maj, ny, &model->W, 0, 0);
-        // NOTE(oj): W_chol is computed in _initialize(), called in preparation phase, if W changed
+        model->W_changed = 1;
     }
     else if (!strcmp(field, "y_ref") || !strcmp(field, "yref"))
     {


### PR DESCRIPTION
Hi @FreyJo 

I recently switched from a `LINEAR_LS` to a `NONLINEAR_LS` cost module in my problem formulation. I realized that the cost
 matrices were not properly updated when I set them online. It appears that there was a minor mistake in #878, i.e., the `W_changed` flag is only set to true for the linear least squares module: https://github.com/acados/acados/blob/master/acados/ocp_nlp/ocp_nlp_cost_ls.c#L301

Cheers and kind regards from Freiburg ✌🏻 