### PR TITLE
Core: Allow changing all constraint bounds between preparation and feedback phase

### DIFF
--- a/.github/workflows/full_build.yml
+++ b/.github/workflows/full_build.yml
@@ -150,12 +150,12 @@ jobs:
         command: cd examples/acados_matlab_octave/test; simulink_test
 
 
-    - name: Export Paths Simulink zoRO test
-      working-directory: ${{runner.workspace}}/acados/examples/acados_python/zoRO_example/pendulum_on_cart
-      shell: bash
-      run: |
-        echo "LD_RUN_PATH=$LD_RUN_PATH:$(pwd)/c_generated_code" >> $GITHUB_ENV
-        echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:./c_generated_code" >> $GITHUB_ENV
+    # - name: Export Paths Simulink zoRO test
+    #   working-directory: ${{runner.workspace}}/acados/examples/acados_python/zoRO_example/pendulum_on_cart
+    #   shell: bash
+    #   run: |
+    #     echo "LD_RUN_PATH=$LD_RUN_PATH:$(pwd)/c_generated_code" >> $GITHUB_ENV
+    #     echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:./c_generated_code" >> $GITHUB_ENV
 
     # - name: Run Simulink zoRO test
     #   uses: matlab-actions/run-command@v1

--- a/acados/ocp_nlp/ocp_nlp_common.c
+++ b/acados/ocp_nlp/ocp_nlp_common.c
@@ -2173,9 +2173,9 @@ void ocp_nlp_approximate_qp_matrices(ocp_nlp_config *config, ocp_nlp_dims *dims,
 
     }
 
-    for (int i = 0; i <= N; i++)
-    {
-        // TODO(rien) where should the update happen??? move to qp update ???
+    // TODO(rien) where should the update happen??? move to qp update ???
+    // for (int i = 0; i <= N; i++)
+    // {
         // TODO(all): fix and move where appropriate
         //  if (i<N)
         //  {
@@ -2189,7 +2189,7 @@ void ocp_nlp_approximate_qp_matrices(ocp_nlp_config *config, ocp_nlp_dims *dims,
         //     BLASFEO_DVECEL(nlp_mem->cost_grad+i, j) += work->sim_out[i]->grad[nx+j];
         //   }
         //  }
-    }
+    // }
 }
 
 
@@ -2240,8 +2240,6 @@ void ocp_nlp_embed_initial_value(ocp_nlp_config *config, ocp_nlp_dims *dims,
         config->constraints[0]->memory_get_fun_ptr(mem->constraints[0]);
     blasfeo_dveccp(2 * ni[0], ineq_fun, 0, mem->ineq_fun, 0);
 
-    // d
-    blasfeo_dveccp(2 * ni[0], mem->ineq_fun, 0, mem->qp_in->d, 0);
 }
 
 

--- a/acados/ocp_nlp/ocp_nlp_common.c
+++ b/acados/ocp_nlp/ocp_nlp_common.c
@@ -2234,25 +2234,6 @@ void ocp_nlp_approximate_qp_vectors_sqp(ocp_nlp_config *config,
 }
 
 
-// TODO: remove
-void ocp_nlp_embed_initial_value(ocp_nlp_config *config, ocp_nlp_dims *dims,
-    ocp_nlp_in *in, ocp_nlp_out *out, ocp_nlp_opts *opts,
-    ocp_nlp_memory *mem, ocp_nlp_workspace *work)
-{
-    int *ni = dims->ni;
-
-    // constraints
-    // config->constraints[0]->bounds_update(config->constraints[0], dims->constraints[0],
-    //         in->constraints[0], opts->constraints[0], mem->constraints[0], work->constraints[0]);
-
-    // nlp mem: ineq_fun
-    // struct blasfeo_dvec *ineq_fun = config->constraints[0]->memory_get_fun_ptr(mem->constraints[0]);
-    // blasfeo_dveccp(2 * ni[0], ineq_fun, 0, mem->ineq_fun, 0);
-
-}
-
-
-
 double ocp_nlp_compute_merit_gradient(ocp_nlp_config *config, ocp_nlp_dims *dims,
                                   ocp_nlp_in *in, ocp_nlp_out *out, ocp_nlp_opts *opts,
                                   ocp_nlp_memory *mem, ocp_nlp_workspace *work)

--- a/acados/ocp_nlp/ocp_nlp_common.h
+++ b/acados/ocp_nlp/ocp_nlp_common.h
@@ -410,9 +410,6 @@ void ocp_nlp_approximate_qp_matrices(ocp_nlp_config *config, ocp_nlp_dims *dims,
 void ocp_nlp_approximate_qp_vectors_sqp(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in,
                  ocp_nlp_out *out, ocp_nlp_opts *opts, ocp_nlp_memory *mem, ocp_nlp_workspace *work);
 //
-void ocp_nlp_embed_initial_value(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in,
-                 ocp_nlp_out *out, ocp_nlp_opts *opts, ocp_nlp_memory *mem, ocp_nlp_workspace *work);
-//
 void ocp_nlp_update_variables_sqp(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in,
            ocp_nlp_out *out, ocp_nlp_opts *opts, ocp_nlp_memory *mem, ocp_nlp_workspace *work, double alpha);
 //

--- a/acados/ocp_nlp/ocp_nlp_constraints_bgh.c
+++ b/acados/ocp_nlp/ocp_nlp_constraints_bgh.c
@@ -1361,7 +1361,7 @@ void ocp_nlp_constraints_bgh_update_qp_matrices(void *config_, void *dims_, void
 
         struct blasfeo_dmat_args jac_z_tran_out; // Jacobian dhdz treated separately
         if (nz > 0)
-        { 
+        {
             jac_z_tran_out.A = &work->tmp_nz_nh;
             jac_z_tran_out.ai = 0;
             jac_z_tran_out.aj = 0;
@@ -1480,7 +1480,9 @@ void ocp_nlp_constraints_bgh_update_qp_matrices(void *config_, void *dims_, void
                         &memory->fun, 0, &memory->fun, 0);
     }
 
+    // fun[0:nb+ng+nh] = model->d[0:] - tmp_ni
     blasfeo_daxpy(nb+ng+nh, -1.0, &work->tmp_ni, 0, &model->d, 0, &memory->fun, 0);
+    // fun[nb+ng+nh: 2*(nb+ng+nh)] = tmp_ni - model->d[nb+ng+nh:]
     blasfeo_daxpy(nb+ng+nh, -1.0, &model->d, nb+ng+nh, &work->tmp_ni, 0, &memory->fun, nb+ng+nh);
 
     // soft
@@ -1628,9 +1630,8 @@ void ocp_nlp_constraints_bgh_bounds_update(void *config_, void *dims_, void *mod
     int ng = dims->ng;
     int nh = dims->nh;
 
-    // box
+    // box only
     blasfeo_dvecex_sp(nb, 1.0, model->idxb, memory->ux, 0, &work->tmp_ni, 0);
-
     blasfeo_daxpy(nb, -1.0, &work->tmp_ni, 0, &model->d, 0, &memory->fun, 0);
     blasfeo_daxpy(nb, -1.0, &model->d, nb+ng+nh, &work->tmp_ni, 0, &memory->fun, nb+ng+nh);
 

--- a/acados/ocp_nlp/ocp_nlp_constraints_bgh.c
+++ b/acados/ocp_nlp/ocp_nlp_constraints_bgh.c
@@ -1476,6 +1476,7 @@ void ocp_nlp_constraints_bgh_update_qp_matrices(void *config_, void *dims_, void
         }
     }
 
+    // TODO: move this!
     if (nz > 0)
     {
         // update memory->fun wrt z
@@ -1600,41 +1601,6 @@ void ocp_nlp_constraints_bgh_compute_fun(void *config_, void *dims_, void *model
 }
 
 
-
-void ocp_nlp_constraints_bgh_bounds_update(void *config_, void *dims_, void *model_,
-                                            void *opts_, void *memory_, void *work_)
-{
-    ocp_nlp_constraints_bgh_dims *dims = dims_;
-    ocp_nlp_constraints_bgh_model *model = model_;
-    // ocp_nlp_constraints_bgh_opts *opts = opts_;
-    ocp_nlp_constraints_bgh_memory *memory = memory_;
-    ocp_nlp_constraints_bgh_workspace *work = work_;
-
-    // ocp_nlp_constraints_bgh_cast_workspace(config_, dims, opts_, work_);
-
-    // extract dims
-    int nx = dims->nx;
-    int nu = dims->nu;
-    int nb = dims->nb;
-    int ng = dims->ng;
-    int nh = dims->nh;
-    int ns = dims->ns;
-
-    printf("this should not be called anymore\n");
-    error(1);
-
-    // /* old box only variant */
-    // // tmp_ni[0:nb] = ux[idxb]
-    // blasfeo_dvecex_sp(nb, 1.0, model->idxb, memory->ux, 0, &memory->tmp_ni, 0);
-    // // fun[:nb] = - tmp_ni[0:nb] + d[:nb]
-    // blasfeo_daxpy(nb, -1.0, &memory->tmp_ni, 0, &model->d, 0, &memory->fun, 0);
-    // // fun[nb+ng+nh:] = tmp_ni[0:nb] - d[nb+ng+nh]
-    // blasfeo_daxpy(nb, -1.0, &model->d, nb+ng+nh, &memory->tmp_ni, 0, &memory->fun, nb+ng+nh);
-
-    return;
-}
-
-
 void ocp_nlp_constraints_bgh_update_qp_vectors(void *config_, void *dims_, void *model_,
                                             void *opts_, void *memory_, void *work_)
 {
@@ -1642,7 +1608,7 @@ void ocp_nlp_constraints_bgh_update_qp_vectors(void *config_, void *dims_, void 
     ocp_nlp_constraints_bgh_model *model = model_;
     // ocp_nlp_constraints_bgh_opts *opts = opts_;
     ocp_nlp_constraints_bgh_memory *memory = memory_;
-    ocp_nlp_constraints_bgh_workspace *work = work_;
+    // ocp_nlp_constraints_bgh_workspace *work = work_;
 
     // ocp_nlp_constraints_bgh_cast_workspace(config_, dims, opts_, work_);
 
@@ -1710,7 +1676,6 @@ void ocp_nlp_constraints_bgh_config_initialize_default(void *config_)
     config->update_qp_matrices = &ocp_nlp_constraints_bgh_update_qp_matrices;
     config->update_qp_vectors = &ocp_nlp_constraints_bgh_update_qp_vectors;
     config->compute_fun = &ocp_nlp_constraints_bgh_compute_fun;
-    config->bounds_update = &ocp_nlp_constraints_bgh_bounds_update;
     config->config_initialize_default = &ocp_nlp_constraints_bgh_config_initialize_default;
 
     return;

--- a/acados/ocp_nlp/ocp_nlp_constraints_bgh.h
+++ b/acados/ocp_nlp/ocp_nlp_constraints_bgh.h
@@ -146,6 +146,7 @@ typedef struct
 {
     struct blasfeo_dvec fun;
     struct blasfeo_dvec adj;
+    struct blasfeo_dvec tmp_ni;
     struct blasfeo_dvec *ux;     // pointer to ux in nlp_out
     struct blasfeo_dvec *tmp_ux; // pointer to ux in tmp_nlp_out
     struct blasfeo_dvec *lam;    // pointer to lam in nlp_out
@@ -203,7 +204,6 @@ typedef struct
     struct blasfeo_dmat tmp_nv_nh;
     struct blasfeo_dmat tmp_nz_nv;
     struct blasfeo_dmat hess_z;
-    struct blasfeo_dvec tmp_ni;
     struct blasfeo_dvec tmp_nh;
 } ocp_nlp_constraints_bgh_workspace;
 

--- a/acados/ocp_nlp/ocp_nlp_constraints_bgh.h
+++ b/acados/ocp_nlp/ocp_nlp_constraints_bgh.h
@@ -146,7 +146,7 @@ typedef struct
 {
     struct blasfeo_dvec fun;
     struct blasfeo_dvec adj;
-    struct blasfeo_dvec tmp_ni;
+    struct blasfeo_dvec constr_eval_no_bounds;
     struct blasfeo_dvec *ux;     // pointer to ux in nlp_out
     struct blasfeo_dvec *tmp_ux; // pointer to ux in tmp_nlp_out
     struct blasfeo_dvec *lam;    // pointer to lam in nlp_out
@@ -203,6 +203,7 @@ typedef struct
     struct blasfeo_dmat tmp_nz_nh;
     struct blasfeo_dmat tmp_nv_nh;
     struct blasfeo_dmat tmp_nz_nv;
+    struct blasfeo_dvec tmp_ni;
     struct blasfeo_dmat hess_z;
     struct blasfeo_dvec tmp_nh;
 } ocp_nlp_constraints_bgh_workspace;

--- a/acados/ocp_nlp/ocp_nlp_constraints_bgh.h
+++ b/acados/ocp_nlp/ocp_nlp_constraints_bgh.h
@@ -203,8 +203,8 @@ typedef struct
     struct blasfeo_dmat tmp_nz_nh;
     struct blasfeo_dmat tmp_nv_nh;
     struct blasfeo_dmat tmp_nz_nv;
-    struct blasfeo_dvec tmp_ni;
     struct blasfeo_dmat hess_z;
+    struct blasfeo_dvec tmp_ni;
     struct blasfeo_dvec tmp_nh;
 } ocp_nlp_constraints_bgh_workspace;
 

--- a/acados/ocp_nlp/ocp_nlp_constraints_bgp.h
+++ b/acados/ocp_nlp/ocp_nlp_constraints_bgp.h
@@ -132,6 +132,7 @@ typedef struct
 {
     struct blasfeo_dvec fun;
     struct blasfeo_dvec adj;
+    struct blasfeo_dvec constr_eval_no_bounds;
     struct blasfeo_dvec *ux;     // pointer to ux in nlp_out
     struct blasfeo_dvec *tmp_ux; // pointer to ux in tmp_nlp_out
     struct blasfeo_dvec *lam;    // pointer to lam in nlp_out
@@ -179,12 +180,12 @@ void ocp_nlp_constraints_bgh_memory_set_idxe_ptr(int *idxe, void *memory_);
 
 typedef struct
 {
-    struct blasfeo_dvec tmp_ni;
     struct blasfeo_dmat jac_r_ux_tran;
     struct blasfeo_dmat tmp_nr_nphi_nr;
     struct blasfeo_dmat tmp_nv_nr;
     struct blasfeo_dmat tmp_nv_nphi;
     struct blasfeo_dmat tmp_nz_nphi;
+    struct blasfeo_dvec tmp_ni;
 } ocp_nlp_constraints_bgp_workspace;
 
 //
@@ -204,7 +205,7 @@ void ocp_nlp_constraints_bgp_update_qp_matrices(void *config_, void *dims,
 void ocp_nlp_constraints_bgp_compute_fun(void *config_, void *dims,
         void *model_, void *opts_, void *memory_, void *work_);
 //
-void ocp_nlp_constraints_bgp_bounds_update(void *config_, void *dims, void *model_,
+void ocp_nlp_constraints_bgp_update_qp_vectors(void *config_, void *dims, void *model_,
         void *opts_, void *memory_, void *work_);
 
 

--- a/acados/ocp_nlp/ocp_nlp_constraints_common.h
+++ b/acados/ocp_nlp/ocp_nlp_constraints_common.h
@@ -86,7 +86,6 @@ typedef struct
     void (*update_qp_matrices)(void *config, void *dims, void *model, void *opts, void *mem, void *work);
     void (*update_qp_vectors)(void *config, void *dims, void *model, void *opts, void *mem, void *work);
     void (*compute_fun)(void *config, void *dims, void *model, void *opts, void *mem, void *work);
-    void (*bounds_update)(void *config, void *dims, void *model, void *opts, void *mem, void *work);
     void (*config_initialize_default)(void *config);
     // dimension setters
     void (*dims_set)(void *config_, void *dims_, const char *field, const int *value);

--- a/acados/ocp_nlp/ocp_nlp_constraints_common.h
+++ b/acados/ocp_nlp/ocp_nlp_constraints_common.h
@@ -84,6 +84,7 @@ typedef struct
     acados_size_t (*workspace_calculate_size)(void *config, void *dims, void *opts);
     void (*initialize)(void *config, void *dims, void *model, void *opts, void *mem, void *work);
     void (*update_qp_matrices)(void *config, void *dims, void *model, void *opts, void *mem, void *work);
+    void (*update_qp_vectors)(void *config, void *dims, void *model, void *opts, void *mem, void *work);
     void (*compute_fun)(void *config, void *dims, void *model, void *opts, void *mem, void *work);
     void (*bounds_update)(void *config, void *dims, void *model, void *opts, void *mem, void *work);
     void (*config_initialize_default)(void *config);

--- a/acados/ocp_nlp/ocp_nlp_sqp_rti.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp_rti.c
@@ -490,8 +490,8 @@ static void ocp_nlp_sqp_rti_feedback_step(ocp_nlp_config *config, ocp_nlp_dims *
     mem->time_glob = 0.0;
 
     // embed initial value (this actually updates all bounds at stage 0...)
-    ocp_nlp_embed_initial_value(config, dims, nlp_in,
-        nlp_out, nlp_opts, nlp_mem, nlp_work);
+    // ocp_nlp_embed_initial_value(config, dims, nlp_in,
+    //     nlp_out, nlp_opts, nlp_mem, nlp_work);
 
     // update QP rhs for SQP (step prim var, abs dual var)
     ocp_nlp_approximate_qp_vectors_sqp(config, dims, nlp_in,

--- a/acados/ocp_nlp/ocp_nlp_sqp_rti.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp_rti.c
@@ -489,10 +489,6 @@ static void ocp_nlp_sqp_rti_feedback_step(ocp_nlp_config *config, ocp_nlp_dims *
     mem->time_qp_xcond = 0.0;
     mem->time_glob = 0.0;
 
-    // embed initial value (this actually updates all bounds at stage 0...)
-    // ocp_nlp_embed_initial_value(config, dims, nlp_in,
-    //     nlp_out, nlp_opts, nlp_mem, nlp_work);
-
     // update QP rhs for SQP (step prim var, abs dual var)
     ocp_nlp_approximate_qp_vectors_sqp(config, dims, nlp_in,
         nlp_out, nlp_opts, nlp_mem, nlp_work);

--- a/interfaces/acados_matlab_octave/acados_ocp.m
+++ b/interfaces/acados_matlab_octave/acados_ocp.m
@@ -194,7 +194,7 @@ classdef acados_ocp < handle
                 end
             end
 
-            % TODO: call ocp_generate_c_code()
+            % generate templated solver
             if nargin < 3
                 simulink_opts = get_acados_simulink_opts;
             end

--- a/interfaces/acados_template/acados_template/custom_update_templates/custom_update_function_zoro_template.in.c
+++ b/interfaces/acados_template/acados_template/custom_update_templates/custom_update_function_zoro_template.in.c
@@ -464,6 +464,8 @@ static void compute_gh_beta(struct blasfeo_dmat* K_mat, struct blasfeo_dmat* C_m
     blasfeo_dgemm_nn(n_cstr, nx, nx, 1.0, CaDK_mat, 0, 0,
                         P_mat, 0, 0, 0.0,
                         CaDKmP_mat, 0, 0, CaDKmP_mat, 0, 0);
+    // NOTE: here we also compute cross-terms which are not needed.
+    //       Only diag(beta_mat) is used later
     // beta_mat = CaDKmP_mat @ CaDK_mat^T
     blasfeo_dgemm_nt(n_cstr, n_cstr, nx, 1.0, CaDKmP_mat, 0, 0,
                         CaDK_mat, 0, 0, 0.0,
@@ -659,6 +661,17 @@ static void uncertainty_propagate_and_update(ocp_nlp_solver *solver, ocp_nlp_in 
                      &custom_mem->Dh_mat, &custom_mem->temp_CaDK_mat,
                      &custom_mem->temp_CaDKmP_mat, &custom_mem->temp_beta_mat,
                      &custom_mem->uncertainty_matrix_buffer[ii+1], nh, nx, nu);
+
+        // printf("temp_CaDKmP_mat k = %d", ii);
+        // blasfeo_print_dmat(nh, nx, &custom_mem->temp_CaDKmP_mat, 0, 0);
+
+        // TODO: eval hessian(h) -> H_hess (nh*(nx+nu)**2)
+        // temp_Kt_hhess = h_i_hess[:nx, :] + K^T * h_i_hess[nx:nx+nu, :]
+        // tempCD = temp_CaDKmP_mat * temp_Kt_hhess
+        // acados_CD += tempCD
+        // += for upper or -= for lower bound
+
+        // only works if 1 bound is trivially satisfied.
 
     {%- if zoro_description.nlh_t > 0 %}
         {%- for it in zoro_description.idx_lh_t %}


### PR DESCRIPTION
- Constraint modules: add `update_qp_vectors` instead of `bounds_update`
- Fix potential memory issues in BGP
- This fixes the zoRO implementation: Backoffs were delayed by 1 iteration. Backoffs are nonzero now in first iteration