### PR TITLE
Use PROJECT_SOURCE_DIR to allow for better submodulization

### DIFF
--- a/acados/CMakeLists.txt
+++ b/acados/CMakeLists.txt
@@ -71,7 +71,7 @@ add_library(acados ${ACADOS_SRC})
 
 target_include_directories(acados
     PUBLIC
-        $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}> # to be able to include "acados/header.h"
+        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}> # to be able to include "acados/header.h"
         $<BUILD_INTERFACE:${EXTERNAL_SRC_DIR}/qore/QPSOLVER_DENSE/include>
         $<BUILD_INTERFACE:${EXTERNAL_SRC_DIR}/qore/QPSOLVER_DENSE/source>
         $<BUILD_INTERFACE:${EXTERNAL_SRC_DIR}/qore/KKTPACK_DENSE/include>
@@ -80,7 +80,7 @@ target_include_directories(acados
         $<BUILD_INTERFACE:${EXTERNAL_SRC_DIR}/qore>
         $<BUILD_INTERFACE:${EXTERNAL_SRC_DIR}/hpipm/include>
         $<BUILD_INTERFACE:${EXTERNAL_SRC_DIR}>
-        $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/interfaces>
+        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/interfaces>
         $<INSTALL_INTERFACE:include>)
 
 # OPENMP


### PR DESCRIPTION
When using cmake `add_subdirectory` if using acados as a submodule, the use of `CMAKE_SOURCE_DIR` adds the wrong directories. Using `PROJECT_SOURCE_DIR` instead produces the same results when building acados on its own but also adds the correct directories when included in other CMAKE projects.