### PR TITLE
Python get_stats returns float or int instead of single element numpy array and fix cython for custom path

### DIFF
--- a/examples/acados_python/chain_mass/run_nominal_control.py
+++ b/examples/acados_python/chain_mass/run_nominal_control.py
@@ -227,7 +227,7 @@ def run_nominal_control(chain_params):
         acados_ocp_solver.set(0, "ubx", xcurrent)
 
         status = acados_ocp_solver.solve()
-        timings[i] = acados_ocp_solver.get_stats("time_tot")[0]
+        timings[i] = acados_ocp_solver.get_stats("time_tot")
 
         if status != 0:
             raise Exception('acados acados_ocp_solver returned status {} in time step {}. Exiting.'.format(status, i))

--- a/examples/acados_python/getting_started/minimal_example_closed_loop.py
+++ b/examples/acados_python/getting_started/minimal_example_closed_loop.py
@@ -136,7 +136,7 @@ def main(use_RTI=False):
             # preparation phase
             ocp_solver.options_set('rti_phase', 1)
             status = ocp_solver.solve()
-            t_preparation[i] = ocp_solver.get_stats('time_tot').flatten()
+            t_preparation[i] = ocp_solver.get_stats('time_tot')
 
             # set initial state
             ocp_solver.set(0, "lbx", simX[i, :])
@@ -145,7 +145,7 @@ def main(use_RTI=False):
             # feedback phase
             ocp_solver.options_set('rti_phase', 2)
             status = ocp_solver.solve()
-            t_feedback[i] = ocp_solver.get_stats('time_tot').flatten()
+            t_feedback[i] = ocp_solver.get_stats('time_tot')
 
             simU[i, :] = ocp_solver.get(0, "u")
 

--- a/examples/acados_python/linear_mass_model/linear_mass_test_problem.py
+++ b/examples/acados_python/linear_mass_model/linear_mass_test_problem.py
@@ -196,7 +196,7 @@ def solve_marathos_ocp(setting):
     # solve
     status = ocp_solver.solve()
     ocp_solver.print_statistics() # encapsulates: stat = ocp_solver.get_stats("statistics")
-    sqp_iter = ocp_solver.get_stats('sqp_iter')[0]
+    sqp_iter = ocp_solver.get_stats('sqp_iter')
     print(f'acados returned status {status}.')
 
     # ocp_solver.store_iterate(f'it{ocp.solver_options.nlp_solver_max_iter}_{model.name}.json')

--- a/examples/acados_python/non_ocp_nlp/marathos_test_problem.py
+++ b/examples/acados_python/non_ocp_nlp/marathos_test_problem.py
@@ -173,7 +173,7 @@ def solve_marathos_problem_with_setting(setting):
     else:
         ocp_solver.solve()
         ocp_solver.print_statistics()
-        iter = ocp_solver.get_stats('sqp_iter')[0]
+        iter = ocp_solver.get_stats('sqp_iter')
         alphas = ocp_solver.get_stats('alpha')[1:]
         qp_iters = ocp_solver.get_stats('qp_iter')
         residuals = ocp_solver.get_stats('statistics')[1:5,1:iter]

--- a/examples/acados_python/rsm_example/main.py
+++ b/examples/acados_python/rsm_example/main.py
@@ -343,7 +343,7 @@ def main():
             if USE_RTI:
                 acados_solver.options_set('rti_phase', 1)
                 status = acados_solver.solve()
-                time_prep = acados_solver.get_stats('time_tot')[0] * 1e3
+                time_prep = acados_solver.get_stats('time_tot') * 1e3
                 if i_exec == 0:
                     times_prep[i] = time_prep
                 else:
@@ -359,7 +359,7 @@ def main():
 
             # solve
             status = acados_solver.solve()
-            time_feed = acados_solver.get_stats('time_tot')[0] * 1e3
+            time_feed = acados_solver.get_stats('time_tot') * 1e3
             if i_exec == 0:
                 times_feed[i] = time_feed
             else:

--- a/examples/acados_python/tests/armijo_test.py
+++ b/examples/acados_python/tests/armijo_test.py
@@ -122,7 +122,7 @@ def solve_armijo_problem_with_setting(setting):
     # get stats
     status = ocp_solver.solve()
     ocp_solver.print_statistics()
-    iter = ocp_solver.get_stats('sqp_iter')[0]
+    iter = ocp_solver.get_stats('sqp_iter')
     alphas = ocp_solver.get_stats('alpha')[1:]
     qp_iters = ocp_solver.get_stats('qp_iter')
     print(f"acados ocp solver returned status {status}")

--- a/examples/acados_python/zoRO_example/diff_drive/diff_drive_zoro_mpc.py
+++ b/examples/acados_python/zoRO_example/diff_drive/diff_drive_zoro_mpc.py
@@ -212,8 +212,8 @@ class ZoroMPCSolver:
             # preparation rti_phase
             self.acados_ocp_solver.options_set('rti_phase', 1)
             status = self.acados_ocp_solver.solve()
-            self.rti_phase1_t += self.acados_ocp_solver.get_stats("time_tot")[0]
-            self.acados_integrator_time += self.acados_ocp_solver.get_stats("time_sim")[0]
+            self.rti_phase1_t += self.acados_ocp_solver.get_stats("time_tot")
+            self.acados_integrator_time += self.acados_ocp_solver.get_stats("time_sim")
 
             t_start = process_time()
             self.acados_ocp_solver.custom_update([self.cfg.P0_mat.flatten()])
@@ -222,8 +222,8 @@ class ZoroMPCSolver:
             # feedback rti_phase
             self.acados_ocp_solver.options_set('rti_phase', 2)
             status = self.acados_ocp_solver.solve()
-            self.acados_qp_time += self.acados_ocp_solver.get_stats("time_qp")[0]
-            self.rti_phase2_t += self.acados_ocp_solver.get_stats("time_tot")[0]
+            self.acados_qp_time += self.acados_ocp_solver.get_stats("time_qp")
+            self.rti_phase2_t += self.acados_ocp_solver.get_stats("time_tot")
 
             # Get solution
             for i_stage in range(self.cfg.n_hrzn):

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -931,8 +931,9 @@ class AcadosOcpSolver:
         code_export_directory = acados_ocp_json['code_export_directory']
 
         importlib.invalidate_caches()
-        rel_code_export_directory = os.path.relpath(code_export_directory)
-        acados_ocp_solver_pyx = importlib.import_module(f'{rel_code_export_directory}.acados_ocp_solver_pyx')
+
+        sys.path.append(os.path.dirname(code_export_directory))
+        acados_ocp_solver_pyx = importlib.import_module(f'{os.path.split(code_export_directory)[1]}.acados_ocp_solver_pyx')
 
         AcadosOcpSolverCython = getattr(acados_ocp_solver_pyx, 'AcadosOcpSolverCython')
         return AcadosOcpSolverCython(acados_ocp_json['model']['name'],

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -1487,19 +1487,16 @@ class AcadosOcpSolver:
 
 
         if field_ in ['sqp_iter', 'stat_m', 'stat_n']:
-            out = np.ascontiguousarray(np.zeros((1,)), dtype=np.int64)
-            out_data = cast(out.ctypes.data, POINTER(c_int64))
+            out = c_int(0)
             self.shared_lib.ocp_nlp_get.argtypes = [c_void_p, c_void_p, c_char_p, c_void_p]
-            self.shared_lib.ocp_nlp_get(self.nlp_config, self.nlp_solver, field, out_data)
-            return out
+            self.shared_lib.ocp_nlp_get(self.nlp_config, self.nlp_solver, field, byref(out))
+            return out.value
 
-        # TODO: just return double instead of np.
         elif field_ in double_fields:
-            out = np.zeros((1,))
-            out_data = cast(out.ctypes.data, POINTER(c_double))
+            out = c_double(0)
             self.shared_lib.ocp_nlp_get.argtypes = [c_void_p, c_void_p, c_char_p, c_void_p]
-            self.shared_lib.ocp_nlp_get(self.nlp_config, self.nlp_solver, field, out_data)
-            return out
+            self.shared_lib.ocp_nlp_get(self.nlp_config, self.nlp_solver, field, byref(out))
+            return out.value
 
         elif field_ == 'statistics':
             sqp_iter = self.get_stats("sqp_iter")
@@ -1507,7 +1504,7 @@ class AcadosOcpSolver:
             stat_n = self.get_stats("stat_n")
             min_size = min([stat_m, sqp_iter+1])
             out = np.ascontiguousarray(
-                        np.zeros((stat_n[0]+1, min_size[0])), dtype=np.float64)
+                        np.zeros((stat_n+1, min_size)), dtype=np.float64)
             out_data = cast(out.ctypes.data, POINTER(c_double))
             self.shared_lib.ocp_nlp_get.argtypes = [c_void_p, c_void_p, c_char_p, c_void_p]
             self.shared_lib.ocp_nlp_get(self.nlp_config, self.nlp_solver, field, out_data)

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -43,6 +43,7 @@ from ctypes import POINTER, cast, CDLL, c_void_p, c_char_p, c_double, c_int, c_i
 
 from copy import deepcopy
 from pathlib import Path
+from typing import Union
 
 from .casadi_function_generation import generate_c_code_explicit_ode, \
     generate_c_code_implicit_ode, generate_c_code_gnsf, generate_c_code_discrete_dynamics, \
@@ -1435,7 +1436,7 @@ class AcadosOcpSolver:
             self.set(int(stage), field, np.array(solution[key]))
 
 
-    def get_stats(self, field_):
+    def get_stats(self, field_: str) -> Union[int, float, np.ndarray]:
         """
         Get the information of the last solver call.
 

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -931,7 +931,6 @@ class AcadosOcpSolver:
         code_export_directory = acados_ocp_json['code_export_directory']
 
         importlib.invalidate_caches()
-
         sys.path.append(os.path.dirname(code_export_directory))
         acados_ocp_solver_pyx = importlib.import_module(f'{os.path.split(code_export_directory)[1]}.acados_ocp_solver_pyx')
 

--- a/interfaces/acados_template/acados_template/acados_ocp_solver_pyx.pyx
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver_pyx.pyx
@@ -463,8 +463,8 @@ cdef class AcadosOcpSolverCython:
         return out
 
     def __get_stat_double(self, field):
-        cdef cnp.ndarray[cnp.float64_t, ndim=1] out = np.zeros((1,))
-        acados_solver_common.ocp_nlp_get(self.nlp_config, self.nlp_solver, field, <void *> out.data)
+        cdef double out
+        acados_solver_common.ocp_nlp_get(self.nlp_config, self.nlp_solver, field, <void *> &out)
         return out
 
     def __get_stat_matrix(self, field, n, m):

--- a/interfaces/acados_template/acados_template/acados_sim_solver.py
+++ b/interfaces/acados_template/acados_template/acados_sim_solver.py
@@ -280,8 +280,8 @@ class AcadosSimSolver:
         code_export_directory = acados_sim_json['code_export_directory']
 
         importlib.invalidate_caches()
-        rel_code_export_directory = os.path.relpath(code_export_directory)
-        acados_sim_solver_pyx = importlib.import_module(f'{rel_code_export_directory}.acados_sim_solver_pyx')
+        sys.path.append(os.path.dirname(code_export_directory))
+        acados_sim_solver_pyx = importlib.import_module(f'{os.path.split(code_export_directory)[1]}.acados_sim_solver_pyx')
 
         AcadosSimSolverCython = getattr(acados_sim_solver_pyx, 'AcadosSimSolverCython')
         return AcadosSimSolverCython(acados_sim_json['model']['name'])


### PR DESCRIPTION
- Get statistics with their correct types in both python and cython interface - avoid creation of 1-dim numpy array
- Make cython interface working with custom path of the `code_export_directory`

For Release notes:
- BREAKING: change return types of `get_stats` in Python