### PR TITLE
refactored optionally verbose system calls in python interface

### DIFF
--- a/examples/acados_python/getting_started/minimal_example_sim.py
+++ b/examples/acados_python/getting_started/minimal_example_sim.py
@@ -80,8 +80,8 @@ def main():
         # get solution
         simX[i+1,:] = acados_integrator.get("x")
 
-    if status != 0:
-        raise Exception(f'acados returned status {status}.')
+        if status != 0:
+            raise Exception(f'acados returned status {status}.')
 
     S_forw = acados_integrator.get("S_forw")
     print("S_forw, sensitivities of simulation result wrt x,u:\n", S_forw)

--- a/interfaces/acados_template/acados_template/acados_sim_solver.py
+++ b/interfaces/acados_template/acados_template/acados_sim_solver.py
@@ -29,27 +29,28 @@
 # POSSIBILITY OF SUCH DAMAGE.;
 #
 
-import sys
-import os
-import json
 import importlib
+import json
+import os
+import sys
+from copy import deepcopy
+from ctypes import (CDLL, POINTER, byref, c_bool, c_char_p, c_double, c_int,
+                    c_void_p, cast)
 
 import numpy as np
 
-from subprocess import DEVNULL, call, STDOUT
-
-from ctypes import POINTER, cast, CDLL, c_void_p, c_char_p, c_double, c_int, c_bool, byref
-from copy import deepcopy
-
-from .casadi_function_generation import generate_c_code_implicit_ode, generate_c_code_gnsf, generate_c_code_explicit_ode
-from .acados_sim import AcadosSim
 from .acados_ocp import AcadosOcp
-from .utils import is_column, render_template, format_class_dict, make_object_json_dumpable,\
-     make_model_consistent, set_up_imported_gnsf_model, get_python_interface_path, get_lib_ext,\
-     casadi_length, is_empty, check_casadi_version
+from .acados_sim import AcadosSim
 from .builders import CMakeBuilder
+from .casadi_function_generation import (generate_c_code_explicit_ode,
+                                         generate_c_code_gnsf,
+                                         generate_c_code_implicit_ode)
 from .gnsf.detect_gnsf_structure import detect_gnsf_structure
-
+from .utils import (casadi_length, check_casadi_version, format_class_dict,
+                    get_lib_ext, get_python_interface_path, is_column,
+                    is_empty, make_model_consistent, make_object_json_dumpable,
+                    render_template, set_up_imported_gnsf_model,
+                    verbose_system_call)
 
 
 def make_sim_dims_consistent(acados_sim: AcadosSim):
@@ -200,8 +201,7 @@ class AcadosSimSolver:
             `MS Visual Studio`); default: `None`
     """
     if sys.platform=="win32":
-        from ctypes import wintypes
-        from ctypes import WinDLL
+        from ctypes import WinDLL, wintypes
         dlclose = WinDLL('kernel32', use_last_error=True).FreeLibrary
         dlclose.argtypes = [wintypes.HMODULE]
     else:
@@ -245,25 +245,13 @@ class AcadosSimSolver:
         cwd = os.getcwd()
         os.chdir(code_export_dir)
         if with_cython:
-            call(
-                ['make', 'clean_sim_cython'],
-                stdout=None if verbose else DEVNULL,
-                stderr=None if verbose else STDOUT
-            )
-            call(
-                ['make', 'sim_cython'],
-                stdout=None if verbose else DEVNULL,
-                stderr=None if verbose else STDOUT
-            )
+            verbose_system_call(['make', 'clean_sim_cython'], verbose)
+            verbose_system_call(['make', 'sim_cython'], verbose)
         else:
             if cmake_builder is not None:
-                cmake_builder.exec(code_export_dir, verbose=verbose)
+                cmake_builder.exec(code_export_dir, verbose)
             else:
-                call(
-                    ['make', 'sim_shared_lib'],
-                    stdout=None if verbose else DEVNULL,
-                    stderr=None if verbose else STDOUT
-                )
+                verbose_system_call(['make', 'sim_shared_lib'], verbose)
         os.chdir(cwd)
 
 
@@ -296,7 +284,7 @@ class AcadosSimSolver:
             self.generate(acados_sim, json_file=json_file, cmake_builder=cmake_builder)
 
         if build:
-            self.build(code_export_dir, cmake_builder=cmake_builder, verbose=True)
+            self.build(code_export_dir, cmake_builder=cmake_builder, verbose=verbose)
 
         # prepare library loading
         lib_prefix = 'lib'
@@ -317,10 +305,11 @@ class AcadosSimSolver:
             self.__acados_lib_uses_omp = getattr(self.__acados_lib, 'omp_get_thread_num') is not None
         except AttributeError as e:
             self.__acados_lib_uses_omp = False
-        if self.__acados_lib_uses_omp:
-            print('acados was compiled with OpenMP.')
-        else:
-            print('acados was compiled without OpenMP.')
+        if verbose:
+            if self.__acados_lib_uses_omp:
+                print('acados was compiled with OpenMP.')
+            else:
+                print('acados was compiled without OpenMP.')
         libacados_sim_solver_name = f'{lib_prefix}acados_sim_solver_{self.model_name}{lib_ext}'
         self.shared_lib_name = os.path.join(code_export_dir, libacados_sim_solver_name)
 

--- a/interfaces/acados_template/acados_template/builders.py
+++ b/interfaces/acados_template/acados_template/builders.py
@@ -34,7 +34,8 @@
 
 import os
 import sys
-from subprocess import DEVNULL, call, STDOUT
+
+from .utils import verbose_system_call
 
 
 class CMakeBuilder:
@@ -96,32 +97,17 @@ class CMakeBuilder:
             os.chdir(self._build_dir)
             cmd_str = self.get_cmd1_cmake()
             print(f'call("{cmd_str})"')
-            retcode = call(
-                cmd_str,
-                shell=True,
-                stdout=None if verbose else DEVNULL,
-                stderr=None if verbose else STDOUT
-            )
+            retcode = verbose_system_call(cmd_str, verbose)
             if retcode != 0:
                 raise RuntimeError(f'CMake command "{cmd_str}" was terminated by signal {retcode}')
             cmd_str = self.get_cmd2_build()
             print(f'call("{cmd_str}")')
-            retcode = call(
-                cmd_str,
-                shell=True,
-                stdout=None if verbose else DEVNULL,
-                stderr=None if verbose else STDOUT
-            )
+            retcode = verbose_system_call(cmd_str, verbose)
             if retcode != 0:
                 raise RuntimeError(f'Build command "{cmd_str}" was terminated by signal {retcode}')
             cmd_str = self.get_cmd3_install()
             print(f'call("{cmd_str}")')
-            retcode = call(
-                cmd_str,
-                shell=True,
-                stdout=None if verbose else DEVNULL,
-                stderr=None if verbose else STDOUT
-            )
+            retcode = verbose_system_call(cmd_str, verbose)
             if retcode != 0:
                 raise RuntimeError(f'Install command "{cmd_str}" was terminated by signal {retcode}')
         except OSError as e:

--- a/interfaces/acados_template/acados_template/builders.py
+++ b/interfaces/acados_template/acados_template/builders.py
@@ -97,17 +97,17 @@ class CMakeBuilder:
             os.chdir(self._build_dir)
             cmd_str = self.get_cmd1_cmake()
             print(f'call("{cmd_str})"')
-            retcode = verbose_system_call(cmd_str, verbose)
+            retcode = verbose_system_call(cmd_str, verbose, shell=True)
             if retcode != 0:
                 raise RuntimeError(f'CMake command "{cmd_str}" was terminated by signal {retcode}')
             cmd_str = self.get_cmd2_build()
             print(f'call("{cmd_str}")')
-            retcode = verbose_system_call(cmd_str, verbose)
+            retcode = verbose_system_call(cmd_str, verbose, shell=True)
             if retcode != 0:
                 raise RuntimeError(f'Build command "{cmd_str}" was terminated by signal {retcode}')
             cmd_str = self.get_cmd3_install()
             print(f'call("{cmd_str}")')
-            retcode = verbose_system_call(cmd_str, verbose)
+            retcode = verbose_system_call(cmd_str, verbose, shell=True)
             if retcode != 0:
                 raise RuntimeError(f'Install command "{cmd_str}" was terminated by signal {retcode}')
         except OSError as e:

--- a/interfaces/acados_template/acados_template/utils.py
+++ b/interfaces/acados_template/acados_template/utils.py
@@ -29,13 +29,17 @@
 # POSSIBILITY OF SUCH DAMAGE.;
 #
 
-import os, sys, json
-import urllib.request
+import json
+import os
 import shutil
-import numpy as np
-from casadi import SX, MX, DM, Function, CasadiMeta
+import sys
+import urllib.request
+from subprocess import DEVNULL, STDOUT, call
 
-ALLOWED_CASADI_VERSIONS = ('3.5.6', '3.5.5', '3.5.4', '3.5.3', '3.5.2', '3.5.1', '3.4.5', '3.4.0')
+import numpy as np
+from casadi import DM, MX, SX, CasadiMeta, Function
+
+ALLOWED_CASADI_VERSIONS = ('3.6.3', '3.5.6', '3.5.5', '3.5.4', '3.5.3', '3.5.2', '3.5.1', '3.4.5', '3.4.0')
 
 TERA_VERSION = "0.0.34"
 
@@ -433,3 +437,11 @@ def idx_perm_to_ipiv(idx_perm):
 def print_casadi_expression(f):
     for ii in range(casadi_length(f)):
         print(f[ii,:])
+
+
+def verbose_system_call(cmd, verbose=True):
+    return call(
+        cmd,
+        stdout=None if verbose else DEVNULL,
+        stderr=None if verbose else STDOUT
+    )

--- a/interfaces/acados_template/acados_template/utils.py
+++ b/interfaces/acados_template/acados_template/utils.py
@@ -439,9 +439,10 @@ def print_casadi_expression(f):
         print(f[ii,:])
 
 
-def verbose_system_call(cmd, verbose=True):
+def verbose_system_call(cmd, verbose=True, shell=False):
     return call(
         cmd,
         stdout=None if verbose else DEVNULL,
-        stderr=None if verbose else STDOUT
+        stderr=None if verbose else STDOUT,
+        shell=shell
     )


### PR DESCRIPTION
Pursuing the efforts of PR #928, I refactored all the system calls in the python interface by introducing the following utility function:
```python
def verbose_system_call(cmd, verbose=True):
    return call(
        cmd,
        stdout=None if verbose else DEVNULL,
        stderr=None if verbose else STDOUT
    )
```