### PR TITLE
Fix dependency handling in CMake config file

### DIFF
--- a/cmake/acadosConfig.cmake.in
+++ b/cmake/acadosConfig.cmake.in
@@ -29,6 +29,7 @@
 #
 
 # Enabled external modules
+set(ACADOS_WITH_OPENMP @ACADOS_WITH_OPENMP@)
 set(ACADOS_WITH_HPMPC @ACADOS_WITH_HPMPC@)
 set(ACADOS_WITH_QORE @ACADOS_WITH_QORE@)
 set(ACADOS_WITH_QPOASES @ACADOS_WITH_QPOASES@)
@@ -37,12 +38,17 @@ set(ACADOS_WITH_OSQP @ACADOS_WITH_OSQP@)
 set(ACADOS_WITH_OOQP @ACADOS_WITH_OOQP@)
 
 # Add acados CMake folder to CMake prefix and module path
+set(CMAKE_MODULE_PATH_save "${CMAKE_MODULE_PATH}")
 list(APPEND CMAKE_PREFIX_PATH "${CMAKE_CURRENT_LIST_DIR}/../") # for *Config.cmake
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")     # for FindOpenBLAS, FindFortranLibs
 
 # Find the enabled external modules
 find_package(blasfeo)
 find_package(hpipm)
+
+if (ACADOS_WITH_OPENMP)
+    find_package(OpenMP)
+endif()
 
 if(ACADOS_WITH_QPOASES)
     find_package(qpOASES_e)
@@ -65,11 +71,18 @@ if(ACADOS_WITH_OOQP)
 endif()
 
 find_package(OpenBLAS)
-add_library(openblas UNKNOWN IMPORTED)
-set_property(TARGET openblas PROPERTY IMPORTED_LOCATION ${OpenBLAS_LIB})
+if (NOT TARGET openblas)
+    add_library(openblas UNKNOWN IMPORTED)
+    set_property(TARGET openblas PROPERTY IMPORTED_LOCATION ${OpenBLAS_LIB})
+endif()
 
 find_package(FortranLibs)
-add_library(gfortran UNKNOWN IMPORTED)
-set_property(TARGET gfortran PROPERTY IMPORTED_LOCATION ${FORTRAN_LIBRARY})
+if (NOT TARGET gfortran)
+    add_library(gfortran UNKNOWN IMPORTED)
+    set_property(TARGET gfortran PROPERTY IMPORTED_LOCATION ${FORTRAN_LIBRARY})
+endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/acadosTargets.cmake")
+
+set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH_save}")
+unset(CMAKE_MODULE_PATH_save)


### PR DESCRIPTION
This PR addresses 3 issues when consuming acados as a CMake dependency from a downstream project. 

1. Currently `find_package(acados)` breaks all following `find_package` calls since `acadosConfig.cmake` adjusts the `CMAKE_MODULE_PATH`. This should be restored to the original state per [this cmake dev](https://discourse.cmake.org/t/install-findpackage-script/5307/2) in [the manner shown here](https://discourse.cmake.org/t/cant-export-top-level-lib-with-dependency-on-subdir-lib/1084/21).
2. `add_library(gfortran)`  and `add_library(openblas)` triggers *target with the same name already exists* errors if the acados config file is processed twice, so they should be [guarded against double `add_library` by if guards](https://github.com/microsoft/vcpkg/issues/24367#issuecomment-1107798861)
3. If acados is build with `ACADOS_WITH_OPENMP`, the dependency on `OpenMP` is not handled in the config file