### PR TITLE
Rework CasADi requirements in MEX interface

### DIFF
--- a/examples/acados_matlab_octave/pendulum_dae/pendulum_dae_model.m
+++ b/examples/acados_matlab_octave/pendulum_dae/pendulum_dae_model.m
@@ -38,12 +38,7 @@ function [ model ] = pendulum_dae_model()
     
     %% CasADi
     import casadi.*
-    casadi_version = CasadiMeta.version();
-    if ( strcmp(casadi_version(1:3),'3.4') || strcmp(casadi_version(1:3),'3.5')) % require casadi 3.4.x
-        casadi_opts = struct('mex', false, 'casadi_int', 'int', 'casadi_real', 'double');
-    else % old casadi versions
-        error('Please provide CasADi version 3.4 or 3.5 to ensure compatibility with acados')
-    end
+
     model_name_prefix = 'pendulum_dae';
     
     %% Parameters (taken from Rien Quirynen's Master Thesis)

--- a/examples/acados_matlab_octave/simple_dae_model/simple_dae_model.m
+++ b/examples/acados_matlab_octave/simple_dae_model/simple_dae_model.m
@@ -35,36 +35,30 @@ function model = simple_dae_model()
     % that depends on the symbolic CasADi variables x, xdot, u, z,
     % and a model name, which will be used as a prefix for generated C
     % functions later on;
-    
+
     %% CasADi
     import casadi.*
-    casadi_version = CasadiMeta.version();
-    if ( strcmp(casadi_version(1:3),'3.4') || strcmp(casadi_version(1:3),'3.5')) % require casadi 3.4.x
-        casadi_opts = struct('mex', false, 'casadi_int', 'int', 'casadi_real', 'double');
-    else % old casadi versions
-        error('Please provide CasADi version 3.4 or 3.5 to ensure compatibility with acados')
-    end
 
     model_name_prefix = 'simple_dae';
-       
+
     %% Set up States & Controls
     x1    = SX.sym('x1');     % Differential States
     x2    = SX.sym('x2');
     x = vertcat(x1, x2);
-    
+
     z1      = SX.sym('z1');     % Algebraic states
     z2      = SX.sym('z2');
     z = vertcat(z1, z2);
-    
+
     u1      = SX.sym('u1');     % Controls
     u2      = SX.sym('u2');
     u       = vertcat(u1, u2);
-    
+
     %% xdot
     x1_dot    = SX.sym('x1_dot');     % Differential States
     x2_dot    = SX.sym('x2_dot');
     xdot = [x1_dot; x2_dot];
-    
+
 	%% cost
 	expr_y = vertcat(u1, u2, z1, z2);
 
@@ -73,11 +67,11 @@ function model = simple_dae_model()
                      x2_dot+x2+0.01*z1-u2,  ...
                      z1-x1, ...
                      z2-x2);
- 
+
 	%% constraints
     expr_h = vertcat(z1, z2);
     expr_h_e = vertcat(x1, x2);
-    
+
     %% initial value
     %     x0 = [0.1; -0.1];
     %     z0 = [0.0, 0.0];
@@ -92,6 +86,6 @@ function model = simple_dae_model()
     model.expr_h = expr_h;
     model.expr_h_e = expr_h_e;
     model.name = model_name_prefix;
-    
+
 end
 

--- a/interfaces/acados_matlab_octave/check_casadi_version.m
+++ b/interfaces/acados_matlab_octave/check_casadi_version.m
@@ -1,0 +1,37 @@
+%
+% Copyright (c) The acados authors.
+%
+% This file is part of acados.
+%
+% The 2-Clause BSD License
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%
+% 1. Redistributions of source code must retain the above copyright notice,
+% this list of conditions and the following disclaimer.
+%
+% 2. Redistributions in binary form must reproduce the above copyright notice,
+% this list of conditions and the following disclaimer in the documentation
+% and/or other materials provided with the distribution.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.;
+
+%
+function check_casadi_version()
+    import casadi.*
+    casadi_version = CasadiMeta.version();
+    if ~(strcmp(casadi_version(1:3),'3.4') || strcmp(casadi_version(1:3),'3.5') || strcmp(casadi_version(1:3),'3.6'))
+        warning('Tested CasADi versions are 3.4 and 3.5, you are using: %s.', casadi_version);
+    end
+end

--- a/interfaces/acados_matlab_octave/dump_gnsf_functions.m
+++ b/interfaces/acados_matlab_octave/dump_gnsf_functions.m
@@ -40,7 +40,7 @@ addpath(fullfile(acados_folder, 'external', 'jsonlab'))
 import casadi.*
 
 casadi_version = CasadiMeta.version();
-if ( strcmp(casadi_version(1:3),'3.5')) % require casadi 3.5 +
+if ( strcmp(casadi_version(1:3),'3.5') || strcmp(casadi_version(1:3),'3.6'))
 else % old casadi versions
     error('Please provide CasADi version or 3.5 to ensure compatibility with acados')
 end

--- a/interfaces/acados_matlab_octave/dump_gnsf_functions.m
+++ b/interfaces/acados_matlab_octave/dump_gnsf_functions.m
@@ -40,9 +40,8 @@ addpath(fullfile(acados_folder, 'external', 'jsonlab'))
 import casadi.*
 
 casadi_version = CasadiMeta.version();
-if ( strcmp(casadi_version(1:3),'3.5') || strcmp(casadi_version(1:3),'3.6'))
-else % old casadi versions
-    error('Please provide CasADi version or 3.5 to ensure compatibility with acados')
+if ~(strcmp(casadi_version(1:3),'3.5') || strcmp(casadi_version(1:3),'3.6'))
+    warning('CasADi serialization requires CasADi >= 3.5, you are using: %s.', casadi_version);
 end
 
 %% import models
@@ -168,7 +167,7 @@ json_filename = [model.name '_gnsf_functions.json'];
 json_string = savejson('', out, 'ForceRootName', 0);
 
 fid = fopen(json_filename, 'w');
-if fid == -1, error('Cannot create JSON file'); end
+if fid == -1, error('Cannot create json file'); end
 fwrite(fid, json_string, 'char');
 fclose(fid);
 

--- a/interfaces/acados_matlab_octave/generate_c_code_disc_dyn.m
+++ b/interfaces/acados_matlab_octave/generate_c_code_disc_dyn.m
@@ -35,11 +35,8 @@ function generate_c_code_disc_dyn( model, opts )
 %% import casadi
 import casadi.*
 
-casadi_version = CasadiMeta.version();
 casadi_opts = struct('mex', false, 'casadi_int', 'int', 'casadi_real', 'double');
-if ~(strcmp(casadi_version(1:3),'3.4') || strcmp(casadi_version(1:3),'3.5'))
-    warning('Tested CasADi versions are 3.4 and 3.5, you are using: %s.', casadi_version);
-end
+check_casadi_version();
 
 %% load model
 is_template = false;

--- a/interfaces/acados_matlab_octave/generate_c_code_disc_dyn.m
+++ b/interfaces/acados_matlab_octave/generate_c_code_disc_dyn.m
@@ -36,10 +36,9 @@ function generate_c_code_disc_dyn( model, opts )
 import casadi.*
 
 casadi_version = CasadiMeta.version();
-if ( strcmp(casadi_version(1:3),'3.4') || strcmp(casadi_version(1:3),'3.5')) % require casadi 3.4.x
-    casadi_opts = struct('mex', false, 'casadi_int', 'int', 'casadi_real', 'double');
-else % old casadi versions
-    error('Please provide CasADi version 3.4 or 3.5 to ensure compatibility with acados')
+casadi_opts = struct('mex', false, 'casadi_int', 'int', 'casadi_real', 'double');
+if ~(strcmp(casadi_version(1:3),'3.4') || strcmp(casadi_version(1:3),'3.5'))
+    warning('Tested CasADi versions are 3.4 and 3.5, you are using: %s.', casadi_version);
 end
 
 %% load model

--- a/interfaces/acados_matlab_octave/generate_c_code_explicit_ode.m
+++ b/interfaces/acados_matlab_octave/generate_c_code_explicit_ode.m
@@ -36,10 +36,9 @@ function generate_c_code_explicit_ode( model, opts )
 import casadi.*
 
 casadi_version = CasadiMeta.version();
-if ( strcmp(casadi_version(1:3),'3.4') || strcmp(casadi_version(1:3),'3.5')) % require casadi 3.4.x
-    casadi_opts = struct('mex', false, 'casadi_int', 'int', 'casadi_real', 'double');
-else % old casadi versions
-    error('Please provide CasADi version 3.4 or 3.5 to ensure compatibility with acados')
+casadi_opts = struct('mex', false, 'casadi_int', 'int', 'casadi_real', 'double');
+if ~(strcmp(casadi_version(1:3),'3.4') || strcmp(casadi_version(1:3),'3.5'))
+    warning('Tested CasADi versions are 3.4 and 3.5, you are using: %s.', casadi_version);
 end
 
 if nargin > 1

--- a/interfaces/acados_matlab_octave/generate_c_code_explicit_ode.m
+++ b/interfaces/acados_matlab_octave/generate_c_code_explicit_ode.m
@@ -35,7 +35,6 @@ function generate_c_code_explicit_ode( model, opts )
 %% import casadi
 import casadi.*
 
-casadi_version = CasadiMeta.version();
 casadi_opts = struct('mex', false, 'casadi_int', 'int', 'casadi_real', 'double');
 check_casadi_version();
 

--- a/interfaces/acados_matlab_octave/generate_c_code_explicit_ode.m
+++ b/interfaces/acados_matlab_octave/generate_c_code_explicit_ode.m
@@ -37,9 +37,7 @@ import casadi.*
 
 casadi_version = CasadiMeta.version();
 casadi_opts = struct('mex', false, 'casadi_int', 'int', 'casadi_real', 'double');
-if ~(strcmp(casadi_version(1:3),'3.4') || strcmp(casadi_version(1:3),'3.5'))
-    warning('Tested CasADi versions are 3.4 and 3.5, you are using: %s.', casadi_version);
-end
+check_casadi_version();
 
 if nargin > 1
     if isfield(opts, 'sens_hess')

--- a/interfaces/acados_matlab_octave/generate_c_code_ext_cost.m
+++ b/interfaces/acados_matlab_octave/generate_c_code_ext_cost.m
@@ -35,7 +35,6 @@ function generate_c_code_ext_cost( model, opts, target_dir )
 %% import casadi
 import casadi.*
 
-casadi_version = CasadiMeta.version();
 casadi_opts = struct('mex', false, 'casadi_int', 'int', 'casadi_real', 'double');
 check_casadi_version();
 

--- a/interfaces/acados_matlab_octave/generate_c_code_ext_cost.m
+++ b/interfaces/acados_matlab_octave/generate_c_code_ext_cost.m
@@ -37,9 +37,7 @@ import casadi.*
 
 casadi_version = CasadiMeta.version();
 casadi_opts = struct('mex', false, 'casadi_int', 'int', 'casadi_real', 'double');
-if ~(strcmp(casadi_version(1:3),'3.4') || strcmp(casadi_version(1:3),'3.5'))
-    warning('Tested CasADi versions are 3.4 and 3.5, you are using: %s.', casadi_version);
-end
+check_casadi_version();
 
 % cd to target folder
 if nargin > 2

--- a/interfaces/acados_matlab_octave/generate_c_code_ext_cost.m
+++ b/interfaces/acados_matlab_octave/generate_c_code_ext_cost.m
@@ -36,10 +36,9 @@ function generate_c_code_ext_cost( model, opts, target_dir )
 import casadi.*
 
 casadi_version = CasadiMeta.version();
-if ( strcmp(casadi_version(1:3),'3.4') || strcmp(casadi_version(1:3),'3.5')) % require casadi 3.4.x
-    casadi_opts = struct('mex', false, 'casadi_int', 'int', 'casadi_real', 'double');
-else % old casadi versions
-    error('Please provide CasADi version 3.4 or 3.5 to ensure compatibility with acados')
+casadi_opts = struct('mex', false, 'casadi_int', 'int', 'casadi_real', 'double');
+if ~(strcmp(casadi_version(1:3),'3.4') || strcmp(casadi_version(1:3),'3.5'))
+    warning('Tested CasADi versions are 3.4 and 3.5, you are using: %s.', casadi_version);
 end
 
 % cd to target folder

--- a/interfaces/acados_matlab_octave/generate_c_code_gnsf.m
+++ b/interfaces/acados_matlab_octave/generate_c_code_gnsf.m
@@ -37,9 +37,7 @@ import casadi.*
 
 casadi_version = CasadiMeta.version();
 casadi_opts = struct('mex', false, 'casadi_int', 'int', 'casadi_real', 'double');
-if ~(strcmp(casadi_version(1:3),'3.4') || strcmp(casadi_version(1:3),'3.5'))
-    warning('Tested CasADi versions are 3.4 and 3.5, you are using: %s.', casadi_version);
-end
+check_casadi_version();
 
 is_template = false;
 if isa(model, 'acados_template_mex.acados_model_json')

--- a/interfaces/acados_matlab_octave/generate_c_code_gnsf.m
+++ b/interfaces/acados_matlab_octave/generate_c_code_gnsf.m
@@ -36,10 +36,9 @@ function generate_c_code_gnsf(model, opts)
 import casadi.*
 
 casadi_version = CasadiMeta.version();
-if ( strcmp(casadi_version(1:3),'3.4') || strcmp(casadi_version(1:3),'3.5')) % require casadi 3.4.x
-    casadi_opts = struct('mex', false, 'casadi_int', 'int', 'casadi_real', 'double');
-else % old casadi versions
-    error('Please provide CasADi version 3.4 or 3.5 to ensure compatibility with acados')
+casadi_opts = struct('mex', false, 'casadi_int', 'int', 'casadi_real', 'double');
+if ~(strcmp(casadi_version(1:3),'3.4') || strcmp(casadi_version(1:3),'3.5'))
+    warning('Tested CasADi versions are 3.4 and 3.5, you are using: %s.', casadi_version);
 end
 
 is_template = false;

--- a/interfaces/acados_matlab_octave/generate_c_code_gnsf.m
+++ b/interfaces/acados_matlab_octave/generate_c_code_gnsf.m
@@ -35,7 +35,6 @@ function generate_c_code_gnsf(model, opts)
 %% import casadi
 import casadi.*
 
-casadi_version = CasadiMeta.version();
 casadi_opts = struct('mex', false, 'casadi_int', 'int', 'casadi_real', 'double');
 check_casadi_version();
 

--- a/interfaces/acados_matlab_octave/generate_c_code_implicit_ode.m
+++ b/interfaces/acados_matlab_octave/generate_c_code_implicit_ode.m
@@ -36,10 +36,9 @@ function generate_c_code_implicit_ode( model, opts )
 import casadi.*
 
 casadi_version = CasadiMeta.version();
-if ( strcmp(casadi_version(1:3),'3.4') || strcmp(casadi_version(1:3),'3.5')) % require casadi 3.4.x
-    casadi_opts = struct('mex', false, 'casadi_int', 'int', 'casadi_real', 'double');
-else % old casadi versions
-    error('Please provide CasADi version 3.4 or 3.5 to ensure compatibility with acados')
+casadi_opts = struct('mex', false, 'casadi_int', 'int', 'casadi_real', 'double');
+if ~(strcmp(casadi_version(1:3),'3.4') || strcmp(casadi_version(1:3),'3.5'))
+    warning('Tested CasADi versions are 3.4 and 3.5, you are using: %s.', casadi_version);
 end
 
 if nargin > 1

--- a/interfaces/acados_matlab_octave/generate_c_code_implicit_ode.m
+++ b/interfaces/acados_matlab_octave/generate_c_code_implicit_ode.m
@@ -35,7 +35,6 @@ function generate_c_code_implicit_ode( model, opts )
 %% import casadi
 import casadi.*
 
-casadi_version = CasadiMeta.version();
 casadi_opts = struct('mex', false, 'casadi_int', 'int', 'casadi_real', 'double');
 check_casadi_version();
 

--- a/interfaces/acados_matlab_octave/generate_c_code_implicit_ode.m
+++ b/interfaces/acados_matlab_octave/generate_c_code_implicit_ode.m
@@ -37,9 +37,7 @@ import casadi.*
 
 casadi_version = CasadiMeta.version();
 casadi_opts = struct('mex', false, 'casadi_int', 'int', 'casadi_real', 'double');
-if ~(strcmp(casadi_version(1:3),'3.4') || strcmp(casadi_version(1:3),'3.5'))
-    warning('Tested CasADi versions are 3.4 and 3.5, you are using: %s.', casadi_version);
-end
+check_casadi_version();
 
 if nargin > 1
     if isfield(opts, 'sens_hess')

--- a/interfaces/acados_matlab_octave/generate_c_code_nonlinear_constr.m
+++ b/interfaces/acados_matlab_octave/generate_c_code_nonlinear_constr.m
@@ -35,7 +35,6 @@ function generate_c_code_nonlinear_constr( model, opts, target_dir )
 %% import casadi
 import casadi.*
 
-casadi_version = CasadiMeta.version();
 casadi_opts = struct('mex', false, 'casadi_int', 'int', 'casadi_real', 'double');
 check_casadi_version();
 

--- a/interfaces/acados_matlab_octave/generate_c_code_nonlinear_constr.m
+++ b/interfaces/acados_matlab_octave/generate_c_code_nonlinear_constr.m
@@ -36,10 +36,9 @@ function generate_c_code_nonlinear_constr( model, opts, target_dir )
 import casadi.*
 
 casadi_version = CasadiMeta.version();
-if ( strcmp(casadi_version(1:3),'3.4') || strcmp(casadi_version(1:3),'3.5')) % require casadi 3.4.x
-    casadi_opts = struct('mex', false, 'casadi_int', 'int', 'casadi_real', 'double');
-else % old casadi versions
-    error('Please provide CasADi version 3.4 or 3.5 to ensure compatibility with acados')
+casadi_opts = struct('mex', false, 'casadi_int', 'int', 'casadi_real', 'double');
+if ~(strcmp(casadi_version(1:3),'3.4') || strcmp(casadi_version(1:3),'3.5'))
+    warning('Tested CasADi versions are 3.4 and 3.5, you are using: %s.', casadi_version);
 end
 
 %% load model

--- a/interfaces/acados_matlab_octave/generate_c_code_nonlinear_constr.m
+++ b/interfaces/acados_matlab_octave/generate_c_code_nonlinear_constr.m
@@ -37,9 +37,7 @@ import casadi.*
 
 casadi_version = CasadiMeta.version();
 casadi_opts = struct('mex', false, 'casadi_int', 'int', 'casadi_real', 'double');
-if ~(strcmp(casadi_version(1:3),'3.4') || strcmp(casadi_version(1:3),'3.5'))
-    warning('Tested CasADi versions are 3.4 and 3.5, you are using: %s.', casadi_version);
-end
+check_casadi_version();
 
 %% load model
 % x

--- a/interfaces/acados_matlab_octave/generate_c_code_nonlinear_least_squares.m
+++ b/interfaces/acados_matlab_octave/generate_c_code_nonlinear_least_squares.m
@@ -36,10 +36,9 @@ function generate_c_code_nonlinear_least_squares( model, opts, target_dir )
 import casadi.*
 
 casadi_version = CasadiMeta.version();
-if ( strcmp(casadi_version(1:3),'3.4') || strcmp(casadi_version(1:3),'3.5')) % require casadi 3.4.x
-    casadi_opts = struct('mex', false, 'casadi_int', 'int', 'casadi_real', 'double');
-else % old casadi versions
-    error('Please provide CasADi version 3.4 or 3.5 to ensure compatibility with acados')
+casadi_opts = struct('mex', false, 'casadi_int', 'int', 'casadi_real', 'double');
+if ~(strcmp(casadi_version(1:3),'3.4') || strcmp(casadi_version(1:3),'3.5'))
+    warning('Tested CasADi versions are 3.4 and 3.5, you are using: %s.', casadi_version);
 end
 
 %% load model

--- a/interfaces/acados_matlab_octave/generate_c_code_nonlinear_least_squares.m
+++ b/interfaces/acados_matlab_octave/generate_c_code_nonlinear_least_squares.m
@@ -35,7 +35,6 @@ function generate_c_code_nonlinear_least_squares( model, opts, target_dir )
 %% import casadi
 import casadi.*
 
-casadi_version = CasadiMeta.version();
 casadi_opts = struct('mex', false, 'casadi_int', 'int', 'casadi_real', 'double');
 check_casadi_version();
 

--- a/interfaces/acados_matlab_octave/generate_c_code_nonlinear_least_squares.m
+++ b/interfaces/acados_matlab_octave/generate_c_code_nonlinear_least_squares.m
@@ -37,9 +37,7 @@ import casadi.*
 
 casadi_version = CasadiMeta.version();
 casadi_opts = struct('mex', false, 'casadi_int', 'int', 'casadi_real', 'double');
-if ~(strcmp(casadi_version(1:3),'3.4') || strcmp(casadi_version(1:3),'3.5'))
-    warning('Tested CasADi versions are 3.4 and 3.5, you are using: %s.', casadi_version);
-end
+check_casadi_version();
 
 %% load model
 % x

--- a/interfaces/acados_matlab_octave/gnsf/determine_trivial_gnsf_transcription.m
+++ b/interfaces/acados_matlab_octave/gnsf/determine_trivial_gnsf_transcription.m
@@ -40,7 +40,6 @@ function [ gnsf ] = determine_trivial_gnsf_transcription(model, print_info)
 % import CasADi
 import casadi.*
 
-casadi_version = CasadiMeta.version();
 casadi_opts = struct('mex', false, 'casadi_int', 'int', 'casadi_real', 'double');
 check_casadi_version();
 

--- a/interfaces/acados_matlab_octave/gnsf/determine_trivial_gnsf_transcription.m
+++ b/interfaces/acados_matlab_octave/gnsf/determine_trivial_gnsf_transcription.m
@@ -41,10 +41,9 @@ function [ gnsf ] = determine_trivial_gnsf_transcription(model, print_info)
 import casadi.*
 
 casadi_version = CasadiMeta.version();
-if ( strcmp(casadi_version(1:3),'3.4') || strcmp(casadi_version(1:3),'3.5')) % require casadi 3.4.x
-    casadi_opts = struct('mex', false, 'casadi_int', 'int', 'casadi_real', 'double');
-else % old casadi versions
-    error('Please provide CasADi version 3.4 or 3.5 to ensure compatibility with acados')
+casadi_opts = struct('mex', false, 'casadi_int', 'int', 'casadi_real', 'double');
+if ~(strcmp(casadi_version(1:3),'3.4') || strcmp(casadi_version(1:3),'3.5'))
+    warning('Tested CasADi versions are 3.4 and 3.5, you are using: %s.', casadi_version);
 end
 
 % initial print

--- a/interfaces/acados_matlab_octave/gnsf/determine_trivial_gnsf_transcription.m
+++ b/interfaces/acados_matlab_octave/gnsf/determine_trivial_gnsf_transcription.m
@@ -42,9 +42,7 @@ import casadi.*
 
 casadi_version = CasadiMeta.version();
 casadi_opts = struct('mex', false, 'casadi_int', 'int', 'casadi_real', 'double');
-if ~(strcmp(casadi_version(1:3),'3.4') || strcmp(casadi_version(1:3),'3.5'))
-    warning('Tested CasADi versions are 3.4 and 3.5, you are using: %s.', casadi_version);
-end
+check_casadi_version();
 
 % initial print
 disp('*****************************************************************');


### PR DESCRIPTION
Following https://github.com/acados/acados/issues/981
- Tested 3.6 on some examples locally
- Only raise Warning on untested CasADi versions