### PR TITLE
Fix bugs with slack dimensions Python interface

### DIFF
--- a/interfaces/acados_template/acados_template/acados_ocp.py
+++ b/interfaces/acados_template/acados_template/acados_ocp.py
@@ -538,18 +538,17 @@ class AcadosOcp:
         ns_0 = nsbu + nsg + nsh_0 + nsphi_0 + nsh_0  # NOTE: nsbx not supported at stage 0
 
         if cost.zl_0 is None and cost.zu_0 is None and cost.Zl_0 is None and cost.Zu_0 is None:
-            print("Fields cost.[zl_0, zu_0, Zl_0, Zu_0] are not provided.")
             if ns_0 == 0:
                 cost.zl_0 = np.array([])
                 cost.zu_0 = np.array([])
                 cost.Zl_0 = np.array([])
                 cost.Zu_0 = np.array([])
-                print("Using empty arrays at intial node for slack penalties.\n")
             elif ns_0 == ns:
                 cost.zl_0 = cost.zl
                 cost.zu_0 = cost.zu
                 cost.Zl_0 = cost.Zl
                 cost.Zu_0 = cost.Zu
+                print("Fields cost.[zl_0, zu_0, Zl_0, Zu_0] are not provided.")
                 print("Using entries [zl, zu, Zl, Zu] at intial node for slack penalties.\n")
             else:
                 raise ValueError("Fields cost.[zl_0, zu_0, Zl_0, Zu_0] are not provided and cannot be inferred from other fields.\n")
@@ -725,7 +724,6 @@ class AcadosOcp:
                 self.zoro_description = process_zoro_description(self.zoro_description)
 
         return
-
 
 
     def remove_x0_elimination(self) -> None:

--- a/interfaces/acados_template/acados_template/acados_ocp.py
+++ b/interfaces/acados_template/acados_template/acados_ocp.py
@@ -535,7 +535,7 @@ class AcadosOcp:
         dims.nsphi_0 = nsphi_0
 
         # Note: at stage 0 bounds on x are not slacked!
-        ns_0 = nsbu + nsg + nsh_0 + nsphi_0 + nsh_0  # NOTE: nsbx not supported at stage 0
+        ns_0 = nsbu + nsg + nsphi_0 + nsh_0  # NOTE: nsbx not supported at stage 0
 
         if cost.zl_0 is None and cost.zu_0 is None and cost.Zl_0 is None and cost.Zu_0 is None:
             if ns_0 == 0:

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -2339,7 +2339,7 @@ int {{ model.name }}_acados_reset({{ model.name }}_solver_capsule* capsule, int 
     ocp_nlp_in* nlp_in = capsule->nlp_in;
     ocp_nlp_solver* nlp_solver = capsule->nlp_solver;
 
-    double* buffer = calloc(NX+NU+NZ+2*NS+2*NSN+NBX+NBU+NG+NH+NPHI+NBX0+NBXN+NHN+NH0+NPHIN+NGN, sizeof(double));
+    double* buffer = calloc(NX+NU+NZ+2*NS+2*NSN+2*NS0+NBX+NBU+NG+NH+NPHI+NBX0+NBXN+NHN+NH0+NPHIN+NGN, sizeof(double));
 
     for(int i=0; i<N+1; i++)
     {

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -1128,11 +1128,11 @@ void {{ model.name }}_acados_create_5_set_nlp_in({{ model.name }}_solver_capsule
 
 {% if dims.ns_0 > 0 %}
     // slacks terminal
-    double* zlu0_mem = calloc(4*NSN, sizeof(double));
-    double* Zl_0 = zlu0_mem+NSN*0;
-    double* Zu_0 = zlu0_mem+NSN*1;
-    double* zl_0 = zlu0_mem+NSN*2;
-    double* zu_0 = zlu0_mem+NSN*3;
+    double* zlu0_mem = calloc(4*NS0, sizeof(double));
+    double* Zl_0 = zlu0_mem+NS0*0;
+    double* Zu_0 = zlu0_mem+NS0*1;
+    double* zl_0 = zlu0_mem+NS0*2;
+    double* zu_0 = zlu0_mem+NS0*3;
 
     // change only the non-zero elements:
     {% for j in range(end=dims.ns_0) %}


### PR DESCRIPTION
* fix bug in Python interface detecting ns_0, reported in https://discourse.acados.org/t/possible-bug-in-python-interface-slack-dimensions/1335
* fix buffer size with NS0
* fix: ns_0 in template
* remove redundant print
