### PR TITLE
extend AcadosMultiphaseOcp

### DIFF
--- a/examples/acados_python/mocp_transition_example/main.py
+++ b/examples/acados_python/mocp_transition_example/main.py
@@ -1,0 +1,306 @@
+# -*- coding: future_fstrings -*-
+#
+# Copyright (c) The acados authors.
+#
+# This file is part of acados.
+#
+# The 2-Clause BSD License
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.;
+#
+
+import numpy as np
+import casadi as ca
+
+from acados_template import AcadosModel, AcadosOcp, AcadosMultiphaseOcp, AcadosOcpSolver, casadi_length, is_empty, latexify_plot
+
+
+X0 = np.array([2.0, 0.0])
+PENALTY_X = 1e0
+T_HORIZON = 1.0
+N_HORIZON = 20
+
+L2_COST_V = 1e-1
+L2_COST_P = 1e0
+L2_COST_A = 1e-3
+
+def get_double_integrator_model() -> AcadosModel:
+
+    # set up states & controls
+    p = ca.SX.sym('p')
+    v = ca.SX.sym('v')
+    x = ca.vertcat(p, v)
+    nx = casadi_length(x)
+
+    u = ca.SX.sym('u')
+
+    # set up dynamics
+    f_expl = ca.vertcat(v, u)
+    xdot = ca.SX.sym('xdot', nx)
+    f_impl = f_expl - xdot
+
+    # set up model
+    model = AcadosModel()
+    model.name = 'double_integrator'
+    model.x = x
+    model.xdot = xdot
+    model.u = u
+    model.f_impl_expr = f_impl
+    model.f_expl_expr = f_expl
+
+    return model
+
+
+def get_single_integrator_model() -> AcadosModel:
+
+    # set up states & controls
+    p = ca.SX.sym('p')
+    x = ca.vertcat(p)
+    nx = casadi_length(x)
+
+    u = ca.SX.sym('v')
+
+    # set up dynamics
+    f_expl = ca.vertcat(u)
+    xdot = ca.SX.sym('xdot', nx)
+    f_impl = f_expl - xdot
+
+    # set up model
+    model = AcadosModel()
+    model.name = 'single_integrator'
+    model.x = x
+    model.xdot = xdot
+    model.u = u
+    model.f_impl_expr = f_impl
+    model.f_expl_expr = f_expl
+    return model
+
+
+def get_transition_model() -> AcadosModel:
+
+    # set up states & controls
+    p = ca.SX.sym('p')
+    v = ca.SX.sym('v')
+    x = ca.vertcat(p, v)
+
+    # set up dynamics
+    new_x = p
+
+    # set up model
+    model = AcadosModel()
+    model.name = 'transition_model'
+    model.x = x
+    model.u = ca.SX.sym('u', 0, 0)
+    model.disc_dyn_expr = new_x
+
+    return model
+
+
+
+def formulate_double_integrator_ocp() -> AcadosOcp:
+    ocp = AcadosOcp()
+
+    ocp.model = get_double_integrator_model()
+
+    ocp.dims.N = N_HORIZON
+
+    ocp.cost.cost_type = 'NONLINEAR_LS'
+    ocp.cost.cost_type_e = 'NONLINEAR_LS'
+    ocp.cost.W = np.diag([L2_COST_P, L2_COST_V, L2_COST_A])
+    ocp.cost.W_e = np.diag([1e1, 1e1])
+    ocp.cost.yref = np.array([0.0, 0.0, 0.0])
+    ocp.cost.yref_e = np.array([0.0, 0.0])
+
+    ocp.model.cost_y_expr = ca.vertcat(ocp.model.x, ocp.model.u)
+    ocp.model.cost_y_expr_e = ocp.model.x
+
+    u_max = 50.0
+    ocp.constraints.lbu = np.array([-u_max])
+    ocp.constraints.ubu = np.array([u_max])
+    ocp.constraints.idxbu = np.array([0])
+
+    ocp.constraints.x0 = X0
+
+    return ocp
+
+
+def formulate_single_integrator_ocp() -> AcadosOcp:
+    ocp = AcadosOcp()
+
+    ocp.model = get_single_integrator_model()
+
+    ocp.dims.N = N_HORIZON
+
+    ocp.cost.cost_type = 'NONLINEAR_LS'
+    ocp.cost.cost_type_e = 'NONLINEAR_LS'
+    ocp.cost.W = np.diag([L2_COST_P, L2_COST_V])
+    ocp.cost.W_e = np.diag([1e1])
+    ocp.cost.yref = np.array([0.0, 0.0])
+    ocp.cost.yref_e = np.array([0.0])
+
+    ocp.model.cost_y_expr = ca.vertcat(ocp.model.x, ocp.model.u)
+    ocp.model.cost_y_expr_e = ocp.model.x
+
+    u_max = 5.0
+    ocp.constraints.lbu = np.array([-u_max])
+    ocp.constraints.ubu = np.array([u_max])
+    ocp.constraints.idxbu = np.array([0])
+
+    # ocp.constraints.x0 = X0
+
+    return ocp
+
+
+
+def main_multiphase_ocp() -> AcadosMultiphaseOcp:
+    N_list = [10, 1, 15]
+    ocp = AcadosMultiphaseOcp(N_list=N_list)
+
+    phase_0 = formulate_double_integrator_ocp()
+    ocp.set_phase(phase_0, 0)
+
+    phase_1 = AcadosOcp()
+    phase_1.model = get_transition_model()
+    phase_1.cost.cost_type = 'NONLINEAR_LS'
+    phase_1.model.cost_y_expr = phase_1.model.x
+    # TODO: how to choose this transition cost
+    phase_1.cost.W = np.diag([L2_COST_P, 1e-1 * L2_COST_V])
+    phase_1.cost.yref = np.array([0., 0.])
+
+    ocp.set_phase(phase_1, 1)
+
+    phase_2 = formulate_single_integrator_ocp()
+    ocp.set_phase(phase_2, 2)
+
+    ocp.solver_options.tf = T_HORIZON + 1.0
+    ocp.solver_options.nlp_solver_type = 'SQP'
+    ocp.mocp_opts.integrator_type = ['IRK', 'DISCRETE', 'IRK']
+    T_HORIZON_1 = 0.4 * T_HORIZON
+    T_HORIZON_2 = T_HORIZON - T_HORIZON_1
+    ocp.solver_options.time_steps = np.array(N_list[0] * [T_HORIZON_1/N_list[0]] + [1.0] + N_list[2] * [T_HORIZON_2/N_list[2]] )
+
+    acados_ocp_solver = AcadosOcpSolver(ocp, verbose=False)
+    acados_ocp_solver.solve_for_x0(X0)
+
+
+    n_phases = len(N_list)
+
+    x_traj_phases = n_phases*[None]
+    u_traj_phases = n_phases*[None]
+    t_grid_phases = n_phases*[None]
+
+    for i_phase in range(n_phases):
+        x_traj_phases[i_phase] = [acados_ocp_solver.get(i, 'x') for i in range(ocp.start_idx[i_phase], ocp.end_idx[i_phase]+1)]
+        u_traj_phases[i_phase] = [acados_ocp_solver.get(i, 'u') for i in range(ocp.start_idx[i_phase], ocp.end_idx[i_phase])]
+        t_grid_phases[i_phase] = ocp.solver_options.shooting_nodes[ocp.start_idx[i_phase]: ocp.end_idx[i_phase]+1]
+        print(f"Phase {i_phase}:\nt grid \n {t_grid_phases[i_phase]} \nx traj\n {x_traj_phases[i_phase]} \nu traj {u_traj_phases[i_phase]}")
+        print("-----------------------------------")
+
+    ## plot solution
+    t_grid_2_plot = t_grid_phases[2] - 1.0
+    import matplotlib.pyplot as plt
+    latexify_plot()
+    fig, ax = plt.subplots(3, 1, sharex=True)
+    ax[0].grid(True)
+    ax[0].set_xlim([0, T_HORIZON])
+    plt.xlabel('$t$ [s]')
+
+    p_traj_0 = [x[0] for x in x_traj_phases[0]]
+    ax[0].plot(t_grid_phases[0], p_traj_0, color='C0', label='phase 1')
+
+    p_traj_2 = [x[0] for x in x_traj_phases[2]]
+    ax[0].plot(t_grid_2_plot, p_traj_2, '-.', color='C0', label='phase 2')
+    ax[0].set_ylabel('$p$')
+
+
+    ax[1].set_ylabel('$v$')
+    ax[1].grid(True)
+
+    v_traj_0 = [x[1] for x in x_traj_phases[0]]
+    ax[1].plot(t_grid_phases[0], v_traj_0, color='C0')
+    v_traj_2 = [u_traj_phases[2][0][0]] + [x[0] for x in u_traj_phases[2]]
+    ax[1].step(t_grid_2_plot, v_traj_2, '-.', color='C0')
+
+
+    isub = 2
+    ax[isub].set_ylabel('$a$')
+    ax[isub].grid(True)
+    a_traj = [u_traj_phases[0][0][0]] + [x[0] for x in u_traj_phases[0]]
+    ax[isub].step(t_grid_phases[0], a_traj, '-', color='C0')
+
+    plt.show()
+
+
+
+    # for i_phase in [0, 2]:
+    #     # breakpoint()
+    #     plot_ocp_solution(t_grid_phases[i_phase], x_traj_phases[i_phase], u_traj_phases[i_phase], title=f"Phase {i_phase}")
+
+
+
+def main():
+    ocp = formulate_double_integrator_ocp()
+    ocp.solver_options.tf = T_HORIZON
+    ocp.solver_options.nlp_solver_type = 'SQP'
+
+
+    acados_ocp_solver = AcadosOcpSolver(ocp, verbose=False)
+
+    status = acados_ocp_solver.solve_for_x0(X0)
+    acados_ocp_solver.print_statistics()
+
+    x_traj = [acados_ocp_solver.get(i, 'x') for i in range(ocp.dims.N+1)]
+    u_traj = [acados_ocp_solver.get(i, 'u') for i in range(ocp.dims.N)]
+
+    t_grid = ocp.solver_options.shooting_nodes
+
+    plot_ocp_solution(t_grid, x_traj, u_traj)
+
+    return
+
+
+def plot_ocp_solution(t_grid: np.ndarray, x_traj: list, u_traj: list, x_labels=["p", "v"], title=None):
+    import matplotlib.pyplot as plt
+    latexify_plot()
+    nx = len(x_traj[0])
+    nu = len(u_traj[0])
+    # use subplots
+    fig, ax = plt.subplots(nx, 1, sharex=True)
+
+    if title is not None:
+        plt.title(title)
+    ax[0].grid(True)
+    plt.xlabel('t [s]')
+
+    for i in range(nx):
+        iplot = i
+        ax[iplot].plot(t_grid, np.array(x_traj)[:,i], color='C0')
+        ax[iplot].grid(True)
+        ax[iplot].set_ylabel(x_labels[i])
+    plt.show()
+    return
+
+
+if __name__ == "__main__":
+    main_multiphase_ocp()
+    main()

--- a/examples/acados_python/mocp_transition_example/main.py
+++ b/examples/acados_python/mocp_transition_example/main.py
@@ -33,7 +33,9 @@ import numpy as np
 import casadi as ca
 
 from acados_template import AcadosModel, AcadosOcp, AcadosMultiphaseOcp, AcadosOcpSolver, casadi_length, is_empty, latexify_plot
+import matplotlib.pyplot as plt
 
+latexify_plot()
 
 X0 = np.array([2.0, 0.0])
 PENALTY_X = 1e0
@@ -202,7 +204,6 @@ def main_multiphase_ocp() -> AcadosMultiphaseOcp:
     acados_ocp_solver = AcadosOcpSolver(ocp, verbose=False)
     acados_ocp_solver.solve_for_x0(X0)
 
-
     n_phases = len(N_list)
 
     x_traj_phases = n_phases*[None]
@@ -218,51 +219,36 @@ def main_multiphase_ocp() -> AcadosMultiphaseOcp:
 
     ## plot solution
     t_grid_2_plot = t_grid_phases[2] - 1.0
-    import matplotlib.pyplot as plt
-    latexify_plot()
+
     fig, ax = plt.subplots(3, 1, sharex=True)
-    ax[0].grid(True)
-    ax[0].set_xlim([0, T_HORIZON])
-    plt.xlabel('$t$ [s]')
 
     p_traj_0 = [x[0] for x in x_traj_phases[0]]
     ax[0].plot(t_grid_phases[0], p_traj_0, color='C0', label='phase 1')
 
     p_traj_2 = [x[0] for x in x_traj_phases[2]]
-    ax[0].plot(t_grid_2_plot, p_traj_2, '-.', color='C0', label='phase 2')
-    ax[0].set_ylabel('$p$')
-
-
-    ax[1].set_ylabel('$v$')
-    ax[1].grid(True)
+    ax[0].plot(t_grid_2_plot, p_traj_2, color='C1', label='phase 2')
 
     v_traj_0 = [x[1] for x in x_traj_phases[0]]
     ax[1].plot(t_grid_phases[0], v_traj_0, color='C0')
+
     v_traj_2 = [u_traj_phases[2][0][0]] + [x[0] for x in u_traj_phases[2]]
-    ax[1].step(t_grid_2_plot, v_traj_2, '-.', color='C0')
+    ax[1].step(t_grid_2_plot, v_traj_2, '-', color='C1')
 
-
-    isub = 2
-    ax[isub].set_ylabel('$a$')
-    ax[isub].grid(True)
     a_traj = [u_traj_phases[0][0][0]] + [x[0] for x in u_traj_phases[0]]
-    ax[isub].step(t_grid_phases[0], a_traj, '-', color='C0')
+    ax[2].step(t_grid_phases[0], a_traj, color='C0')
 
-    plt.show()
+    for i, l in enumerate(['$p$', '$v$', '$a$']):
+        ax[i].grid()
+        ax[i].set_ylabel(l)
 
-
-
-    # for i_phase in [0, 2]:
-    #     # breakpoint()
-    #     plot_ocp_solution(t_grid_phases[i_phase], x_traj_phases[i_phase], u_traj_phases[i_phase], title=f"Phase {i_phase}")
-
+    ax[0].set_xlim([0, T_HORIZON])
+    ax[0].legend()
 
 
 def main():
     ocp = formulate_double_integrator_ocp()
     ocp.solver_options.tf = T_HORIZON
     ocp.solver_options.nlp_solver_type = 'SQP'
-
 
     acados_ocp_solver = AcadosOcpSolver(ocp, verbose=False)
 
@@ -279,28 +265,24 @@ def main():
     return
 
 
-def plot_ocp_solution(t_grid: np.ndarray, x_traj: list, u_traj: list, x_labels=["p", "v"], title=None):
-    import matplotlib.pyplot as plt
-    latexify_plot()
+def plot_ocp_solution(t_grid: np.ndarray, x_traj: list, u_traj: list, x_labels=["$p$", "$v$"], title=None):
     nx = len(x_traj[0])
-    nu = len(u_traj[0])
-    # use subplots
+
     fig, ax = plt.subplots(nx, 1, sharex=True)
 
     if title is not None:
         plt.title(title)
-    ax[0].grid(True)
-    plt.xlabel('t [s]')
+
+    plt.xlabel('$t$ [s]')
 
     for i in range(nx):
-        iplot = i
-        ax[iplot].plot(t_grid, np.array(x_traj)[:,i], color='C0')
-        ax[iplot].grid(True)
-        ax[iplot].set_ylabel(x_labels[i])
-    plt.show()
+        ax[i].plot(t_grid, np.array(x_traj)[:,i], color='C0')
+        ax[i].grid(True)
+        ax[i].set_ylabel(x_labels[i])
     return
 
 
 if __name__ == "__main__":
     main_multiphase_ocp()
     main()
+    plt.show()

--- a/interfaces/acados_template/acados_template/acados_multiphase_ocp.py
+++ b/interfaces/acados_template/acados_template/acados_multiphase_ocp.py
@@ -265,8 +265,8 @@ class AcadosMultiphaseOcp:
 
             # set phase dependent options
             ocp.solver_options.integrator_type = self.mocp_opts.integrator_type[i]
-            # ocp.solver_options.collocation_type = self.mocp_opts.collocation_type[i]
-            # ocp.solver_options.cost_discretization = self.mocp_opts.cost_discretization[i]
+            ocp.solver_options.collocation_type = self.mocp_opts.collocation_type[i]
+            ocp.solver_options.cost_discretization = self.mocp_opts.cost_discretization[i]
 
             if i != self.n_phases - 1:
                 nondefault_fields = []

--- a/interfaces/acados_template/acados_template/acados_multiphase_ocp.py
+++ b/interfaces/acados_template/acados_template/acados_multiphase_ocp.py
@@ -191,9 +191,13 @@ class AcadosMultiphaseOcp:
 
     def set_phase(self, ocp: AcadosOcp, phase_idx: int) -> None:
         """
-        Set phase of the multiphase ocp.
+        Set phase of the multiphase OCP to match the given OCP.
 
-        - phase_idx: index of the phase, must be in [0, n_phases-1]
+        NOTE: model, cost, constraints and parameter_values are taken from phase OCP,
+              all other fields, especially options are ignored.
+
+        :param ocp: OCP to be set as phase
+        :param phase_idx: index of the phase, must be in [0, n_phases-1]
         """
         if phase_idx >= self.n_phases:
             raise Exception(f"phase_idx {phase_idx} out of bounds, must be in [0, {self.n_phases-1}].")

--- a/interfaces/acados_template/acados_template/acados_multiphase_ocp.py
+++ b/interfaces/acados_template/acados_template/acados_multiphase_ocp.py
@@ -290,8 +290,11 @@ class AcadosMultiphaseOcp:
 
         nx_list = [self.phases_dims[i].nx for i in range(self.n_phases)]
         if len(set(nx_list)) != 1:
-            raise Exception(f"make_consistent: all phases must have the same dimension nx, detected nx_list = {nx_list}.")
-
+            for i in range(1, self.n_phases):
+                if nx_list[i] != nx_list[i-1]:
+                    print(f"nx differs between phases {i-1} and {i}: {nx_list[i-1]} != {nx_list[i]}")
+                    if self.N_list[i-1] != 1:
+                        raise Exception("nx must be the same for all phases if N_list[i] != 1.")
         return
 
 

--- a/interfaces/acados_template/acados_template/acados_multiphase_ocp.py
+++ b/interfaces/acados_template/acados_template/acados_multiphase_ocp.py
@@ -224,6 +224,12 @@ class AcadosMultiphaseOcp:
         # check options
         self.mocp_opts.make_consistent(opts, n_phases=self.n_phases)
 
+        # check phases formulation objects are distinct
+        warning = "\nNOTE: this can happen if set_phase() is called with the same ocp object for multiple phases."
+        for field in ['model', 'cost', 'constraints']:
+            if len(set(getattr(self, field))) != self.n_phases:
+                raise Exception(f"AcadosMultiphaseOcp: make_consistent: {field} objects are not distinct.{warning}")
+
         # compute phase indices
         phase_idx = np.cumsum([0] + self.N_list).tolist()
 

--- a/interfaces/acados_template/acados_template/acados_ocp.py
+++ b/interfaces/acados_template/acados_template/acados_ocp.py
@@ -661,7 +661,7 @@ class AcadosOcp:
         dims.ns_e = ns_e
 
         # discretization
-        if not isinstance(opts.tf, float):
+        if not isinstance(opts.tf, (float, int)):
             raise Exception(f'Time horizon tf should be float provided, got tf = {opts.tf}.')
 
         if is_empty(opts.time_steps) and is_empty(opts.shooting_nodes):

--- a/interfaces/acados_template/acados_template/acados_ocp.py
+++ b/interfaces/acados_template/acados_template/acados_ocp.py
@@ -661,6 +661,9 @@ class AcadosOcp:
         dims.ns_e = ns_e
 
         # discretization
+        if not isinstance(opts.tf, float):
+            raise Exception(f'Time horizon tf should be float provided, got tf = {opts.tf}.')
+
         if is_empty(opts.time_steps) and is_empty(opts.shooting_nodes):
             # uniform discretization
             opts.time_steps = opts.tf / dims.N * np.ones((dims.N,))

--- a/interfaces/acados_template/acados_template/acados_ocp_options.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_options.py
@@ -31,6 +31,12 @@
 
 import numpy as np
 
+
+INTEGRATOR_TYPES = ('ERK', 'IRK', 'GNSF', 'DISCRETE', 'LIFTED_IRK')
+COLLOCATION_TYPES = ('GAUSS_RADAU_IIA', 'GAUSS_LEGENDRE', 'EXPLICIT_RUNGE_KUTTA')
+COST_DISCRETIZATION_TYPES = ('EULER', 'INTEGRATOR')
+
+
 class AcadosOcpOptions:
     """
     class containing the description of the solver options
@@ -600,7 +606,12 @@ class AcadosOcpOptions:
 
     @property
     def cost_discretization(self):
-        """Cost discretization"""
+        """
+        Cost discretization: string in {'EULER', 'INTEGRATOR'}.
+        Default: 'EULER'
+        'EULER': cost is evaluated at shooting nodes
+        'INTEGRATOR': cost is integrated over the shooting intervals - only supported for IRK integrator
+        """
         return self.__cost_discretization
 
     @qp_solver.setter
@@ -627,12 +638,11 @@ class AcadosOcpOptions:
 
     @collocation_type.setter
     def collocation_type(self, collocation_type):
-        collocation_types = ('GAUSS_RADAU_IIA', 'GAUSS_LEGENDRE', 'EXPLICIT_RUNGE_KUTTA')
-        if collocation_type in collocation_types:
+        if collocation_type in COLLOCATION_TYPES:
             self.__collocation_type = collocation_type
         else:
             raise Exception('Invalid collocation_type value. Possible values are:\n\n' \
-                    + ',\n'.join(collocation_types) + '.\n\nYou have: ' + collocation_type + '.\n\n')
+                    + ',\n'.join(COLLOCATION_TYPES) + '.\n\nYou have: ' + collocation_type + '.\n\n')
 
     @hpipm_mode.setter
     def hpipm_mode(self, hpipm_mode):
@@ -695,12 +705,11 @@ class AcadosOcpOptions:
 
     @integrator_type.setter
     def integrator_type(self, integrator_type):
-        integrator_types = ('ERK', 'IRK', 'GNSF', 'DISCRETE', 'LIFTED_IRK')
-        if integrator_type in integrator_types:
+        if integrator_type in INTEGRATOR_TYPES:
             self.__integrator_type = integrator_type
         else:
             raise Exception('Invalid integrator_type value. Possible values are:\n\n' \
-                    + ',\n'.join(integrator_types) + '.\n\nYou have: ' + integrator_type + '.\n\n')
+                    + ',\n'.join(INTEGRATOR_TYPES) + '.\n\nYou have: ' + integrator_type + '.\n\n')
 
     @tf.setter
     def tf(self, tf):
@@ -829,12 +838,11 @@ class AcadosOcpOptions:
 
     @cost_discretization.setter
     def cost_discretization(self, cost_discretization):
-        cost_discretizations = ('EULER', 'INTEGRATOR')
-        if cost_discretization in cost_discretizations:
+        if cost_discretization in COST_DISCRETIZATION_TYPES:
             self.__cost_discretization = cost_discretization
         else:
             raise Exception('Invalid cost_discretization value. Possible values are:\n\n' \
-                    + ',\n'.join(cost_discretizations) + '.\n\nYou have: ' + cost_discretization + '.')
+                    + ',\n'.join(COST_DISCRETIZATION_TYPES) + '.\n\nYou have: ' + cost_discretization + '.')
 
     @nlp_solver_step_length.setter
     def nlp_solver_step_length(self, nlp_solver_step_length):

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -162,7 +162,9 @@ def __mocp_get_template_list(ocp: AcadosMultiphaseOcp, cmake_builder=None, simul
 def mocp_render_templates(ocp: AcadosMultiphaseOcp, json_file: str, cmake_builder=None, simulink_opts=None):
 
     # model templates
-    for dummy_ocp in ocp.dummy_ocp_list:
+    for i, dummy_ocp in enumerate(ocp.dummy_ocp_list):
+        # this is the only option that can vary and influence external functions to be generated
+        dummy_ocp.solver_options.integrator_type = ocp.mocp_opts.integrator_type[i]
         template_list = __ocp_get_external_function_header_templates(dummy_ocp)
         # dump dummy_ocp
         tmp_json_file = 'tmp_ocp.json'

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -723,7 +723,7 @@ class AcadosOcpSolver:
         return
 
 
-    def get(self, stage_, field_):
+    def get(self, stage_: int, field_: str):
         """
         Get the last solution of the solver:
 
@@ -1137,7 +1137,7 @@ class AcadosOcpSolver:
 
 
     # Note: this function should not be used anymore, better use cost_set, constraints_set
-    def set(self, stage_, field_, value_):
+    def set(self, stage_: int, field_: str, value_):
         """
         Set numerical data inside the solver.
 
@@ -1232,7 +1232,7 @@ class AcadosOcpSolver:
         return
 
 
-    def cost_set(self, stage_, field_, value_, api='warn'):
+    def cost_set(self, stage_: int, field_: str, value_, api='warn'):
         """
         Set numerical data in the cost module of the solver.
 

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.c
@@ -2828,7 +2828,7 @@ int {{ name }}_acados_free({{ name }}_solver_capsule* capsule)
   {%- endif %}
     free(capsule->gnsf_get_matrices_fun_{{ jj }});
 {%- elif mocp_opts.integrator_type[jj] == "DISCRETE" %}
-    for (int i_fun = 0; i_fun < {{ end_idx[jj] - start_idx[jj] }}; i++)
+    for (int i_fun = 0; i_fun < {{ end_idx[jj] - start_idx[jj] }}; i_fun++)
     {
         external_function_param_{{ model[jj].dyn_ext_fun_type }}_free(&capsule->discr_dyn_phi_fun_{{ jj }}[i_fun]);
         external_function_param_{{ model[jj].dyn_ext_fun_type }}_free(&capsule->discr_dyn_phi_fun_jac_ut_xt_{{ jj }}[i_fun]);

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.h
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.h
@@ -75,29 +75,29 @@ typedef struct {{ name }}_solver_capsule
 	{%- for jj in range(end=n_phases) %}{# phases loop !#}
     /* external functions phase {{ jj }} */
     // dynamics
-{% if solver_options.integrator_type == "ERK" %}
+{% if mocp_opts.integrator_type[jj] == "ERK" %}
     external_function_param_casadi *forw_vde_casadi_{{ jj }};
     external_function_param_casadi *expl_ode_fun_{{ jj }};
 {% if solver_options.hessian_approx == "EXACT" %}
     external_function_param_casadi *hess_vde_casadi_{{ jj }};
 {%- endif %}
-{% elif solver_options.integrator_type == "IRK" %}
+{% elif mocp_opts.integrator_type[jj] == "IRK" %}
     external_function_param_{{ model[jj].dyn_ext_fun_type }} *impl_dae_fun_{{ jj }};
     external_function_param_{{ model[jj].dyn_ext_fun_type }} *impl_dae_fun_jac_x_xdot_z_{{ jj }};
     external_function_param_{{ model[jj].dyn_ext_fun_type }} *impl_dae_jac_x_xdot_u_z_{{ jj }};
 {% if solver_options.hessian_approx == "EXACT" %}
     external_function_param_{{ model[jj].dyn_ext_fun_type }} *impl_dae_hess_{{ jj }};
 {%- endif %}
-{% elif solver_options.integrator_type == "LIFTED_IRK" %}
+{% elif mocp_opts.integrator_type[jj] == "LIFTED_IRK" %}
     external_function_param_{{ model[jj].dyn_ext_fun_type }} *impl_dae_fun_{{ jj }};
     external_function_param_{{ model[jj].dyn_ext_fun_type }} *impl_dae_fun_jac_x_xdot_u_{{ jj }};
-{% elif solver_options.integrator_type == "GNSF" %}
+{% elif mocp_opts.integrator_type[jj] == "GNSF" %}
     external_function_param_casadi *gnsf_phi_fun_{{ jj }};
     external_function_param_casadi *gnsf_phi_fun_jac_y_{{ jj }};
     external_function_param_casadi *gnsf_phi_jac_y_uhat_{{ jj }};
     external_function_param_casadi *gnsf_f_lo_jac_x1_x1dot_u_z_{{ jj }};
     external_function_param_casadi *gnsf_get_matrices_fun_{{ jj }};
-{% elif solver_options.integrator_type == "DISCRETE" %}
+{% elif mocp_opts.integrator_type[jj] == "DISCRETE" %}
     external_function_param_{{ model[jj].dyn_ext_fun_type }} *discr_dyn_phi_fun_{{ jj }};
     external_function_param_{{ model[jj].dyn_ext_fun_type }} *discr_dyn_phi_fun_jac_ut_xt_{{ jj }};
 {%- if solver_options.hessian_approx == "EXACT" %}

--- a/interfaces/acados_template/acados_template/c_templates_tera/multi_Makefile.in
+++ b/interfaces/acados_template/acados_template/c_templates_tera/multi_Makefile.in
@@ -93,27 +93,27 @@ MODEL_SRC=
 
 {%- for jj in range(end=n_phases) %}{# phases loop !#}
 	{%- if model[jj].dyn_ext_fun_type == "casadi" %}
-{%- if solver_options.integrator_type == "ERK" %}
+{%- if mocp_opts.integrator_type[jj] == "ERK" %}
 MODEL_SRC+= {{ model[jj].name }}_model/{{ model[jj].name }}_expl_ode_fun.c
 MODEL_SRC+= {{ model[jj].name }}_model/{{ model[jj].name }}_expl_vde_forw.c
 MODEL_SRC+= {{ model[jj].name }}_model/{{ model[jj].name }}_expl_vde_adj.c
 	{%- if hessian_approx == "EXACT" %}
 MODEL_SRC+= {{ model[jj].name }}_model/{{ model[jj].name }}_expl_ode_hess.c
 	{%- endif %}
-{%- elif solver_options.integrator_type == "IRK" %}
+{%- elif mocp_opts.integrator_type[jj] == "IRK" %}
 MODEL_SRC+= {{ model[jj].name }}_model/{{ model[jj].name }}_impl_dae_fun.c
 MODEL_SRC+= {{ model[jj].name }}_model/{{ model[jj].name }}_impl_dae_fun_jac_x_xdot_z.c
 MODEL_SRC+= {{ model[jj].name }}_model/{{ model[jj].name }}_impl_dae_jac_x_xdot_u_z.c
 		{%- if hessian_approx == "EXACT" %}
 MODEL_SRC+= {{ model[jj].name }}_model/{{ model[jj].name }}_impl_dae_hess.c
 		{%- endif %}
-{%- elif solver_options.integrator_type == "LIFTED_IRK" %}
+{%- elif mocp_opts.integrator_type[jj] == "LIFTED_IRK" %}
 MODEL_SRC+= {{ model[jj].name }}_model/{{ model[jj].name }}_impl_dae_fun.c
 MODEL_SRC+= {{ model[jj].name }}_model/{{ model[jj].name }}_impl_dae_fun_jac_x_xdot_u.c
 	{%- if hessian_approx == "EXACT" %}
 MODEL_SRC+= {{ model[jj].name }}_model/{{ model[jj].name }}_impl_dae_hess.c
 	{%- endif %}
-{%- elif solver_options.integrator_type == "GNSF" %}
+{%- elif mocp_opts.integrator_type[jj] == "GNSF" %}
 	{% if model[jj].gnsf.purely_linear != 1 %}
 MODEL_SRC+= {{ model[jj].name }}_model/{{ model[jj].name }}_gnsf_phi_fun.c
 MODEL_SRC+= {{ model[jj].name }}_model/{{ model[jj].name }}_gnsf_phi_fun_jac_y.c
@@ -123,7 +123,7 @@ MODEL_SRC+= {{ model[jj].name }}_model/{{ model[jj].name }}_gnsf_f_lo_fun_jac_x1
 		{%- endif %}
 	{%- endif %}
 MODEL_SRC+= {{ model[jj].name }}_model/{{ model[jj].name }}_gnsf_get_matrices_fun.c
-{%- elif solver_options.integrator_type == "DISCRETE" %}
+{%- elif mocp_opts.integrator_type[jj] == "DISCRETE" %}
 MODEL_SRC+= {{ model[jj].name }}_model/{{ model[jj].name }}_dyn_disc_phi_fun.c
 MODEL_SRC+= {{ model[jj].name }}_model/{{ model[jj].name }}_dyn_disc_phi_fun_jac.c
 		{%- if hessian_approx == "EXACT" %}

--- a/interfaces/acados_template/acados_template/casadi_function_generation.py
+++ b/interfaces/acados_template/acados_template/casadi_function_generation.py
@@ -48,6 +48,8 @@ def get_casadi_symbol(x):
 
 def mocp_generate_external_functions(mocp: AcadosMultiphaseOcp):
     for i in range(mocp.n_phases):
+        # this is the only option that can vary and influence external functions to be generated
+        mocp.dummy_ocp_list[i].solver_options.integrator_type = mocp.mocp_opts.integrator_type[i]
         ocp_generate_external_functions(mocp.dummy_ocp_list[i])
 
 

--- a/interfaces/acados_template/acados_template/casadi_function_generation.py
+++ b/interfaces/acados_template/acados_template/casadi_function_generation.py
@@ -138,8 +138,12 @@ def generate_c_code_discrete_dynamics( model, opts ):
     nx = casadi_length(x)
 
     symbol = get_casadi_symbol(x)
-    # assume nx1 = nx !!!
-    lam = symbol('lam', nx, 1)
+    nx1 = casadi_length(phi)
+
+    if nx != nx1:
+        print('Warning: generate_c_code_discrete_dynamics: got nx != nx1, this only works for a single shooting interval.')
+
+    lam = symbol('lam', nx1, 1)
 
     # generate jacobians
     ux = ca.vertcat(u,x)


### PR DESCRIPTION
This is a follow up of https://github.com/acados/acados/pull/1004 removing the limitations described therein.

An `ocp` instance of the class  `AcadosMultiphaseOcp`, now has the additional field `mocp_opts`.
This field is of the class  `AcadosMultiphaseOptions`, "containing options that might be different for each phase", namely `integrator_type`, `collocation_type`, `cost_discretization`.
All of these fields can be either `None`, then the corresponding value from `ocp.solver_options` is used, or a list of length `n_phases` describing the value for this option at each phase.
This especially allows one to define OCPs with varying state dimensions which can be formulated using a transition stage which uses discrete dynamics to map the state representation of one phase to the next phase.
An example of such an OCP formulation is given in `examples/acados_python/mocp_transition_example/main.py`.