### PR TITLE
Split condensing and regularization into preparation and feedback

### DIFF
--- a/acados/ocp_nlp/ocp_nlp_dynamics_cont.c
+++ b/acados/ocp_nlp/ocp_nlp_dynamics_cont.c
@@ -818,7 +818,6 @@ void ocp_nlp_dynamics_cont_update_qp_matrices(void *config_, void *dims_, void *
     config->sim_solver->evaluate(config->sim_solver, work->sim_in, work->sim_out, opts->sim_solver,
             mem->sim_solver, work->sim_solver);
 
-    // TODO transition functions for changing dimensions not yet implemented!
 
     // B
     blasfeo_pack_tran_dmat(nx1, nu, work->sim_out->S_forw + nx1 * nx, nx1, mem->BAbt, 0, 0);

--- a/acados/ocp_nlp/ocp_nlp_reg_common.h
+++ b/acados/ocp_nlp/ocp_nlp_reg_common.h
@@ -95,7 +95,9 @@ typedef struct
     void (*memory_set_pi_ptr)(ocp_nlp_reg_dims *dims, struct blasfeo_dvec *vec, void *memory);
     void (*memory_set_lam_ptr)(ocp_nlp_reg_dims *dims, struct blasfeo_dvec *vec, void *memory);
     /* functions */
-    void (*regularize_hessian)(void *config, ocp_nlp_reg_dims *dims, void *opts, void *memory);
+    void (*regularize)(void *config, ocp_nlp_reg_dims *dims, void *opts, void *memory);
+    void (*regularize_lhs)(void *config, ocp_nlp_reg_dims *dims, void *opts, void *memory);
+    void (*regularize_rhs)(void *config, ocp_nlp_reg_dims *dims, void *opts, void *memory);
     void (*correct_dual_sol)(void *config, ocp_nlp_reg_dims *dims, void *opts, void *memory);
 } ocp_nlp_reg_config;
 

--- a/acados/ocp_nlp/ocp_nlp_reg_common.h
+++ b/acados/ocp_nlp/ocp_nlp_reg_common.h
@@ -48,7 +48,7 @@ extern "C" {
 
 /* dims */
 
-//typedef ocp_qp_dims ocp_nlp_reg_dims;
+// same as qp_dims
 typedef struct
 {
     int *nx;

--- a/acados/ocp_nlp/ocp_nlp_reg_convexify.c
+++ b/acados/ocp_nlp/ocp_nlp_reg_convexify.c
@@ -166,14 +166,14 @@ acados_size_t ocp_nlp_reg_convexify_calculate_memory_size(void *config_, ocp_nlp
     {
         size += 2*blasfeo_memsize_dmat(nu[ii]+nx[ii]+1, nu[ii]+nx[ii]); // original_RSQrq
     }
-	size += blasfeo_memsize_dmat(nuxM, nuxM); // tmp_RSQ
+    size += blasfeo_memsize_dmat(nuxM, nuxM); // tmp_RSQ
 
 //    size += 2*blasfeo_memsize_dvec(nxM); // grad b2
 
     // giaf's
     size += (2*(N+1)+N)*sizeof(struct blasfeo_dmat *); // RSQrq BAbt DCt
     size += (3*(N+1)+2*N)*sizeof(struct blasfeo_dvec *); // rq b ux pi lam
-	size += (N+1)*sizeof(int *); // idxb
+    size += (N+1)*sizeof(int *); // idxb
 
     return size;
 }
@@ -264,8 +264,8 @@ void *ocp_nlp_reg_convexify_assign_memory(void *config_, ocp_nlp_reg_dims *dims,
     mem->lam = (struct blasfeo_dvec **) c_ptr;
     c_ptr += (N+1)*sizeof(struct blasfeo_dvec *);
 
-	mem->idxb = (int **) c_ptr;
-	c_ptr += (N+1)*sizeof(int *);
+    mem->idxb = (int **) c_ptr;
+    c_ptr += (N+1)*sizeof(int *);
 
     align_char_to(64, &c_ptr);
 
@@ -541,9 +541,9 @@ void ocp_nlp_reg_convexify_memory_set(void *config_, ocp_nlp_reg_dims *dims, voi
  * functions
  ************************************************/
 
-// NOTE this only considers the case of (dynamcs) equality constraints (no inequality constraints)
+// NOTE this only considers the case of (dynamics) equality constraints (no inequality constraints)
 // TODO inequality constraints case
-void ocp_nlp_reg_convexify_regularize_hessian(void *config, ocp_nlp_reg_dims *dims, void *opts_, void *mem_)
+void ocp_nlp_reg_convexify_regularize(void *config, ocp_nlp_reg_dims *dims, void *opts_, void *mem_)
 {
     ocp_nlp_reg_convexify_memory *mem = mem_;
     ocp_nlp_reg_convexify_opts *opts = opts_;
@@ -555,24 +555,24 @@ void ocp_nlp_reg_convexify_regularize_hessian(void *config, ocp_nlp_reg_dims *di
     int N = dims->N;
 
 #if 0
-	for(ii=0; ii<=N; ii++)
-	{
+    for(ii=0; ii<=N; ii++)
+    {
         blasfeo_drowin(nu[ii]+nx[ii], 1.0, mem->rq[ii], 0, mem->RSQrq[ii], nu[ii]+nx[ii], 0);
         blasfeo_dgecp(nu[ii]+nx[ii]+1, nu[ii]+nx[ii], mem->RSQrq[ii], 0, 0, &mem->original_RSQrq[ii], 0, 0);
-	}
-	return;
+    }
+    return;
 #endif
 
     double delta = opts->delta;
 
     // Algorithm 6 from Verschueren2017
 
-	blasfeo_drowin(nu[N]+nx[N], 1.0, mem->rq[N], 0, mem->RSQrq[N], nu[N]+nx[N], 0);
+    blasfeo_drowin(nu[N]+nx[N], 1.0, mem->rq[N], 0, mem->RSQrq[N], nu[N]+nx[N], 0);
 
     blasfeo_dgecp(nu[N]+nx[N]+1, nu[N]+nx[N], mem->RSQrq[N], 0, 0, &mem->original_RSQrq[N], 0, 0);
 
     // TODO regularize R at last stage if needed !!!
-	// TODO fix for nu[N]>0 !!!!!!!!!!
+    // TODO fix for nu[N]>0 !!!!!!!!!!
     blasfeo_dgese(nx[N], nx[N], 0.0, &mem->delta_eye, 0, 0);
     blasfeo_ddiare(nx[N], delta, &mem->delta_eye, 0, 0);
     blasfeo_dgecp(nx[N], nx[N], &mem->delta_eye, 0, 0, &mem->Q_tilde, 0, 0);
@@ -605,7 +605,7 @@ void ocp_nlp_reg_convexify_regularize_hessian(void *config, ocp_nlp_reg_dims *di
         blasfeo_dgemm_nt(nu[ii]+nx[ii], nx[ii], nx[ii+1], 1.0, mem->BAbt[ii], 0, 0, &mem->Q_bar, 0, 0, 0.0, &mem->BAQ, 0, 0, &mem->BAQ, 0, 0);
         blasfeo_dsyrk_ln_mn(nu[ii]+nx[ii]+1, nu[ii]+nx[ii], nx[ii+1], 1.0, mem->BAbt[ii], 0, 0, &mem->BAQ, 0, 0, 1.0, mem->RSQrq[ii], 0, 0, mem->RSQrq[ii], 0, 0);
 
-		blasfeo_drowex(nu[ii]+nx[ii], 1.0, mem->RSQrq[ii], nu[ii]+nx[ii], 0, mem->rq[ii], 0);
+        blasfeo_drowex(nu[ii]+nx[ii], 1.0, mem->RSQrq[ii], nu[ii]+nx[ii], 0, mem->rq[ii], 0);
 
         // printf("BAQ\n");
         // blasfeo_print_dmat(nx+nu, nx, &BAQ, 0, 0);
@@ -620,32 +620,32 @@ void ocp_nlp_reg_convexify_regularize_hessian(void *config, ocp_nlp_reg_dims *di
 
         if (needs_regularization)
         {
-			blasfeo_dgecp(nu[ii]+nx[ii], nu[ii]+nx[ii], mem->RSQrq[ii], 0, 0, &mem->tmp_RSQ, 0, 0);
-			// TODO project only nu instead ???????????
-			// TODO compute correction as a separate matrix, and apply to original_RSQrq too (TODO change this name then)
+            blasfeo_dgecp(nu[ii]+nx[ii], nu[ii]+nx[ii], mem->RSQrq[ii], 0, 0, &mem->tmp_RSQ, 0, 0);
+            // TODO project only nu instead ???????????
+            // TODO compute correction as a separate matrix, and apply to original_RSQrq too (TODO change this name then)
 //            acados_mirror(nu[ii]+nx[ii], mem->reg_hess, mem->V, mem->d, mem->e, 1e-4);
 #if 1
-			blasfeo_unpack_dmat(nu[ii]+nx[ii], nu[ii]+nx[ii], mem->RSQrq[ii], 0, 0, mem->reg_hess, nu[ii]+nx[ii]);
-			acados_project(nu[ii]+nx[ii], mem->reg_hess, mem->V, mem->d, mem->e, 1e-4);
-			blasfeo_pack_dmat(nu[ii]+nx[ii], nu[ii]+nx[ii], mem->reg_hess, nu[ii]+nx[ii], mem->RSQrq[ii], 0, 0);
+            blasfeo_unpack_dmat(nu[ii]+nx[ii], nu[ii]+nx[ii], mem->RSQrq[ii], 0, 0, mem->reg_hess, nu[ii]+nx[ii]);
+            acados_project(nu[ii]+nx[ii], mem->reg_hess, mem->V, mem->d, mem->e, 1e-4);
+            blasfeo_pack_dmat(nu[ii]+nx[ii], nu[ii]+nx[ii], mem->reg_hess, nu[ii]+nx[ii], mem->RSQrq[ii], 0, 0);
 #else
-			blasfeo_unpack_dmat(nu[ii], nu[ii], mem->RSQrq[ii], 0, 0, mem->reg_hess, nu[ii]);
-			acados_project(nu[ii], mem->reg_hess, mem->V, mem->d, mem->e, 1e-4);
-			blasfeo_pack_dmat(nu[ii], nu[ii], mem->reg_hess, nu[ii], mem->RSQrq[ii], 0, 0);
+            blasfeo_unpack_dmat(nu[ii], nu[ii], mem->RSQrq[ii], 0, 0, mem->reg_hess, nu[ii]);
+            acados_project(nu[ii], mem->reg_hess, mem->V, mem->d, mem->e, 1e-4);
+            blasfeo_pack_dmat(nu[ii], nu[ii], mem->reg_hess, nu[ii], mem->RSQrq[ii], 0, 0);
 #endif
 //            blasfeo_unpack_dmat(nu[ii], nu[ii], mem->RSQrq[ii], 0, 0, mem->reg_hess, nu[ii]);
 //            acados_mirror(nu[ii], mem->reg_hess, mem->V, mem->d, mem->e, 1e-4);
 //            acados_project(nu[ii], mem->reg_hess, mem->V, mem->d, mem->e, 1e-4);
 //            blasfeo_pack_dmat(nu[ii], nu[ii], mem->reg_hess, nu[ii], mem->RSQrq[ii], 0, 0);
-			blasfeo_dgead(nu[ii]+nx[ii], nu[ii]+nx[ii], -1.0, mem->RSQrq[ii], 0, 0, &mem->tmp_RSQ, 0, 0);
-			blasfeo_dgead(nu[ii]+nx[ii], nu[ii]+nx[ii], -1.0, &mem->tmp_RSQ, 0, 0, &mem->original_RSQrq[ii], 0, 0);
+            blasfeo_dgead(nu[ii]+nx[ii], nu[ii]+nx[ii], -1.0, mem->RSQrq[ii], 0, 0, &mem->tmp_RSQ, 0, 0);
+            blasfeo_dgead(nu[ii]+nx[ii], nu[ii]+nx[ii], -1.0, &mem->tmp_RSQ, 0, 0, &mem->original_RSQrq[ii], 0, 0);
         }
 
         // printf("QSR_hat\n");
         // blasfeo_print_dmat(nx+nu+1, nx+nu, &work->qp_in->RSQrq[i], 0, 0);
 
 
-		// backup Q
+        // backup Q
         blasfeo_dgecp(nx[ii], nx[ii], mem->RSQrq[ii], nu[ii], nu[ii], &mem->Q_bar, 0, 0);
 
         // R = L * L^T
@@ -656,8 +656,8 @@ void ocp_nlp_reg_convexify_regularize_hessian(void *config, ocp_nlp_reg_dims *di
         blasfeo_dtrsm_rltn(nx[ii], nu[ii], 1.0, &mem->L, 0, 0, &mem->St_copy, 0, 0, &mem->St_copy, 0, 0);
 
         // Q = S^T * R^-1 * S + delta*I
-		blasfeo_dgese(nx[ii], nx[ii], 0.0, &mem->delta_eye, 0, 0);
-		blasfeo_ddiare(nx[ii], delta, &mem->delta_eye, 0, 0);
+        blasfeo_dgese(nx[ii], nx[ii], 0.0, &mem->delta_eye, 0, 0);
+        blasfeo_ddiare(nx[ii], delta, &mem->delta_eye, 0, 0);
 //        blasfeo_dsyrk_ln(nx[ii], nx[ii], 1.0, &mem->Q_tilde, 0, 0, &mem->Q_tilde, 0, 0, 1.0, &mem->delta_eye, 0, 0, mem->RSQrq[ii], nu[ii], nu[ii]);
         blasfeo_dsyrk_ln(nx[ii], nu[ii], 1.0, &mem->St_copy, 0, 0, &mem->St_copy, 0, 0, 1.0, &mem->delta_eye, 0, 0, mem->RSQrq[ii], nu[ii], nu[ii]);
 
@@ -689,6 +689,181 @@ void ocp_nlp_reg_convexify_regularize_hessian(void *config, ocp_nlp_reg_dims *di
     return;
 }
 
+
+void ocp_nlp_reg_convexify_regularize_lhs(void *config, ocp_nlp_reg_dims *dims, void *opts_, void *mem_)
+{
+    ocp_nlp_reg_convexify_memory *mem = mem_;
+    ocp_nlp_reg_convexify_opts *opts = opts_;
+
+    int ii, jj;
+
+    int *nx = dims->nx;
+    int *nu = dims->nu;
+    int N = dims->N;
+
+
+    double delta = opts->delta;
+
+    // Algorithm 6 from Verschueren2017
+
+    blasfeo_drowin(nu[N]+nx[N], 1.0, mem->rq[N], 0, mem->RSQrq[N], nu[N]+nx[N], 0);
+
+    blasfeo_dgecp(nu[N]+nx[N]+1, nu[N]+nx[N], mem->RSQrq[N], 0, 0, &mem->original_RSQrq[N], 0, 0);
+
+    blasfeo_dgese(nx[N], nx[N], 0.0, &mem->delta_eye, 0, 0);
+    blasfeo_ddiare(nx[N], delta, &mem->delta_eye, 0, 0);
+    blasfeo_dgecp(nx[N], nx[N], &mem->delta_eye, 0, 0, &mem->Q_tilde, 0, 0);
+    blasfeo_dgecp(nx[N], nx[N], mem->RSQrq[N], nu[N], nu[N], &mem->Q_bar, 0, 0);
+    blasfeo_dgecp(nx[N], nx[N], &mem->Q_tilde, 0, 0, mem->RSQrq[N], nu[N], nu[N]);
+    blasfeo_dgead(nx[N], nx[N], -1.0, &mem->Q_tilde, 0, 0, &mem->Q_bar, 0, 0);
+    blasfeo_dtrtr_l(nx[N], &mem->Q_bar, 0, 0, &mem->Q_bar, 0, 0);
+
+    for (ii = N-1; ii >= 0; --ii)
+    {
+        blasfeo_drowin(nx[ii+1], 1.0, mem->b[ii], 0, mem->BAbt[ii], nu[ii]+nx[ii], 0);
+        blasfeo_drowin(nu[ii]+nx[ii], 1.0, mem->rq[ii], 0, mem->RSQrq[ii], nu[ii]+nx[ii], 0);
+
+        blasfeo_dgecp(nu[ii]+nx[ii]+1, nu[ii]+nx[ii], mem->RSQrq[ii], 0, 0, &mem->original_RSQrq[ii], 0, 0);
+
+        blasfeo_dgemm_nt(nu[ii]+nx[ii], nx[ii], nx[ii+1], 1.0, mem->BAbt[ii], 0, 0, &mem->Q_bar, 0, 0, 0.0, &mem->BAQ, 0, 0, &mem->BAQ, 0, 0);
+        blasfeo_dsyrk_ln_mn(nu[ii]+nx[ii]+1, nu[ii]+nx[ii], nx[ii+1], 1.0, mem->BAbt[ii], 0, 0, &mem->BAQ, 0, 0, 1.0, mem->RSQrq[ii], 0, 0, mem->RSQrq[ii], 0, 0);
+
+        blasfeo_drowex(nu[ii]+nx[ii], 1.0, mem->RSQrq[ii], nu[ii]+nx[ii], 0, mem->rq[ii], 0);
+
+        blasfeo_unpack_dmat(nu[ii], nu[ii], mem->RSQrq[ii], 0, 0, mem->R, nu[ii]);
+        acados_eigen_decomposition(nu[ii], mem->R, mem->V, mem->d, mem->e);
+
+        bool needs_regularization = false;
+        for (jj = 0; jj < nu[ii]; jj++)
+            if (mem->d[jj] < 1e-10)
+                needs_regularization = true;
+
+        if (needs_regularization)
+        {
+            blasfeo_dgecp(nu[ii]+nx[ii], nu[ii]+nx[ii], mem->RSQrq[ii], 0, 0, &mem->tmp_RSQ, 0, 0);
+
+            blasfeo_unpack_dmat(nu[ii]+nx[ii], nu[ii]+nx[ii], mem->RSQrq[ii], 0, 0, mem->reg_hess, nu[ii]+nx[ii]);
+            acados_project(nu[ii]+nx[ii], mem->reg_hess, mem->V, mem->d, mem->e, 1e-4);
+            blasfeo_pack_dmat(nu[ii]+nx[ii], nu[ii]+nx[ii], mem->reg_hess, nu[ii]+nx[ii], mem->RSQrq[ii], 0, 0);
+
+            blasfeo_dgead(nu[ii]+nx[ii], nu[ii]+nx[ii], -1.0, mem->RSQrq[ii], 0, 0, &mem->tmp_RSQ, 0, 0);
+            blasfeo_dgead(nu[ii]+nx[ii], nu[ii]+nx[ii], -1.0, &mem->tmp_RSQ, 0, 0, &mem->original_RSQrq[ii], 0, 0);
+        }
+
+        // backup Q
+        blasfeo_dgecp(nx[ii], nx[ii], mem->RSQrq[ii], nu[ii], nu[ii], &mem->Q_bar, 0, 0);
+
+        // R = L * L^T
+        blasfeo_dpotrf_l(nu[ii], mem->RSQrq[ii], 0, 0, &mem->L, 0, 0);
+        // Q = S^T * L^-T
+        blasfeo_dgecp(nx[ii], nu[ii], mem->RSQrq[ii], nu[ii], 0, &mem->St_copy, 0, 0);
+//        blasfeo_dtrsm_rltn(nx[ii], nu[ii], 1.0, &mem->L, 0, 0, &mem->St_copy, 0, 0, &mem->Q_tilde, 0, 0);
+        blasfeo_dtrsm_rltn(nx[ii], nu[ii], 1.0, &mem->L, 0, 0, &mem->St_copy, 0, 0, &mem->St_copy, 0, 0);
+
+        // Q = S^T * R^-1 * S + delta*I
+        blasfeo_dgese(nx[ii], nx[ii], 0.0, &mem->delta_eye, 0, 0);
+        blasfeo_ddiare(nx[ii], delta, &mem->delta_eye, 0, 0);
+//        blasfeo_dsyrk_ln(nx[ii], nx[ii], 1.0, &mem->Q_tilde, 0, 0, &mem->Q_tilde, 0, 0, 1.0, &mem->delta_eye, 0, 0, mem->RSQrq[ii], nu[ii], nu[ii]);
+        blasfeo_dsyrk_ln(nx[ii], nu[ii], 1.0, &mem->St_copy, 0, 0, &mem->St_copy, 0, 0, 1.0, &mem->delta_eye, 0, 0, mem->RSQrq[ii], nu[ii], nu[ii]);
+
+        blasfeo_dgead(nx[ii], nx[ii], -1.0, mem->RSQrq[ii], nu[ii], nu[ii], &mem->Q_bar, 0, 0);
+
+        // make symmetric
+        blasfeo_dtrtr_l(nx[ii], &mem->Q_bar, 0, 0, &mem->Q_bar, 0, 0);
+
+    }
+
+    return;
+}
+
+
+
+void ocp_nlp_reg_convexify_regularize_rhs(void *config, ocp_nlp_reg_dims *dims, void *opts_, void *mem_)
+{
+    ocp_nlp_reg_convexify_memory *mem = mem_;
+    ocp_nlp_reg_convexify_opts *opts = opts_;
+
+    int ii, jj;
+
+    int *nx = dims->nx;
+    int *nu = dims->nu;
+    int N = dims->N;
+
+
+    double delta = opts->delta;
+
+    // Algorithm 6 from Verschueren2017
+
+    blasfeo_drowin(nu[N]+nx[N], 1.0, mem->rq[N], 0, mem->RSQrq[N], nu[N]+nx[N], 0);
+
+    blasfeo_dgecp(nu[N]+nx[N]+1, nu[N]+nx[N], mem->RSQrq[N], 0, 0, &mem->original_RSQrq[N], 0, 0);
+
+    blasfeo_dgese(nx[N], nx[N], 0.0, &mem->delta_eye, 0, 0);
+    blasfeo_ddiare(nx[N], delta, &mem->delta_eye, 0, 0);
+    blasfeo_dgecp(nx[N], nx[N], &mem->delta_eye, 0, 0, &mem->Q_tilde, 0, 0);
+    blasfeo_dgecp(nx[N], nx[N], mem->RSQrq[N], nu[N], nu[N], &mem->Q_bar, 0, 0);
+    blasfeo_dgecp(nx[N], nx[N], &mem->Q_tilde, 0, 0, mem->RSQrq[N], nu[N], nu[N]);
+    blasfeo_dgead(nx[N], nx[N], -1.0, &mem->Q_tilde, 0, 0, &mem->Q_bar, 0, 0);
+    blasfeo_dtrtr_l(nx[N], &mem->Q_bar, 0, 0, &mem->Q_bar, 0, 0);
+
+    for (ii = N-1; ii >= 0; --ii)
+    {
+        blasfeo_drowin(nx[ii+1], 1.0, mem->b[ii], 0, mem->BAbt[ii], nu[ii]+nx[ii], 0);
+        blasfeo_drowin(nu[ii]+nx[ii], 1.0, mem->rq[ii], 0, mem->RSQrq[ii], nu[ii]+nx[ii], 0);
+
+        blasfeo_dgecp(nu[ii]+nx[ii]+1, nu[ii]+nx[ii], mem->RSQrq[ii], 0, 0, &mem->original_RSQrq[ii], 0, 0);
+
+        blasfeo_dgemm_nt(nu[ii]+nx[ii], nx[ii], nx[ii+1], 1.0, mem->BAbt[ii], 0, 0, &mem->Q_bar, 0, 0, 0.0, &mem->BAQ, 0, 0, &mem->BAQ, 0, 0);
+        blasfeo_dsyrk_ln_mn(nu[ii]+nx[ii]+1, nu[ii]+nx[ii], nx[ii+1], 1.0, mem->BAbt[ii], 0, 0, &mem->BAQ, 0, 0, 1.0, mem->RSQrq[ii], 0, 0, mem->RSQrq[ii], 0, 0);
+
+        blasfeo_drowex(nu[ii]+nx[ii], 1.0, mem->RSQrq[ii], nu[ii]+nx[ii], 0, mem->rq[ii], 0);
+
+        blasfeo_unpack_dmat(nu[ii], nu[ii], mem->RSQrq[ii], 0, 0, mem->R, nu[ii]);
+        acados_eigen_decomposition(nu[ii], mem->R, mem->V, mem->d, mem->e);
+
+        bool needs_regularization = false;
+        for (jj = 0; jj < nu[ii]; jj++)
+            if (mem->d[jj] < 1e-10)
+                needs_regularization = true;
+
+        if (needs_regularization)
+        {
+            blasfeo_dgecp(nu[ii]+nx[ii], nu[ii]+nx[ii], mem->RSQrq[ii], 0, 0, &mem->tmp_RSQ, 0, 0);
+
+            blasfeo_unpack_dmat(nu[ii]+nx[ii], nu[ii]+nx[ii], mem->RSQrq[ii], 0, 0, mem->reg_hess, nu[ii]+nx[ii]);
+            acados_project(nu[ii]+nx[ii], mem->reg_hess, mem->V, mem->d, mem->e, 1e-4);
+            blasfeo_pack_dmat(nu[ii]+nx[ii], nu[ii]+nx[ii], mem->reg_hess, nu[ii]+nx[ii], mem->RSQrq[ii], 0, 0);
+
+            blasfeo_dgead(nu[ii]+nx[ii], nu[ii]+nx[ii], -1.0, mem->RSQrq[ii], 0, 0, &mem->tmp_RSQ, 0, 0);
+            blasfeo_dgead(nu[ii]+nx[ii], nu[ii]+nx[ii], -1.0, &mem->tmp_RSQ, 0, 0, &mem->original_RSQrq[ii], 0, 0);
+        }
+
+        // backup Q
+        blasfeo_dgecp(nx[ii], nx[ii], mem->RSQrq[ii], nu[ii], nu[ii], &mem->Q_bar, 0, 0);
+
+        // R = L * L^T
+        blasfeo_dpotrf_l(nu[ii], mem->RSQrq[ii], 0, 0, &mem->L, 0, 0);
+        // Q = S^T * L^-T
+        blasfeo_dgecp(nx[ii], nu[ii], mem->RSQrq[ii], nu[ii], 0, &mem->St_copy, 0, 0);
+//        blasfeo_dtrsm_rltn(nx[ii], nu[ii], 1.0, &mem->L, 0, 0, &mem->St_copy, 0, 0, &mem->Q_tilde, 0, 0);
+        blasfeo_dtrsm_rltn(nx[ii], nu[ii], 1.0, &mem->L, 0, 0, &mem->St_copy, 0, 0, &mem->St_copy, 0, 0);
+
+        // Q = S^T * R^-1 * S + delta*I
+        blasfeo_dgese(nx[ii], nx[ii], 0.0, &mem->delta_eye, 0, 0);
+        blasfeo_ddiare(nx[ii], delta, &mem->delta_eye, 0, 0);
+//        blasfeo_dsyrk_ln(nx[ii], nx[ii], 1.0, &mem->Q_tilde, 0, 0, &mem->Q_tilde, 0, 0, 1.0, &mem->delta_eye, 0, 0, mem->RSQrq[ii], nu[ii], nu[ii]);
+        blasfeo_dsyrk_ln(nx[ii], nu[ii], 1.0, &mem->St_copy, 0, 0, &mem->St_copy, 0, 0, 1.0, &mem->delta_eye, 0, 0, mem->RSQrq[ii], nu[ii], nu[ii]);
+
+        blasfeo_dgead(nx[ii], nx[ii], -1.0, mem->RSQrq[ii], nu[ii], nu[ii], &mem->Q_bar, 0, 0);
+
+        // make symmetric
+        blasfeo_dtrtr_l(nx[ii], &mem->Q_bar, 0, 0, &mem->Q_bar, 0, 0);
+
+    }
+}
+
+
+
 // TODO: check if inequality constraints case is implemented correctly
 void ocp_nlp_reg_convexify_correct_dual_sol(void *config, ocp_nlp_reg_dims *dims, void *opts_, void *mem_)
 {
@@ -704,58 +879,58 @@ void ocp_nlp_reg_convexify_correct_dual_sol(void *config, ocp_nlp_reg_dims *dims
     int *nbu = dims->nbu;
     int *ng = dims->ng;
 
-//	printf("\nRSQrq reg\n");
-//	for(ii=0; ii<=N; ii++)
-//		blasfeo_print_dmat(nu[ii]+nx[ii]+1, nu[ii]+nx[ii], mem->RSQrq[ii], 0, 0);
+//    printf("\nRSQrq reg\n");
+//    for(ii=0; ii<=N; ii++)
+//        blasfeo_print_dmat(nu[ii]+nx[ii]+1, nu[ii]+nx[ii], mem->RSQrq[ii], 0, 0);
 
-	// restore original hessian and gradient
-	for(ii=0; ii<=N; ii++)
-	{
+    // restore original hessian and gradient
+    for(ii=0; ii<=N; ii++)
+    {
         blasfeo_dgecp(nu[ii]+nx[ii]+1, nu[ii]+nx[ii], &mem->original_RSQrq[ii], 0, 0, mem->RSQrq[ii], 0, 0);
-		blasfeo_drowex(nu[ii]+nx[ii], 1.0, &mem->original_RSQrq[ii], nu[ii]+nx[ii], 0, mem->rq[ii], 0);
-	}
+        blasfeo_drowex(nu[ii]+nx[ii], 1.0, &mem->original_RSQrq[ii], nu[ii]+nx[ii], 0, mem->rq[ii], 0);
+    }
 
-//	printf("\nRSQrq orig\n");
-//	for(ii=0; ii<=N; ii++)
-//		blasfeo_print_dmat(nu[ii]+nx[ii]+1, nu[ii]+nx[ii], mem->RSQrq[ii], 0, 0);
+//    printf("\nRSQrq orig\n");
+//    for(ii=0; ii<=N; ii++)
+//        blasfeo_print_dmat(nu[ii]+nx[ii]+1, nu[ii]+nx[ii], mem->RSQrq[ii], 0, 0);
 
 
 
-	// compute multipliers of equality constraints
+    // compute multipliers of equality constraints
 
 #if 0
     blasfeo_dgemv_n(nx[N], nu[N]+nx[N], 1.0, mem->RSQrq[N], nu[N], 0, mem->ux[N], 0, 1.0, mem->rq[N], nu[N], mem->pi[N-1], 0);
 
     for(ii=1; ii<N; ii++)
     {
-		ss = N-ii;
+        ss = N-ii;
         blasfeo_dgemv_n(nx[ss], nu[ss]+nx[ss], 1.0, mem->RSQrq[ss], nu[ss], 0, mem->ux[ss], 0, 1.0, mem->rq[ss], nu[ss], mem->pi[ss-1], 0);
         blasfeo_dgemv_n(nx[ss], nx[ss+1], 1.0, mem->BAbt[ss], nu[ss], 0, mem->pi[ss], 0, 1.0, mem->pi[ss-1], 0, mem->pi[ss-1], 0);
     }
 
 #else
 
-	// last stage
-	blasfeo_dveccp(nx[N], mem->rq[N], nu[N], &mem->tmp_nuxM, nu[N]);
-	blasfeo_daxpy(nbu[N]+nbx[N]+ng[N], -1.0, mem->lam[N], 0, mem->lam[N], nbu[N]+nbx[N]+ng[N], &mem->tmp_nbgM, 0);
-	blasfeo_dvecad_sp(nbu[N]+nbx[N], 1.0, &mem->tmp_nbgM, 0, mem->idxb[N], &mem->tmp_nuxM, 0);
-	// TODO avoid to multiply by R ???
-	blasfeo_dsymv_l(nu[N]+nx[N], 1.0, mem->RSQrq[N], 0, 0, mem->ux[N], 0, 1.0, &mem->tmp_nuxM, 0, &mem->tmp_nuxM, 0);
-	blasfeo_dgemv_n(nx[N], ng[N], 1.0, mem->DCt[N], nu[N], 0, &mem->tmp_nbgM, nbu[N]+nbx[N], 1.0, &mem->tmp_nuxM, nu[N], &mem->tmp_nuxM, nu[N]);
-	blasfeo_dveccp(nx[N], &mem->tmp_nuxM, nu[N], mem->pi[N-1], 0);
+    // last stage
+    blasfeo_dveccp(nx[N], mem->rq[N], nu[N], &mem->tmp_nuxM, nu[N]);
+    blasfeo_daxpy(nbu[N]+nbx[N]+ng[N], -1.0, mem->lam[N], 0, mem->lam[N], nbu[N]+nbx[N]+ng[N], &mem->tmp_nbgM, 0);
+    blasfeo_dvecad_sp(nbu[N]+nbx[N], 1.0, &mem->tmp_nbgM, 0, mem->idxb[N], &mem->tmp_nuxM, 0);
+    // TODO avoid to multiply by R ???
+    blasfeo_dsymv_l(nu[N]+nx[N], 1.0, mem->RSQrq[N], 0, 0, mem->ux[N], 0, 1.0, &mem->tmp_nuxM, 0, &mem->tmp_nuxM, 0);
+    blasfeo_dgemv_n(nx[N], ng[N], 1.0, mem->DCt[N], nu[N], 0, &mem->tmp_nbgM, nbu[N]+nbx[N], 1.0, &mem->tmp_nuxM, nu[N], &mem->tmp_nuxM, nu[N]);
+    blasfeo_dveccp(nx[N], &mem->tmp_nuxM, nu[N], mem->pi[N-1], 0);
 
-	// middle stages
-	for(ii=0; ii<N-1; ii++)
-		{
-		blasfeo_dveccp(nx[N-1-ii], mem->rq[N-1-ii], nu[N-1-ii], &mem->tmp_nuxM, nu[N-1-ii]);
-		blasfeo_daxpy(nbu[N-1-ii]+nbx[N-1-ii]+ng[N-1-ii], -1.0, mem->lam[N-1-ii], 0, mem->lam[N-1-ii], nbu[N-1-ii]+nbx[N-1-ii]+ng[N-1-ii], &mem->tmp_nbgM, 0);
-		blasfeo_dvecad_sp(nbu[N-1-ii]+nbx[N-1-ii], 1.0, &mem->tmp_nbgM, 0, mem->idxb[N-1-ii], &mem->tmp_nuxM, 0);
-		// TODO avoid to multiply by R ???
-		blasfeo_dsymv_l(nu[N-1-ii]+nx[N-1-ii], 1.0, mem->RSQrq[N-1-ii], 0, 0, mem->ux[N-1-ii], 0, 1.0, &mem->tmp_nuxM, 0, &mem->tmp_nuxM, 0);
-		blasfeo_dgemv_n(nx[N-1-ii], nx[N-ii], 1.0, mem->BAbt[N-1-ii], nu[N-1-ii], 0, mem->pi[N-1-ii], 0, 1.0, &mem->tmp_nuxM, nu[N-1-ii], &mem->tmp_nuxM, nu[N-1-ii]);
-		blasfeo_dgemv_n(nx[N-1-ii], ng[N-1-ii], 1.0, mem->DCt[N-1-ii], nu[N-1-ii], 0, &mem->tmp_nbgM, nbu[N-1-ii]+nbx[N-1-ii], 1.0, &mem->tmp_nuxM, nu[N-1-ii], &mem->tmp_nuxM, nu[N-1-ii]);
-		blasfeo_dveccp(nx[N-1-ii], &mem->tmp_nuxM, nu[N-1-ii], mem->pi[N-2-ii], 0);
-		}
+    // middle stages
+    for(ii=0; ii<N-1; ii++)
+        {
+        blasfeo_dveccp(nx[N-1-ii], mem->rq[N-1-ii], nu[N-1-ii], &mem->tmp_nuxM, nu[N-1-ii]);
+        blasfeo_daxpy(nbu[N-1-ii]+nbx[N-1-ii]+ng[N-1-ii], -1.0, mem->lam[N-1-ii], 0, mem->lam[N-1-ii], nbu[N-1-ii]+nbx[N-1-ii]+ng[N-1-ii], &mem->tmp_nbgM, 0);
+        blasfeo_dvecad_sp(nbu[N-1-ii]+nbx[N-1-ii], 1.0, &mem->tmp_nbgM, 0, mem->idxb[N-1-ii], &mem->tmp_nuxM, 0);
+        // TODO avoid to multiply by R ???
+        blasfeo_dsymv_l(nu[N-1-ii]+nx[N-1-ii], 1.0, mem->RSQrq[N-1-ii], 0, 0, mem->ux[N-1-ii], 0, 1.0, &mem->tmp_nuxM, 0, &mem->tmp_nuxM, 0);
+        blasfeo_dgemv_n(nx[N-1-ii], nx[N-ii], 1.0, mem->BAbt[N-1-ii], nu[N-1-ii], 0, mem->pi[N-1-ii], 0, 1.0, &mem->tmp_nuxM, nu[N-1-ii], &mem->tmp_nuxM, nu[N-1-ii]);
+        blasfeo_dgemv_n(nx[N-1-ii], ng[N-1-ii], 1.0, mem->DCt[N-1-ii], nu[N-1-ii], 0, &mem->tmp_nbgM, nbu[N-1-ii]+nbx[N-1-ii], 1.0, &mem->tmp_nuxM, nu[N-1-ii], &mem->tmp_nuxM, nu[N-1-ii]);
+        blasfeo_dveccp(nx[N-1-ii], &mem->tmp_nuxM, nu[N-1-ii], mem->pi[N-2-ii], 0);
+        }
 #endif
 
     return;
@@ -788,6 +963,9 @@ void ocp_nlp_reg_convexify_config_initialize_default(ocp_nlp_reg_config *config)
     config->memory_set_pi_ptr = &ocp_nlp_reg_convexify_memory_set_pi_ptr;
     config->memory_set_lam_ptr = &ocp_nlp_reg_convexify_memory_set_lam_ptr;
     // functions
-    config->regularize_hessian = &ocp_nlp_reg_convexify_regularize_hessian;
+    // TODO: fix split
+    config->regularize = &ocp_nlp_reg_convexify_regularize;
+    config->regularize_lhs = &ocp_nlp_reg_convexify_regularize_lhs;
+    config->regularize_rhs = &ocp_nlp_reg_convexify_regularize_rhs;
     config->correct_dual_sol = &ocp_nlp_reg_convexify_correct_dual_sol;
 }

--- a/acados/ocp_nlp/ocp_nlp_reg_convexify.c
+++ b/acados/ocp_nlp/ocp_nlp_reg_convexify.c
@@ -784,6 +784,12 @@ void ocp_nlp_reg_convexify_regularize_rhs(void *config, ocp_nlp_reg_dims *dims, 
 
     double delta = opts->delta;
 
+    // start from original qp and do it all from scratch
+    for (ii = 0; ii<=N; ii++)
+    {
+        blasfeo_dgecp(nu[ii]+nx[ii], nu[ii]+nx[ii], &mem->original_RSQrq[ii], 0, 0, mem->RSQrq[ii], 0, 0);
+    }
+
     // Algorithm 6 from Verschueren2017
 
     blasfeo_drowin(nu[N]+nx[N], 1.0, mem->rq[N], 0, mem->RSQrq[N], nu[N]+nx[N], 0);

--- a/acados/ocp_nlp/ocp_nlp_reg_convexify.c
+++ b/acados/ocp_nlp/ocp_nlp_reg_convexify.c
@@ -689,8 +689,7 @@ void ocp_nlp_reg_convexify_regularize_hessian(void *config, ocp_nlp_reg_dims *di
     return;
 }
 
-
-
+// TODO: check if inequality constraints case is implemented correctly
 void ocp_nlp_reg_convexify_correct_dual_sol(void *config, ocp_nlp_reg_dims *dims, void *opts_, void *mem_)
 {
     ocp_nlp_reg_convexify_memory *mem = mem_;

--- a/acados/ocp_nlp/ocp_nlp_reg_convexify.c
+++ b/acados/ocp_nlp/ocp_nlp_reg_convexify.c
@@ -720,7 +720,7 @@ void ocp_nlp_reg_convexify_regularize_lhs(void *config, ocp_nlp_reg_dims *dims, 
         blasfeo_dgemm_nt(nu[ii]+nx[ii], nx[ii], nx[ii+1], 1.0, mem->BAbt[ii], 0, 0, &mem->Q_bar, 0, 0, 0.0, &mem->BAQ, 0, 0, &mem->BAQ, 0, 0);
         blasfeo_dsyrk_ln_mn(nu[ii]+nx[ii]+1, nu[ii]+nx[ii], nx[ii+1], 1.0, mem->BAbt[ii], 0, 0, &mem->BAQ, 0, 0, 1.0, mem->RSQrq[ii], 0, 0, mem->RSQrq[ii], 0, 0);
 
-        blasfeo_drowex(nu[ii]+nx[ii], 1.0, mem->RSQrq[ii], nu[ii]+nx[ii], 0, mem->rq[ii], 0);
+        // blasfeo_drowex(nu[ii]+nx[ii], 1.0, mem->RSQrq[ii], nu[ii]+nx[ii], 0, mem->rq[ii], 0);
 
         blasfeo_unpack_dmat(nu[ii], nu[ii], mem->RSQrq[ii], 0, 0, mem->R, nu[ii]);
         acados_eigen_decomposition(nu[ii], mem->R, mem->V, mem->d, mem->e);
@@ -791,7 +791,6 @@ void ocp_nlp_reg_convexify_regularize_rhs(void *config, ocp_nlp_reg_dims *dims, 
     }
 
     // Algorithm 6 from Verschueren2017
-
     blasfeo_drowin(nu[N]+nx[N], 1.0, mem->rq[N], 0, mem->RSQrq[N], nu[N]+nx[N], 0);
 
     blasfeo_dgecp(nu[N]+nx[N]+1, nu[N]+nx[N], mem->RSQrq[N], 0, 0, &mem->original_RSQrq[N], 0, 0);

--- a/acados/ocp_nlp/ocp_nlp_reg_convexify.c
+++ b/acados/ocp_nlp/ocp_nlp_reg_convexify.c
@@ -691,8 +691,6 @@ void ocp_nlp_reg_convexify_regularize_hessian(void *config, ocp_nlp_reg_dims *di
 
 
 
-// NOTE this only considers the case of (dynamcs) equality constraints (no inequality constraints)
-// TODO inequality constraints case
 void ocp_nlp_reg_convexify_correct_dual_sol(void *config, ocp_nlp_reg_dims *dims, void *opts_, void *mem_)
 {
     ocp_nlp_reg_convexify_memory *mem = mem_;

--- a/acados/ocp_nlp/ocp_nlp_reg_mirror.c
+++ b/acados/ocp_nlp/ocp_nlp_reg_mirror.c
@@ -267,7 +267,7 @@ void ocp_nlp_reg_mirror_memory_set(void *config_, ocp_nlp_reg_dims *dims, void *
  * functions
  ************************************************/
 
-void ocp_nlp_reg_mirror_regularize_hessian(void *config, ocp_nlp_reg_dims *dims, void *opts_, void *mem_)
+void ocp_nlp_reg_mirror_regularize(void *config, ocp_nlp_reg_dims *dims, void *opts_, void *mem_)
 {
     ocp_nlp_reg_mirror_memory *mem = (ocp_nlp_reg_mirror_memory *) mem_;
     ocp_nlp_reg_mirror_opts *opts = opts_;
@@ -290,6 +290,19 @@ void ocp_nlp_reg_mirror_regularize_hessian(void *config, ocp_nlp_reg_dims *dims,
     }
 }
 
+
+
+void ocp_nlp_reg_mirror_regularize_lhs(void *config, ocp_nlp_reg_dims *dims, void *opts_, void *mem_)
+{
+    ocp_nlp_reg_mirror_regularize(config, dims, opts_, mem_);
+}
+
+
+
+void ocp_nlp_reg_mirror_regularize_rhs(void *config, ocp_nlp_reg_dims *dims, void *opts_, void *mem_)
+{
+    return;
+}
 
 
 void ocp_nlp_reg_mirror_correct_dual_sol(void *config, ocp_nlp_reg_dims *dims, void *opts_, void *mem_)
@@ -324,6 +337,8 @@ void ocp_nlp_reg_mirror_config_initialize_default(ocp_nlp_reg_config *config)
     config->memory_set_pi_ptr = &ocp_nlp_reg_mirror_memory_set_pi_ptr;
     config->memory_set_lam_ptr = &ocp_nlp_reg_mirror_memory_set_lam_ptr;
     // functions
-    config->regularize_hessian = &ocp_nlp_reg_mirror_regularize_hessian;
+    config->regularize = &ocp_nlp_reg_mirror_regularize;
+    config->regularize_rhs = &ocp_nlp_reg_mirror_regularize_rhs;
+    config->regularize_lhs = &ocp_nlp_reg_mirror_regularize_lhs;
     config->correct_dual_sol = &ocp_nlp_reg_mirror_correct_dual_sol;
 }

--- a/acados/ocp_nlp/ocp_nlp_reg_noreg.c
+++ b/acados/ocp_nlp/ocp_nlp_reg_noreg.c
@@ -229,6 +229,7 @@ void ocp_nlp_reg_noreg_config_initialize_default(ocp_nlp_reg_config *config)
     config->memory_set_pi_ptr = &ocp_nlp_reg_noreg_memory_set_pi_ptr;
     config->memory_set_lam_ptr = &ocp_nlp_reg_noreg_memory_set_lam_ptr;
     // functions
+    config->regularize = &ocp_nlp_reg_noreg_regularize;
     config->regularize_lhs = &ocp_nlp_reg_noreg_regularize_lhs;
     config->regularize_rhs = &ocp_nlp_reg_noreg_regularize_rhs;
     config->correct_dual_sol = &ocp_nlp_reg_noreg_correct_dual_sol;

--- a/acados/ocp_nlp/ocp_nlp_reg_noreg.c
+++ b/acados/ocp_nlp/ocp_nlp_reg_noreg.c
@@ -180,11 +180,22 @@ void ocp_nlp_reg_noreg_memory_set(void *config_, ocp_nlp_reg_dims *dims, void *m
  * functions
  ************************************************/
 
-void ocp_nlp_reg_noreg_regularize_hessian(void *config, ocp_nlp_reg_dims *dims, void *opts_, void *mem_)
+void ocp_nlp_reg_noreg_regularize(void *config, ocp_nlp_reg_dims *dims, void *opts_, void *mem_)
 {
     return;
 }
 
+
+void ocp_nlp_reg_noreg_regularize_lhs(void *config, ocp_nlp_reg_dims *dims, void *opts_, void *mem_)
+{
+    return;
+}
+
+
+void ocp_nlp_reg_noreg_regularize_rhs(void *config, ocp_nlp_reg_dims *dims, void *opts_, void *mem_)
+{
+    return;
+}
 
 void ocp_nlp_reg_noreg_correct_dual_sol(void *config, ocp_nlp_reg_dims *dims, void *opts_, void *mem_)
 {
@@ -218,7 +229,8 @@ void ocp_nlp_reg_noreg_config_initialize_default(ocp_nlp_reg_config *config)
     config->memory_set_pi_ptr = &ocp_nlp_reg_noreg_memory_set_pi_ptr;
     config->memory_set_lam_ptr = &ocp_nlp_reg_noreg_memory_set_lam_ptr;
     // functions
-    config->regularize_hessian = &ocp_nlp_reg_noreg_regularize_hessian;
+    config->regularize_lhs = &ocp_nlp_reg_noreg_regularize_lhs;
+    config->regularize_rhs = &ocp_nlp_reg_noreg_regularize_rhs;
     config->correct_dual_sol = &ocp_nlp_reg_noreg_correct_dual_sol;
 }
 

--- a/acados/ocp_nlp/ocp_nlp_reg_project.c
+++ b/acados/ocp_nlp/ocp_nlp_reg_project.c
@@ -267,7 +267,7 @@ void ocp_nlp_reg_project_memory_set(void *config_, ocp_nlp_reg_dims *dims, void 
  * functions
  ************************************************/
 
-void ocp_nlp_reg_project_regularize_hessian(void *config, ocp_nlp_reg_dims *dims, void *opts_, void *mem_)
+void ocp_nlp_reg_project_regularize(void *config, ocp_nlp_reg_dims *dims, void *opts_, void *mem_)
 {
     ocp_nlp_reg_project_memory *mem = (ocp_nlp_reg_project_memory *) mem_;
     ocp_nlp_reg_project_opts *opts = opts_;
@@ -289,6 +289,17 @@ void ocp_nlp_reg_project_regularize_hessian(void *config, ocp_nlp_reg_dims *dims
     }
 }
 
+
+void ocp_nlp_reg_project_regularize_lhs(void *config, ocp_nlp_reg_dims *dims, void *opts_, void *mem_)
+{
+    ocp_nlp_reg_project_regularize(config, dims, opts_, mem_);
+}
+
+
+void ocp_nlp_reg_project_regularize_rhs(void *config, ocp_nlp_reg_dims *dims, void *opts_, void *mem_)
+{
+    return;
+}
 
 
 void ocp_nlp_reg_project_correct_dual_sol(void *config, ocp_nlp_reg_dims *dims, void *opts_, void *mem_)
@@ -323,7 +334,9 @@ void ocp_nlp_reg_project_config_initialize_default(ocp_nlp_reg_config *config)
     config->memory_set_pi_ptr = &ocp_nlp_reg_project_memory_set_pi_ptr;
     config->memory_set_lam_ptr = &ocp_nlp_reg_project_memory_set_lam_ptr;
     // functions
-    config->regularize_hessian = &ocp_nlp_reg_project_regularize_hessian;
+    config->regularize = &ocp_nlp_reg_project_regularize;
+    config->regularize_rhs = &ocp_nlp_reg_project_regularize_rhs;
+    config->regularize_lhs = &ocp_nlp_reg_project_regularize_lhs;
     config->correct_dual_sol = &ocp_nlp_reg_project_correct_dual_sol;
 }
 

--- a/acados/ocp_nlp/ocp_nlp_reg_project_reduc_hess.c
+++ b/acados/ocp_nlp/ocp_nlp_reg_project_reduc_hess.c
@@ -329,7 +329,7 @@ void ocp_nlp_reg_project_reduc_hess_memory_set(void *config_, ocp_nlp_reg_dims *
  * functions
  ************************************************/
 
-void ocp_nlp_reg_project_reduc_hess_regularize_hessian(void *config, ocp_nlp_reg_dims *dims, void *opts_, void *mem_)
+void ocp_nlp_reg_project_reduc_hess_regularize(void *config, ocp_nlp_reg_dims *dims, void *opts_, void *mem_)
 {
     ocp_nlp_reg_project_reduc_hess_memory *mem = (ocp_nlp_reg_project_reduc_hess_memory *) mem_;
     ocp_nlp_reg_project_reduc_hess_opts *opts = opts_;
@@ -445,7 +445,7 @@ void ocp_nlp_reg_project_reduc_hess_regularize_hessian(void *config, ocp_nlp_reg
 						}
 					}
 				}
-					
+
 				pivot = BLASFEO_DMATEL(L3, jj, jj);
 				if ((pivot<opts->min_pivot) & (pivot>-opts->min_pivot))
 				{
@@ -521,6 +521,18 @@ void ocp_nlp_reg_project_reduc_hess_regularize_hessian(void *config, ocp_nlp_reg
 }
 
 
+void ocp_nlp_reg_project_reduc_hess_regularize_lhs(void *config, ocp_nlp_reg_dims *dims, void *opts_, void *mem_)
+{
+    ocp_nlp_reg_project_reduc_hess_regularize(config, dims, opts_, mem_);
+}
+
+void ocp_nlp_reg_project_reduc_hess_regularize_rhs(void *config, ocp_nlp_reg_dims *dims, void *opts_, void *mem_)
+{
+    return;
+}
+
+
+
 
 void ocp_nlp_reg_project_reduc_hess_correct_dual_sol(void *config, ocp_nlp_reg_dims *dims, void *opts_, void *mem_)
 {
@@ -554,7 +566,9 @@ void ocp_nlp_reg_project_reduc_hess_config_initialize_default(ocp_nlp_reg_config
     config->memory_set_pi_ptr = &ocp_nlp_reg_project_reduc_hess_memory_set_pi_ptr;
     config->memory_set_lam_ptr = &ocp_nlp_reg_project_reduc_hess_memory_set_lam_ptr;
     // functions
-    config->regularize_hessian = &ocp_nlp_reg_project_reduc_hess_regularize_hessian;
+    config->regularize = &ocp_nlp_reg_project_reduc_hess_regularize;
+    config->regularize_rhs = &ocp_nlp_reg_project_reduc_hess_regularize_rhs;
+    config->regularize_lhs = &ocp_nlp_reg_project_reduc_hess_regularize_lhs;
     config->correct_dual_sol = &ocp_nlp_reg_project_reduc_hess_correct_dual_sol;
 }
 

--- a/acados/ocp_nlp/ocp_nlp_reg_project_reduc_hess.c
+++ b/acados/ocp_nlp/ocp_nlp_reg_project_reduc_hess.c
@@ -466,7 +466,7 @@ void ocp_nlp_reg_project_reduc_hess_regularize_hessian(void *config, ocp_nlp_reg
 			}
 		}
 
-		// apply shur to P
+		// apply schur to P
 		blasfeo_dgecp(nx[ss], nx[ss], L, nu[ss], nu[ss], P, 0, 0);
 		if(do_reg)
 //		if(0)

--- a/acados/ocp_nlp/ocp_nlp_sqp.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp.c
@@ -591,7 +591,7 @@ int ocp_nlp_sqp(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
 
         // regularize Hessian
         acados_tic(&timer1);
-        config->regularize->regularize_hessian(config->regularize, dims->regularize,
+        config->regularize->regularize(config->regularize, dims->regularize,
                                                opts->nlp_opts->regularize, nlp_mem->regularize_mem);
         mem->time_reg += acados_toc(&timer1);
 

--- a/acados/ocp_nlp/ocp_nlp_sqp_rti.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp_rti.c
@@ -457,6 +457,13 @@ static void ocp_nlp_sqp_rti_preparation_step(ocp_nlp_config *config, ocp_nlp_dim
 
     mem->time_lin += acados_toc(&timer1);
 
+
+    // regularize Hessian
+    acados_tic(&timer1);
+    config->regularize->regularize_hessian(config->regularize,
+        dims->regularize, opts->nlp_opts->regularize, nlp_mem->regularize_mem);
+    mem->time_reg += acados_toc(&timer1);
+
 #if defined(ACADOS_WITH_OPENMP)
     // restore number of threads
     omp_set_num_threads(num_threads_bkp);
@@ -489,12 +496,6 @@ static void ocp_nlp_sqp_rti_feedback_step(ocp_nlp_config *config, ocp_nlp_dims *
     // update QP rhs for SQP (step prim var, abs dual var)
     ocp_nlp_approximate_qp_vectors_sqp(config, dims, nlp_in,
         nlp_out, nlp_opts, nlp_mem, nlp_work);
-
-    // regularize Hessian
-    acados_tic(&timer1);
-    config->regularize->regularize_hessian(config->regularize,
-        dims->regularize, opts->nlp_opts->regularize, nlp_mem->regularize_mem);
-    mem->time_reg += acados_toc(&timer1);
 
     if (nlp_opts->print_level > 0) {
         printf("\n------- qp_in --------\n");

--- a/acados/ocp_nlp/ocp_nlp_sqp_rti.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp_rti.c
@@ -499,16 +499,15 @@ static void ocp_nlp_sqp_rti_feedback_step(ocp_nlp_config *config, ocp_nlp_dims *
     mem->time_qp_xcond = 0.0;
     mem->time_glob = 0.0;
 
+    // update QP rhs for SQP (step prim var, abs dual var)
+    ocp_nlp_approximate_qp_vectors_sqp(config, dims, nlp_in,
+        nlp_out, nlp_opts, nlp_mem, nlp_work);
 
     // finish regularization
     acados_tic(&timer1);
     config->regularize->regularize_rhs(config->regularize,
         dims->regularize, opts->nlp_opts->regularize, nlp_mem->regularize_mem);
     mem->time_reg += acados_toc(&timer1);
-
-    // update QP rhs for SQP (step prim var, abs dual var)
-    ocp_nlp_approximate_qp_vectors_sqp(config, dims, nlp_in,
-        nlp_out, nlp_opts, nlp_mem, nlp_work);
 
     if (nlp_opts->print_level > 0) {
         printf("\n------- qp_in --------\n");

--- a/acados/ocp_nlp/ocp_nlp_sqp_rti.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp_rti.c
@@ -460,13 +460,13 @@ static void ocp_nlp_sqp_rti_preparation_step(ocp_nlp_config *config, ocp_nlp_dim
 
     // regularize Hessian
     acados_tic(&timer1);
-    config->regularize->regularize_hessian(config->regularize,
+    config->regularize->regularize_lhs(config->regularize,
         dims->regularize, opts->nlp_opts->regularize, nlp_mem->regularize_mem);
     mem->time_reg += acados_toc(&timer1);
 
     if (opts->rti_phase == 1)
     {
-        int qp_status = qp_solver->condense_lhs(qp_solver, dims->qp_solver,
+        qp_solver->condense_lhs(qp_solver, dims->qp_solver,
             nlp_mem->qp_in, nlp_mem->qp_out, opts->nlp_opts->qp_solver_opts,
             nlp_mem->qp_solver_mem, nlp_work->qp_work);
     }
@@ -498,6 +498,13 @@ static void ocp_nlp_sqp_rti_feedback_step(ocp_nlp_config *config, ocp_nlp_dims *
     mem->time_qp_solver_call = 0.0;
     mem->time_qp_xcond = 0.0;
     mem->time_glob = 0.0;
+
+
+    // finish regularization
+    acados_tic(&timer1);
+    config->regularize->regularize_rhs(config->regularize,
+        dims->regularize, opts->nlp_opts->regularize, nlp_mem->regularize_mem);
+    mem->time_reg += acados_toc(&timer1);
 
     // update QP rhs for SQP (step prim var, abs dual var)
     ocp_nlp_approximate_qp_vectors_sqp(config, dims, nlp_in,

--- a/acados/ocp_qp/ocp_qp_common.h
+++ b/acados/ocp_qp/ocp_qp_common.h
@@ -94,7 +94,8 @@ typedef struct
     void (*memory_get)(void *config, void *mem, const char *field, void* value);
     acados_size_t (*workspace_calculate_size)(void *dims, void *opts);
     int (*condensing)(void *qp_in, void *qp_out, void *opts, void *mem, void *work);
-    int (*condensing_rhs)(void *qp_in, void *qp_out, void *opts, void *mem, void *work);
+    int (*condense_rhs)(void *qp_in, void *qp_out, void *opts, void *mem, void *work);
+    int (*condense_lhs)(void *qp_in, void *qp_out, void *opts, void *mem, void *work);
     int (*expansion)(void *qp_in, void *qp_out, void *opts, void *mem, void *work);
 } ocp_qp_xcond_config;
 

--- a/acados/ocp_qp/ocp_qp_full_condensing.h
+++ b/acados/ocp_qp/ocp_qp_full_condensing.h
@@ -103,6 +103,10 @@ acados_size_t ocp_qp_full_condensing_workspace_calculate_size(void *dims, void *
 //
 int ocp_qp_full_condensing(void *in, void *out, void *opts, void *mem, void *work);
 //
+int ocp_qp_full_condensing_condense_rhs(void *in, void *out, void *opts, void *mem, void *work);
+//
+int ocp_qp_full_condensing_condense_lhs(void *in, void *out, void *opts, void *mem, void *work);
+//
 int ocp_qp_full_expansion(void *in, void *out, void *opts, void *mem, void *work);
 //
 void ocp_qp_full_condensing_config_initialize_default(void *config_);

--- a/acados/ocp_qp/ocp_qp_partial_condensing.c
+++ b/acados/ocp_qp/ocp_qp_partial_condensing.c
@@ -483,7 +483,6 @@ int ocp_qp_partial_condensing(void *qp_in_, void *pcond_qp_in_, void *opts_, voi
 //exit(1);
 
     // convert to partially condensed qp structure
-    // TODO only if N2<N
     d_part_cond_qp_cond(mem->red_qp, pcond_qp_in, opts->hpipm_pcond_opts, mem->hpipm_pcond_work);
 
     // stop timer
@@ -492,9 +491,34 @@ int ocp_qp_partial_condensing(void *qp_in_, void *pcond_qp_in_, void *opts_, voi
     return ACADOS_SUCCESS;
 }
 
+int ocp_qp_partial_condensing_condense_lhs(void *qp_in_, void *pcond_qp_in_, void *opts_, void *mem_, void *work)
+{
+    ocp_qp_in *qp_in = qp_in_;
+    ocp_qp_in *pcond_qp_in = pcond_qp_in_;
+    ocp_qp_partial_condensing_opts *opts = opts_;
+    ocp_qp_partial_condensing_memory *mem = mem_;
+
+    acados_timer timer;
+
+    assert(opts->N2 == opts->N2_bkp);
+
+    // save pointers to ocp_qp_in in memory (needed for expansion)
+    mem->ptr_qp_in = qp_in;
+    mem->ptr_pcond_qp_in = pcond_qp_in;
+
+    acados_tic(&timer);
+
+    d_ocp_qp_reduce_eq_dof_lhs(qp_in, mem->red_qp, opts->hpipm_red_opts, mem->hpipm_red_work);
+    d_part_cond_qp_cond_lhs(mem->red_qp, pcond_qp_in, opts->hpipm_pcond_opts, mem->hpipm_pcond_work);
+
+    mem->time_qp_xcond = acados_toc(&timer);
+
+    return ACADOS_SUCCESS;
+}
 
 
-int ocp_qp_partial_condensing_rhs(void *qp_in_, void *pcond_qp_in_, void *opts_, void *mem_, void *work)
+
+int ocp_qp_partial_condensing_condense_rhs(void *qp_in_, void *pcond_qp_in_, void *opts_, void *mem_, void *work)
 {
     ocp_qp_in *qp_in = qp_in_;
     ocp_qp_in *pcond_qp_in = pcond_qp_in_;
@@ -513,10 +537,9 @@ int ocp_qp_partial_condensing_rhs(void *qp_in_, void *pcond_qp_in_, void *opts_,
     mem->ptr_pcond_qp_in = pcond_qp_in;
 
     // reduce eq constr DOF
-    d_ocp_qp_reduce_eq_dof(qp_in, mem->red_qp, opts->hpipm_red_opts, mem->hpipm_red_work);
+    d_ocp_qp_reduce_eq_dof_rhs(qp_in, mem->red_qp, opts->hpipm_red_opts, mem->hpipm_red_work);
 
     // convert to partially condensed qp structure
-    // TODO only if N2<N
     d_part_cond_qp_cond_rhs(mem->red_qp, pcond_qp_in, opts->hpipm_pcond_opts, mem->hpipm_pcond_work);
 
     // stop timer
@@ -574,7 +597,8 @@ void ocp_qp_partial_condensing_config_initialize_default(void *config_)
     config->memory_get = &ocp_qp_partial_condensing_memory_get;
     config->workspace_calculate_size = &ocp_qp_partial_condensing_workspace_calculate_size;
     config->condensing = &ocp_qp_partial_condensing;
-    config->condensing_rhs = &ocp_qp_partial_condensing_rhs;
+    config->condense_lhs = &ocp_qp_partial_condensing_condense_lhs;
+    config->condense_rhs = &ocp_qp_partial_condensing_condense_rhs;
     config->expansion = &ocp_qp_partial_expansion;
 
     return;

--- a/acados/ocp_qp/ocp_qp_partial_condensing.h
+++ b/acados/ocp_qp/ocp_qp_partial_condensing.h
@@ -107,6 +107,10 @@ acados_size_t ocp_qp_partial_condensing_workspace_calculate_size(void *dims, voi
 //
 int ocp_qp_partial_condensing(void *in, void *out, void *opts, void *mem, void *work);
 //
+int ocp_qp_partial_condensing_condense_lhs(void *in, void *out, void *opts, void *mem, void *work);
+//
+int ocp_qp_partial_condensing_condense_rhs(void *in, void *out, void *opts, void *mem, void *work);
+//
 int ocp_qp_partial_expansion(void *in, void *out, void *opts, void *mem, void *work);
 //
 void ocp_qp_partial_condensing_config_initialize_default(void *config_);

--- a/acados/ocp_qp/ocp_qp_xcond_solver.c
+++ b/acados/ocp_qp/ocp_qp_xcond_solver.c
@@ -485,7 +485,7 @@ static void cast_workspace(void *config_, ocp_qp_xcond_solver_dims *dims,
  * functions
  ************************************************/
 
-int ocp_qp_xcond_solver(void *config_, ocp_qp_xcond_solver_dims *dims, ocp_qp_in *qp_in, ocp_qp_out *qp_out,
+int ocp_qp_xcond_solve(void *config_, ocp_qp_xcond_solver_dims *dims, ocp_qp_in *qp_in, ocp_qp_out *qp_out,
                                      void *opts_, void *mem_, void *work_)
 {
     ocp_qp_xcond_solver_config *config = config_;
@@ -535,6 +535,88 @@ int ocp_qp_xcond_solver(void *config_, ocp_qp_xcond_solver_dims *dims, ocp_qp_in
 
 
 
+int ocp_qp_xcond_condense_lhs(void *config_, ocp_qp_xcond_solver_dims *dims, ocp_qp_in *qp_in, ocp_qp_out *qp_out,
+                                     void *opts_, void *mem_, void *work_)
+{
+    ocp_qp_xcond_solver_config *config = config_;
+    qp_solver_config *qp_solver = config->qp_solver;
+    ocp_qp_xcond_config *xcond = config->xcond;
+
+    qp_info *info = (qp_info *) qp_out->misc;
+    acados_timer tot_timer, cond_timer;
+    acados_tic(&tot_timer);
+
+    // cast data structures
+    ocp_qp_xcond_solver_opts *opts = opts_;
+    ocp_qp_xcond_solver_memory *memory = mem_;
+    ocp_qp_xcond_solver_workspace *work = work_;
+
+    // cast workspace
+    cast_workspace(config_, dims, opts, memory, work);
+
+    int solver_status = ACADOS_SUCCESS;
+
+    // condensing
+    acados_tic(&cond_timer);
+    xcond->condense_lhs(qp_in, memory->xcond_qp_in, opts->xcond_opts, memory->xcond_memory, work->xcond_work);
+    info->condensing_time = acados_toc(&cond_timer);
+
+    info->total_time = acados_toc(&tot_timer);
+
+    return solver_status;
+}
+
+
+int ocp_qp_xcond_condense_rhs_and_solve(void *config_, ocp_qp_xcond_solver_dims *dims, ocp_qp_in *qp_in, ocp_qp_out *qp_out,
+                                     void *opts_, void *mem_, void *work_)
+{
+    ocp_qp_xcond_solver_config *config = config_;
+    qp_solver_config *qp_solver = config->qp_solver;
+    ocp_qp_xcond_config *xcond = config->xcond;
+
+    qp_info *info = (qp_info *) qp_out->misc;
+    acados_timer tot_timer, cond_timer;
+    acados_tic(&tot_timer);
+
+    // cast data structures
+    ocp_qp_xcond_solver_opts *opts = opts_;
+    ocp_qp_xcond_solver_memory *memory = mem_;
+    ocp_qp_xcond_solver_workspace *work = work_;
+
+    // cast workspace
+    cast_workspace(config_, dims, opts, memory, work);
+
+    int solver_status = ACADOS_SUCCESS;
+
+    // condensing
+    acados_tic(&cond_timer);
+    xcond->condense_rhs(qp_in, memory->xcond_qp_in, opts->xcond_opts, memory->xcond_memory, work->xcond_work);
+    info->condensing_time += acados_toc(&cond_timer);
+
+    // solve qp
+    solver_status = qp_solver->evaluate(qp_solver, memory->xcond_qp_in, memory->xcond_qp_out,
+                                opts->qp_solver_opts, memory->solver_memory, work->qp_solver_work);
+
+    // expansion
+    acados_tic(&cond_timer);
+    xcond->expansion(memory->xcond_qp_out, qp_out, opts->xcond_opts, memory->xcond_memory, work->xcond_work);
+    info->condensing_time += acados_toc(&cond_timer);
+
+    // output qp info
+    qp_info *info_mem;
+    xcond->memory_get(xcond, memory->xcond_memory, "qp_out_info", &info_mem);
+
+    info->total_time += acados_toc(&tot_timer);
+    info->solve_QP_time = info_mem->solve_QP_time;
+    info->interface_time = info_mem->interface_time;
+    info->num_iter = info_mem->num_iter;
+    info->t_computed = info_mem->t_computed;
+
+    return solver_status;
+}
+
+
+
 void ocp_qp_xcond_solver_eval_sens(void *config_, ocp_qp_xcond_solver_dims *dims, ocp_qp_in *param_qp_in, ocp_qp_out *sens_qp_out,
         void *opts_, void *mem_, void *work_)
 {
@@ -557,7 +639,7 @@ void ocp_qp_xcond_solver_eval_sens(void *config_, ocp_qp_xcond_solver_dims *dims
 
     // condensing
 //    acados_tic(&cond_timer);
-    xcond->condensing_rhs(param_qp_in, memory->xcond_qp_in, opts->xcond_opts, memory->xcond_memory, work->xcond_work);
+    xcond->condense_rhs(param_qp_in, memory->xcond_qp_in, opts->xcond_opts, memory->xcond_memory, work->xcond_work);
 //    info->condensing_time = acados_toc(&cond_timer);
 
     // qp evaluate sensitivity
@@ -603,7 +685,9 @@ void ocp_qp_xcond_solver_config_initialize_default(void *config_)
     config->solver_get = &ocp_qp_xcond_solver_get;
     config->memory_reset = &ocp_qp_xcond_solver_memory_reset; // TODO: unused?
     config->workspace_calculate_size = &ocp_qp_xcond_solver_workspace_calculate_size;
-    config->evaluate = &ocp_qp_xcond_solver;
+    config->evaluate = &ocp_qp_xcond_solve;
+    config->condense_lhs = &ocp_qp_xcond_condense_lhs;
+    config->condense_rhs_and_solve = &ocp_qp_xcond_condense_rhs_and_solve;
     config->eval_sens = &ocp_qp_xcond_solver_eval_sens;
 
     return;

--- a/acados/ocp_qp/ocp_qp_xcond_solver.c
+++ b/acados/ocp_qp/ocp_qp_xcond_solver.c
@@ -539,7 +539,7 @@ int ocp_qp_xcond_condense_lhs(void *config_, ocp_qp_xcond_solver_dims *dims, ocp
                                      void *opts_, void *mem_, void *work_)
 {
     ocp_qp_xcond_solver_config *config = config_;
-    qp_solver_config *qp_solver = config->qp_solver;
+    // qp_solver_config *qp_solver = config->qp_solver;
     ocp_qp_xcond_config *xcond = config->xcond;
 
     qp_info *info = (qp_info *) qp_out->misc;

--- a/acados/ocp_qp/ocp_qp_xcond_solver.h
+++ b/acados/ocp_qp/ocp_qp_xcond_solver.h
@@ -94,6 +94,8 @@ typedef struct
     void (*memory_reset)(void *config, ocp_qp_xcond_solver_dims *dims, ocp_qp_in *qp_in, ocp_qp_out *qp_out, void *opts, void *mem, void *work);
     acados_size_t (*workspace_calculate_size)(void *config, ocp_qp_xcond_solver_dims *dims, void *opts);
     int (*evaluate)(void *config, ocp_qp_xcond_solver_dims *dims, ocp_qp_in *qp_in, ocp_qp_out *qp_out, void *opts, void *mem, void *work);
+    int (*condense_lhs)(void *config, ocp_qp_xcond_solver_dims *dims, ocp_qp_in *qp_in, ocp_qp_out *qp_out, void *opts, void *mem, void *work);
+    int (*condense_rhs_and_solve)(void *config, ocp_qp_xcond_solver_dims *dims, ocp_qp_in *qp_in, ocp_qp_out *qp_out, void *opts, void *mem, void *work);
     void (*eval_sens)(void *config, ocp_qp_xcond_solver_dims *dims, ocp_qp_in *param_qp_in, ocp_qp_out *sens_qp_out, void *opts, void *mem, void *work);
     qp_solver_config *qp_solver;  // either ocp_qp_solver or dense_solver
     ocp_qp_xcond_config *xcond;
@@ -139,7 +141,12 @@ acados_size_t ocp_qp_xcond_solver_workspace_calculate_size(void *config, ocp_qp_
 
 /* config */
 //
-int ocp_qp_xcond_solver(void *config, ocp_qp_xcond_solver_dims *dims, ocp_qp_in *qp_in, ocp_qp_out *qp_out, void *opts_, void *mem_, void *work_);
+int ocp_qp_xcond_solve(void *config, ocp_qp_xcond_solver_dims *dims, ocp_qp_in *qp_in, ocp_qp_out *qp_out, void *opts_, void *mem_, void *work_);
+
+int ocp_qp_xcond_cond_lhs(void *config, ocp_qp_xcond_solver_dims *dims, ocp_qp_in *qp_in, ocp_qp_out *qp_out, void *opts_, void *mem_, void *work_);
+
+int ocp_qp_xcond_cond_rhs_and_solve(void *config, ocp_qp_xcond_solver_dims *dims, ocp_qp_in *qp_in, ocp_qp_out *qp_out, void *opts_, void *mem_, void *work_);
+
 
 //
 void ocp_qp_xcond_solver_config_initialize_default(void *config_);

--- a/docs/algorithm_overview/index.md
+++ b/docs/algorithm_overview/index.md
@@ -23,7 +23,7 @@ The following steps are carried out:
     - or exact Hessian (always used with `EXTERNAL` cost module) if no "custom hessian" is set (see `cost_expr_ext_cost_custom_hess`, `cost_expr_ext_cost_custom_hess_0`, `cost_expr_ext_cost_custom_hess_e`)
   - add the inequality constraints contribution to the Hessian (can be turned off via `exact_hess_constr`)
 
-- call the regularization module (`regularize_hessian`, see [`regularize_method`](https://docs.acados.org/python_interface/index.html?highlight=regularize#acados_template.acados_ocp_options.AcadosOcpOptions.regularize_method))
+- call the regularization module (`regularize`, see [`regularize_method`](https://docs.acados.org/python_interface/index.html?highlight=regularize#acados_template.acados_ocp_options.AcadosOcpOptions.regularize_method))
 
 <!-- TODO: change this to have a seperate levenberg_marquardt term on the terminal stage (instead of 1 replacing Ts).
 + add the option to provide a vector that is added on diagonal, i.e. make levenberg_marquardt a vector of size nx+nu. -->

--- a/examples/acados_python/pendulum_on_cart/ocp/example_sqp_rti_loop.py
+++ b/examples/acados_python/pendulum_on_cart/ocp/example_sqp_rti_loop.py
@@ -109,12 +109,20 @@ def main():
     simX = np.ndarray((N+1, nx))
     simU = np.ndarray((N, nu))
 
-
     # call SQP_RTI solver in the loop:
     tol = 1e-6
 
+    SPLIT_RTI = True
     for i in range(20):
-        status = ocp_solver.solve()
+        if SPLIT_RTI:
+            # preparation
+            ocp_solver.options_set("rti_phase", 1)
+            status = ocp_solver.solve()
+            # feedback
+            ocp_solver.options_set("rti_phase", 2)
+            status = ocp_solver.solve()
+        else:
+            status = ocp_solver.solve()
         # ocp_solver.custom_update(np.array([]))
         ocp_solver.print_statistics() # encapsulates: stat = ocp_solver.get_stats("statistics")
         residuals = ocp_solver.get_residuals()
@@ -137,7 +145,7 @@ def main():
     cost = ocp_solver.get_cost()
     print("cost function value of solution = ", cost)
 
-    PRINT_QP = True
+    PRINT_QP = False
 
     range_without_terminal = [0, 1, N-2, N-1]
     range_with_terminal = [0, 1, N-1, N]

--- a/examples/c/regularization.c
+++ b/examples/c/regularization.c
@@ -136,7 +136,7 @@ int main()
 		blasfeo_print_dmat(nu[ii]+nx[ii], nu[ii]+nx[ii], RSQrq+ii, 0, 0);
 
 	// regularization
-	config->regularize_hessian(config, dims, opts, memory);
+	config->regularize(config, dims, opts, memory);
 
 	printf("\nafter regularization\n\n");
 	for(ii=0; ii<=N; ii++)


### PR DESCRIPTION
Condensing modules now provide
- `condense` - all condensing operations
- `condense_rhs` - condensing the right hand side
- `condense_lhs` - condensing the left hand side

Similarly, regularization modules now provide
- `regularize` - all operations
- `regularize_rhs` - operations on the right hand side
- `regularize_lhs` - operations on the left hand side

Only if RTI is split into preparation and feedback, the `_rhs` / `_lhs` routines are called.
Otherwise, operations are done all together.
Addresses https://github.com/acados/acados/issues/1031

NOTE: using convexify with split RTI phase has now relatively overhead, see https://github.com/acados/acados/issues/1035
Splitting the computations for `convexify` more efficiently should be done in another PR.
