### PR TITLE
Support slack penalties for initial stage in MEX interface

### DIFF
--- a/interfaces/acados_matlab_octave/acados_ocp.m
+++ b/interfaces/acados_matlab_octave/acados_ocp.m
@@ -197,7 +197,7 @@ classdef acados_ocp < handle
 
             % generate templated solver
             if nargin < 3
-                simulink_opts = get_acados_simulink_opts;
+                simulink_opts = get_acados_simulink_opts();
             end
             obj.acados_ocp_nlp_json = set_up_acados_ocp_nlp_json(obj, simulink_opts);
             ocp_generate_c_code(obj);

--- a/interfaces/acados_matlab_octave/acados_ocp_model.m
+++ b/interfaces/acados_matlab_octave/acados_ocp_model.m
@@ -188,6 +188,14 @@ classdef acados_ocp_model < handle
                     obj.model_struct.cost_zu = value;
                 elseif (strcmp(field, 'cost_zu_e'))
                     obj.model_struct.cost_zu_e = value;
+                elseif (strcmp(field, 'cost_zl_0'))
+                    obj.model_struct.cost_zl_0 = value;
+                elseif (strcmp(field, 'cost_zu_0'))
+                    obj.model_struct.cost_zu_0 = value;
+                elseif (strcmp(field, 'cost_Zl_0'))
+                    obj.model_struct.cost_Zl_0 = value;
+                elseif (strcmp(field, 'cost_Zu_0'))
+                    obj.model_struct.cost_Zu_0 = value;
                 else
                     disp(['acados_ocp_model: set: wrong field: ', field]);
                     keyboard;
@@ -295,6 +303,8 @@ classdef acados_ocp_model < handle
                     obj.model_struct.constr_uh_e = value;
                 elseif (strcmp(field, 'constr_Jsbu'))
                     obj.model_struct.constr_Jsbu = value;
+                elseif (strcmp(field, 'constr_Jsbu_0'))
+                    obj.model_struct.constr_Jsbu_0 = value;
     %            elseif (strcmp(field, 'constr_lsbu'))
     %                obj.model_struct.constr_lsbu = value;
     %            elseif (strcmp(field, 'constr_usbu'))

--- a/interfaces/acados_matlab_octave/acados_ocp_model.m
+++ b/interfaces/acados_matlab_octave/acados_ocp_model.m
@@ -303,8 +303,6 @@ classdef acados_ocp_model < handle
                     obj.model_struct.constr_uh_e = value;
                 elseif (strcmp(field, 'constr_Jsbu'))
                     obj.model_struct.constr_Jsbu = value;
-                elseif (strcmp(field, 'constr_Jsbu_0'))
-                    obj.model_struct.constr_Jsbu_0 = value;
     %            elseif (strcmp(field, 'constr_lsbu'))
     %                obj.model_struct.constr_lsbu = value;
     %            elseif (strcmp(field, 'constr_usbu'))

--- a/interfaces/acados_matlab_octave/set_up_acados_ocp_nlp_json.m
+++ b/interfaces/acados_matlab_octave/set_up_acados_ocp_nlp_json.m
@@ -485,6 +485,19 @@ function ocp_json = set_up_acados_ocp_nlp_json(obj, simulink_opts)
         ocp_json.cost.zu = model.cost_zu;
     end
 
+    if isfield(model, 'cost_Zl_0')
+        ocp_json.cost.Zl_0 = diag(model.cost_Zl_0);
+    end
+    if isfield(model, 'cost_Zu_0')
+        ocp_json.cost.Zu_0 = diag(model.cost_Zu_0);
+    end
+    if isfield(model, 'cost_zl_0')
+        ocp_json.cost.zl_0 = model.cost_zl_0;
+    end
+    if isfield(model, 'cost_zu_0')
+        ocp_json.cost.zu_0 = model.cost_zu_0;
+    end
+
 
     if isfield(model, 'cost_Zl_e')
         ocp_json.cost.Zl_e = diag(model.cost_Zl_e);

--- a/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/make_sfun_sim.in.m
+++ b/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/make_sfun_sim.in.m
@@ -77,7 +77,7 @@ CFLAGS  = ' -O';
 
 LIB_PATH = '{{ acados_lib_path }}';
 
-LIBS = '-lacados -lblasfeo -lhpipm';
+LIBS = '-lacados -lhpipm -lblasfeo';
 
 try
     % eval( [ 'mex -v -output  acados_sim_solver_sfunction_{{ model.name }} ', ...


### PR DESCRIPTION
Support slack penalties for initial stage in MEX interface.

Follow-up on https://discourse.acados.org/t/issue-in-setting-slack-variable-on-control-input/1456

The convention is as follows now:
- bounds on u and general linear constraints are also enforced on the initial node
- bounds on x and nonlinear constraints are fully split and have to be explicitly stated with `_0` correspondence to be enforced on the stage.