### PR TITLE
Cleanup RTI, fix timings and comments

### DIFF
--- a/acados/ocp_nlp/ocp_nlp_common.c
+++ b/acados/ocp_nlp/ocp_nlp_common.c
@@ -2204,7 +2204,8 @@ void ocp_nlp_approximate_qp_matrices(ocp_nlp_config *config, ocp_nlp_dims *dims,
 
 
 // update QP rhs for SQP (step prim var, abs dual var)
-// evaluate constraints wrt bounds -> allows to update all bounds between preparation and feedback phase.
+// - use cost gradient and dynamics residual from memory
+// - evaluate constraints wrt bounds -> allows to update all bounds between preparation and feedback phase.
 void ocp_nlp_approximate_qp_vectors_sqp(ocp_nlp_config *config,
     ocp_nlp_dims *dims, ocp_nlp_in *in, ocp_nlp_out *out, ocp_nlp_opts *opts,
     ocp_nlp_memory *mem, ocp_nlp_workspace *work)

--- a/acados/ocp_nlp/ocp_nlp_common.c
+++ b/acados/ocp_nlp/ocp_nlp_common.c
@@ -2083,7 +2083,7 @@ void ocp_nlp_initialize_t_slacks(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp
 
 
 
-void ocp_nlp_approximate_qp_preparation(ocp_nlp_config *config, ocp_nlp_dims *dims,
+void ocp_nlp_approximate_qp_matrices(ocp_nlp_config *config, ocp_nlp_dims *dims,
     ocp_nlp_in *in, ocp_nlp_out *out, ocp_nlp_opts *opts, ocp_nlp_memory *mem,
     ocp_nlp_workspace *work)
 {
@@ -2162,18 +2162,16 @@ void ocp_nlp_approximate_qp_preparation(ocp_nlp_config *config, ocp_nlp_dims *di
     for (int i=0; i <= N; i++)
     {
 
-        // update cost gradient in QP and nlp_mem
+        // nlp mem: cost_grad
         struct blasfeo_dvec *cost_grad = config->cost[i]->memory_get_grad_ptr(mem->cost[i]);
         blasfeo_dveccp(nv[i], cost_grad, 0, mem->cost_grad + i, 0);
-        blasfeo_dveccp(nv[i], mem->cost_grad + i, 0, mem->qp_in->rqz + i, 0);
 
-        // update dynamics residual in QP and nlp_mem
+        // nlp mem: dyn_fun
         if (i < N)
         {
             struct blasfeo_dvec *dyn_fun
                 = config->dynamics[i]->memory_get_fun_ptr(mem->dynamics[i]);
             blasfeo_dveccp(nx[i + 1], dyn_fun, 0, mem->dyn_fun + i, 0);
-            blasfeo_dveccp(nx[i + 1], mem->dyn_fun + i, 0, mem->qp_in->b + i, 0);
         }
 
         // nlp mem: dyn_adj
@@ -2199,6 +2197,7 @@ void ocp_nlp_approximate_qp_preparation(ocp_nlp_config *config, ocp_nlp_dims *di
         struct blasfeo_dvec *ineq_adj =
             config->constraints[i]->memory_get_adj_ptr(mem->constraints[i]);
         blasfeo_dveccp(nv[i], ineq_adj, 0, mem->ineq_adj + i, 0);
+
     }
 }
 
@@ -2206,7 +2205,7 @@ void ocp_nlp_approximate_qp_preparation(ocp_nlp_config *config, ocp_nlp_dims *di
 
 // update QP rhs for SQP (step prim var, abs dual var)
 // evaluate constraints wrt bounds -> allows to update all bounds between preparation and feedback phase.
-void ocp_nlp_approximate_qp_feedback(ocp_nlp_config *config,
+void ocp_nlp_approximate_qp_vectors_sqp(ocp_nlp_config *config,
     ocp_nlp_dims *dims, ocp_nlp_in *in, ocp_nlp_out *out, ocp_nlp_opts *opts,
     ocp_nlp_memory *mem, ocp_nlp_workspace *work)
 {
@@ -2222,6 +2221,13 @@ void ocp_nlp_approximate_qp_feedback(ocp_nlp_config *config,
 #endif
     for (int i = 0; i <= N; i++)
     {
+        // g
+        blasfeo_dveccp(nv[i], mem->cost_grad + i, 0, mem->qp_in->rqz + i, 0);
+
+        // b
+        if (i < N)
+            blasfeo_dveccp(nx[i + 1], mem->dyn_fun + i, 0, mem->qp_in->b + i, 0);
+
         // evaluate constraint residuals
         config->constraints[i]->update_qp_vectors(config->constraints[i], dims->constraints[i],
             in->constraints[i], opts->constraints[i], mem->constraints[i], work->constraints[i]);
@@ -2806,7 +2812,7 @@ int ocp_nlp_precompute_common(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nl
     if (opts->fixed_hess)
     {
         mem->compute_hess = 1;
-        ocp_nlp_approximate_qp_preparation(config, dims, in, out, opts, mem, work);
+        ocp_nlp_approximate_qp_matrices(config, dims, in, out, opts, mem, work);
         mem->compute_hess = 0;
         for (ii=0; ii<=N; ii++)
             config->cost[ii]->opts_set(config->cost[ii], opts->cost[ii], "compute_hess", &mem->compute_hess);

--- a/acados/ocp_nlp/ocp_nlp_common.h
+++ b/acados/ocp_nlp/ocp_nlp_common.h
@@ -405,10 +405,10 @@ void ocp_nlp_alias_memory_to_submodules(ocp_nlp_config *config, ocp_nlp_dims *di
 void ocp_nlp_initialize_submodules(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in,
             ocp_nlp_out *out, ocp_nlp_opts *opts, ocp_nlp_memory *mem, ocp_nlp_workspace *work);
 //
-void ocp_nlp_approximate_qp_preparation(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in,
+void ocp_nlp_approximate_qp_matrices(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in,
              ocp_nlp_out *out, ocp_nlp_opts *opts, ocp_nlp_memory *mem, ocp_nlp_workspace *work);
 //
-void ocp_nlp_approximate_qp_feedback(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in,
+void ocp_nlp_approximate_qp_vectors_sqp(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in,
                  ocp_nlp_out *out, ocp_nlp_opts *opts, ocp_nlp_memory *mem, ocp_nlp_workspace *work);
 //
 void ocp_nlp_update_variables_sqp(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in,

--- a/acados/ocp_nlp/ocp_nlp_common.h
+++ b/acados/ocp_nlp/ocp_nlp_common.h
@@ -91,7 +91,7 @@ typedef struct ocp_nlp_config
     // prepare memory
     int (*precompute)(void *config, void *dims, void *nlp_in, void *nlp_out, void *opts_, void *mem, void *work);
     void (*memory_reset_qp_solver)(void *config, void *dims, void *nlp_in, void *nlp_out, void *opts_, void *mem, void *work);
-    // initalize this struct with default values
+    // initialize this struct with default values
     void (*config_initialize_default)(void *config);
     // general getter
     void (*get)(void *config_, void *dims, void *mem_, const char *field, void *return_value_);
@@ -143,7 +143,7 @@ acados_size_t ocp_nlp_dims_calculate_size(void *config);
 ocp_nlp_dims *ocp_nlp_dims_assign(void *config, void *raw_memory);
 
 /// Sets the dimension of optimization variables
-/// (states, constrols, algebraic variables, slack variables).
+/// (states, controls, algebraic variables, slack variables).
 ///
 /// \param config_ The configuration struct.
 /// \param dims_ The dimension struct.
@@ -169,7 +169,7 @@ void ocp_nlp_dims_set_constraints(void *config_, void *dims_, int stage,
 /// \param config_ The configuration struct.
 /// \param dims_ The dimension struct.
 /// \param stage Stage number.
-/// \param field Type of cost term, can be eiter ny.
+/// \param field Type of cost dimension
 /// \param value_field Number of cost terms/residuals for the given stage.
 void ocp_nlp_dims_set_cost(void *config_, void *dims_, int stage, const char *field,
                            const void* value_field);
@@ -191,7 +191,7 @@ void ocp_nlp_dims_set_dynamics(void *config_, void *dims_, int stage, const char
 /// Struct for storing the inputs of an OCP NLP solver
 typedef struct ocp_nlp_in
 {
-    /// Length of sampling intervals/timesteps.
+    /// Timesteps.
     double *Ts;
 
     /// Pointers to cost functions (TBC).
@@ -225,9 +225,9 @@ ocp_nlp_in *ocp_nlp_in_assign(ocp_nlp_config *config, ocp_nlp_dims *dims, void *
 typedef struct ocp_nlp_out
 {
     struct blasfeo_dvec *ux;  // NOTE: this contains [u; x; s_l; s_u]! - rename to uxs?
-    struct blasfeo_dvec *z;  // algebraic vairables
+    struct blasfeo_dvec *z;  // algebraic variables
     struct blasfeo_dvec *pi;  // multipliers for dynamics
-    struct blasfeo_dvec *lam;  // inequality mulitpliers
+    struct blasfeo_dvec *lam;  // inequality multipliers
     struct blasfeo_dvec *t;  // slack variables corresponding to evaluation of all inequalities (at the solution)
 
     // NOTE: the inequalities are internally organized in the following order:

--- a/acados/ocp_nlp/ocp_nlp_common.h
+++ b/acados/ocp_nlp/ocp_nlp_common.h
@@ -405,10 +405,10 @@ void ocp_nlp_alias_memory_to_submodules(ocp_nlp_config *config, ocp_nlp_dims *di
 void ocp_nlp_initialize_submodules(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in,
             ocp_nlp_out *out, ocp_nlp_opts *opts, ocp_nlp_memory *mem, ocp_nlp_workspace *work);
 //
-void ocp_nlp_approximate_qp_matrices(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in,
+void ocp_nlp_approximate_qp_preparation(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in,
              ocp_nlp_out *out, ocp_nlp_opts *opts, ocp_nlp_memory *mem, ocp_nlp_workspace *work);
 //
-void ocp_nlp_approximate_qp_vectors_sqp(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in,
+void ocp_nlp_approximate_qp_feedback(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in,
                  ocp_nlp_out *out, ocp_nlp_opts *opts, ocp_nlp_memory *mem, ocp_nlp_workspace *work);
 //
 void ocp_nlp_update_variables_sqp(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in,

--- a/acados/ocp_nlp/ocp_nlp_dynamics_cont.c
+++ b/acados/ocp_nlp/ocp_nlp_dynamics_cont.c
@@ -640,7 +640,7 @@ static void ocp_nlp_dynamics_cont_cast_workspace(void *config_, void *dims_, voi
     ocp_nlp_dynamics_cont_memory *mem = mem_;
     ocp_nlp_dynamics_config *config = config_;
     ocp_nlp_dynamics_cont_dims *dims = dims_;
-    ocp_nlp_dynamics_cont_opts *opts = opts_;
+    // ocp_nlp_dynamics_cont_opts *opts = opts_;
     ocp_nlp_dynamics_cont_workspace *work = work_;
 
     char *c_ptr = (char *) work_;
@@ -658,7 +658,7 @@ static void ocp_nlp_dynamics_cont_cast_workspace(void *config_, void *dims_, voi
     c_ptr += sim_out_calculate_size(config->sim_solver, dims->sim);
     // workspace
     work->sim_solver = c_ptr;
-    c_ptr += config->sim_solver->workspace_calculate_size(config->sim_solver, dims->sim, opts->sim_solver);
+    c_ptr += mem->sim_workspace_size;
 
     // blasfeo_mem align
     align_char_to(64, &c_ptr);
@@ -971,13 +971,15 @@ int ocp_nlp_dynamics_cont_precompute(void *config_, void *dims_, void *model_, v
 {
     ocp_nlp_dynamics_cont_memory *mem = mem_;
     ocp_nlp_dynamics_config *config = config_;
-    mem->workspace_size = ocp_nlp_dynamics_cont_workspace_calculate_size(config, dims_, opts_);
-    ocp_nlp_dynamics_cont_cast_workspace(config_, dims_, opts_, work_, mem_);
-
-    // ocp_nlp_dynamics_cont_dims *dims = dims_;
-    ocp_nlp_dynamics_cont_opts *opts = opts_;
-    ocp_nlp_dynamics_cont_workspace *work = work_;
     ocp_nlp_dynamics_cont_model *model = model_;
+    ocp_nlp_dynamics_cont_opts *opts = opts_;
+    ocp_nlp_dynamics_cont_dims *dims = dims_;
+
+    mem->workspace_size = ocp_nlp_dynamics_cont_workspace_calculate_size(config, dims_, opts_);
+    mem->sim_workspace_size = config->sim_solver->workspace_calculate_size(config->sim_solver, dims->sim, opts->sim_solver);
+
+    ocp_nlp_dynamics_cont_cast_workspace(config_, dims_, opts_, work_, mem_);
+    ocp_nlp_dynamics_cont_workspace *work = work_;
     work->sim_in->model = model->sim_model;
     work->sim_in->T = model->T;
 

--- a/acados/ocp_nlp/ocp_nlp_dynamics_cont.h
+++ b/acados/ocp_nlp/ocp_nlp_dynamics_cont.h
@@ -122,6 +122,7 @@ typedef struct
     struct blasfeo_dmat *dzduxt;        // pointer to dzdux transposed
     void *sim_solver;                   // sim solver memory
     acados_size_t workspace_size;
+    acados_size_t sim_workspace_size;
 
 } ocp_nlp_dynamics_cont_memory;
 

--- a/acados/ocp_nlp/ocp_nlp_sqp.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp.c
@@ -511,7 +511,7 @@ int ocp_nlp_sqp(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
 
     for (; sqp_iter < opts->max_iter; sqp_iter++)
     {
-        // linearizate NLP and update QP matrices
+        // linearize NLP and update QP matrices
         acados_tic(&timer1);
         ocp_nlp_approximate_qp_matrices(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work);
         mem->time_lin += acados_toc(&timer1);

--- a/acados/ocp_nlp/ocp_nlp_sqp.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp.c
@@ -513,7 +513,7 @@ int ocp_nlp_sqp(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
     {
         // linearize NLP and update QP matrices
         acados_tic(&timer1);
-        ocp_nlp_approximate_qp_preparation(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work);
+        ocp_nlp_approximate_qp_matrices(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work);
         mem->time_lin += acados_toc(&timer1);
 
         // get timings from integrator
@@ -528,7 +528,7 @@ int ocp_nlp_sqp(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
         }
 
         // update QP rhs for SQP (step prim var, abs dual var)
-        ocp_nlp_approximate_qp_feedback(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work);
+        ocp_nlp_approximate_qp_vectors_sqp(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work);
 
         // compute nlp residuals
         ocp_nlp_res_compute(dims, nlp_in, nlp_out, nlp_res, nlp_mem);

--- a/acados/ocp_nlp/ocp_nlp_sqp.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp.c
@@ -742,41 +742,10 @@ int ocp_nlp_sqp(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
                 // int *ni = dims->ni;
 
                 /* evaluate constraints & dynamics at new step */
-                // The following (setting up ux + p in tmp_nlp_out and evaluation of constraints + dynamics)
-                // is not needed anymore because done in prelim. line search with early termination)
+                // NOTE: setting up the new iterate and evaluating is not needed here,
+                //   since this evaluation was perfomed just before this call in the early terminated line search.
+
                 // NOTE: similar to ocp_nlp_evaluate_merit_fun
-                // set up new linearization point in work->tmp_nlp_out
-                // for (ii = 0; ii < N; ii++)
-                //     blasfeo_dveccp(nx[ii+1], nlp_out->pi+ii, 0, work->nlp_work->tmp_nlp_out->pi+ii, 0);
-
-                // for (ii = 0; ii <= N; ii++)
-                //     blasfeo_dveccp(2*ni[ii], nlp_out->lam+ii, 0, work->nlp_work->tmp_nlp_out->lam+ii, 0);
-
-                // // tmp_nlp_out = iterate + step
-                // for (ii = 0; ii <= N; ii++)
-                //     blasfeo_daxpy(nv[ii], 1.0, qp_out->ux+ii, 0, nlp_out->ux+ii, 0, work->nlp_work->tmp_nlp_out->ux+ii, 0);
-
-    //             // evaluate
-    // #if defined(ACADOS_WITH_OPENMP)
-    //     #pragma omp parallel for
-    // #endif
-    //             for (ii=0; ii<N; ii++)
-    //             {
-    //                 config->dynamics[ii]->compute_fun(config->dynamics[ii], dims->dynamics[ii], nlp_in->dynamics[ii],
-    //                                                 nlp_opts->dynamics[ii], nlp_mem->dynamics[ii], work->nlp_work->dynamics[ii]);
-    //             }
-    // #if defined(ACADOS_WITH_OPENMP)
-    //     #pragma omp parallel for
-    // #endif
-    //             for (ii=0; ii<=N; ii++)
-    //             {
-    //                 config->constraints[ii]->compute_fun(config->constraints[ii], dims->constraints[ii],
-    //                                                     nlp_in->constraints[ii], nlp_opts->constraints[ii],
-    //                                                     nlp_mem->constraints[ii], work->nlp_work->constraints[ii]);
-    //             }
-    // #if defined(ACADOS_WITH_OPENMP)
-    //     #pragma omp parallel for
-    // #endif
                 // update QP rhs
                 // d_i = c_i(x_k + p_k) - \nabla c_i(x_k)^T * p_k
                 struct blasfeo_dvec *tmp_fun_vec;
@@ -799,7 +768,8 @@ int ocp_nlp_sqp(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
                     // d -- constraints
                     tmp_fun_vec = config->constraints[ii]->memory_get_fun_ptr(nlp_mem->constraints[ii]);
                     /* SOC for bounds can be skipped (because linear) */
-                    // NOTE: SOC can also be skipped for truely linear constraint, i.e. ng of nlp, now using ng of QP = (nh+ng)
+                    // NOTE: SOC can also be skipped for truely linear constraint, i.e. ng of nlp,
+                    //      now using ng of QP = (nh+ng)
 
                     // upper & lower
                     blasfeo_dveccp(ng[ii], tmp_fun_vec, nb[ii], qp_in->d+ii, nb[ii]); // lg
@@ -859,6 +829,7 @@ int ocp_nlp_sqp(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
                 // acados_tic(&timer1);
                 qp_status = qp_solver->evaluate(qp_solver, dims->qp_solver, qp_in, qp_out,
                                                 opts->nlp_opts->qp_solver_opts, nlp_mem->qp_solver_mem, nlp_work->qp_work);
+                // NOTE: QP is not timed, since this computation time is attributed to globalization.
                 // tmp_time = acados_toc(&timer1);
                 // mem->time_qp_sol += tmp_time;
                 // qp_solver->memory_get(qp_solver, nlp_mem->qp_solver_mem, "time_qp_solver_call", &tmp_time);

--- a/acados/ocp_nlp/ocp_nlp_sqp.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp.c
@@ -513,7 +513,7 @@ int ocp_nlp_sqp(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
     {
         // linearize NLP and update QP matrices
         acados_tic(&timer1);
-        ocp_nlp_approximate_qp_matrices(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work);
+        ocp_nlp_approximate_qp_preparation(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work);
         mem->time_lin += acados_toc(&timer1);
 
         // get timings from integrator
@@ -528,7 +528,7 @@ int ocp_nlp_sqp(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
         }
 
         // update QP rhs for SQP (step prim var, abs dual var)
-        ocp_nlp_approximate_qp_vectors_sqp(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work);
+        ocp_nlp_approximate_qp_feedback(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work);
 
         // compute nlp residuals
         ocp_nlp_res_compute(dims, nlp_in, nlp_out, nlp_res, nlp_mem);

--- a/acados/ocp_nlp/ocp_nlp_sqp_rti.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp_rti.c
@@ -299,7 +299,6 @@ acados_size_t ocp_nlp_sqp_rti_workspace_calculate_size(void *config_,
 
     acados_size_t size = 0;
 
-    // sqp
     size += sizeof(ocp_nlp_sqp_rti_workspace);
 
     // nlp
@@ -575,7 +574,6 @@ int ocp_nlp_sqp_rti(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
 
     switch(rti_phase)
     {
-
         case PREPARATION_AND_FEEDBACK:
             ocp_nlp_sqp_rti_preparation_step(config, dims, nlp_in, nlp_out, opts, mem, work);
             ocp_nlp_sqp_rti_feedback_step(config, dims, nlp_in, nlp_out, opts, mem, work);
@@ -585,7 +583,6 @@ int ocp_nlp_sqp_rti(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
             ocp_nlp_sqp_rti_preparation_step(config, dims, nlp_in, nlp_out, opts, mem, work);
             break;
 
-        // perform feedback rti_phase
         case FEEDBACK:
             ocp_nlp_sqp_rti_feedback_step(config, dims, nlp_in, nlp_out, opts, mem, work);
             break;
@@ -700,7 +697,6 @@ void ocp_nlp_sqp_rti_eval_param_sens(void *config_, void *dims_, void *opts_,
                 sens_nlp_out->t + i, 0);
 
         }
-
     }
     else
     {
@@ -716,7 +712,6 @@ void ocp_nlp_sqp_rti_eval_param_sens(void *config_, void *dims_, void *opts_,
 
 
 
-// TODO rename memory_get ???
 void ocp_nlp_sqp_rti_get(void *config_, void *dims_, void *mem_,
     const char *field, void *return_value_)
 {

--- a/acados/ocp_nlp/ocp_nlp_sqp_rti.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp_rti.c
@@ -408,7 +408,7 @@ static void ocp_nlp_sqp_rti_preparation_step(ocp_nlp_config *config, ocp_nlp_dim
 
     // linearize NLP and update QP matrices
     acados_tic(&timer1);
-    ocp_nlp_approximate_qp_preparation(config, dims, nlp_in,
+    ocp_nlp_approximate_qp_matrices(config, dims, nlp_in,
         nlp_out, nlp_opts, nlp_mem, nlp_work);
     mem->time_lin += acados_toc(&timer1);
 
@@ -451,7 +451,7 @@ static void ocp_nlp_sqp_rti_feedback_step(ocp_nlp_config *config, ocp_nlp_dims *
 
     // update QP rhs for SQP (step prim var, abs dual var)
     acados_tic(&timer1);
-    ocp_nlp_approximate_qp_feedback(config, dims, nlp_in,
+    ocp_nlp_approximate_qp_vectors_sqp(config, dims, nlp_in,
         nlp_out, nlp_opts, nlp_mem, nlp_work);
     mem->time_lin += acados_toc(&timer1);
 

--- a/acados/ocp_nlp/ocp_nlp_sqp_rti.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp_rti.c
@@ -444,8 +444,10 @@ static void ocp_nlp_sqp_rti_feedback_step(ocp_nlp_config *config, ocp_nlp_dims *
     double tmp_time;
 
     // update QP rhs for SQP (step prim var, abs dual var)
+    acados_tic(&timer1);
     ocp_nlp_approximate_qp_vectors_sqp(config, dims, nlp_in,
         nlp_out, nlp_opts, nlp_mem, nlp_work);
+    mem->time_lin += acados_toc(&timer1);
 
     // regularization
     acados_tic(&timer1);

--- a/acados/ocp_nlp/ocp_nlp_sqp_rti.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp_rti.c
@@ -107,40 +107,12 @@ void ocp_nlp_sqp_rti_opts_initialize_default(void *config_,
     ocp_nlp_sqp_rti_opts *opts = opts_;
     ocp_nlp_opts *nlp_opts = opts->nlp_opts;
 
-    // ocp_qp_xcond_solver_config *qp_solver = config->qp_solver;
-    // ocp_nlp_dynamics_config **dynamics = config->dynamics;
-    // ocp_nlp_constraints_config **constraints = config->constraints;
-
-    // int ii;
-
-    // int N = dims->N;
-
-    // this first !!!
     ocp_nlp_opts_initialize_default(config, dims, nlp_opts);
 
     // SQP RTI opts
     opts->ext_qp_res = 0;
     opts->warm_start_first_qp = false;
     opts->rti_phase = 0;
-
-    // overwrite default submodules opts
-
-    // do not compute adjoint in dynamics and constraints
-    // int compute_adj = 0;
-
-    // // dynamics
-    // for (ii = 0; ii < N; ii++)
-    // {
-    //     dynamics[ii]->opts_set(dynamics[ii],
-    //         opts->nlp_opts->dynamics[ii], "compute_adj", &compute_adj);
-    // }
-
-    // // constraints
-    // for (ii = 0; ii <= N; ii++)
-    // {
-    //     constraints[ii]->opts_set(constraints[ii],
-    //         opts->nlp_opts->constraints[ii], "compute_adj", &compute_adj);
-    // }
 
     return;
 }
@@ -252,16 +224,6 @@ acados_size_t ocp_nlp_sqp_rti_memory_calculate_size(void *config_,
     ocp_nlp_sqp_rti_opts *opts = opts_;
     ocp_nlp_opts *nlp_opts = opts->nlp_opts;
 
-    // ocp_qp_xcond_solver_config *qp_solver = config->qp_solver;
-    // ocp_nlp_dynamics_config **dynamics = config->dynamics;
-    // ocp_nlp_cost_config **cost = config->cost;
-    // ocp_nlp_constraints_config **constraints = config->constraints;
-
-    // int N = dims->N;
-    // int *nx = dims->nx;
-    // int *nu = dims->nu;
-    // int *nz = dims->nz;
-
     acados_size_t size = 0;
 
     size += sizeof(ocp_nlp_sqp_rti_memory);
@@ -293,19 +255,7 @@ void *ocp_nlp_sqp_rti_memory_assign(void *config_, void *dims_,
     ocp_nlp_sqp_rti_opts *opts = opts_;
     ocp_nlp_opts *nlp_opts = opts->nlp_opts;
 
-    // ocp_qp_xcond_solver_config *qp_solver = config->qp_solver;
-    // ocp_nlp_dynamics_config **dynamics = config->dynamics;
-    // ocp_nlp_cost_config **cost = config->cost;
-    // ocp_nlp_constraints_config **constraints = config->constraints;
-
     char *c_ptr = (char *) raw_memory;
-
-    // int ii;
-
-    // int N = dims->N;
-    // int *nx = dims->nx;
-    // int *nu = dims->nu;
-    // int *nz = dims->nz;
 
     // initial align
     align_char_to(8, &c_ptr);
@@ -571,7 +521,6 @@ static void ocp_nlp_sqp_rti_feedback_step(ocp_nlp_config *config, ocp_nlp_dims *
         ocp_qp_res_compute_nrm_inf(work->qp_res, mem->stat+(mem->stat_n*1+2));
     }
 
-
     // save statistics
     mem->stat[mem->stat_n*1+0] = qp_status;
     mem->stat[mem->stat_n*1+1] = qp_iter;
@@ -662,7 +611,6 @@ void ocp_nlp_sqp_rti_memory_reset_qp_solver(void *config_, void *dims_, void *nl
     ocp_nlp_sqp_rti_workspace *work = work_;
     ocp_nlp_workspace *nlp_work = work->nlp_work;
 
-    // printf("in ocp_nlp_sqp_rti_memory_reset_qp_solver\n\n");
     config->qp_solver->memory_reset(qp_solver, dims->qp_solver,
         nlp_mem->qp_in, nlp_mem->qp_out, opts->nlp_opts->qp_solver_opts,
         nlp_mem->qp_solver_mem, nlp_work->qp_work);

--- a/acados/ocp_nlp/ocp_nlp_sqp_rti.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp_rti.c
@@ -576,19 +576,17 @@ int ocp_nlp_sqp_rti(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
     switch(rti_phase)
     {
 
-        // perform preparation and feedback rti_phase
-        case 0:
+        case PREPARATION_AND_FEEDBACK:
             ocp_nlp_sqp_rti_preparation_step(config, dims, nlp_in, nlp_out, opts, mem, work);
             ocp_nlp_sqp_rti_feedback_step(config, dims, nlp_in, nlp_out, opts, mem, work);
             break;
 
-        // perform preparation rti_phase
-        case 1:
+        case PREPARATION:
             ocp_nlp_sqp_rti_preparation_step(config, dims, nlp_in, nlp_out, opts, mem, work);
             break;
 
         // perform feedback rti_phase
-        case 2:
+        case FEEDBACK:
             ocp_nlp_sqp_rti_feedback_step(config, dims, nlp_in, nlp_out, opts, mem, work);
             break;
     }

--- a/acados/ocp_nlp/ocp_nlp_sqp_rti.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp_rti.c
@@ -368,6 +368,18 @@ static void ocp_nlp_sqp_rti_cast_workspace(
 }
 
 
+// utility functions
+static void reset_sub_timers(ocp_nlp_sqp_rti_memory *mem)
+{
+    mem->time_lin = 0.0;
+    mem->time_reg = 0.0;
+    mem->time_qp_sol = 0.0;
+    mem->time_qp_solver_call = 0.0;
+    mem->time_qp_xcond = 0.0;
+    mem->time_glob = 0.0;
+}
+
+
 
 /************************************************
  * functions
@@ -383,13 +395,7 @@ static void ocp_nlp_sqp_rti_preparation_step(ocp_nlp_config *config, ocp_nlp_dim
 
     ocp_nlp_workspace *nlp_work = work->nlp_work;
 
-    mem->time_lin = 0.0;
-    mem->time_reg = 0.0;
-    mem->time_qp_sol = 0.0;
-    mem->time_qp_solver_call = 0.0;
-    mem->time_qp_xcond = 0.0;
-    mem->time_glob = 0.0;
-
+    reset_sub_timers(mem);
 #if defined(ACADOS_WITH_OPENMP)
     // backup number of threads
     int num_threads_bkp = omp_get_num_threads();

--- a/acados/ocp_nlp/ocp_nlp_sqp_rti.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp_rti.c
@@ -408,7 +408,7 @@ static void ocp_nlp_sqp_rti_preparation_step(ocp_nlp_config *config, ocp_nlp_dim
 
     // linearize NLP and update QP matrices
     acados_tic(&timer1);
-    ocp_nlp_approximate_qp_matrices(config, dims, nlp_in,
+    ocp_nlp_approximate_qp_preparation(config, dims, nlp_in,
         nlp_out, nlp_opts, nlp_mem, nlp_work);
     mem->time_lin += acados_toc(&timer1);
 
@@ -451,7 +451,7 @@ static void ocp_nlp_sqp_rti_feedback_step(ocp_nlp_config *config, ocp_nlp_dims *
 
     // update QP rhs for SQP (step prim var, abs dual var)
     acados_tic(&timer1);
-    ocp_nlp_approximate_qp_vectors_sqp(config, dims, nlp_in,
+    ocp_nlp_approximate_qp_feedback(config, dims, nlp_in,
         nlp_out, nlp_opts, nlp_mem, nlp_work);
     mem->time_lin += acados_toc(&timer1);
 

--- a/acados/ocp_nlp/ocp_nlp_sqp_rti.h
+++ b/acados/ocp_nlp/ocp_nlp_sqp_rti.h
@@ -53,6 +53,15 @@ extern "C" {
  * options
  ************************************************/
 
+typedef enum
+{
+    PREPARATION_AND_FEEDBACK, // = 0,
+    PREPARATION, // = 1,
+    FEEDBACK, // = 2,
+} rti_phase_t;
+
+
+
 typedef struct
 {
     ocp_nlp_opts *nlp_opts;
@@ -60,7 +69,7 @@ typedef struct
     int ext_qp_res;           // compute external QP residuals (i.e. at SQP level) at each SQP iteration (for debugging)
     int qp_warm_start;        // NOTE: this is not actually setting the warm_start! Just for compatibility with sqp.
     bool warm_start_first_qp; // to set qp_warm_start in first iteration
-    int rti_phase;            // phase of RTI. Possible values 1 (preparation), 2 (feedback) 0 (both)
+    rti_phase_t rti_phase;
 
 } ocp_nlp_sqp_rti_opts;
 

--- a/acados/ocp_nlp/ocp_nlp_sqp_rti.h
+++ b/acados/ocp_nlp/ocp_nlp_sqp_rti.h
@@ -98,6 +98,7 @@ typedef struct
     // nlp memory
     ocp_nlp_memory *nlp_mem;
 
+    // timers
     double time_qp_sol;
     double time_qp_solver_call;
     double time_qp_xcond;

--- a/acados/ocp_qp/ocp_qp_partial_condensing.c
+++ b/acados/ocp_qp/ocp_qp_partial_condensing.c
@@ -543,7 +543,7 @@ int ocp_qp_partial_condensing_condense_rhs(void *qp_in_, void *pcond_qp_in_, voi
     d_part_cond_qp_cond_rhs(mem->red_qp, pcond_qp_in, opts->hpipm_pcond_opts, mem->hpipm_pcond_work);
 
     // stop timer
-    mem->time_qp_xcond = acados_toc(&timer);
+    mem->time_qp_xcond += acados_toc(&timer);
 
     return ACADOS_SUCCESS;
 }

--- a/docs/algorithm_overview/index.md
+++ b/docs/algorithm_overview/index.md
@@ -10,7 +10,7 @@ The Hessian of the QP is computed in the `ocp_nlp_sqp`, `ocp_nlp_sqp_rti` module
 
 The following steps are carried out:
 
-- `ocp_nlp_approximate_qp_preparation()`
+- `ocp_nlp_approximate_qp_matrices()`
   - sets all Hessian blocks to 0.0
   - for `i in range(N+1)`
     - if `i<N:`

--- a/docs/algorithm_overview/index.md
+++ b/docs/algorithm_overview/index.md
@@ -10,7 +10,7 @@ The Hessian of the QP is computed in the `ocp_nlp_sqp`, `ocp_nlp_sqp_rti` module
 
 The following steps are carried out:
 
-- `ocp_nlp_approximate_qp_matrices()`
+- `ocp_nlp_approximate_qp_preparation()`
   - sets all Hessian blocks to 0.0
   - for `i in range(N+1)`
     - if `i<N:`

--- a/interfaces/acados_c/ocp_nlp_interface.c
+++ b/interfaces/acados_c/ocp_nlp_interface.c
@@ -476,10 +476,6 @@ ocp_nlp_out *ocp_nlp_out_create(ocp_nlp_config *config, ocp_nlp_dims *dims)
     ocp_nlp_out *nlp_out = ocp_nlp_out_assign(config, dims, ptr);
     nlp_out->raw_memory = ptr;
 
-    // initialize to zeros
-//    for (int ii = 0; ii <= dims->N; ++ii)
-//        blasfeo_dvecse(dims->qp_solver->nu[ii] + dims->qp_solver->nx[ii], 0.0, nlp_out->ux + ii, 0);
-
     return nlp_out;
 }
 


### PR DESCRIPTION
- fix timings for RTI: subtimers `time_qp*`, `time_reg` now start at 0 when starting preparation and count operations in both phases
- cleanup comments
- make enum for RTI phase
- precompute integrator workspace_size