### PR TITLE
Cleanup SQP submodules - only use single evaluation point at a time

### DIFF
--- a/acados/ocp_nlp/ocp_nlp_constraints_bgh.c
+++ b/acados/ocp_nlp/ocp_nlp_constraints_bgh.c
@@ -1080,14 +1080,6 @@ void ocp_nlp_constraints_bgh_memory_set_ux_ptr(struct blasfeo_dvec *ux, void *me
 
 
 
-void ocp_nlp_constraints_bgh_memory_set_tmp_ux_ptr(struct blasfeo_dvec *tmp_ux, void *memory_)
-{
-    ocp_nlp_constraints_bgh_memory *memory = memory_;
-
-    memory->tmp_ux = tmp_ux;
-}
-
-
 
 void ocp_nlp_constraints_bgh_memory_set_lam_ptr(struct blasfeo_dvec *lam, void *memory_)
 {
@@ -1096,14 +1088,6 @@ void ocp_nlp_constraints_bgh_memory_set_lam_ptr(struct blasfeo_dvec *lam, void *
     memory->lam = lam;
 }
 
-
-
-void ocp_nlp_constraints_bgh_memory_set_tmp_lam_ptr(struct blasfeo_dvec *tmp_lam, void *memory_)
-{
-    ocp_nlp_constraints_bgh_memory *memory = memory_;
-
-    memory->tmp_lam = tmp_lam;
-}
 
 
 
@@ -1517,7 +1501,7 @@ void ocp_nlp_constraints_bgh_update_qp_matrices(void *config_, void *dims_, void
 
 
 void ocp_nlp_constraints_bgh_compute_fun(void *config_, void *dims_, void *model_,
-                                            void *opts_, void *memory_, void *work_, bool use_tmp_values)
+                                            void *opts_, void *memory_, void *work_)
 {
     ocp_nlp_constraints_bgh_dims *dims = dims_;
     ocp_nlp_constraints_bgh_model *model = model_;
@@ -1541,15 +1525,7 @@ void ocp_nlp_constraints_bgh_compute_fun(void *config_, void *dims_, void *model
     ext_fun_arg_t ext_fun_type_out[3];
     void *ext_fun_out[3];
 
-    struct blasfeo_dvec *ux;
-    if (use_tmp_values)
-    {
-        ux = memory->tmp_ux;
-    }
-    else
-    {
-        ux = memory->ux;
-    }
+    struct blasfeo_dvec *ux = memory->ux;
 
     // box
     blasfeo_dvecex_sp(nb, 1.0, model->idxb, ux, 0, &work->tmp_ni, 0);
@@ -1681,9 +1657,7 @@ void ocp_nlp_constraints_bgh_config_initialize_default(void *config_)
     config->memory_get_fun_ptr = &ocp_nlp_constraints_bgh_memory_get_fun_ptr;
     config->memory_get_adj_ptr = &ocp_nlp_constraints_bgh_memory_get_adj_ptr;
     config->memory_set_ux_ptr = &ocp_nlp_constraints_bgh_memory_set_ux_ptr;
-    config->memory_set_tmp_ux_ptr = &ocp_nlp_constraints_bgh_memory_set_tmp_ux_ptr;
     config->memory_set_lam_ptr = &ocp_nlp_constraints_bgh_memory_set_lam_ptr;
-    config->memory_set_tmp_lam_ptr = &ocp_nlp_constraints_bgh_memory_set_tmp_lam_ptr;
     config->memory_set_DCt_ptr = &ocp_nlp_constraints_bgh_memory_set_DCt_ptr;
     config->memory_set_RSQrq_ptr = &ocp_nlp_constraints_bgh_memory_set_RSQrq_ptr;
     config->memory_set_z_alg_ptr = &ocp_nlp_constraints_bgh_memory_set_z_alg_ptr;

--- a/acados/ocp_nlp/ocp_nlp_constraints_bgh.c
+++ b/acados/ocp_nlp/ocp_nlp_constraints_bgh.c
@@ -1609,9 +1609,12 @@ void ocp_nlp_constraints_bgh_compute_fun(void *config_, void *dims_, void *model
     blasfeo_daxpy(nb+ng+nh, -1.0, &model->d, nb+ng+nh, &work->tmp_ni, 0, &memory->fun, nb+ng+nh);
 
     // soft
+    // subtract slacks from softened constraints
+    // fun_i = fun_i - slack_i for i \in I_slacked
     blasfeo_dvecad_sp(ns, -1.0, ux, nu+nx, model->idxs, &memory->fun, 0);
     blasfeo_dvecad_sp(ns, -1.0, ux, nu+nx+ns, model->idxs, &memory->fun, nb+ng+nh);
 
+    // fun[2*ni : 2*(ni+ns)] = - slack + slack_bounds
     blasfeo_daxpy(2*ns, -1.0, ux, nu+nx, &model->d, 2*nb+2*ng+2*nh, &memory->fun, 2*nb+2*ng+2*nh);
 
     return;

--- a/acados/ocp_nlp/ocp_nlp_constraints_bgh.h
+++ b/acados/ocp_nlp/ocp_nlp_constraints_bgh.h
@@ -148,9 +148,7 @@ typedef struct
     struct blasfeo_dvec adj;
     struct blasfeo_dvec constr_eval_no_bounds;
     struct blasfeo_dvec *ux;     // pointer to ux in nlp_out
-    struct blasfeo_dvec *tmp_ux; // pointer to ux in tmp_nlp_out
     struct blasfeo_dvec *lam;    // pointer to lam in nlp_out
-    struct blasfeo_dvec *tmp_lam;// pointer to lam in tmp_nlp_out
     struct blasfeo_dvec *z_alg;  // pointer to z_alg in ocp_nlp memory
     struct blasfeo_dmat *DCt;    // pointer to DCt in qp_in
     struct blasfeo_dmat *RSQrq;  // pointer to RSQrq in qp_in
@@ -171,11 +169,7 @@ struct blasfeo_dvec *ocp_nlp_constraints_bgh_memory_get_adj_ptr(void *memory_);
 //
 void ocp_nlp_constraints_bgh_memory_set_ux_ptr(struct blasfeo_dvec *ux, void *memory_);
 //
-void ocp_nlp_constraints_bgh_memory_set_tmp_ux_ptr(struct blasfeo_dvec *tmp_ux, void *memory_);
-//
 void ocp_nlp_constraints_bgh_memory_set_lam_ptr(struct blasfeo_dvec *lam, void *memory_);
-//
-void ocp_nlp_constraints_bgh_memory_set_tmp_lam_ptr(struct blasfeo_dvec *tmp_lam, void *memory_);
 //
 void ocp_nlp_constraints_bgh_memory_set_DCt_ptr(struct blasfeo_dmat *DCt, void *memory);
 //
@@ -224,7 +218,7 @@ void ocp_nlp_constraints_bgh_update_qp_matrices(void *config_, void *dims, void 
 
 //
 void ocp_nlp_constraints_bgh_compute_fun(void *config_, void *dims, void *model_,
-                                            void *opts_, void *memory_, void *work_, bool use_tmp_values);
+                                            void *opts_, void *memory_, void *work_);
 //
 void ocp_nlp_constraints_bgh_bounds_update(void *config_, void *dims, void *model_,
                                             void *opts_, void *memory_, void *work_);

--- a/acados/ocp_nlp/ocp_nlp_constraints_bgh.h
+++ b/acados/ocp_nlp/ocp_nlp_constraints_bgh.h
@@ -224,7 +224,7 @@ void ocp_nlp_constraints_bgh_update_qp_matrices(void *config_, void *dims, void 
 
 //
 void ocp_nlp_constraints_bgh_compute_fun(void *config_, void *dims, void *model_,
-                                            void *opts_, void *memory_, void *work_);
+                                            void *opts_, void *memory_, void *work_, bool use_tmp_values);
 //
 void ocp_nlp_constraints_bgh_bounds_update(void *config_, void *dims, void *model_,
                                             void *opts_, void *memory_, void *work_);

--- a/acados/ocp_nlp/ocp_nlp_constraints_bgp.c
+++ b/acados/ocp_nlp/ocp_nlp_constraints_bgp.c
@@ -1472,9 +1472,12 @@ void ocp_nlp_constraints_bgp_compute_fun(void *config_, void *dims_, void *model
     blasfeo_daxpy(nb+ng+nphi, -1.0, &model->d, nb+ng+nphi, &work->tmp_ni, 0, &memory->fun, nb+ng+nphi);
 
     // soft
+    // subtract slacks from softened constraints
+    // fun_i = fun_i - slack_i for i \in I_slacked
     blasfeo_dvecad_sp(ns, -1.0, ux, nu+nx, model->idxs, &memory->fun, 0);
     blasfeo_dvecad_sp(ns, -1.0, ux, nu+nx+ns, model->idxs, &memory->fun, nb+ng+nphi);
 
+    // fun[2*ni : 2*(ni+ns)] = - slack + slack_bounds
     blasfeo_daxpy(2*ns, -1.0, ux, nu+nx, &model->d, 2*nb+2*ng+2*nphi, &memory->fun, 2*nb+2*ng+2*nphi);
 
     return;

--- a/acados/ocp_nlp/ocp_nlp_constraints_bgp.c
+++ b/acados/ocp_nlp/ocp_nlp_constraints_bgp.c
@@ -1007,16 +1007,6 @@ void ocp_nlp_constraints_bgp_memory_set_ux_ptr(struct blasfeo_dvec *ux, void *me
 }
 
 
-
-void ocp_nlp_constraints_bgp_memory_set_tmp_ux_ptr(struct blasfeo_dvec *tmp_ux, void *memory_)
-{
-    ocp_nlp_constraints_bgp_memory *memory = memory_;
-
-    memory->tmp_ux = tmp_ux;
-}
-
-
-
 void ocp_nlp_constraints_bgp_memory_set_lam_ptr(struct blasfeo_dvec *lam, void *memory_)
 {
     ocp_nlp_constraints_bgp_memory *memory = memory_;
@@ -1024,14 +1014,6 @@ void ocp_nlp_constraints_bgp_memory_set_lam_ptr(struct blasfeo_dvec *lam, void *
     memory->lam = lam;
 }
 
-
-
-void ocp_nlp_constraints_bgp_memory_set_tmp_lam_ptr(struct blasfeo_dvec *tmp_lam, void *memory_)
-{
-    ocp_nlp_constraints_bgp_memory *memory = memory_;
-
-    memory->tmp_lam = tmp_lam;
-}
 
 
 
@@ -1383,7 +1365,7 @@ void ocp_nlp_constraints_bgp_update_qp_matrices(void *config_, void *dims_, void
 
 
 
-void ocp_nlp_constraints_bgp_compute_fun(void *config_, void *dims_, void *model_, void *opts_, void *memory_, void *work_, bool use_tmp_values)
+void ocp_nlp_constraints_bgp_compute_fun(void *config_, void *dims_, void *model_, void *opts_, void *memory_, void *work_)
 {
     ocp_nlp_constraints_bgp_dims *dims = dims_;
     ocp_nlp_constraints_bgp_model *model = model_;
@@ -1407,15 +1389,7 @@ void ocp_nlp_constraints_bgp_compute_fun(void *config_, void *dims_, void *model
     ext_fun_arg_t ext_fun_type_out[3];
     void *ext_fun_out[3];
 
-    struct blasfeo_dvec *ux;
-    if (use_tmp_values)
-    {
-        ux = memory->tmp_ux;
-    }
-    else
-    {
-        ux = memory->ux;
-    }
+    struct blasfeo_dvec *ux = memory->ux;
 
     // box
     blasfeo_dvecex_sp(nb, 1.0, model->idxb, ux, 0, &work->tmp_ni, 0);
@@ -1548,9 +1522,7 @@ void ocp_nlp_constraints_bgp_config_initialize_default(void *config_)
     config->memory_get_fun_ptr = &ocp_nlp_constraints_bgp_memory_get_fun_ptr;
     config->memory_get_adj_ptr = &ocp_nlp_constraints_bgp_memory_get_adj_ptr;
     config->memory_set_ux_ptr = &ocp_nlp_constraints_bgp_memory_set_ux_ptr;
-    config->memory_set_tmp_ux_ptr = &ocp_nlp_constraints_bgp_memory_set_tmp_ux_ptr;
     config->memory_set_lam_ptr = &ocp_nlp_constraints_bgp_memory_set_lam_ptr;
-    config->memory_set_tmp_lam_ptr = &ocp_nlp_constraints_bgp_memory_set_tmp_lam_ptr;
     config->memory_set_DCt_ptr = &ocp_nlp_constraints_bgp_memory_set_DCt_ptr;
     config->memory_set_RSQrq_ptr = &ocp_nlp_constraints_bgp_memory_set_RSQrq_ptr;
     config->memory_set_z_alg_ptr = &ocp_nlp_constraints_bgp_memory_set_z_alg_ptr;

--- a/acados/ocp_nlp/ocp_nlp_constraints_bgp.h
+++ b/acados/ocp_nlp/ocp_nlp_constraints_bgp.h
@@ -203,7 +203,7 @@ void ocp_nlp_constraints_bgp_update_qp_matrices(void *config_, void *dims,
         void *model_, void *opts_, void *memory_, void *work_);
 //
 void ocp_nlp_constraints_bgp_compute_fun(void *config_, void *dims,
-        void *model_, void *opts_, void *memory_, void *work_);
+        void *model_, void *opts_, void *memory_, void *work_, bool use_tmp_values);
 //
 void ocp_nlp_constraints_bgp_update_qp_vectors(void *config_, void *dims, void *model_,
         void *opts_, void *memory_, void *work_);

--- a/acados/ocp_nlp/ocp_nlp_constraints_bgp.h
+++ b/acados/ocp_nlp/ocp_nlp_constraints_bgp.h
@@ -134,9 +134,7 @@ typedef struct
     struct blasfeo_dvec adj;
     struct blasfeo_dvec constr_eval_no_bounds;
     struct blasfeo_dvec *ux;     // pointer to ux in nlp_out
-    struct blasfeo_dvec *tmp_ux; // pointer to ux in tmp_nlp_out
     struct blasfeo_dvec *lam;    // pointer to lam in nlp_out
-    struct blasfeo_dvec *tmp_lam;// pointer to lam in tmp_nlp_out
     struct blasfeo_dvec *z_alg;  // pointer to z_alg in ocp_nlp memory
     struct blasfeo_dmat *DCt;    // pointer to DCt in qp_in
     struct blasfeo_dmat *RSQrq;  // pointer to RSQrq in qp_in
@@ -158,11 +156,7 @@ struct blasfeo_dvec *ocp_nlp_constraints_bgp_memory_get_adj_ptr(void *memory_);
 //
 void ocp_nlp_constraints_bgp_memory_set_ux_ptr(struct blasfeo_dvec *ux, void *memory_);
 //
-void ocp_nlp_constraints_bgp_memory_set_tmp_ux_ptr(struct blasfeo_dvec *tmp_ux, void *memory_);
-//
 void ocp_nlp_constraints_bgp_memory_set_lam_ptr(struct blasfeo_dvec *lam, void *memory_);
-//
-void ocp_nlp_constraints_bgp_memory_set_tmp_lam_ptr(struct blasfeo_dvec *tmp_lam, void *memory_);
 //
 void ocp_nlp_constraints_bgp_memory_set_DCt_ptr(struct blasfeo_dmat *DCt, void *memory);
 //
@@ -203,7 +197,7 @@ void ocp_nlp_constraints_bgp_update_qp_matrices(void *config_, void *dims,
         void *model_, void *opts_, void *memory_, void *work_);
 //
 void ocp_nlp_constraints_bgp_compute_fun(void *config_, void *dims,
-        void *model_, void *opts_, void *memory_, void *work_, bool use_tmp_values);
+        void *model_, void *opts_, void *memory_, void *work_);
 //
 void ocp_nlp_constraints_bgp_update_qp_vectors(void *config_, void *dims, void *model_,
         void *opts_, void *memory_, void *work_);

--- a/acados/ocp_nlp/ocp_nlp_constraints_common.h
+++ b/acados/ocp_nlp/ocp_nlp_constraints_common.h
@@ -70,9 +70,7 @@ typedef struct
     struct blasfeo_dvec *(*memory_get_fun_ptr)(void *memory);
     struct blasfeo_dvec *(*memory_get_adj_ptr)(void *memory);
     void (*memory_set_ux_ptr)(struct blasfeo_dvec *ux, void *memory);
-    void (*memory_set_tmp_ux_ptr)(struct blasfeo_dvec *tmp_ux, void *memory);
     void (*memory_set_lam_ptr)(struct blasfeo_dvec *lam, void *memory);
-    void (*memory_set_tmp_lam_ptr)(struct blasfeo_dvec *tmp_lam, void *memory);
     void (*memory_set_DCt_ptr)(struct blasfeo_dmat *DCt, void *memory);
     void (*memory_set_RSQrq_ptr)(struct blasfeo_dmat *RSQrq, void *memory);
     void (*memory_set_z_alg_ptr)(struct blasfeo_dvec *z_alg, void *memory);
@@ -85,7 +83,7 @@ typedef struct
     void (*initialize)(void *config, void *dims, void *model, void *opts, void *mem, void *work);
     void (*update_qp_matrices)(void *config, void *dims, void *model, void *opts, void *mem, void *work);
     void (*update_qp_vectors)(void *config, void *dims, void *model, void *opts, void *mem, void *work);
-    void (*compute_fun)(void *config, void *dims, void *model, void *opts, void *mem, void *work, bool use_tmp_values);
+    void (*compute_fun)(void *config, void *dims, void *model, void *opts, void *mem, void *work);
     void (*config_initialize_default)(void *config);
     // dimension setters
     void (*dims_set)(void *config_, void *dims_, const char *field, const int *value);

--- a/acados/ocp_nlp/ocp_nlp_constraints_common.h
+++ b/acados/ocp_nlp/ocp_nlp_constraints_common.h
@@ -85,7 +85,7 @@ typedef struct
     void (*initialize)(void *config, void *dims, void *model, void *opts, void *mem, void *work);
     void (*update_qp_matrices)(void *config, void *dims, void *model, void *opts, void *mem, void *work);
     void (*update_qp_vectors)(void *config, void *dims, void *model, void *opts, void *mem, void *work);
-    void (*compute_fun)(void *config, void *dims, void *model, void *opts, void *mem, void *work);
+    void (*compute_fun)(void *config, void *dims, void *model, void *opts, void *mem, void *work, bool use_tmp_values);
     void (*config_initialize_default)(void *config);
     // dimension setters
     void (*dims_set)(void *config_, void *dims_, const char *field, const int *value);

--- a/acados/ocp_nlp/ocp_nlp_cost_common.h
+++ b/acados/ocp_nlp/ocp_nlp_cost_common.h
@@ -75,7 +75,6 @@ typedef struct
     struct blasfeo_dvec *(*model_get_y_ref_ptr)(void *memory);
     struct blasfeo_dmat *(*memory_get_W_chol_ptr)(void *memory_);
     void (*memory_set_ux_ptr)(struct blasfeo_dvec *ux, void *memory);
-    void (*memory_set_tmp_ux_ptr)(struct blasfeo_dvec *tmp_ux, void *memory);
     void (*memory_set_z_alg_ptr)(struct blasfeo_dvec *z_alg, void *memory);
     void (*memory_set_dzdux_tran_ptr)(struct blasfeo_dmat *dzdux, void *memory);
     void (*memory_set_RSQrq_ptr)(struct blasfeo_dmat *RSQrq, void *memory);
@@ -87,7 +86,7 @@ typedef struct
     // computes the function value, gradient and hessian (approximation) of the cost function
     void (*update_qp_matrices)(void *config_, void *dims, void *model_, void *opts_, void *mem_, void *work_);
     // computes the cost function value (intended for globalization)
-    void (*compute_fun)(void *config_, void *dims, void *model_, void *opts_, void *mem_, void *work_, bool use_tmp_values);
+    void (*compute_fun)(void *config_, void *dims, void *model_, void *opts_, void *mem_, void *work_);
     void (*config_initialize_default)(void *config);
     void (*precompute)(void *config_, void *dims_, void *model_, void *opts_, void *memory_, void *work_);
 

--- a/acados/ocp_nlp/ocp_nlp_cost_common.h
+++ b/acados/ocp_nlp/ocp_nlp_cost_common.h
@@ -87,7 +87,7 @@ typedef struct
     // computes the function value, gradient and hessian (approximation) of the cost function
     void (*update_qp_matrices)(void *config_, void *dims, void *model_, void *opts_, void *mem_, void *work_);
     // computes the cost function value (intended for globalization)
-    void (*compute_fun)(void *config_, void *dims, void *model_, void *opts_, void *mem_, void *work_);
+    void (*compute_fun)(void *config_, void *dims, void *model_, void *opts_, void *mem_, void *work_, bool use_tmp_values);
     void (*config_initialize_default)(void *config);
     void (*precompute)(void *config_, void *dims_, void *model_, void *opts_, void *memory_, void *work_);
 

--- a/acados/ocp_nlp/ocp_nlp_cost_conl.c
+++ b/acados/ocp_nlp/ocp_nlp_cost_conl.c
@@ -466,17 +466,6 @@ void ocp_nlp_cost_conl_memory_set_ux_ptr(struct blasfeo_dvec *ux, void *memory_)
 
 
 
-void ocp_nlp_cost_conl_memory_set_tmp_ux_ptr(struct blasfeo_dvec *tmp_ux, void *memory_)
-{
-    ocp_nlp_cost_conl_memory *memory = memory_;
-
-    memory->tmp_ux = tmp_ux;
-
-    return;
-}
-
-
-
 void ocp_nlp_cost_conl_memory_set_z_alg_ptr(struct blasfeo_dvec *z_alg, void *memory_)
 {
     ocp_nlp_cost_conl_memory *memory = memory_;
@@ -724,7 +713,7 @@ void ocp_nlp_cost_conl_update_qp_matrices(void *config_, void *dims_, void *mode
 
 
 void ocp_nlp_cost_conl_compute_fun(void *config_, void *dims_, void *model_,
-                                  void *opts_, void *memory_, void *work_, bool use_tmp_values)
+                                  void *opts_, void *memory_, void *work_)
 {
     ocp_nlp_cost_conl_dims *dims = dims_;
     ocp_nlp_cost_conl_model *model = model_;
@@ -738,15 +727,7 @@ void ocp_nlp_cost_conl_compute_fun(void *config_, void *dims_, void *model_,
     int nu = dims->nu;
     int ns = dims->ns;
 
-    struct blasfeo_dvec *ux;
-    if (use_tmp_values)
-    {
-        ux = memory->tmp_ux;
-    }
-    else
-    {
-        ux = memory->ux;
-    }
+    struct blasfeo_dvec *ux = memory->ux;
 
     if (opts->integrator_cost == 0)
     {
@@ -823,7 +804,6 @@ void ocp_nlp_cost_conl_config_initialize_default(void *config_)
     config->memory_get_W_chol_ptr = &ocp_nlp_cost_conl_memory_get_W_chol_ptr;
     config->model_get_y_ref_ptr = &ocp_nlp_cost_conl_model_get_y_ref_ptr;
     config->memory_set_ux_ptr = &ocp_nlp_cost_conl_memory_set_ux_ptr;
-    config->memory_set_tmp_ux_ptr = &ocp_nlp_cost_conl_memory_set_tmp_ux_ptr;
     config->memory_set_z_alg_ptr = &ocp_nlp_cost_conl_memory_set_z_alg_ptr;
     config->memory_set_dzdux_tran_ptr = &ocp_nlp_cost_conl_memory_set_dzdux_tran_ptr;
     config->memory_set_RSQrq_ptr = &ocp_nlp_cost_conl_memory_set_RSQrq_ptr;

--- a/acados/ocp_nlp/ocp_nlp_cost_conl.c
+++ b/acados/ocp_nlp/ocp_nlp_cost_conl.c
@@ -724,7 +724,7 @@ void ocp_nlp_cost_conl_update_qp_matrices(void *config_, void *dims_, void *mode
 
 
 void ocp_nlp_cost_conl_compute_fun(void *config_, void *dims_, void *model_,
-                                  void *opts_, void *memory_, void *work_)
+                                  void *opts_, void *memory_, void *work_, bool use_tmp_values)
 {
     ocp_nlp_cost_conl_dims *dims = dims_;
     ocp_nlp_cost_conl_model *model = model_;
@@ -738,6 +738,16 @@ void ocp_nlp_cost_conl_compute_fun(void *config_, void *dims_, void *model_,
     int nu = dims->nu;
     int ns = dims->ns;
 
+    struct blasfeo_dvec *ux;
+    if (use_tmp_values)
+    {
+        ux = memory->tmp_ux;
+    }
+    else
+    {
+        ux = memory->ux;
+    }
+
     if (opts->integrator_cost == 0)
     {
         /* specify input types and pointers for external cost function */
@@ -748,11 +758,11 @@ void ocp_nlp_cost_conl_compute_fun(void *config_, void *dims_, void *model_,
 
         // INPUT
         struct blasfeo_dvec_args x_in;  // input x
-        x_in.x = memory->tmp_ux;
+        x_in.x = ux;
         x_in.xi = nu;
 
         struct blasfeo_dvec_args u_in;  // input u
-        u_in.x = memory->tmp_ux;
+        u_in.x = ux;
         u_in.xi = 0;
 
         ext_fun_type_in[0] = BLASFEO_DVEC_ARGS;
@@ -776,8 +786,8 @@ void ocp_nlp_cost_conl_compute_fun(void *config_, void *dims_, void *model_,
 
     // slack update function value
     blasfeo_dveccpsc(2*ns, 2.0, &model->z, 0, &work->tmp_2ns, 0);
-    blasfeo_dvecmulacc(2*ns, &model->Z, 0, memory->tmp_ux, nu+nx, &work->tmp_2ns, 0);
-    memory->fun += 0.5 * blasfeo_ddot(2*ns, &work->tmp_2ns, 0, memory->tmp_ux, nu+nx);
+    blasfeo_dvecmulacc(2*ns, &model->Z, 0, ux, nu+nx, &work->tmp_2ns, 0);
+    memory->fun += 0.5 * blasfeo_ddot(2*ns, &work->tmp_2ns, 0, ux, nu+nx);
 
     // scale
     if (model->scaling!=1.0)

--- a/acados/ocp_nlp/ocp_nlp_cost_conl.h
+++ b/acados/ocp_nlp/ocp_nlp_cost_conl.h
@@ -198,7 +198,7 @@ void ocp_nlp_cost_conl_initialize(void *config_, void *dims, void *model_, void 
 //
 void ocp_nlp_cost_conl_update_qp_matrices(void *config_, void *dims, void *model_, void *opts_, void *memory_, void *work_);
 //
-void ocp_nlp_cost_conl_compute_fun(void *config_, void *dims, void *model_, void *opts_, void *memory_, void *work_);
+void ocp_nlp_cost_conl_compute_fun(void *config_, void *dims, void *model_, void *opts_, void *memory_, void *work_, bool use_tmp_values);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/acados/ocp_nlp/ocp_nlp_cost_conl.h
+++ b/acados/ocp_nlp/ocp_nlp_cost_conl.h
@@ -136,7 +136,6 @@ typedef struct
 {
     struct blasfeo_dvec grad;    // gradient of cost function
     struct blasfeo_dvec *ux;     // pointer to ux in nlp_out
-    struct blasfeo_dvec *tmp_ux; // pointer to ux in tmp_nlp_out
     struct blasfeo_dmat *RSQrq;  // pointer to RSQrq in qp_in
     struct blasfeo_dvec *Z;      // pointer to Z in qp_in
     struct blasfeo_dvec *z_alg;         ///< pointer to z in sim_out
@@ -160,8 +159,6 @@ void ocp_nlp_cost_conl_memory_set_RSQrq_ptr(struct blasfeo_dmat *RSQrq, void *me
 void ocp_nlp_cost_conl_memory_set_Z_ptr(struct blasfeo_dvec *Z, void *memory);
 //
 void ocp_nlp_cost_conl_memory_set_ux_ptr(struct blasfeo_dvec *ux, void *memory_);
-//
-void ocp_nlp_cost_conl_memory_set_tmp_ux_ptr(struct blasfeo_dvec *tmp_ux, void *memory_);
 //
 void ocp_nlp_cost_conl_memory_set_z_alg_ptr(struct blasfeo_dvec *z_alg, void *memory_);
 //
@@ -198,7 +195,7 @@ void ocp_nlp_cost_conl_initialize(void *config_, void *dims, void *model_, void 
 //
 void ocp_nlp_cost_conl_update_qp_matrices(void *config_, void *dims, void *model_, void *opts_, void *memory_, void *work_);
 //
-void ocp_nlp_cost_conl_compute_fun(void *config_, void *dims, void *model_, void *opts_, void *memory_, void *work_, bool use_tmp_values);
+void ocp_nlp_cost_conl_compute_fun(void *config_, void *dims, void *model_, void *opts_, void *memory_, void *work_);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/acados/ocp_nlp/ocp_nlp_cost_external.c
+++ b/acados/ocp_nlp/ocp_nlp_cost_external.c
@@ -448,18 +448,6 @@ void ocp_nlp_cost_external_memory_set_ux_ptr(struct blasfeo_dvec *ux, void *memo
 }
 
 
-
-void ocp_nlp_cost_external_memory_set_tmp_ux_ptr(struct blasfeo_dvec *tmp_ux, void *memory_)
-{
-    ocp_nlp_cost_external_memory *memory = memory_;
-
-    memory->tmp_ux = tmp_ux;
-
-    return;
-}
-
-
-
 void ocp_nlp_cost_external_memory_set_z_alg_ptr(struct blasfeo_dvec *z_alg, void *memory_)
 {
     ocp_nlp_cost_external_memory *memory = memory_;
@@ -698,7 +686,7 @@ void ocp_nlp_cost_external_update_qp_matrices(void *config_, void *dims_, void *
 
 
 void ocp_nlp_cost_external_compute_fun(void *config_, void *dims_, void *model_,
-                                       void *opts_, void *memory_, void *work_, bool use_tmp_values)
+                                       void *opts_, void *memory_, void *work_)
 {
 
     ocp_nlp_cost_external_dims *dims = dims_;
@@ -709,15 +697,7 @@ void ocp_nlp_cost_external_compute_fun(void *config_, void *dims_, void *model_,
 
     ocp_nlp_cost_external_cast_workspace(config_, dims, opts_, work_);
 
-    struct blasfeo_dvec *ux;
-    if (use_tmp_values)
-    {
-        ux = memory->tmp_ux;
-    }
-    else
-    {
-        ux = memory->ux;
-    }
+    struct blasfeo_dvec *ux = memory->ux;
 
     int nx = dims->nx;
     int nu = dims->nu;
@@ -796,7 +776,6 @@ void ocp_nlp_cost_external_config_initialize_default(void *config_)
     config->memory_get_fun_ptr = &ocp_nlp_cost_external_memory_get_fun_ptr;
     config->memory_get_grad_ptr = &ocp_nlp_cost_external_memory_get_grad_ptr;
     config->memory_set_ux_ptr = &ocp_nlp_cost_external_memory_set_ux_ptr;
-    config->memory_set_tmp_ux_ptr = &ocp_nlp_cost_external_memory_set_tmp_ux_ptr;
     config->memory_set_z_alg_ptr = &ocp_nlp_cost_external_memory_set_z_alg_ptr;
     config->memory_set_dzdux_tran_ptr = &ocp_nlp_cost_external_memory_set_dzdux_tran_ptr;
     config->memory_set_RSQrq_ptr = &ocp_nlp_cost_external_memory_set_RSQrq_ptr;

--- a/acados/ocp_nlp/ocp_nlp_cost_external.h
+++ b/acados/ocp_nlp/ocp_nlp_cost_external.h
@@ -117,7 +117,6 @@ typedef struct
 {
     struct blasfeo_dvec grad;    // gradient of cost function
     struct blasfeo_dvec *ux;     // pointer to ux in nlp_out
-    struct blasfeo_dvec *tmp_ux; // pointer to tmp_ux in nlp_out
     struct blasfeo_dmat *RSQrq;  // pointer to RSQrq in qp_in
     struct blasfeo_dvec *Z;      // pointer to Z in qp_in
     struct blasfeo_dvec *z_alg;         ///< pointer to z in sim_out
@@ -139,8 +138,6 @@ void ocp_nlp_cost_external_memory_set_RSQrq_ptr(struct blasfeo_dmat *RSQrq, void
 void ocp_nlp_cost_ls_memory_set_Z_ptr(struct blasfeo_dvec *Z, void *memory);
 //
 void ocp_nlp_cost_external_memory_set_ux_ptr(struct blasfeo_dvec *ux, void *memory_);
-//
-void ocp_nlp_cost_external_memory_set_tmp_ux_ptr(struct blasfeo_dvec *tmp_ux, void *memory_);
 //
 void ocp_nlp_cost_external_memory_set_z_alg_ptr(struct blasfeo_dvec *z_alg, void *memory_);
 //
@@ -178,7 +175,7 @@ void ocp_nlp_cost_external_update_qp_matrices(void *config_, void *dims, void *m
                                                void *opts_, void *memory_, void *work_);
 //
 void ocp_nlp_cost_external_compute_fun(void *config_, void *dims, void *model_,
-                                       void *opts_, void *memory_, void *work_, bool use_tmp_values);
+                                       void *opts_, void *memory_, void *work_);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/acados/ocp_nlp/ocp_nlp_cost_external.h
+++ b/acados/ocp_nlp/ocp_nlp_cost_external.h
@@ -178,7 +178,7 @@ void ocp_nlp_cost_external_update_qp_matrices(void *config_, void *dims, void *m
                                                void *opts_, void *memory_, void *work_);
 //
 void ocp_nlp_cost_external_compute_fun(void *config_, void *dims, void *model_,
-                                       void *opts_, void *memory_, void *work_);
+                                       void *opts_, void *memory_, void *work_, bool use_tmp_values);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/acados/ocp_nlp/ocp_nlp_cost_ls.c
+++ b/acados/ocp_nlp/ocp_nlp_cost_ls.c
@@ -576,15 +576,6 @@ void ocp_nlp_cost_ls_memory_set_ux_ptr(struct blasfeo_dvec *ux, void *memory_)
 
 
 
-void ocp_nlp_cost_ls_memory_set_tmp_ux_ptr(struct blasfeo_dvec *tmp_ux, void *memory_)
-{
-    ocp_nlp_cost_ls_memory *memory = memory_;
-
-    memory->tmp_ux = tmp_ux;
-}
-
-
-
 void ocp_nlp_cost_ls_memory_set_z_alg_ptr(struct blasfeo_dvec *z_alg, void *memory_)
 {
     ocp_nlp_cost_ls_memory *memory = memory_;
@@ -860,7 +851,7 @@ void ocp_nlp_cost_ls_update_qp_matrices(void *config_, void *dims_,
 
 
 void ocp_nlp_cost_ls_compute_fun(void *config_, void *dims_, void *model_, void *opts_,
-                                 void *memory_, void *work_, bool use_tmp_values)
+                                 void *memory_, void *work_)
 {
     ocp_nlp_cost_ls_dims *dims = dims_;
     ocp_nlp_cost_ls_model *model = model_;
@@ -875,15 +866,7 @@ void ocp_nlp_cost_ls_compute_fun(void *config_, void *dims_, void *model_, void 
     int ny = dims->ny;
     int ns = dims->ns;
 
-    struct blasfeo_dvec *ux;
-    if (use_tmp_values)
-    {
-        ux = memory->tmp_ux;
-    }
-    else
-    {
-        ux = memory->ux;
-    }
+    struct blasfeo_dvec *ux = memory->ux;
 
     // TODO should this overwrite memory->{res,fun,...} (as now) or not ????
     if (nz > 0)
@@ -966,7 +949,6 @@ void ocp_nlp_cost_ls_config_initialize_default(void *config_)
     config->memory_get_fun_ptr = &ocp_nlp_cost_ls_memory_get_fun_ptr;
     config->memory_get_grad_ptr = &ocp_nlp_cost_ls_memory_get_grad_ptr;
     config->memory_set_ux_ptr = &ocp_nlp_cost_ls_memory_set_ux_ptr;
-    config->memory_set_tmp_ux_ptr = &ocp_nlp_cost_ls_memory_set_tmp_ux_ptr;
     config->memory_set_z_alg_ptr = &ocp_nlp_cost_ls_memory_set_z_alg_ptr;
     config->memory_set_dzdux_tran_ptr = &ocp_nlp_cost_ls_memory_set_dzdux_tran_ptr;
     config->memory_set_RSQrq_ptr = &ocp_nlp_cost_ls_memory_set_RSQrq_ptr;

--- a/acados/ocp_nlp/ocp_nlp_cost_ls.h
+++ b/acados/ocp_nlp/ocp_nlp_cost_ls.h
@@ -162,7 +162,6 @@ typedef struct
     struct blasfeo_dvec res;            ///< ls residual r(x)
     struct blasfeo_dvec grad;           ///< gradient of cost function
     struct blasfeo_dvec *ux;            ///< pointer to ux in nlp_out
-    struct blasfeo_dvec *tmp_ux;        ///< pointer to ux in tmp_nlp_out
     struct blasfeo_dvec *z_alg;         ///< pointer to z in sim_out
     struct blasfeo_dmat *dzdux_tran;    ///< pointer to sensitivity of a wrt ux in sim_out
     struct blasfeo_dmat *RSQrq;         ///< pointer to RSQrq in qp_in
@@ -184,8 +183,6 @@ void ocp_nlp_cost_ls_memory_set_RSQrq_ptr(struct blasfeo_dmat *RSQrq, void *memo
 void ocp_nlp_cost_ls_memory_set_Z_ptr(struct blasfeo_dvec *Z, void *memory);
 //
 void ocp_nlp_cost_ls_memory_set_ux_ptr(struct blasfeo_dvec *ux, void *memory_);
-//
-void ocp_nlp_cost_ls_memory_set_tmp_ux_ptr(struct blasfeo_dvec *tmp_ux, void *memory_);
 //
 void ocp_nlp_cost_ls_memory_set_z_alg_ptr(struct blasfeo_dvec *z_alg, void *memory_);
 //
@@ -232,7 +229,7 @@ void ocp_nlp_cost_ls_update_qp_matrices(void *config_, void *dims, void *model_,
                                         void *opts_, void *memory_, void *work_);
 //
 void ocp_nlp_cost_ls_compute_fun(void *config_, void *dims, void *model_, void *opts_,
-                                 void *memory_, void *work_, bool use_tmp_values);
+                                 void *memory_, void *work_);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/acados/ocp_nlp/ocp_nlp_cost_ls.h
+++ b/acados/ocp_nlp/ocp_nlp_cost_ls.h
@@ -231,7 +231,8 @@ void ocp_nlp_cost_ls_initialize(void *config_, void *dims, void *model_, void *o
 void ocp_nlp_cost_ls_update_qp_matrices(void *config_, void *dims, void *model_,
                                         void *opts_, void *memory_, void *work_);
 //
-void ocp_nlp_cost_ls_compute_fun(void *config_, void *dims, void *model_, void *opts_, void *memory_, void *work_);
+void ocp_nlp_cost_ls_compute_fun(void *config_, void *dims, void *model_, void *opts_,
+                                 void *memory_, void *work_, bool use_tmp_values);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/acados/ocp_nlp/ocp_nlp_cost_nls.c
+++ b/acados/ocp_nlp/ocp_nlp_cost_nls.c
@@ -868,16 +868,23 @@ void ocp_nlp_cost_nls_update_qp_matrices(void *config_, void *dims_, void *model
 
 
 void ocp_nlp_cost_nls_compute_fun(void *config_, void *dims_, void *model_,
-                                  void *opts_, void *memory_, void *work_)
+                                  void *opts_, void *memory_, void *work_, bool use_tmp_values)
 {
-//    printf("\nerror: ocp_nlp_cost_nls_compute_fun: not implemented yet\n");
-//    exit(1);
-
     ocp_nlp_cost_nls_dims *dims = dims_;
     ocp_nlp_cost_nls_model *model = model_;
     ocp_nlp_cost_nls_opts *opts = opts_;
     ocp_nlp_cost_nls_memory *memory = memory_;
     ocp_nlp_cost_nls_workspace *work = work_;
+
+    struct blasfeo_dvec *ux;
+    if (use_tmp_values)
+    {
+        ux = memory->tmp_ux;
+    }
+    else
+    {
+        ux = memory->ux;
+    }
 
     ocp_nlp_cost_nls_cast_workspace(config_, dims, opts_, work_);
 
@@ -896,10 +903,10 @@ void ocp_nlp_cost_nls_compute_fun(void *config_, void *dims_, void *model_,
         struct blasfeo_dvec_args x_in;  // input x of external fun;
         struct blasfeo_dvec_args u_in;  // input u of external fun;
 
-        x_in.x = memory->tmp_ux;
+        x_in.x = ux;
         x_in.xi = nu;
 
-        u_in.x = memory->tmp_ux;
+        u_in.x = ux;
         u_in.xi = 0;
 
         nls_y_fun_type_in[0] = BLASFEO_DVEC_ARGS;
@@ -936,8 +943,8 @@ void ocp_nlp_cost_nls_compute_fun(void *config_, void *dims_, void *model_,
 
     // slack update function value
     blasfeo_dveccpsc(2*ns, 2.0, &model->z, 0, &work->tmp_2ns, 0);
-    blasfeo_dvecmulacc(2*ns, &model->Z, 0, memory->tmp_ux, nu+nx, &work->tmp_2ns, 0);
-    memory->fun += 0.5 * blasfeo_ddot(2*ns, &work->tmp_2ns, 0, memory->tmp_ux, nu+nx);
+    blasfeo_dvecmulacc(2*ns, &model->Z, 0, ux, nu+nx, &work->tmp_2ns, 0);
+    memory->fun += 0.5 * blasfeo_ddot(2*ns, &work->tmp_2ns, 0, ux, nu+nx);
 
     // scale
     if (model->scaling!=1.0)

--- a/acados/ocp_nlp/ocp_nlp_cost_nls.c
+++ b/acados/ocp_nlp/ocp_nlp_cost_nls.c
@@ -526,17 +526,6 @@ void ocp_nlp_cost_nls_memory_set_ux_ptr(struct blasfeo_dvec *ux, void *memory_)
 
 
 
-void ocp_nlp_cost_nls_memory_set_tmp_ux_ptr(struct blasfeo_dvec *tmp_ux, void *memory_)
-{
-    ocp_nlp_cost_nls_memory *memory = memory_;
-
-    memory->tmp_ux = tmp_ux;
-
-    return;
-}
-
-
-
 void ocp_nlp_cost_nls_memory_set_z_alg_ptr(struct blasfeo_dvec *z_alg, void *memory_)
 {
     ocp_nlp_cost_nls_memory *memory = memory_;
@@ -868,7 +857,7 @@ void ocp_nlp_cost_nls_update_qp_matrices(void *config_, void *dims_, void *model
 
 
 void ocp_nlp_cost_nls_compute_fun(void *config_, void *dims_, void *model_,
-                                  void *opts_, void *memory_, void *work_, bool use_tmp_values)
+                                  void *opts_, void *memory_, void *work_)
 {
     ocp_nlp_cost_nls_dims *dims = dims_;
     ocp_nlp_cost_nls_model *model = model_;
@@ -876,15 +865,7 @@ void ocp_nlp_cost_nls_compute_fun(void *config_, void *dims_, void *model_,
     ocp_nlp_cost_nls_memory *memory = memory_;
     ocp_nlp_cost_nls_workspace *work = work_;
 
-    struct blasfeo_dvec *ux;
-    if (use_tmp_values)
-    {
-        ux = memory->tmp_ux;
-    }
-    else
-    {
-        ux = memory->ux;
-    }
+    struct blasfeo_dvec *ux = memory->ux;
 
     ocp_nlp_cost_nls_cast_workspace(config_, dims, opts_, work_);
 
@@ -981,7 +962,6 @@ void ocp_nlp_cost_nls_config_initialize_default(void *config_)
     config->memory_get_W_chol_ptr = &ocp_nlp_cost_nls_memory_get_W_chol_ptr;
     config->model_get_y_ref_ptr = &ocp_nlp_cost_nls_model_get_y_ref_ptr;
     config->memory_set_ux_ptr = &ocp_nlp_cost_nls_memory_set_ux_ptr;
-    config->memory_set_tmp_ux_ptr = &ocp_nlp_cost_nls_memory_set_tmp_ux_ptr;
     config->memory_set_z_alg_ptr = &ocp_nlp_cost_nls_memory_set_z_alg_ptr;
     config->memory_set_dzdux_tran_ptr = &ocp_nlp_cost_nls_memory_set_dzdux_tran_ptr;
     config->memory_set_RSQrq_ptr = &ocp_nlp_cost_nls_memory_set_RSQrq_ptr;

--- a/acados/ocp_nlp/ocp_nlp_cost_nls.h
+++ b/acados/ocp_nlp/ocp_nlp_cost_nls.h
@@ -141,7 +141,6 @@ typedef struct
     struct blasfeo_dvec res;     // nls residual r(x)
     struct blasfeo_dvec grad;    // gradient of cost function
     struct blasfeo_dvec *ux;     // pointer to ux in nlp_out
-    struct blasfeo_dvec *tmp_ux;     // pointer to ux in tmp_nlp_out
     struct blasfeo_dmat *RSQrq;  // pointer to RSQrq in qp_in
     struct blasfeo_dvec *Z;      // pointer to Z in qp_in
     struct blasfeo_dvec *z_alg;         ///< pointer to z in sim_out
@@ -165,8 +164,6 @@ void ocp_nlp_cost_nls_memory_set_RSQrq_ptr(struct blasfeo_dmat *RSQrq, void *mem
 void ocp_nlp_cost_nls_memory_set_Z_ptr(struct blasfeo_dvec *Z, void *memory);
 //
 void ocp_nlp_cost_nls_memory_set_ux_ptr(struct blasfeo_dvec *ux, void *memory_);
-//
-void ocp_nlp_cost_nls_memory_set_tmp_ux_ptr(struct blasfeo_dvec *tmp_ux, void *memory_);
 //
 void ocp_nlp_cost_nls_memory_set_z_alg_ptr(struct blasfeo_dvec *z_alg, void *memory_);
 //
@@ -204,7 +201,7 @@ void ocp_nlp_cost_nls_initialize(void *config_, void *dims, void *model_, void *
 void ocp_nlp_cost_nls_update_qp_matrices(void *config_, void *dims, void *model_, void *opts_, void *memory_, void *work_);
 //
 void ocp_nlp_cost_nls_compute_fun(void *config_, void *dims, void *model_, void *opts_,
-                                  void *memory_, void *work_, bool use_tmp_values);
+                                  void *memory_, void *work_);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/acados/ocp_nlp/ocp_nlp_cost_nls.h
+++ b/acados/ocp_nlp/ocp_nlp_cost_nls.h
@@ -203,7 +203,8 @@ void ocp_nlp_cost_nls_initialize(void *config_, void *dims, void *model_, void *
 //
 void ocp_nlp_cost_nls_update_qp_matrices(void *config_, void *dims, void *model_, void *opts_, void *memory_, void *work_);
 //
-void ocp_nlp_cost_nls_compute_fun(void *config_, void *dims, void *model_, void *opts_, void *memory_, void *work_);
+void ocp_nlp_cost_nls_compute_fun(void *config_, void *dims, void *model_, void *opts_,
+                                  void *memory_, void *work_, bool use_tmp_values);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/acados/ocp_nlp/ocp_nlp_dynamics_common.h
+++ b/acados/ocp_nlp/ocp_nlp_dynamics_common.h
@@ -101,7 +101,7 @@ typedef struct
     acados_size_t (*workspace_calculate_size)(void *config, void *dims, void *opts);
     void (*initialize)(void *config_, void *dims, void *model_, void *opts_, void *mem_, void *work_);
     void (*update_qp_matrices)(void *config_, void *dims, void *model_, void *opts_, void *mem_, void *work_);
-    void (*compute_fun)(void *config_, void *dims, void *model_, void *opts_, void *mem_, void *work_);
+    void (*compute_fun)(void *config_, void *dims, void *model_, void *opts_, void *mem_, void *work_, bool use_tmp_values);
     int (*precompute)(void *config_, void *dims, void *model_, void *opts_, void *mem_, void *work_);
 } ocp_nlp_dynamics_config;
 

--- a/acados/ocp_nlp/ocp_nlp_dynamics_common.h
+++ b/acados/ocp_nlp/ocp_nlp_dynamics_common.h
@@ -85,11 +85,8 @@ typedef struct
     struct blasfeo_dvec *(*memory_get_fun_ptr)(void *memory_);
     struct blasfeo_dvec *(*memory_get_adj_ptr)(void *memory_);
     void (*memory_set_ux_ptr)(struct blasfeo_dvec *ux, void *memory_);
-    void (*memory_set_tmp_ux_ptr)(struct blasfeo_dvec *tmp_ux, void *memory_);
     void (*memory_set_ux1_ptr)(struct blasfeo_dvec *ux1, void *memory_);
-    void (*memory_set_tmp_ux1_ptr)(struct blasfeo_dvec *tmp_ux1, void *memory_);
     void (*memory_set_pi_ptr)(struct blasfeo_dvec *pi, void *memory_);
-    void (*memory_set_tmp_pi_ptr)(struct blasfeo_dvec *tmp_pi, void *memory_);
     void (*memory_set_BAbt_ptr)(struct blasfeo_dmat *BAbt, void *memory_);
     void (*memory_set_RSQrq_ptr)(struct blasfeo_dmat *RSQrq, void *memory_);
     void (*memory_set_dzduxt_ptr)(struct blasfeo_dmat *mat, void *memory_);
@@ -101,7 +98,7 @@ typedef struct
     acados_size_t (*workspace_calculate_size)(void *config, void *dims, void *opts);
     void (*initialize)(void *config_, void *dims, void *model_, void *opts_, void *mem_, void *work_);
     void (*update_qp_matrices)(void *config_, void *dims, void *model_, void *opts_, void *mem_, void *work_);
-    void (*compute_fun)(void *config_, void *dims, void *model_, void *opts_, void *mem_, void *work_, bool use_tmp_values);
+    void (*compute_fun)(void *config_, void *dims, void *model_, void *opts_, void *mem_, void *work_);
     int (*precompute)(void *config_, void *dims, void *model_, void *opts_, void *mem_, void *work_);
 } ocp_nlp_dynamics_config;
 

--- a/acados/ocp_nlp/ocp_nlp_dynamics_cont.c
+++ b/acados/ocp_nlp/ocp_nlp_dynamics_cont.c
@@ -449,17 +449,6 @@ void ocp_nlp_dynamics_cont_memory_set_ux_ptr(struct blasfeo_dvec *ux, void *memo
 
 
 
-void ocp_nlp_dynamics_cont_memory_set_tmp_ux_ptr(struct blasfeo_dvec *tmp_ux, void *memory_)
-{
-    ocp_nlp_dynamics_cont_memory *memory = memory_;
-
-    memory->tmp_ux = tmp_ux;
-
-    return;
-}
-
-
-
 void ocp_nlp_dynamics_cont_memory_set_ux1_ptr(struct blasfeo_dvec *ux1, void *memory_)
 {
     ocp_nlp_dynamics_cont_memory *memory = memory_;
@@ -470,34 +459,11 @@ void ocp_nlp_dynamics_cont_memory_set_ux1_ptr(struct blasfeo_dvec *ux1, void *me
 }
 
 
-
-void ocp_nlp_dynamics_cont_memory_set_tmp_ux1_ptr(struct blasfeo_dvec *tmp_ux1, void *memory_)
-{
-    ocp_nlp_dynamics_cont_memory *memory = memory_;
-
-    memory->tmp_ux1 = tmp_ux1;
-
-    return;
-}
-
-
-
 void ocp_nlp_dynamics_cont_memory_set_pi_ptr(struct blasfeo_dvec *pi, void *memory_)
 {
     ocp_nlp_dynamics_cont_memory *memory = memory_;
 
     memory->pi = pi;
-
-    return;
-}
-
-
-
-void ocp_nlp_dynamics_cont_memory_set_tmp_pi_ptr(struct blasfeo_dvec *tmp_pi, void *memory_)
-{
-    ocp_nlp_dynamics_cont_memory *memory = memory_;
-
-    memory->tmp_pi = tmp_pi;
 
     return;
 }
@@ -895,7 +861,7 @@ void ocp_nlp_dynamics_cont_update_qp_matrices(void *config_, void *dims_, void *
 
 
 
-void ocp_nlp_dynamics_cont_compute_fun(void *config_, void *dims_, void *model_, void *opts_, void *mem_, void *work_, bool use_tmp_values)
+void ocp_nlp_dynamics_cont_compute_fun(void *config_, void *dims_, void *model_, void *opts_, void *mem_, void *work_)
 {
     ocp_nlp_dynamics_cont_cast_workspace(config_, dims_, opts_, work_, mem_);
 
@@ -906,18 +872,8 @@ void ocp_nlp_dynamics_cont_compute_fun(void *config_, void *dims_, void *model_,
     ocp_nlp_dynamics_cont_memory *mem = mem_;
     ocp_nlp_dynamics_cont_model *model = model_;
 
-    struct blasfeo_dvec *ux;
-    struct blasfeo_dvec *ux1;
-    if (use_tmp_values)
-    {
-        ux = mem->tmp_ux;
-        ux1 = mem->tmp_ux1;
-    }
-    else
-    {
-        ux = mem->ux;
-        ux1 = mem->ux1;
-    }
+    struct blasfeo_dvec *ux = mem->ux;
+    struct blasfeo_dvec *ux1 = mem->ux1;
 
     int nx = dims->nx;
     int nu = dims->nu;
@@ -1027,11 +983,8 @@ void ocp_nlp_dynamics_cont_config_initialize_default(void *config_)
     config->memory_get_adj_ptr = &ocp_nlp_dynamics_cont_memory_get_adj_ptr;
     config->memory_set = &ocp_nlp_dynamics_cont_memory_set;
     config->memory_set_ux_ptr = &ocp_nlp_dynamics_cont_memory_set_ux_ptr;
-    config->memory_set_tmp_ux_ptr = &ocp_nlp_dynamics_cont_memory_set_tmp_ux_ptr;
     config->memory_set_ux1_ptr = &ocp_nlp_dynamics_cont_memory_set_ux1_ptr;
-    config->memory_set_tmp_ux1_ptr = &ocp_nlp_dynamics_cont_memory_set_tmp_ux1_ptr;
     config->memory_set_pi_ptr = &ocp_nlp_dynamics_cont_memory_set_pi_ptr;
-    config->memory_set_tmp_pi_ptr = &ocp_nlp_dynamics_cont_memory_set_tmp_pi_ptr;
     config->memory_set_BAbt_ptr = &ocp_nlp_dynamics_cont_memory_set_BAbt_ptr;
     config->memory_set_RSQrq_ptr = &ocp_nlp_dynamics_cont_memory_set_RSQrq_ptr;
     config->memory_set_dzduxt_ptr = &ocp_nlp_dynamics_cont_memory_set_dzduxt_ptr;

--- a/acados/ocp_nlp/ocp_nlp_dynamics_cont.h
+++ b/acados/ocp_nlp/ocp_nlp_dynamics_cont.h
@@ -108,11 +108,8 @@ typedef struct
     struct blasfeo_dvec fun;
     struct blasfeo_dvec adj;
     struct blasfeo_dvec *ux;            // pointer to ux in nlp_out at current stage
-    struct blasfeo_dvec *tmp_ux;        // pointer to ux in tmp_nlp_out at current stage
     struct blasfeo_dvec *ux1;           // pointer to ux in nlp_out at next stage
-    struct blasfeo_dvec *tmp_ux1;       // pointer to ux in tmp_nlp_out at next stage
     struct blasfeo_dvec *pi;            // pointer to pi in nlp_out at current stage
-    struct blasfeo_dvec *tmp_pi;        // pointer to pi in tmp_nlp_out at current stage
     struct blasfeo_dmat *BAbt;          // pointer to BAbt in qp_in
     struct blasfeo_dmat *RSQrq;         // pointer to RSQrq in qp_in
     struct blasfeo_dvec *z_alg;         // pointer to output z at t = 0
@@ -136,15 +133,9 @@ struct blasfeo_dvec *ocp_nlp_dynamics_cont_memory_get_adj_ptr(void *memory);
 //
 void ocp_nlp_dynamics_cont_memory_set_ux_ptr(struct blasfeo_dvec *ux, void *memory);
 //
-void ocp_nlp_dynamics_cont_memory_set_tmp_ux_ptr(struct blasfeo_dvec *tmp_ux, void *memory);
-//
 void ocp_nlp_dynamics_cont_memory_set_ux1_ptr(struct blasfeo_dvec *ux1, void *memory);
 //
-void ocp_nlp_dynamics_cont_memory_set_tmp_ux1_ptr(struct blasfeo_dvec *tmp_ux1, void *memory);
-//
 void ocp_nlp_dynamics_cont_memory_set_pi_ptr(struct blasfeo_dvec *pi, void *memory);
-//
-void ocp_nlp_dynamics_cont_memory_set_tmp_pi_ptr(struct blasfeo_dvec *tmp_pi, void *memory);
 //
 void ocp_nlp_dynamics_cont_memory_set_BAbt_ptr(struct blasfeo_dmat *BAbt, void *memory);
 
@@ -197,7 +188,7 @@ void ocp_nlp_dynamics_cont_initialize(void *config_, void *dims, void *model_, v
 //
 void ocp_nlp_dynamics_cont_update_qp_matrices(void *config_, void *dims, void *model_, void *opts, void *mem, void *work_);
 //
-void ocp_nlp_dynamics_cont_compute_fun(void *config_, void *dims, void *model_, void *opts, void *mem, void *work_, bool use_tmp_values);
+void ocp_nlp_dynamics_cont_compute_fun(void *config_, void *dims, void *model_, void *opts, void *mem, void *work_);
 //
 int ocp_nlp_dynamics_cont_precompute(void *config_, void *dims, void *model_, void *opts_, void *mem_, void *work_);
 

--- a/acados/ocp_nlp/ocp_nlp_dynamics_cont.h
+++ b/acados/ocp_nlp/ocp_nlp_dynamics_cont.h
@@ -197,7 +197,7 @@ void ocp_nlp_dynamics_cont_initialize(void *config_, void *dims, void *model_, v
 //
 void ocp_nlp_dynamics_cont_update_qp_matrices(void *config_, void *dims, void *model_, void *opts, void *mem, void *work_);
 //
-void ocp_nlp_dynamics_cont_compute_fun(void *config_, void *dims, void *model_, void *opts, void *mem, void *work_);
+void ocp_nlp_dynamics_cont_compute_fun(void *config_, void *dims, void *model_, void *opts, void *mem, void *work_, bool use_tmp_values);
 //
 int ocp_nlp_dynamics_cont_precompute(void *config_, void *dims, void *model_, void *opts_, void *mem_, void *work_);
 

--- a/acados/ocp_nlp/ocp_nlp_dynamics_disc.c
+++ b/acados/ocp_nlp/ocp_nlp_dynamics_disc.c
@@ -365,18 +365,6 @@ void ocp_nlp_dynamics_disc_memory_set_ux_ptr(struct blasfeo_dvec *ux, void *memo
 }
 
 
-
-void ocp_nlp_dynamics_disc_memory_set_tmp_ux_ptr(struct blasfeo_dvec *tmp_ux, void *memory_)
-{
-    ocp_nlp_dynamics_disc_memory *memory = memory_;
-
-    memory->tmp_ux = tmp_ux;
-
-    return;
-}
-
-
-
 void ocp_nlp_dynamics_disc_memory_set_ux1_ptr(struct blasfeo_dvec *ux1, void *memory_)
 {
     ocp_nlp_dynamics_disc_memory *memory = memory_;
@@ -385,18 +373,6 @@ void ocp_nlp_dynamics_disc_memory_set_ux1_ptr(struct blasfeo_dvec *ux1, void *me
 
     return;
 }
-
-
-
-void ocp_nlp_dynamics_disc_memory_set_tmp_ux1_ptr(struct blasfeo_dvec *tmp_ux1, void *memory_)
-{
-    ocp_nlp_dynamics_disc_memory *memory = memory_;
-
-    memory->tmp_ux1 = tmp_ux1;
-
-    return;
-}
-
 
 
 void ocp_nlp_dynamics_disc_memory_set_pi_ptr(struct blasfeo_dvec *pi, void *memory_)
@@ -408,16 +384,6 @@ void ocp_nlp_dynamics_disc_memory_set_pi_ptr(struct blasfeo_dvec *pi, void *memo
     return;
 }
 
-
-
-void ocp_nlp_dynamics_disc_memory_set_tmp_pi_ptr(struct blasfeo_dvec *tmp_pi, void *memory_)
-{
-    ocp_nlp_dynamics_disc_memory *memory = memory_;
-
-    memory->tmp_pi = tmp_pi;
-
-    return;
-}
 
 
 
@@ -741,7 +707,7 @@ void ocp_nlp_dynamics_disc_update_qp_matrices(void *config_, void *dims_, void *
 
 
 void ocp_nlp_dynamics_disc_compute_fun(void *config_, void *dims_, void *model_, void *opts_,
-                                              void *mem_, void *work_, bool use_tmp_values)
+                                              void *mem_, void *work_)
 {
     ocp_nlp_dynamics_disc_cast_workspace(config_, dims_, opts_, work_);
 
@@ -762,18 +728,8 @@ void ocp_nlp_dynamics_disc_compute_fun(void *config_, void *dims_, void *model_,
     ext_fun_arg_t ext_fun_type_out[1];
     void *ext_fun_out[1];
 
-    struct blasfeo_dvec *ux;
-    struct blasfeo_dvec *ux1;
-    if (use_tmp_values)
-    {
-        ux = memory->tmp_ux;
-        ux1 = memory->tmp_ux1;
-    }
-    else
-    {
-        ux = memory->ux;
-        ux1 = memory->ux1;
-    }
+    struct blasfeo_dvec *ux = memory->ux;
+    struct blasfeo_dvec *ux1 = memory->ux1;
 
     // pass state and control to integrator
     struct blasfeo_dvec_args x_in;  // input x of external fun;
@@ -837,11 +793,8 @@ void ocp_nlp_dynamics_disc_config_initialize_default(void *config_)
     config->memory_get_fun_ptr = &ocp_nlp_dynamics_disc_memory_get_fun_ptr;
     config->memory_get_adj_ptr = &ocp_nlp_dynamics_disc_memory_get_adj_ptr;
     config->memory_set_ux_ptr = &ocp_nlp_dynamics_disc_memory_set_ux_ptr;
-    config->memory_set_tmp_ux_ptr = &ocp_nlp_dynamics_disc_memory_set_tmp_ux_ptr;
     config->memory_set_ux1_ptr = &ocp_nlp_dynamics_disc_memory_set_ux1_ptr;
-    config->memory_set_tmp_ux1_ptr = &ocp_nlp_dynamics_disc_memory_set_tmp_ux1_ptr;
     config->memory_set_pi_ptr = &ocp_nlp_dynamics_disc_memory_set_pi_ptr;
-    config->memory_set_tmp_pi_ptr = &ocp_nlp_dynamics_disc_memory_set_tmp_pi_ptr;
     config->memory_set_BAbt_ptr = &ocp_nlp_dynamics_disc_memory_set_BAbt_ptr;
     config->memory_set_RSQrq_ptr = &ocp_nlp_dynamics_disc_memory_set_RSQrq_ptr;
     config->memory_set_dzduxt_ptr = &ocp_nlp_dynamics_disc_memory_set_dzduxt_ptr;

--- a/acados/ocp_nlp/ocp_nlp_dynamics_disc.h
+++ b/acados/ocp_nlp/ocp_nlp_dynamics_disc.h
@@ -180,7 +180,7 @@ void ocp_nlp_dynamics_disc_initialize(void *config_, void *dims, void *model_, v
 //
 void ocp_nlp_dynamics_disc_update_qp_matrices(void *config_, void *dims, void *model_, void *opts, void *mem, void *work_);
 //
-void ocp_nlp_dynamics_disc_compute_fun(void *config_, void *dims, void *model_, void *opts, void *mem, void *work_);
+void ocp_nlp_dynamics_disc_compute_fun(void *config_, void *dims, void *model_, void *opts, void *mem, void *work_, bool use_tmp_values);
 
 
 

--- a/acados/ocp_nlp/ocp_nlp_dynamics_disc.h
+++ b/acados/ocp_nlp/ocp_nlp_dynamics_disc.h
@@ -102,11 +102,8 @@ typedef struct
     struct blasfeo_dvec fun;
     struct blasfeo_dvec adj;
     struct blasfeo_dvec *ux;     // pointer to ux in nlp_out at current stage
-    struct blasfeo_dvec *tmp_ux; // pointer to ux in tmp_nlp_out at current stage
     struct blasfeo_dvec *ux1;    // pointer to ux in nlp_out at next stage
-    struct blasfeo_dvec *tmp_ux1;// pointer to ux in tmp_nlp_out at next stage
     struct blasfeo_dvec *pi;     // pointer to pi in nlp_out at current stage
-    struct blasfeo_dvec *tmp_pi; // pointer to pi in tmp_nlp_out at current stage
     struct blasfeo_dmat *BAbt;   // pointer to BAbt in qp_in
     struct blasfeo_dmat *RSQrq;  // pointer to RSQrq in qp_in
 } ocp_nlp_dynamics_disc_memory;
@@ -122,15 +119,9 @@ struct blasfeo_dvec *ocp_nlp_dynamics_disc_memory_get_adj_ptr(void *memory);
 //
 void ocp_nlp_dynamics_disc_memory_set_ux_ptr(struct blasfeo_dvec *ux, void *memory);
 //
-void ocp_nlp_dynamics_disc_memory_set_tmp_ux_ptr(struct blasfeo_dvec *tmp_ux, void *memory);
-//
 void ocp_nlp_dynamics_disc_memory_set_ux1_ptr(struct blasfeo_dvec *ux1, void *memory);
 //
-void ocp_nlp_dynamics_disc_memory_set_tmp_ux1_ptr(struct blasfeo_dvec *tmp_ux1, void *memory);
-//
 void ocp_nlp_dynamics_disc_memory_set_pi_ptr(struct blasfeo_dvec *pi, void *memory);
-//
-void ocp_nlp_dynamics_disc_memory_set_tmp_pi_ptr(struct blasfeo_dvec *tmp_pi, void *memory);
 //
 void ocp_nlp_dynamics_disc_memory_set_BAbt_ptr(struct blasfeo_dmat *BAbt, void *memory);
 
@@ -180,7 +171,7 @@ void ocp_nlp_dynamics_disc_initialize(void *config_, void *dims, void *model_, v
 //
 void ocp_nlp_dynamics_disc_update_qp_matrices(void *config_, void *dims, void *model_, void *opts, void *mem, void *work_);
 //
-void ocp_nlp_dynamics_disc_compute_fun(void *config_, void *dims, void *model_, void *opts, void *mem, void *work_, bool use_tmp_values);
+void ocp_nlp_dynamics_disc_compute_fun(void *config_, void *dims, void *model_, void *opts, void *mem, void *work_);
 
 
 

--- a/examples/acados_python/linear_mass_model/linear_mass_test_problem.py
+++ b/examples/acados_python/linear_mass_model/linear_mass_test_problem.py
@@ -223,14 +223,8 @@ def solve_marathos_ocp(setting):
         if sqp_iter != 18:
             raise Exception(f"acados solver took {sqp_iter} iterations, expected 18.")
     elif globalization == "MERIT_BACKTRACKING":
-        if globalization_use_SOC == 1 and line_search_use_sufficient_descent == 0 and sqp_iter not in range(21, 23):
-            raise Exception(f"acados solver took {sqp_iter} iterations, expected range(21, 23).")
-        elif globalization_use_SOC == 1 and line_search_use_sufficient_descent == 1 and sqp_iter not in range(21, 24):
-            raise Exception(f"acados solver took {sqp_iter} iterations, expected range(21, 24).")
-        elif globalization_use_SOC == 0 and line_search_use_sufficient_descent == 0 and sqp_iter not in range(155, 165):
-            raise Exception(f"acados solver took {sqp_iter} iterations, expected range(155, 165).")
-        elif globalization_use_SOC == 0 and line_search_use_sufficient_descent == 1 and sqp_iter not in range(160, 175):
-            raise Exception(f"acados solver took {sqp_iter} iterations, expected range(160, 175).")
+        if sqp_iter not in range(17, 23):
+            raise Exception(f"acados solver took {sqp_iter} iterations, expected range(17, 23).")
 
     if PLOT:
         plot_linear_mass_system_X_state_space(simX, circle=circle, x_goal=x_goal)


### PR DESCRIPTION
In some places `tmp_ux` and `ux` where used in a mixed way, i.e. `compute_fun` of constraint modules and what was fixed in #1039 
- fixes bug when using globalization and cost computation
- fixes bug in globalization with slacks. Constraint was evaluated with slack values from SQP iterate instead of values from the line search candidate

Implementation:
- Removed all `tmp_*` pointers in SQP submodules
- Always evaluate at `ux`
- When one wants to evaluate at another iterate, these pointers have to be temporarily set to another iterate and afterwards reset to the nominal SQP iterate, as done in `ocp_nlp_evaluate_merit_fun` now.