### PR TITLE
Implement advanced-step real-time iteration: AS-RTI

### DIFF
--- a/acados/ocp_nlp/ocp_nlp_common.c
+++ b/acados/ocp_nlp/ocp_nlp_common.c
@@ -2199,6 +2199,7 @@ void ocp_nlp_approximate_qp_matrices(ocp_nlp_config *config, ocp_nlp_dims *dims,
         }
         if (i > 0)
         {
+            // TODO: this could be simplified by not copying pi in the dynamics module.
             struct blasfeo_dvec *dyn_adj
                 = config->dynamics[i-1]->memory_get_adj_ptr(mem->dynamics[i-1]);
             blasfeo_daxpy(nx[i], 1.0, dyn_adj, nu[i-1]+nx[i-1], mem->dyn_adj+i, nu[i],

--- a/acados/ocp_nlp/ocp_nlp_common.c
+++ b/acados/ocp_nlp/ocp_nlp_common.c
@@ -2262,7 +2262,7 @@ void ocp_nlp_zero_order_qp_update(ocp_nlp_config *config,
     ocp_nlp_memory *mem, ocp_nlp_workspace *work)
 {
     int N = dims->N;
-    int *nv = dims->nv;
+    // int *nv = dims->nv;
     int *nx = dims->nx;
     int *nu = dims->nu;
     int *ni = dims->ni;

--- a/acados/ocp_nlp/ocp_nlp_common.c
+++ b/acados/ocp_nlp/ocp_nlp_common.c
@@ -2296,8 +2296,8 @@ void ocp_nlp_zero_order_qp_update(ocp_nlp_config *config,
     // rqz += Hess * last_step = RQ * qp_out
     for (int i = 0; i <= N; i++)
     {
-        // TODO: Make sure RSQ is full (not just triagonal stored!)
-        blasfeo_dgemv_n(nx[i]+nu[i], nx[i]+nu[i], 1.0, mem->qp_in->RSQrq+i, 0, 0,
+        // NOTE: only lower triagonal of RSQ is stored
+        blasfeo_dsymv_l_mn(nx[i]+nu[i], nx[i]+nu[i], 1.0, mem->qp_in->RSQrq+i, 0, 0,
                         mem->qp_out->ux+i, 0, 1.0, mem->qp_in->rqz+i, 0, mem->qp_in->rqz+i, 0);
         // TODO: fix for ns > 0.
     }

--- a/acados/ocp_nlp/ocp_nlp_common.c
+++ b/acados/ocp_nlp/ocp_nlp_common.c
@@ -2278,6 +2278,8 @@ void ocp_nlp_zero_order_qp_update(ocp_nlp_config *config,
         // copy ineq function value into QP
         struct blasfeo_dvec *ineq_fun = config->constraints[i]->memory_get_fun_ptr(mem->constraints[i]);
         blasfeo_dveccp(2 * ni[i], ineq_fun, 0, mem->qp_in->d + i, 0);
+        // copy into nlp_mem
+        blasfeo_dveccp(2 * ni[i], ineq_fun, 0, mem->ineq_fun + i, 0);
     }
 
 #if defined(ACADOS_WITH_OPENMP)
@@ -2291,6 +2293,7 @@ void ocp_nlp_zero_order_qp_update(ocp_nlp_config *config,
 
         struct blasfeo_dvec *dyn_fun = config->dynamics[i]->memory_get_fun_ptr(mem->dynamics[i]);
         blasfeo_dveccp(nx[i + 1], dyn_fun, 0, mem->qp_in->b + i, 0);
+        blasfeo_dveccp(nx[i + 1], dyn_fun, 0, mem->dyn_fun + i, 0);
     }
 
     // add gradient correction
@@ -2327,6 +2330,8 @@ void ocp_nlp_level_c_update(ocp_nlp_config *config,
         // copy ineq function value into QP
         struct blasfeo_dvec *ineq_fun = config->constraints[i]->memory_get_fun_ptr(mem->constraints[i]);
         blasfeo_dveccp(2 * ni[i], ineq_fun, 0, mem->qp_in->d + i, 0);
+        // copy into nlp_mem
+        blasfeo_dveccp(2 * ni[i], ineq_fun, 0, mem->ineq_fun + i, 0);
     }
 
 #if defined(ACADOS_WITH_OPENMP)
@@ -2341,6 +2346,7 @@ void ocp_nlp_level_c_update(ocp_nlp_config *config,
 
         struct blasfeo_dvec *dyn_fun = config->dynamics[i]->memory_get_fun_ptr(mem->dynamics[i]);
         blasfeo_dveccp(nx[i + 1], dyn_fun, 0, mem->qp_in->b + i, 0);
+        blasfeo_dveccp(nx[i + 1], dyn_fun, 0, mem->dyn_fun + i, 0);
 
         // add adjoint contribution to gradient
         struct blasfeo_dvec *dyn_adj = config->dynamics[i]->memory_get_adj_ptr(mem->dynamics[i]);
@@ -3084,8 +3090,8 @@ void ocp_nlp_res_compute(ocp_nlp_dims *dims, ocp_nlp_in *in, ocp_nlp_out *out, o
     // res_stat
     for (int i = 0; i <= N; i++)
     {
-        blasfeo_daxpy(nv[i], -1.0, mem->ineq_adj + i, 0, mem->cost_grad + i, 0, res->res_stat + i,
-                      0);
+        blasfeo_daxpy(nv[i], -1.0, mem->ineq_adj + i, 0, mem->cost_grad + i, 0,
+                      res->res_stat + i, 0);
         blasfeo_daxpy(nu[i] + nx[i], -1.0, mem->dyn_adj + i, 0, res->res_stat + i, 0,
                       res->res_stat + i, 0);
         blasfeo_dvecnrm_inf(nv[i], res->res_stat + i, 0, &tmp_res);

--- a/acados/ocp_nlp/ocp_nlp_common.c
+++ b/acados/ocp_nlp/ocp_nlp_common.c
@@ -2311,7 +2311,7 @@ void ocp_nlp_level_c_update(ocp_nlp_config *config,
     ocp_nlp_memory *mem, ocp_nlp_workspace *work)
 {
     int N = dims->N;
-    int *nv = dims->nv;
+    // int *nv = dims->nv;
     int *nx = dims->nx;
     int *nu = dims->nu;
     int *ni = dims->ni;

--- a/acados/ocp_nlp/ocp_nlp_common.h
+++ b/acados/ocp_nlp/ocp_nlp_common.h
@@ -417,6 +417,10 @@ void ocp_nlp_zero_order_qp_update(ocp_nlp_config *config,
     ocp_nlp_dims *dims, ocp_nlp_in *in, ocp_nlp_out *out, ocp_nlp_opts *opts,
     ocp_nlp_memory *mem, ocp_nlp_workspace *work);
 //
+void ocp_nlp_level_c_update(ocp_nlp_config *config,
+    ocp_nlp_dims *dims, ocp_nlp_in *in, ocp_nlp_out *out, ocp_nlp_opts *opts,
+    ocp_nlp_memory *mem, ocp_nlp_workspace *work);
+//
 void ocp_nlp_update_variables_sqp(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in,
            ocp_nlp_out *out, ocp_nlp_opts *opts, ocp_nlp_memory *mem, ocp_nlp_workspace *work, double alpha);
 //

--- a/acados/ocp_nlp/ocp_nlp_common.h
+++ b/acados/ocp_nlp/ocp_nlp_common.h
@@ -413,6 +413,10 @@ void ocp_nlp_approximate_qp_matrices(ocp_nlp_config *config, ocp_nlp_dims *dims,
 void ocp_nlp_approximate_qp_vectors_sqp(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in,
                  ocp_nlp_out *out, ocp_nlp_opts *opts, ocp_nlp_memory *mem, ocp_nlp_workspace *work);
 //
+void ocp_nlp_zero_order_qp_update(ocp_nlp_config *config,
+    ocp_nlp_dims *dims, ocp_nlp_in *in, ocp_nlp_out *out, ocp_nlp_opts *opts,
+    ocp_nlp_memory *mem, ocp_nlp_workspace *work);
+//
 void ocp_nlp_update_variables_sqp(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in,
            ocp_nlp_out *out, ocp_nlp_opts *opts, ocp_nlp_memory *mem, ocp_nlp_workspace *work, double alpha);
 //

--- a/acados/ocp_nlp/ocp_nlp_common.h
+++ b/acados/ocp_nlp/ocp_nlp_common.h
@@ -384,6 +384,8 @@ typedef struct ocp_nlp_workspace
     struct blasfeo_dvec tmp_nxu;
     struct blasfeo_dvec tmp_ni;
     struct blasfeo_dvec dxnext_dy;
+    // AS-RTI
+    double *tmp_nxu_double;
 
 } ocp_nlp_workspace;
 

--- a/acados/ocp_nlp/ocp_nlp_constraints_bgh.c
+++ b/acados/ocp_nlp/ocp_nlp_constraints_bgh.c
@@ -1479,13 +1479,20 @@ void ocp_nlp_constraints_bgh_update_qp_matrices(void *config_, void *dims_, void
     // nlp_mem: ineq_adj
     if (opts->compute_adj)
     {
+        // adj = zeros(nu+nx+2*ns)
         blasfeo_dvecse(nu+nx+2*ns, 0.0, &memory->adj, 0);
+        // tmp_ni = - lam_lower + lam_upper
         blasfeo_daxpy(nb+ng+nh, -1.0, memory->lam, nb+ng+nh, memory->lam, 0, &work->tmp_ni, 0);
+        // adj[idxb] += tmp_ni[:nb]
         blasfeo_dvecad_sp(nb, 1.0, &work->tmp_ni, 0, model->idxb, &memory->adj, 0);
+        // adj += DCt * tmp_ni[nb:]
         blasfeo_dgemv_n(nu+nx, ng+nh, 1.0, memory->DCt, 0, 0, &work->tmp_ni, nb, 1.0, &memory->adj, 0, &memory->adj, 0);
         // soft
+        // adj[nu+nx:nu+nx+ns] = lam[idxs]
         blasfeo_dvecex_sp(ns, 1.0, model->idxs, memory->lam, 0, &memory->adj, nu+nx);
+        // adj[nu+nx+ns : nu+nx+2*ns] = lam[idxs + nb+ng+nh]
         blasfeo_dvecex_sp(ns, 1.0, model->idxs, memory->lam, nb+ng+nh, &memory->adj, nu+nx+ns);
+        // adj[nu+nx: ] += lam[2*nb+2*ng+2*nh :]
         blasfeo_daxpy(2*ns, 1.0, memory->lam, 2*nb+2*ng+2*nh, &memory->adj, nu+nx, &memory->adj, nu+nx);
     }
 

--- a/acados/ocp_nlp/ocp_nlp_cost_common.h
+++ b/acados/ocp_nlp/ocp_nlp_cost_common.h
@@ -87,6 +87,7 @@ typedef struct
     void (*update_qp_matrices)(void *config_, void *dims, void *model_, void *opts_, void *mem_, void *work_);
     // computes the cost function value (intended for globalization)
     void (*compute_fun)(void *config_, void *dims, void *model_, void *opts_, void *mem_, void *work_);
+    void (*compute_gradient)(void *config_, void *dims, void *model_, void *opts_, void *mem_, void *work_);
     void (*config_initialize_default)(void *config);
     void (*precompute)(void *config_, void *dims_, void *model_, void *opts_, void *memory_, void *work_);
 

--- a/acados/ocp_nlp/ocp_nlp_cost_conl.c
+++ b/acados/ocp_nlp/ocp_nlp_cost_conl.c
@@ -712,6 +712,118 @@ void ocp_nlp_cost_conl_update_qp_matrices(void *config_, void *dims_, void *mode
 
 
 
+
+void ocp_nlp_cost_conl_compute_gradient(void *config_, void *dims_, void *model_, void *opts_,
+                                         void *memory_, void *work_)
+{
+    ocp_nlp_cost_conl_dims *dims = dims_;
+    ocp_nlp_cost_conl_model *model = model_;
+    ocp_nlp_cost_conl_memory *memory = memory_;
+    ocp_nlp_cost_conl_workspace *work = work_;
+    ocp_nlp_cost_conl_opts *opts = (ocp_nlp_cost_conl_opts *) opts_;
+
+    ocp_nlp_cost_conl_cast_workspace(config_, dims, opts_, work_);
+
+    int nx = dims->nx;
+    int nz = dims->nz;
+    int nu = dims->nu;
+    int ny = dims->ny;
+    int ns = dims->ns;
+
+    if (opts->integrator_cost == 0)
+    {
+        ext_fun_arg_t conl_fun_jac_hess_type_in[5];
+        void *conl_fun_jac_hess_in[5];
+        ext_fun_arg_t conl_fun_jac_hess_type_out[5];
+        void *conl_fun_jac_hess_out[5];
+
+        // INPUT
+        struct blasfeo_dvec_args x_in;  // input x
+        x_in.x = memory->ux;
+        x_in.xi = nu;
+
+        struct blasfeo_dvec_args u_in;  // input u
+        u_in.x = memory->ux;
+        u_in.xi = 0;
+
+        conl_fun_jac_hess_type_in[0] = BLASFEO_DVEC_ARGS;
+        conl_fun_jac_hess_in[0] = &x_in;
+        conl_fun_jac_hess_type_in[1] = BLASFEO_DVEC_ARGS;
+        conl_fun_jac_hess_in[1] = &u_in;
+
+        conl_fun_jac_hess_type_in[2] = BLASFEO_DVEC;
+        conl_fun_jac_hess_in[2] = memory->z_alg;
+        conl_fun_jac_hess_type_in[3] = BLASFEO_DVEC;
+        conl_fun_jac_hess_in[3] = &model->y_ref;
+
+        conl_fun_jac_hess_type_in[4] = COLMAJ;
+        conl_fun_jac_hess_in[4] = &model->t;
+
+        // OUTPUT
+        conl_fun_jac_hess_type_out[0] = COLMAJ;
+        conl_fun_jac_hess_out[0] = &memory->fun;         // fun: scalar
+        conl_fun_jac_hess_type_out[1] = BLASFEO_DVEC;
+        conl_fun_jac_hess_out[1] = &work->tmp_ny;        // grad of outer loss wrt residual, ny
+        conl_fun_jac_hess_type_out[2] = BLASFEO_DMAT;
+        conl_fun_jac_hess_out[2] = &work->Jt_ux;         // inner Jacobian wrt ux, transposed, (nu+nx) x ny
+        conl_fun_jac_hess_type_out[3] = BLASFEO_DMAT;
+        conl_fun_jac_hess_out[3] = &work->Jt_z;          // inner Jacobian wrt z, transposed, nz x ny
+        conl_fun_jac_hess_type_out[4] = BLASFEO_DMAT;
+        conl_fun_jac_hess_out[4] = &work->W;             // outer hessian: ny x ny
+
+        // evaluate external function
+        model->conl_cost_fun_jac_hess->evaluate(model->conl_cost_fun_jac_hess, conl_fun_jac_hess_type_in,
+                                                conl_fun_jac_hess_in, conl_fun_jac_hess_type_out, conl_fun_jac_hess_out);
+
+        // hessian of outer loss function
+        blasfeo_dpotrf_l(ny, &work->W, 0, 0, &memory->W_chol, 0, 0);
+
+        if (nz > 0)
+        {
+            // Jt_ux_tilde = Jt_ux + dzdux_tran*Jt_z
+            blasfeo_dgemm_nn(nu + nx, ny, nz, 1.0, memory->dzdux_tran, 0, 0,
+                    &work->Jt_z, 0, 0, 1.0, &work->Jt_ux, 0, 0, &work->Jt_ux_tilde, 0, 0);
+
+            // grad = Jt_ux_tilde * tmp_ny
+            blasfeo_dgemv_n(nu+nx, ny, 1.0, &work->Jt_ux_tilde, 0, 0, &work->tmp_ny, 0,
+                            0.0, &memory->grad, 0, &memory->grad, 0);
+
+            // // tmp_nv_ny = Jt_ux_tilde * W_chol
+            // blasfeo_dtrmm_rlnn(nu + nx, ny, 1.0, &memory->W_chol, 0, 0,
+            //                 &work->Jt_ux_tilde, 0, 0, &work->tmp_nv_ny, 0, 0);
+        }
+        else
+        {
+            // grad = Jt_ux * tmp_ny
+            blasfeo_dgemv_n(nu+nx, ny, 1.0, &work->Jt_ux, 0, 0, &work->tmp_ny, 0,
+                            0.0, &memory->grad, 0, &memory->grad, 0);
+
+            // // tmp_nv_ny = Jt_ux * W_chol, where W_chol is lower triangular
+            // blasfeo_dtrmm_rlnn(nu+nx, ny, 1.0, &memory->W_chol, 0, 0, &work->Jt_ux, 0, 0,
+            //                     &work->tmp_nv_ny, 0, 0);
+
+        }
+        // // RSQrq += scaling * tmp_nv_ny * tmp_nv_ny^T
+        // blasfeo_dsyrk_ln(nu+nx, ny, model->scaling, &work->tmp_nv_ny, 0, 0, &work->tmp_nv_ny, 0, 0,
+        //                 1.0, memory->RSQrq, 0, 0, memory->RSQrq, 0, 0);
+    }
+
+    // slack update gradient
+    blasfeo_dveccp(2*ns, &model->z, 0, &memory->grad, nu+nx);
+    blasfeo_dvecmulacc(2*ns, &model->Z, 0, memory->ux, nu+nx, &memory->grad, nu+nx);
+
+    // scale
+    if(model->scaling!=1.0)
+    {
+        blasfeo_dvecsc(nu+nx+2*ns, model->scaling, &memory->grad, 0);
+    }
+
+    return;
+}
+
+
+
+
 void ocp_nlp_cost_conl_compute_fun(void *config_, void *dims_, void *model_,
                                   void *opts_, void *memory_, void *work_)
 {
@@ -812,6 +924,7 @@ void ocp_nlp_cost_conl_config_initialize_default(void *config_)
     config->initialize = &ocp_nlp_cost_conl_initialize;
     config->update_qp_matrices = &ocp_nlp_cost_conl_update_qp_matrices;
     config->compute_fun = &ocp_nlp_cost_conl_compute_fun;
+    config->compute_gradient = &ocp_nlp_cost_conl_compute_gradient;
     config->config_initialize_default = &ocp_nlp_cost_conl_config_initialize_default;
     config->precompute = &ocp_nlp_cost_conl_precompute;
 

--- a/acados/ocp_nlp/ocp_nlp_cost_conl.c
+++ b/acados/ocp_nlp/ocp_nlp_cost_conl.c
@@ -771,12 +771,13 @@ void ocp_nlp_cost_conl_compute_gradient(void *config_, void *dims_, void *model_
         conl_fun_jac_hess_type_out[4] = BLASFEO_DMAT;
         conl_fun_jac_hess_out[4] = &work->W;             // outer hessian: ny x ny
 
+        // NOTE: could be done more efficiently by generating a function that does not evalutate hessian
         // evaluate external function
         model->conl_cost_fun_jac_hess->evaluate(model->conl_cost_fun_jac_hess, conl_fun_jac_hess_type_in,
                                                 conl_fun_jac_hess_in, conl_fun_jac_hess_type_out, conl_fun_jac_hess_out);
 
         // hessian of outer loss function
-        blasfeo_dpotrf_l(ny, &work->W, 0, 0, &memory->W_chol, 0, 0);
+        // blasfeo_dpotrf_l(ny, &work->W, 0, 0, &memory->W_chol, 0, 0);
 
         if (nz > 0)
         {

--- a/acados/ocp_nlp/ocp_nlp_cost_external.c
+++ b/acados/ocp_nlp/ocp_nlp_cost_external.c
@@ -690,7 +690,7 @@ void ocp_nlp_cost_external_compute_gradient(void *config_, void *dims_, void *mo
 {
     ocp_nlp_cost_external_dims *dims = dims_;
     ocp_nlp_cost_external_model *model = model_;
-    ocp_nlp_cost_external_opts *opts = opts_;
+    // ocp_nlp_cost_external_opts *opts = opts_;
     ocp_nlp_cost_external_memory *memory = memory_;
     ocp_nlp_cost_external_workspace *work = work_;
 

--- a/acados/ocp_nlp/ocp_nlp_cost_external.c
+++ b/acados/ocp_nlp/ocp_nlp_cost_external.c
@@ -685,6 +685,15 @@ void ocp_nlp_cost_external_update_qp_matrices(void *config_, void *dims_, void *
 
 
 
+void ocp_nlp_cost_external_compute_gradient(void *config_, void *dims_, void *model_, void *opts_,
+                                 void *memory_, void *work_)
+{
+    printf("\nocp_nlp_cost_external_compute_gradient not implemented.\n\n");
+    exit(1);
+}
+
+
+
 void ocp_nlp_cost_external_compute_fun(void *config_, void *dims_, void *model_,
                                        void *opts_, void *memory_, void *work_)
 {
@@ -784,6 +793,7 @@ void ocp_nlp_cost_external_config_initialize_default(void *config_)
     config->initialize = &ocp_nlp_cost_external_initialize;
     config->update_qp_matrices = &ocp_nlp_cost_external_update_qp_matrices;
     config->compute_fun = &ocp_nlp_cost_external_compute_fun;
+    config->compute_gradient = &ocp_nlp_cost_external_compute_gradient;
     config->config_initialize_default = &ocp_nlp_cost_external_config_initialize_default;
     config->precompute = &ocp_nlp_cost_external_precompute;
 

--- a/acados/ocp_nlp/ocp_nlp_cost_external.h
+++ b/acados/ocp_nlp/ocp_nlp_cost_external.h
@@ -176,7 +176,9 @@ void ocp_nlp_cost_external_update_qp_matrices(void *config_, void *dims, void *m
 //
 void ocp_nlp_cost_external_compute_fun(void *config_, void *dims, void *model_,
                                        void *opts_, void *memory_, void *work_);
-
+//
+void ocp_nlp_cost_external_compute_gradient(void *config_, void *dims, void *model_,
+                                       void *opts_, void *memory_, void *work_);
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/acados/ocp_nlp/ocp_nlp_cost_ls.c
+++ b/acados/ocp_nlp/ocp_nlp_cost_ls.c
@@ -849,6 +849,13 @@ void ocp_nlp_cost_ls_update_qp_matrices(void *config_, void *dims_,
 }
 
 
+void ocp_nlp_cost_ls_compute_gradient(void *config_, void *dims_, void *model_, void *opts_,
+                                 void *memory_, void *work_)
+{
+    printf("\nocp_nlp_cost_ls_compute_gradient not implemented.\n\n");
+    exit(1);
+}
+
 
 void ocp_nlp_cost_ls_compute_fun(void *config_, void *dims_, void *model_, void *opts_,
                                  void *memory_, void *work_)
@@ -957,6 +964,7 @@ void ocp_nlp_cost_ls_config_initialize_default(void *config_)
     config->initialize = &ocp_nlp_cost_ls_initialize;
     config->update_qp_matrices = &ocp_nlp_cost_ls_update_qp_matrices;
     config->compute_fun = &ocp_nlp_cost_ls_compute_fun;
+    config->compute_gradient = &ocp_nlp_cost_ls_compute_gradient;
     config->config_initialize_default = &ocp_nlp_cost_ls_config_initialize_default;
     config->precompute = &ocp_nlp_cost_ls_precompute;
 

--- a/acados/ocp_nlp/ocp_nlp_cost_nls.c
+++ b/acados/ocp_nlp/ocp_nlp_cost_nls.c
@@ -856,6 +856,15 @@ void ocp_nlp_cost_nls_update_qp_matrices(void *config_, void *dims_, void *model
 
 
 
+void ocp_nlp_cost_nls_compute_gradient(void *config_, void *dims_, void *model_, void *opts_,
+                                 void *memory_, void *work_)
+{
+    printf("\nocp_nlp_cost_nls_compute_gradient not implemented.\n\n");
+    exit(1);
+}
+
+
+
 void ocp_nlp_cost_nls_compute_fun(void *config_, void *dims_, void *model_,
                                   void *opts_, void *memory_, void *work_)
 {
@@ -970,6 +979,7 @@ void ocp_nlp_cost_nls_config_initialize_default(void *config_)
     config->initialize = &ocp_nlp_cost_nls_initialize;
     config->update_qp_matrices = &ocp_nlp_cost_nls_update_qp_matrices;
     config->compute_fun = &ocp_nlp_cost_nls_compute_fun;
+    config->compute_gradient = &ocp_nlp_cost_nls_compute_gradient;
     config->config_initialize_default = &ocp_nlp_cost_nls_config_initialize_default;
     config->precompute = &ocp_nlp_cost_nls_precompute;
 

--- a/acados/ocp_nlp/ocp_nlp_dynamics_common.h
+++ b/acados/ocp_nlp/ocp_nlp_dynamics_common.h
@@ -99,6 +99,7 @@ typedef struct
     void (*initialize)(void *config_, void *dims, void *model_, void *opts_, void *mem_, void *work_);
     void (*update_qp_matrices)(void *config_, void *dims, void *model_, void *opts_, void *mem_, void *work_);
     void (*compute_fun)(void *config_, void *dims, void *model_, void *opts_, void *mem_, void *work_);
+    void (*compute_fun_and_adjoint)(void *config_, void *dims, void *model_, void *opts_, void *mem_, void *work_);
     int (*precompute)(void *config_, void *dims, void *model_, void *opts_, void *mem_, void *work_);
 } ocp_nlp_dynamics_config;
 

--- a/acados/ocp_nlp/ocp_nlp_dynamics_cont.c
+++ b/acados/ocp_nlp/ocp_nlp_dynamics_cont.c
@@ -818,6 +818,7 @@ void ocp_nlp_dynamics_cont_update_qp_matrices(void *config_, void *dims_, void *
         {
             blasfeo_dgemv_n(nu+nx, nx1, -1.0, mem->BAbt, 0, 0, mem->pi, 0, 0.0, &mem->adj, 0, &mem->adj, 0);
         }
+        // adj[nu+nx: nu+nx+nx1] = pi
         blasfeo_dveccp(nx1, mem->pi, 0, &mem->adj, nu+nx);
     }
 
@@ -933,6 +934,87 @@ void ocp_nlp_dynamics_cont_compute_fun(void *config_, void *dims_, void *model_,
 
 
 
+
+void ocp_nlp_dynamics_cont_compute_fun_and_adjoint(void *config_, void *dims_, void *model_, void *opts_, void *mem_, void *work_)
+{
+    ocp_nlp_dynamics_cont_cast_workspace(config_, dims_, opts_, work_, mem_);
+
+    ocp_nlp_dynamics_config *config = config_;
+    ocp_nlp_dynamics_cont_dims *dims = dims_;
+    ocp_nlp_dynamics_cont_opts *opts = opts_;
+    ocp_nlp_dynamics_cont_workspace *work = work_;
+    ocp_nlp_dynamics_cont_memory *mem = mem_;
+    ocp_nlp_dynamics_cont_model *model = model_;
+
+    struct blasfeo_dvec *ux = mem->ux;
+    struct blasfeo_dvec *ux1 = mem->ux1;
+
+    int nx = dims->nx;
+    int nu = dims->nu;
+    // int nz = dims->nz;
+    int nx1 = dims->nx1;
+    int nu1 = dims->nu1;
+
+    // setup model
+    work->sim_in->model = model->sim_model;
+    work->sim_in->T = model->T;
+
+    // pass state and control to integrator
+    blasfeo_unpack_dvec(nu, ux, 0, work->sim_in->u, 1);
+    blasfeo_unpack_dvec(nx, ux, nu, work->sim_in->x, 1);
+
+    if (mem->set_sim_guess!=NULL && mem->set_sim_guess[0])
+    {
+        config->sim_solver->memory_set(config->sim_solver, work->sim_in->dims, mem->sim_solver,
+                                       "guesses_blasfeo", mem->sim_guess);
+        // only use/pass the initial guess once
+        mem->set_sim_guess[0] = false;
+    }
+
+    // adjoint seed
+    for (int jj = 0; jj < nx + nu; jj++)
+        work->sim_in->S_adj[jj] = 0.0;
+    blasfeo_unpack_dvec(nx1, mem->pi, 0, work->sim_in->S_adj, 1);
+
+    // backup sens options
+    bool sens_forw_bkp, sens_adj_bkp, sens_hess_bkp;
+    config->sim_solver->opts_get(config->sim_solver, opts->sim_solver, "sens_forw", &sens_forw_bkp);
+    config->sim_solver->opts_get(config->sim_solver, opts->sim_solver, "sens_adj", &sens_adj_bkp);
+    config->sim_solver->opts_get(config->sim_solver, opts->sim_solver, "sens_hess", &sens_hess_bkp);
+
+    // compute only adjoint sensitivities
+    bool sens_tmp = false;
+    config->sim_solver->opts_set(config->sim_solver, opts->sim_solver, "sens_forw", &sens_tmp);
+    config->sim_solver->opts_set(config->sim_solver, opts->sim_solver, "sens_hess", &sens_tmp);
+    sens_tmp = true;
+    config->sim_solver->opts_set(config->sim_solver, opts->sim_solver, "sens_adj", &sens_tmp);
+
+    // call integrator
+    config->sim_solver->evaluate(config->sim_solver, work->sim_in, work->sim_out, opts->sim_solver,
+            mem->sim_solver, work->sim_solver);
+
+    // restore sens options
+    config->sim_solver->opts_set(config->sim_solver, opts->sim_solver, "sens_forw", &sens_forw_bkp);
+    config->sim_solver->opts_set(config->sim_solver, opts->sim_solver, "sens_adj", &sens_adj_bkp);
+    config->sim_solver->opts_set(config->sim_solver, opts->sim_solver, "sens_hess", &sens_hess_bkp);
+
+    // fun = integrator(x, u) - x[next_stage]
+    blasfeo_pack_dvec(nx1, work->sim_out->xn, 1, &mem->fun, 0);
+    blasfeo_daxpy(nx1, -1.0, ux1, nu1, &mem->fun, 0, &mem->fun, 0);
+
+    // pack adjoint
+    blasfeo_pack_dvec(nu, work->sim_out->S_adj+nx, 1, &mem->adj, 0);
+    blasfeo_pack_dvec(nx, work->sim_out->S_adj+0, 1, &mem->adj, nu);
+    blasfeo_dvecsc(nu+nx, -1.0, &mem->adj, 0);
+
+    // adj[nu+nx: nu+nx+nx1] = pi
+    blasfeo_dveccp(nx1, mem->pi, 0, &mem->adj, nu+nx);
+
+    return;
+}
+
+
+
 int ocp_nlp_dynamics_cont_precompute(void *config_, void *dims_, void *model_, void *opts_,
                                         void *mem_, void *work_)
 {
@@ -997,6 +1079,7 @@ void ocp_nlp_dynamics_cont_config_initialize_default(void *config_)
     config->initialize = &ocp_nlp_dynamics_cont_initialize;
     config->update_qp_matrices = &ocp_nlp_dynamics_cont_update_qp_matrices;
     config->compute_fun = &ocp_nlp_dynamics_cont_compute_fun;
+    config->compute_fun_and_adjoint = &ocp_nlp_dynamics_cont_compute_fun_and_adjoint;
     config->precompute = &ocp_nlp_dynamics_cont_precompute;
     config->config_initialize_default = &ocp_nlp_dynamics_cont_config_initialize_default;
 

--- a/acados/ocp_nlp/ocp_nlp_dynamics_cont.h
+++ b/acados/ocp_nlp/ocp_nlp_dynamics_cont.h
@@ -191,6 +191,8 @@ void ocp_nlp_dynamics_cont_update_qp_matrices(void *config_, void *dims, void *m
 //
 void ocp_nlp_dynamics_cont_compute_fun(void *config_, void *dims, void *model_, void *opts, void *mem, void *work_);
 //
+void ocp_nlp_dynamics_cont_compute_fun_and_adjoint(void *config_, void *dims, void *model_, void *opts, void *mem, void *work_);
+//
 int ocp_nlp_dynamics_cont_precompute(void *config_, void *dims, void *model_, void *opts_, void *mem_, void *work_);
 
 

--- a/acados/ocp_nlp/ocp_nlp_dynamics_disc.c
+++ b/acados/ocp_nlp/ocp_nlp_dynamics_disc.c
@@ -763,6 +763,76 @@ void ocp_nlp_dynamics_disc_compute_fun(void *config_, void *dims_, void *model_,
 
 
 
+void ocp_nlp_dynamics_disc_compute_fun_and_adjoint(void *config_, void *dims_, void *model_, void *opts_,
+                                              void *mem_, void *work_)
+{
+    /* TODO: this is inefficient! Generate a separate function for discrete dynamics to compute fun and adj! */
+    ocp_nlp_dynamics_disc_cast_workspace(config_, dims_, opts_, work_);
+
+    // ocp_nlp_dynamics_config *config = config_;
+    ocp_nlp_dynamics_disc_dims *dims = dims_;
+    ocp_nlp_dynamics_disc_opts *opts = opts_;
+    ocp_nlp_dynamics_disc_workspace *work = work_;
+    ocp_nlp_dynamics_disc_memory *memory = mem_;
+    ocp_nlp_dynamics_disc_model *model = model_;
+
+    int nx = dims->nx;
+    int nu = dims->nu;
+    int nx1 = dims->nx1;
+    int nu1 = dims->nu1;
+
+    ext_fun_arg_t ext_fun_type_in[3];
+    void *ext_fun_in[3];
+    ext_fun_arg_t ext_fun_type_out[3];
+    void *ext_fun_out[3];
+
+    // pass state and control to integrator
+    struct blasfeo_dvec_args x_in;  // input x of external fun;
+    x_in.x = memory->ux;
+    x_in.xi = nu;
+
+    struct blasfeo_dvec_args u_in;  // input u of external fun;
+    u_in.x = memory->ux;
+    u_in.xi = 0;
+
+    struct blasfeo_dvec_args fun_out;
+    fun_out.x = &memory->fun;
+    fun_out.xi = 0;
+
+    struct blasfeo_dmat_args jac_out;
+    jac_out.A = &work->tmp_nv_nv;
+    jac_out.ai = 0;
+    jac_out.aj = 0;
+
+
+    ext_fun_type_in[0] = BLASFEO_DVEC_ARGS;
+    ext_fun_in[0] = &x_in;
+    ext_fun_type_in[1] = BLASFEO_DVEC_ARGS;
+    ext_fun_in[1] = &u_in;
+
+    ext_fun_type_out[0] = BLASFEO_DVEC_ARGS;
+    ext_fun_out[0] = &fun_out;  // fun: nx1
+    ext_fun_type_out[1] = BLASFEO_DMAT_ARGS;
+    ext_fun_out[1] = &jac_out;  // jac': (nu+nx) * nx1
+
+    // call external function
+    model->disc_dyn_fun_jac->evaluate(model->disc_dyn_fun_jac, ext_fun_type_in, ext_fun_in, ext_fun_type_out, ext_fun_out);
+
+    // fun
+    blasfeo_daxpy(nx1, -1.0, memory->ux1, nu1, &memory->fun, 0, &memory->fun, 0);
+
+    // adj TODO if not computed by the external function
+    if (opts->compute_adj)
+    {
+        blasfeo_dgemv_n(nu+nx, nx1, -1.0, &work->tmp_nv_nv, 0, 0, memory->pi, 0, 0.0, &memory->adj, 0, &memory->adj, 0);
+        blasfeo_dveccp(nx1, memory->pi, 0, &memory->adj, nu + nx);
+    }
+
+    return;
+}
+
+
+
 int ocp_nlp_dynamics_disc_precompute(void *config_, void *dims, void *model_, void *opts_,
                                         void *mem_, void *work_)
 {
@@ -805,6 +875,7 @@ void ocp_nlp_dynamics_disc_config_initialize_default(void *config_)
     config->initialize = &ocp_nlp_dynamics_disc_initialize;
     config->update_qp_matrices = &ocp_nlp_dynamics_disc_update_qp_matrices;
     config->compute_fun = &ocp_nlp_dynamics_disc_compute_fun;
+    config->compute_fun_and_adjoint = &ocp_nlp_dynamics_disc_compute_fun_and_adjoint;
     config->precompute = &ocp_nlp_dynamics_disc_precompute;
     config->config_initialize_default = &ocp_nlp_dynamics_disc_config_initialize_default;
 

--- a/acados/ocp_nlp/ocp_nlp_sqp.h
+++ b/acados/ocp_nlp/ocp_nlp_sqp.h
@@ -64,7 +64,7 @@ typedef struct
     int ext_qp_res;      // compute external QP residuals (i.e. at SQP level) at each SQP iteration (for debugging)
     int qp_warm_start;   // qp_warm_start in all but the first sqp iterations
     bool warm_start_first_qp; // to set qp_warm_start in first iteration
-    int rti_phase;       // only phase 0 at the moment 
+    int rti_phase;       // only phase 0 at the moment
     int initialize_t_slacks;  // 0-false or 1-true
 
 } ocp_nlp_sqp_opts;

--- a/acados/ocp_nlp/ocp_nlp_sqp_rti.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp_rti.c
@@ -1237,9 +1237,14 @@ int ocp_nlp_sqp_rti(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
     {
         ocp_nlp_sqp_rti_preparation_advanced_step(config, dims, nlp_in, nlp_out, opts, mem, work);
     }
-    else
+    else if (rti_phase == PREPARATION_AND_FEEDBACK && opts->as_rti_level != STANDARD_RTI)
     {
-        // rti_phas == PREPARATION_AND_FEEDBACK
+        printf("ocp_nlp_sqp_rti: rti_phase == PREPARATION_AND_FEEDBACK not supported with AS-RTI (opts->as_rti_level != STANDARD_RTI).\n\n");
+        exit(1);
+    }
+    else if (rti_phase == PREPARATION_AND_FEEDBACK)
+    {
+        // rti_phase == PREPARATION_AND_FEEDBACK
         ocp_nlp_sqp_rti_preparation_step(config, dims, nlp_in, nlp_out, opts, mem, work);
         ocp_nlp_sqp_rti_feedback_step(config, dims, nlp_in, nlp_out, opts, mem, work);
     }

--- a/acados/ocp_nlp/ocp_nlp_sqp_rti.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp_rti.c
@@ -548,6 +548,10 @@ static void ocp_nlp_sqp_rti_feedback_step(ocp_nlp_config *config, ocp_nlp_dims *
         ocp_qp_res_compute(nlp_mem->qp_in, nlp_mem->qp_out, work->qp_res, work->qp_res_ws);
         ocp_qp_res_compute_nrm_inf(work->qp_res, mem->stat+(mem->stat_n*1+2));
     }
+    if (nlp_opts->print_level > 0) {
+        printf("\n------- qp_out --------\n");
+        print_ocp_qp_out(nlp_mem->qp_out);
+    }
 
     // save statistics
     mem->stat[mem->stat_n*1+0] = qp_status;
@@ -720,6 +724,13 @@ static void ocp_nlp_sqp_rti_preparation_advanced_step(ocp_nlp_config *config, oc
 #endif
                 mem->status = ACADOS_QP_FAILURE;
                 return;
+            }
+
+            if (nlp_opts->print_level > 0) {
+                printf("\n------- qp_in B-iter %d --------\n", i);
+                print_ocp_qp_in(nlp_mem->qp_in);
+                printf("\n------- qp_out B-iter %d --------\n", i);
+                print_ocp_qp_out(nlp_mem->qp_out);
             }
 
             // globalization

--- a/acados/ocp_nlp/ocp_nlp_sqp_rti.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp_rti.c
@@ -750,6 +750,18 @@ static void as_rti_sanity_checks(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp
             }
         }
     }
+    if (opts->as_rti_level == LEVEL_B)
+    {
+        for (int k = 0; k <= dims->N; k++)
+        {
+            if (dims->ns[k] > 0)
+            {
+                printf("\n\nAS-RTI with LEVEL_B not implemented for soft constraints yet.\n");
+                printf("Got ns[%d] = %d. Exiting\n", k, dims->ns[k]);
+                exit(1);
+            }
+        }
+    }
     if (opts->as_rti_iter < 1)
     {
         printf("\n\nAS-RTI: as_rti_iter < 1: no advanced step iteration will be performed!\n\n");

--- a/acados/ocp_nlp/ocp_nlp_sqp_rti.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp_rti.c
@@ -746,18 +746,15 @@ static void ocp_nlp_sqp_rti_preparation_advanced_step(ocp_nlp_config *config, oc
         nlp_out, nlp_opts, nlp_mem, nlp_work);
     mem->time_lin += acados_toc(&timer1);
 
-    if (opts->rti_phase == PREPARATION || opts->rti_phase == PREPARATION_ADVANCED_STEP)
-    {
-        // regularize Hessian
-        acados_tic(&timer1);
-        config->regularize->regularize_lhs(config->regularize,
-            dims->regularize, opts->nlp_opts->regularize, nlp_mem->regularize_mem);
-        mem->time_reg += acados_toc(&timer1);
-        // condense lhs
-        qp_solver->condense_lhs(qp_solver, dims->qp_solver,
-            nlp_mem->qp_in, nlp_mem->qp_out, opts->nlp_opts->qp_solver_opts,
-            nlp_mem->qp_solver_mem, nlp_work->qp_work);
-    }
+    // regularize Hessian
+    acados_tic(&timer1);
+    config->regularize->regularize_lhs(config->regularize,
+        dims->regularize, opts->nlp_opts->regularize, nlp_mem->regularize_mem);
+    mem->time_reg += acados_toc(&timer1);
+    // condense lhs
+    qp_solver->condense_lhs(qp_solver, dims->qp_solver,
+        nlp_mem->qp_in, nlp_mem->qp_out, opts->nlp_opts->qp_solver_opts,
+        nlp_mem->qp_solver_mem, nlp_work->qp_work);
 #if defined(ACADOS_WITH_OPENMP)
     // restore number of threads
     omp_set_num_threads(num_threads_bkp);

--- a/acados/ocp_nlp/ocp_nlp_sqp_rti.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp_rti.c
@@ -115,6 +115,7 @@ void ocp_nlp_sqp_rti_opts_initialize_default(void *config_,
     opts->ext_qp_res = 0;
     opts->warm_start_first_qp = false;
     opts->rti_phase = 0;
+    opts->as_rti_level = LEVEL_A;
 
     return;
 }
@@ -632,11 +633,17 @@ static void ocp_nlp_sqp_rti_preparation_advanced_step(ocp_nlp_config *config, oc
         if (dims->nx[0] != dims->nx[1])
         {
             printf("dimensions nx[0] != nx[1], cannot perform AS-RTI!");
+            exit(1);
+        }
+        if (opts->as_rti_level != LEVEL_A)
+        {
+            printf("AS-RTI -- only LEVEL_A implemented");
+            exit(1);
         }
     }
 
-    // TODO: if as_prep == A and not first call!
-    if (!mem->is_first_call)
+    // if AS_RTI-A and not first call!
+    if (opts->as_rti_level == LEVEL_A && !mem->is_first_call)
     {
         // load iterate from tmp
         copy_ocp_nlp_out(dims, tmp_nlp_out, nlp_out);
@@ -675,8 +682,7 @@ static void ocp_nlp_sqp_rti_preparation_advanced_step(ocp_nlp_config *config, oc
 #endif
 
     /* AS-RTI */
-    // TODO: if as_prep == A
-    if (1) //(!mem->is_first_call)
+    if (opts->as_rti_level == LEVEL_A)
     {
         // backup iterate:
         // tmp_nlp_out <- nlp_out

--- a/acados/ocp_nlp/ocp_nlp_sqp_rti.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp_rti.c
@@ -210,10 +210,10 @@ void ocp_nlp_sqp_rti_opts_set(void *config_, void *opts_,
         else if (!strcmp(field, "as_rti_level"))
         {
             int* as_rti_level = (int *) value;
-            if (*as_rti_level < LEVEL_A || *as_rti_level > LEVEL_D)
+            if (*as_rti_level < LEVEL_A || *as_rti_level > STANDARD_RTI)
             {
                 printf("\nerror: ocp_nlp_sqp_opts_set: invalid value for as_rti_level field.\n");
-                printf("possible values are: 0, 1, 2, 3, got %d.\n", *as_rti_level);
+                printf("possible values are: 0, 1, 2, 3, 4, got %d.\n", *as_rti_level);
                 exit(1);
             }
             opts->as_rti_level = *as_rti_level;

--- a/acados/ocp_nlp/ocp_nlp_sqp_rti.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp_rti.c
@@ -639,6 +639,8 @@ static void ocp_nlp_sqp_rti_preparation_advanced_step(ocp_nlp_config *config, oc
 #endif
 
     // printf("AS_RTI preparation\n");
+    qp_info *qp_info_;
+    int qp_iter;
 
     // prepare submodules
     ocp_nlp_initialize_submodules(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work);
@@ -725,6 +727,9 @@ static void ocp_nlp_sqp_rti_preparation_advanced_step(ocp_nlp_config *config, oc
             qp_solver->memory_get(qp_solver, nlp_mem->qp_solver_mem, "time_qp_xcond", &tmp_time);
             mem->time_qp_xcond += tmp_time;
 
+            ocp_qp_out_get(nlp_mem->qp_out, "qp_info", &qp_info_);
+            qp_iter = qp_info_->num_iter;
+
             // compute correct dual solution in case of Hessian regularization
             acados_tic(&timer1);
             config->regularize->correct_dual_sol(config->regularize,
@@ -789,6 +794,9 @@ static void ocp_nlp_sqp_rti_preparation_advanced_step(ocp_nlp_config *config, oc
             mem->time_qp_solver_call += tmp_time;
             qp_solver->memory_get(qp_solver, nlp_mem->qp_solver_mem, "time_qp_xcond", &tmp_time);
             mem->time_qp_xcond += tmp_time;
+
+            ocp_qp_out_get(nlp_mem->qp_out, "qp_info", &qp_info_);
+            qp_iter = qp_info_->num_iter;
 
             // compute correct dual solution in case of Hessian regularization
             acados_tic(&timer1);
@@ -863,6 +871,9 @@ static void ocp_nlp_sqp_rti_preparation_advanced_step(ocp_nlp_config *config, oc
             mem->time_qp_solver_call += tmp_time;
             qp_solver->memory_get(qp_solver, nlp_mem->qp_solver_mem, "time_qp_xcond", &tmp_time);
             mem->time_qp_xcond += tmp_time;
+
+            ocp_qp_out_get(nlp_mem->qp_out, "qp_info", &qp_info_);
+            qp_iter = qp_info_->num_iter;
 
             // compute correct dual solution in case of Hessian regularization
             acados_tic(&timer1);

--- a/acados/ocp_nlp/ocp_nlp_sqp_rti.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp_rti.c
@@ -731,15 +731,6 @@ static void ocp_nlp_sqp_rti_preparation_advanced_step(ocp_nlp_config *config, oc
             // update variables
             ocp_nlp_update_variables_sqp(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work, alpha);
 
-            // DEBUG
-            // d_ocp_qp_print(nlp_mem->qp_in->dim, nlp_mem->qp_in);
-            // for (int jj = 0; jj < 3; jj++)
-            // {
-            //     printf("rq %d\n", jj);
-            //     blasfeo_print_tran_dvec(dims->nx[jj]+dims->nu[jj], nlp_mem->qp_in->rqz+jj, 0);
-            //     printf("RSQ %d\n", jj);
-            //     blasfeo_print_dmat(dims->nx[jj]+dims->nu[jj], dims->nx[jj]+dims->nu[jj], nlp_mem->qp_in->RSQrq, 0, 0);
-            // }
         }
     }
     else if (opts->as_rti_level == LEVEL_D)

--- a/acados/ocp_nlp/ocp_nlp_sqp_rti.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp_rti.c
@@ -449,7 +449,7 @@ static void prepare_full_residual_computation(ocp_nlp_config *config,
     int *nv = dims->nv;
     int *nx = dims->nx;
     int *nu = dims->nu;
-    int *ni = dims->ni;
+    // int *ni = dims->ni;
 
     for (int i=0; i < N; i++)
     {
@@ -795,7 +795,7 @@ static void level_c_prepare_residual_computation(ocp_nlp_config *config,
     int *nv = dims->nv;
     int *nx = dims->nx;
     int *nu = dims->nu;
-    int *ni = dims->ni;
+    // int *ni = dims->ni;
 
 
     // evaluate constraint adjoint
@@ -935,7 +935,7 @@ static void ocp_nlp_sqp_rti_preparation_advanced_step(ocp_nlp_config *config, oc
         // globalization
         acados_tic(&timer1);
         // TODO: not clear if line search should be called with sqp_iter==0 in RTI;
-        double alpha = ocp_nlp_line_search(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work, 0, 1);
+        alpha = ocp_nlp_line_search(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work, 0, 1);
         mem->time_glob += acados_toc(&timer1);
 
         // update variables

--- a/acados/ocp_nlp/ocp_nlp_sqp_rti.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp_rti.c
@@ -675,11 +675,27 @@ static void ocp_nlp_sqp_rti_preparation_advanced_step(ocp_nlp_config *config, oc
     }
     else
     {
-        // sanity check
+        // sanity checks
         if (dims->nx[0] != dims->nx[1])
         {
-            printf("dimensions nx[0] != nx[1], cannot perform AS-RTI!");
+            printf("dimensions nx[0] != nx[1], cannot perform AS-RTI!\n");
             exit(1);
+        }
+        if (opts->as_rti_level == LEVEL_C)
+        {
+            int ng_ineq, ng_qp;
+            // does not work for nonlinear constraints yet
+            for (int k = 0; k < dims->N; k++)
+            {
+                config->constraints[k]->dims_get(config->constraints[k], dims->constraints[k], "ng", &ng_ineq);
+                config->qp_solver->dims_get(config->qp_solver, dims->qp_solver, k, "ng", &ng_qp);
+                if (ng_ineq != ng_qp)
+                {
+                    printf("AS-RTI with LEVEL_C not implemented for nonlinear inequality constraints.");
+                    printf("Got ng_ineq = %d != %d = ng_qp at stage %d \n\n", ng_ineq, ng_qp, k);
+                    exit(1);
+                }
+            }
         }
     }
 

--- a/acados/ocp_nlp/ocp_nlp_sqp_rti.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp_rti.c
@@ -117,7 +117,7 @@ void ocp_nlp_sqp_rti_opts_initialize_default(void *config_,
     opts->rti_phase = 0;
     opts->as_rti_level = LEVEL_A;
     opts->as_rti_advancement_strategy = SIMULATE_ADVANCE;
-    opts->as_rti_iter = 1;
+    opts->as_rti_iter = 0;
     opts->rti_log_residuals = 0;
 
     return;
@@ -682,6 +682,10 @@ static void as_rti_sanity_checks(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp
                 exit(1);
             }
         }
+    }
+    if (opts->as_rti_iter < 1)
+    {
+        printf("\n\nAS-RTI: as_rti_iter < 1: no advanced step iteration will be performed!\n\n");
     }
 }
 

--- a/acados/ocp_nlp/ocp_nlp_sqp_rti.h
+++ b/acados/ocp_nlp/ocp_nlp_sqp_rti.h
@@ -58,7 +58,6 @@ typedef enum
     PREPARATION_AND_FEEDBACK, // = 0,
     PREPARATION, // = 1,
     FEEDBACK, // = 2,
-    PREPARATION_ADVANCED_STEP, // = 3,
 } rti_phase_t;
 
 typedef enum
@@ -74,6 +73,7 @@ typedef enum
     LEVEL_B, // 1
     LEVEL_C, // 2
     LEVEL_D, // 3
+    STANDARD_RTI, // 4
 } as_rti_level_t;
 
 typedef struct

--- a/acados/ocp_nlp/ocp_nlp_sqp_rti.h
+++ b/acados/ocp_nlp/ocp_nlp_sqp_rti.h
@@ -61,7 +61,13 @@ typedef enum
     PREPARATION_ADVANCED_STEP, // = 3,
 } rti_phase_t;
 
-
+typedef enum
+{
+    LEVEL_A, // 0
+    LEVEL_B, // 1
+    LEVEL_C, // 2
+    LEVEL_D, // 3
+} as_rti_level_t;
 
 typedef struct
 {
@@ -71,6 +77,7 @@ typedef struct
     int qp_warm_start;        // NOTE: this is not actually setting the warm_start! Just for compatibility with sqp.
     bool warm_start_first_qp; // to set qp_warm_start in first iteration
     rti_phase_t rti_phase;
+    as_rti_level_t as_rti_level;
 
 } ocp_nlp_sqp_rti_opts;
 

--- a/acados/ocp_nlp/ocp_nlp_sqp_rti.h
+++ b/acados/ocp_nlp/ocp_nlp_sqp_rti.h
@@ -78,6 +78,7 @@ typedef struct
     bool warm_start_first_qp; // to set qp_warm_start in first iteration
     rti_phase_t rti_phase;
     as_rti_level_t as_rti_level;
+    int as_rti_iter;
 
 } ocp_nlp_sqp_rti_opts;
 

--- a/acados/ocp_nlp/ocp_nlp_sqp_rti.h
+++ b/acados/ocp_nlp/ocp_nlp_sqp_rti.h
@@ -58,6 +58,7 @@ typedef enum
     PREPARATION_AND_FEEDBACK, // = 0,
     PREPARATION, // = 1,
     FEEDBACK, // = 2,
+    PREPARATION_ADVANCED_STEP, // = 3,
 } rti_phase_t;
 
 
@@ -114,6 +115,7 @@ typedef struct
     int stat_n;
 
     int status;
+    bool is_first_call;
 
 } ocp_nlp_sqp_rti_memory;
 

--- a/acados/ocp_nlp/ocp_nlp_sqp_rti.h
+++ b/acados/ocp_nlp/ocp_nlp_sqp_rti.h
@@ -87,6 +87,7 @@ typedef struct
     as_rti_level_t as_rti_level;
     as_rti_advancement_strategy_t as_rti_advancement_strategy;
     int as_rti_iter;
+    int rti_log_residuals;
 
 } ocp_nlp_sqp_rti_opts;
 
@@ -129,6 +130,7 @@ typedef struct
     double *stat;
     int stat_m;
     int stat_n;
+    int sqp_iter;
 
     int status;
     bool is_first_call;

--- a/acados/ocp_nlp/ocp_nlp_sqp_rti.h
+++ b/acados/ocp_nlp/ocp_nlp_sqp_rti.h
@@ -63,6 +63,13 @@ typedef enum
 
 typedef enum
 {
+    SHIFT_ADVANCE, // = 0,
+    SIMULATE_ADVANCE, // = 1,
+    NO_ADVANCE, // = 2,
+} as_rti_advancement_strategy_t;
+
+typedef enum
+{
     LEVEL_A, // 0
     LEVEL_B, // 1
     LEVEL_C, // 2
@@ -78,6 +85,7 @@ typedef struct
     bool warm_start_first_qp; // to set qp_warm_start in first iteration
     rti_phase_t rti_phase;
     as_rti_level_t as_rti_level;
+    as_rti_advancement_strategy_t as_rti_advancement_strategy;
     int as_rti_iter;
 
 } ocp_nlp_sqp_rti_opts;

--- a/acados/sim/sim_erk_integrator.c
+++ b/acados/sim/sim_erk_integrator.c
@@ -440,12 +440,8 @@ acados_size_t sim_erk_workspace_calculate_size(void *config_, void *dims_, void 
 
 
 
-static void *sim_erk_cast_workspace(void *config_, void *dims_, void *opts_, void *raw_memory, void *mem_)
+static void *sim_erk_cast_workspace(void *config_, sim_erk_dims *dims, sim_opts *opts, void *raw_memory, sim_erk_memory *mem)
 {
-    sim_opts *opts = opts_;
-    sim_erk_dims *dims = (sim_erk_dims *) dims_;
-    sim_erk_memory *mem = mem_;
-
     int ns = opts->ns;
 
     int nx = dims->nx;

--- a/examples/acados_python/pendulum_on_cart/as_rti/as_rti_closed_loop_example.py
+++ b/examples/acados_python/pendulum_on_cart/as_rti/as_rti_closed_loop_example.py
@@ -1,0 +1,202 @@
+# -*- coding: future_fstrings -*-
+#
+# Copyright (c) The acados authors.
+#
+# This file is part of acados.
+#
+# The 2-Clause BSD License
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.;
+#
+
+
+import sys
+sys.path.insert(0, '../common')
+
+from acados_template import AcadosOcp, AcadosOcpSolver, AcadosSimSolver
+from pendulum_model import export_pendulum_ode_model
+from utils import plot_pendulum
+import numpy as np
+import scipy.linalg
+from casadi import vertcat
+
+
+REAL_TIME_ALGORITHMS = ["RTI", "AS-RTI-A", "AS-RTI-B", "AS-RTI-C", "AS-RTI-D"]
+ALGORITHMS = ["SQP"] + REAL_TIME_ALGORITHMS
+
+def setup(x0, Fmax, N_horizon, Tf, algorithm, as_rti_iter=1):
+    # create ocp object to formulate the OCP
+    ocp = AcadosOcp()
+
+    # set model
+    model = export_pendulum_ode_model()
+    ocp.model = model
+
+    nx = model.x.size()[0]
+    nu = model.u.size()[0]
+    ny = nx + nu
+    ny_e = nx
+
+    ocp.dims.N = N_horizon
+
+    # set cost module
+    ocp.cost.cost_type = 'NONLINEAR_LS'
+    ocp.cost.cost_type_e = 'NONLINEAR_LS'
+
+    Q_mat = 2*np.diag([1e3, 1e3, 1e-2, 1e-2])
+    R_mat = 2*np.diag([1e-2])
+
+    ocp.cost.W = scipy.linalg.block_diag(Q_mat, R_mat)
+    ocp.cost.W_e = Q_mat
+
+    ocp.model.cost_y_expr = vertcat(model.x, model.u)
+    ocp.model.cost_y_expr_e = model.x
+    ocp.cost.yref  = np.zeros((ny, ))
+    ocp.cost.yref_e = np.zeros((ny_e, ))
+
+    # set constraints
+    ocp.constraints.lbu = np.array([-Fmax])
+    ocp.constraints.ubu = np.array([+Fmax])
+
+    ocp.constraints.x0 = x0
+    ocp.constraints.idxbu = np.array([0])
+
+    ocp.solver_options.qp_solver = 'PARTIAL_CONDENSING_HPIPM' # FULL_CONDENSING_QPOASES
+    ocp.solver_options.hessian_approx = 'GAUSS_NEWTON'
+    ocp.solver_options.integrator_type = 'IRK'
+    ocp.solver_options.sim_method_newton_iter = 10
+
+    ocp.translate_nls_cost_to_conl()
+
+    if algorithm in REAL_TIME_ALGORITHMS:
+        ocp.solver_options.nlp_solver_type = 'SQP_RTI'
+    else:
+        ocp.solver_options.nlp_solver_type = 'SQP'
+
+    if algorithm == "AS-RTI-A":
+        ocp.solver_options.as_rti_iter = as_rti_iter
+        ocp.solver_options.as_rti_level = 0
+    elif algorithm == "AS-RTI-B":
+        ocp.solver_options.as_rti_iter = as_rti_iter
+        ocp.solver_options.as_rti_level = 1
+    elif algorithm == "AS-RTI-C":
+        ocp.solver_options.as_rti_iter = as_rti_iter
+        ocp.solver_options.as_rti_level = 2
+    elif algorithm == "AS-RTI-D":
+        ocp.solver_options.as_rti_iter = as_rti_iter
+        ocp.solver_options.as_rti_level = 3
+
+    ocp.solver_options.qp_solver_cond_N = N_horizon
+
+    # set prediction horizon
+    ocp.solver_options.tf = Tf
+
+    solver_json = 'acados_ocp_' + model.name + '.json'
+    acados_ocp_solver = AcadosOcpSolver(ocp, json_file = solver_json)
+
+    # create an integrator with the same settings as used in the OCP solver.
+    acados_integrator = AcadosSimSolver(ocp, json_file = solver_json)
+
+    return acados_ocp_solver, acados_integrator
+
+
+def main(algorithm='RTI', as_rti_iter=1):
+
+    x0 = np.array([0.0, np.pi, 0.0, 0.0])
+    Fmax = 80
+
+    Tf = .8
+    N_horizon = 40
+
+    ocp_solver, integrator = setup(x0, Fmax, N_horizon, Tf, algorithm, as_rti_iter)
+
+    nx = ocp_solver.acados_ocp.dims.nx
+    nu = ocp_solver.acados_ocp.dims.nu
+
+    Nsim = 100
+    simX = np.ndarray((Nsim+1, nx))
+    simU = np.ndarray((Nsim, nu))
+
+    simX[0,:] = x0
+
+    if algorithm != "SQP":
+        t_preparation = np.zeros((Nsim))
+        t_feedback = np.zeros((Nsim))
+
+    else:
+        t = np.zeros((Nsim))
+
+    # closed loop
+    for i in range(Nsim):
+
+        if algorithm != "SQP":
+            # preparation phase
+            ocp_solver.options_set('rti_phase', 1)
+            status = ocp_solver.solve()
+            t_preparation[i] = ocp_solver.get_stats('time_tot')
+
+            # set initial state
+            ocp_solver.set(0, "lbx", simX[i, :])
+            ocp_solver.set(0, "ubx", simX[i, :])
+
+            # feedback phase
+            ocp_solver.options_set('rti_phase', 2)
+            status = ocp_solver.solve()
+            t_feedback[i] = ocp_solver.get_stats('time_tot')
+
+            simU[i, :] = ocp_solver.get(0, "u")
+
+        else:
+            # solve ocp and get next control input
+            simU[i,:] = ocp_solver.solve_for_x0(x0_bar = simX[i, :])
+
+            t[i] = ocp_solver.get_stats('time_tot')
+
+        # simulate system
+        simX[i+1, :] = integrator.simulate(x=simX[i, :], u=simU[i,:])
+
+    # evaluate timings
+    if algorithm != "SQP":
+        # scale to milliseconds
+        t_preparation *= 1000
+        t_feedback *= 1000
+        print(f'Computation time in preparation phase in ms: \
+                min {np.min(t_preparation):.3f} median {np.median(t_preparation):.3f} max {np.max(t_preparation):.3f}')
+        print(f'Computation time in feedback phase in ms:    \
+                min {np.min(t_feedback):.3f} median {np.median(t_feedback):.3f} max {np.max(t_feedback):.3f}')
+    else:
+        # scale to milliseconds
+        t *= 1000
+        print(f'Computation time in ms: min {np.min(t):.3f} median {np.median(t):.3f} max {np.max(t):.3f}')
+
+    # plot results
+    plot_pendulum(np.linspace(0, (Tf/N_horizon)*Nsim, Nsim+1), Fmax, simU, simX, title=algorithm)
+
+    ocp_solver = None
+
+
+if __name__ == '__main__':
+    main(algorithm="AS-RTI-D", as_rti_iter=1)
+
+    for algorithm in ["SQP", "RTI", "AS-RTI-A", "AS-RTI-B", "AS-RTI-C", "AS-RTI-D"]:
+        main(algorithm=algorithm, as_rti_iter=1)

--- a/examples/acados_python/pendulum_on_cart/common/utils.py
+++ b/examples/acados_python/pendulum_on_cart/common/utils.py
@@ -34,7 +34,8 @@ import numpy as np
 from acados_template import latexify_plot
 
 def plot_pendulum(shooting_nodes, u_max, U, X_true, X_est=None, Y_measured=None, latexify=True, plt_show=True, X_true_label=None,
-    states_lables = ['$x$', r'$\theta$', '$v$', r'$\dot{\theta}$']
+    states_lables = ['$x$', r'$\theta$', '$v$', r'$\dot{\theta}$'],
+    title = None
                   ):
     """
     Params:
@@ -69,7 +70,8 @@ def plot_pendulum(shooting_nodes, u_max, U, X_true, X_est=None, Y_measured=None,
         line.set_label(X_true_label)
     else:
         line.set_color('r')
-    plt.title('closed-loop simulation')
+    if title is not None:
+        plt.title(title)
     plt.ylabel('$u$')
     plt.xlabel('$t$')
     plt.hlines(u_max, t[0], t[-1], linestyles='dashed', alpha=0.7)

--- a/examples/c/no_interface_examples/mass_spring_example.c
+++ b/examples/c/no_interface_examples/mass_spring_example.c
@@ -306,6 +306,10 @@ int main() {
                 case INVALID_QP_SOLVER:
                     printf("\nInvalid QP solver\n\n");
 
+                default:
+                    printf("\nQP solver not implemented in example\n\n");
+
+
             }
 
 //            ocp_qp_full_condensing_dims *xcond_dims = qp_dims->xcond_dims;

--- a/examples/c/sim_gnsf_crane.c
+++ b/examples/c/sim_gnsf_crane.c
@@ -45,6 +45,8 @@
 #include "acados_c/external_function_interface.h"
 #include "acados_c/sim_interface.h"
 
+#include "blasfeo/include/blasfeo_d_aux_ext_dep.h" // for printing
+
 // model
 #include "examples/c/crane_nx9_model/crane_nx9_model.h"
 

--- a/interfaces/CMakeLists.txt
+++ b/interfaces/CMakeLists.txt
@@ -234,6 +234,10 @@ add_test(NAME python_custom_update_example
         COMMAND "${CMAKE_COMMAND}" -E chdir ${PROJECT_SOURCE_DIR}/examples/acados_python/pendulum_on_cart/custom_update
         python example_custom_rti_loop.py)
 
+add_test(NAME python_as_rti_example
+        COMMAND "${CMAKE_COMMAND}" -E chdir ${PROJECT_SOURCE_DIR}/examples/acados_python/pendulum_on_cart/as_rti
+        python as_rti_closed_loop_example.py)
+
 add_test(NAME python_fast_zoro_example
         COMMAND "${CMAKE_COMMAND}" -E chdir ${PROJECT_SOURCE_DIR}/examples/acados_python/zoRO_example
         python pendulum_on_cart/minimal_example_zoro.py)

--- a/interfaces/acados_matlab_octave/acados_template_mex/+acados_template_mex/ocp_nlp_solver_options_json.m
+++ b/interfaces/acados_matlab_octave/acados_template_mex/+acados_template_mex/ocp_nlp_solver_options_json.m
@@ -71,6 +71,7 @@ classdef ocp_nlp_solver_options_json < handle
         alpha_min
         alpha_reduction
         as_rti_iter
+        rti_log_residuals
         globalization
         collocation_type
         line_search_use_sufficient_descent
@@ -129,6 +130,7 @@ classdef ocp_nlp_solver_options_json < handle
             obj.ext_fun_compile_flags = '-O2';
             obj.cost_discretization = 'EULER';
             obj.as_rti_iter = 1;
+            obj.rti_log_residuals = 0;
 
         end
         function s = struct(self)

--- a/interfaces/acados_matlab_octave/acados_template_mex/+acados_template_mex/ocp_nlp_solver_options_json.m
+++ b/interfaces/acados_matlab_octave/acados_template_mex/+acados_template_mex/ocp_nlp_solver_options_json.m
@@ -71,6 +71,7 @@ classdef ocp_nlp_solver_options_json < handle
         alpha_min
         alpha_reduction
         as_rti_iter
+        as_rti_level
         rti_log_residuals
         globalization
         collocation_type
@@ -130,6 +131,7 @@ classdef ocp_nlp_solver_options_json < handle
             obj.ext_fun_compile_flags = '-O2';
             obj.cost_discretization = 'EULER';
             obj.as_rti_iter = 1;
+            obj.as_rti_level = 0;
             obj.rti_log_residuals = 0;
 
         end

--- a/interfaces/acados_matlab_octave/acados_template_mex/+acados_template_mex/ocp_nlp_solver_options_json.m
+++ b/interfaces/acados_matlab_octave/acados_template_mex/+acados_template_mex/ocp_nlp_solver_options_json.m
@@ -70,6 +70,7 @@ classdef ocp_nlp_solver_options_json < handle
         ext_cost_num_hess
         alpha_min
         alpha_reduction
+        as_rti_iter
         globalization
         collocation_type
         line_search_use_sufficient_descent
@@ -127,6 +128,7 @@ classdef ocp_nlp_solver_options_json < handle
             obj.nlp_solver_ext_qp_res = 0;
             obj.ext_fun_compile_flags = '-O2';
             obj.cost_discretization = 'EULER';
+            obj.as_rti_iter = 1;
 
         end
         function s = struct(self)

--- a/interfaces/acados_matlab_octave/acados_template_mex/+acados_template_mex/ocp_nlp_solver_options_json.m
+++ b/interfaces/acados_matlab_octave/acados_template_mex/+acados_template_mex/ocp_nlp_solver_options_json.m
@@ -131,7 +131,7 @@ classdef ocp_nlp_solver_options_json < handle
             obj.ext_fun_compile_flags = '-O2';
             obj.cost_discretization = 'EULER';
             obj.as_rti_iter = 1;
-            obj.as_rti_level = 0;
+            obj.as_rti_level = 4;
             obj.rti_log_residuals = 0;
 
         end

--- a/interfaces/acados_template/acados_template/acados_ocp_options.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_options.py
@@ -101,7 +101,7 @@ class AcadosOcpOptions:
         self.__custom_templates = []
         self.__custom_update_copy = True
         self.__as_rti_iter = 1
-        self.__as_rti_level = 0
+        self.__as_rti_level = 4
 
     @property
     def qp_solver(self):
@@ -427,8 +427,9 @@ class AcadosOcpOptions:
         LEVEL-B: 1
         LEVEL-C: 2
         LEVEL-D: 3
+        STANDARD_RTI: 4
 
-        Default: 0
+        Default: 4
         """
         return self.__as_rti_level
 
@@ -924,10 +925,10 @@ class AcadosOcpOptions:
 
     @as_rti_level.setter
     def as_rti_level(self, as_rti_level):
-        if as_rti_level in [0, 1, 2, 3]:
+        if as_rti_level in [0, 1, 2, 3, 4]:
             self.__as_rti_level = as_rti_level
         else:
-            raise Exception('Invalid as_rti_level value must be in [0, 1, 2, 3].')
+            raise Exception('Invalid as_rti_level value must be in [0, 1, 2, 3, 4].')
 
 
     @qp_solver_ric_alg.setter

--- a/interfaces/acados_template/acados_template/acados_ocp_options.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_options.py
@@ -71,6 +71,7 @@ class AcadosOcpOptions:
         self.__nlp_solver_tol_comp = 1e-6
         self.__nlp_solver_max_iter = 100
         self.__nlp_solver_ext_qp_res = 0
+        self.__rti_log_residuals = 0
         self.__Tsim = None
         self.__print_level = 0
         self.__initialize_t_slacks = 0
@@ -516,6 +517,17 @@ class AcadosOcpOptions:
         Default: 0.
         """
         return self.__nlp_solver_ext_qp_res
+
+
+    @property
+    def rti_log_residuals(self):
+        """Determines if residuals are computed and logged within RTI / AS-RTI iterations (for debugging).
+
+        Type: int; 0 or 1;
+        Default: 0.
+        """
+        return self.__rti_log_residuals
+
 
     @property
     def nlp_solver_tol_comp(self):
@@ -998,6 +1010,13 @@ class AcadosOcpOptions:
             self.__nlp_solver_ext_qp_res = nlp_solver_ext_qp_res
         else:
             raise Exception('Invalid nlp_solver_ext_qp_res value. nlp_solver_ext_qp_res must be in [0, 1].')
+
+    @rti_log_residuals.setter
+    def rti_log_residuals(self, rti_log_residuals):
+        if rti_log_residuals in [0, 1]:
+            self.__rti_log_residuals = rti_log_residuals
+        else:
+            raise Exception('Invalid rti_log_residuals value. rti_log_residuals must be in [0, 1].')
 
     @nlp_solver_tol_comp.setter
     def nlp_solver_tol_comp(self, nlp_solver_tol_comp):

--- a/interfaces/acados_template/acados_template/acados_ocp_options.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_options.py
@@ -101,6 +101,7 @@ class AcadosOcpOptions:
         self.__custom_templates = []
         self.__custom_update_copy = True
         self.__as_rti_iter = 1
+        self.__as_rti_level = 0
 
     @property
     def qp_solver(self):
@@ -415,6 +416,21 @@ class AcadosOcpOptions:
         Default: 1
         """
         return self.__as_rti_iter
+
+
+    @property
+    def as_rti_level(self):
+        """
+        Level of the advanced-step real-time iteration.
+
+        LEVEL-A: 0
+        LEVEL-B: 1
+        LEVEL-C: 2
+        LEVEL-D: 3
+
+        Default: 0
+        """
+        return self.__as_rti_level
 
     @property
     def tol(self):
@@ -905,6 +921,14 @@ class AcadosOcpOptions:
             self.__as_rti_iter = as_rti_iter
         else:
             raise Exception('Invalid as_rti_iter value. as_rti_iter must be a nonnegative int.')
+
+    @as_rti_level.setter
+    def as_rti_level(self, as_rti_level):
+        if as_rti_level in [0, 1, 2, 3]:
+            self.__as_rti_level = as_rti_level
+        else:
+            raise Exception('Invalid as_rti_level value must be in [0, 1, 2, 3].')
+
 
     @qp_solver_ric_alg.setter
     def qp_solver_ric_alg(self, qp_solver_ric_alg):

--- a/interfaces/acados_template/acados_template/acados_ocp_options.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_options.py
@@ -99,6 +99,7 @@ class AcadosOcpOptions:
         self.__custom_update_header_filename = ''
         self.__custom_templates = []
         self.__custom_update_copy = True
+        self.__as_rti_iter = 1
 
     @property
     def qp_solver(self):
@@ -404,6 +405,15 @@ class AcadosOcpOptions:
         Default: 50
         """
         return self.__qp_solver_iter_max
+
+
+    @property
+    def as_rti_iter(self):
+        """
+        Maximum number of iterations in the advanced-step real-time iteration.
+        Default: 1
+        """
+        return self.__as_rti_iter
 
     @property
     def tol(self):
@@ -876,6 +886,13 @@ class AcadosOcpOptions:
             self.__qp_solver_iter_max = qp_solver_iter_max
         else:
             raise Exception('Invalid qp_solver_iter_max value. qp_solver_iter_max must be a positive int.')
+
+    @as_rti_iter.setter
+    def as_rti_iter(self, as_rti_iter):
+        if isinstance(as_rti_iter, int) and as_rti_iter >= 0:
+            self.__as_rti_iter = as_rti_iter
+        else:
+            raise Exception('Invalid as_rti_iter value. as_rti_iter must be a nonnegative int.')
 
     @qp_solver_ric_alg.setter
     def qp_solver_ric_alg(self, qp_solver_ric_alg):

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -1497,7 +1497,6 @@ class AcadosOcpSolver:
             - qp_tau_min: for HPIPM QP solvers: minimum value of barrier parameter in HPIPM
             - qp_mu0: for HPIPM QP solvers: initial value for complementarity slackness
             - warm_start_first_qp: indicates if first QP in SQP is warm_started
-            - rti_phase: phase of the real-time iteration algorithm (0: preparation+feedback, 1: feedback, 2: preparation, 3: advanced step preparation)
         """
         int_fields = ['print_level', 'rti_phase', 'initialize_t_slacks', 'qp_warm_start',
                       'line_search_use_sufficient_descent', 'full_step_dual', 'globalization_use_SOC', 'warm_start_first_qp', "as_rti_level"]
@@ -1530,9 +1529,9 @@ class AcadosOcpSolver:
 
 
         if field_ == 'rti_phase':
-            if value_ < 0 or value_ > 3:
+            if value_ < 0 or value_ > 2:
                 raise Exception('AcadosOcpSolver.options_set(): argument \'rti_phase\' can '
-                    'take only values 0, 1, 2, 3 for SQP-RTI-type solvers')
+                    'take only values 0, 1, 2 for SQP-RTI-type solvers')
             if self.solver_options['nlp_solver_type'] != 'SQP_RTI' and value_ > 0:
                 raise Exception('AcadosOcpSolver.options_set(): argument \'rti_phase\' can '
                     'take only value 0 for SQP-type solvers')

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -837,14 +837,23 @@ class AcadosOcpSolver:
                         stat[8][jj], stat[9][jj], stat[10][jj], stat[11][jj]))
             print('\n')
         elif self.solver_options['nlp_solver_type'] == 'SQP_RTI':
-            print('\niter\tqp_stat\tqp_iter')
-            if stat.shape[0]>3:
-                print('\tqp_res_stat\tqp_res_eq\tqp_res_ineq\tqp_res_comp')
+            header = '\niter\tqp_stat\tqp_iter'
+            if self.solver_options['nlp_solver_ext_qp_res'] == 1:
+                header += '\tqp_res_stat\tqp_res_eq\tqp_res_ineq\tqp_res_comp'
+            if self.solver_options['rti_log_residuals'] == 1:
+                header += '\tres_stat\tres_eq\tres_ineq\tres_comp'
+            print(header)
             for jj in range(stat.shape[1]):
-                print('{:d}\t{:d}\t{:d}'.format( int(stat[0][jj]), int(stat[1][jj]), int(stat[2][jj])))
-                if stat.shape[0]>3:
-                    print('\t{:e}\t{:e}\t{:e}\t{:e}'.format( \
-                         stat[3][jj], stat[4][jj], stat[5][jj], stat[6][jj]))
+                line = '{:d}\t{:d}\t{:d}'.format( int(stat[0][jj]), int(stat[1][jj]), int(stat[2][jj]))
+                offset = 2
+                if self.solver_options['nlp_solver_ext_qp_res'] == 1:
+                    line += '\t{:e}\t{:e}\t{:e}\t{:e}'.format( \
+                         stat[offset+1][jj], stat[offset+2][jj], stat[offset+3][jj], stat[offset+4][jj])
+                    offset += 4
+                if self.solver_options['rti_log_residuals'] == 1:
+                    line += '\t{:e}\t{:e}\t{:e}\t{:e}'.format( \
+                         stat[offset+1][jj], stat[offset+2][jj], stat[offset+3][jj], stat[offset+4][jj])
+                print(line)
             print('\n')
 
         return
@@ -1063,7 +1072,6 @@ class AcadosOcpSolver:
                     out = (full_stats.T)[-2][1:5]
             else:
                 Exception("residuals are not computed for SQP_RTI")
-
 
         else:
             raise Exception(f'AcadosOcpSolver.get_stats(): \'{field}\' is not a valid argument.'

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -1011,6 +1011,8 @@ class AcadosOcpSolver:
                   'stat_n',
                   'residuals',
                   'alpha',
+                  'res_eq_all',
+                  'res_stat_all',
                 ]
         field = field_.encode('utf-8')
 
@@ -1062,6 +1064,26 @@ class AcadosOcpSolver:
 
         elif field_ == 'residuals':
             return self.get_residuals()
+
+        elif field_ == 'res_eq_all':
+            full_stats = self.get_stats('statistics')
+            if self.solver_options['nlp_solver_type'] == 'SQP':
+                return full_stats[2, :]
+            elif self.solver_options['nlp_solver_type'] == 'SQP_RTI':
+                if self.solver_options['rti_log_residuals'] == 1:
+                    return full_stats[4, :]
+                else:
+                    raise Exception("res_eq_all is not available for SQP_RTI if rti_log_residuals is not enabled.")
+
+        elif field_ == 'res_stat_all':
+            full_stats = self.get_stats('statistics')
+            if self.solver_options['nlp_solver_type'] == 'SQP':
+                return full_stats[1, :]
+            elif self.solver_options['nlp_solver_type'] == 'SQP_RTI':
+                if self.solver_options['rti_log_residuals'] == 1:
+                    return full_stats[3, :]
+                else:
+                    raise Exception("res_stat_all is not available for SQP_RTI if rti_log_residuals is not enabled.")
 
         else:
             raise Exception(f'AcadosOcpSolver.get_stats(): \'{field}\' is not a valid argument.'

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -1478,10 +1478,9 @@ class AcadosOcpSolver:
             - qp_mu0: for HPIPM QP solvers: initial value for complementarity slackness
             - warm_start_first_qp: indicates if first QP in SQP is warm_started
             - rti_phase: phase of the real-time iteration algorithm (0: preparation+feedback, 1: feedback, 2: preparation, 3: advanced step preparation)
-            - as_rti_iter: number of iterations in the AS RTI algorithm
         """
         int_fields = ['print_level', 'rti_phase', 'initialize_t_slacks', 'qp_warm_start',
-                      'line_search_use_sufficient_descent', 'full_step_dual', 'globalization_use_SOC', 'warm_start_first_qp', "as_rti_iter", "as_rti_level"]
+                      'line_search_use_sufficient_descent', 'full_step_dual', 'globalization_use_SOC', 'warm_start_first_qp', "as_rti_level"]
         double_fields = ['step_length', 'tol_eq', 'tol_stat', 'tol_ineq', 'tol_comp', 'alpha_min', 'alpha_reduction',
                          'eps_sufficient_descent', 'qp_tol_stat', 'qp_tol_eq', 'qp_tol_ineq', 'qp_tol_comp', 'qp_tau_min', 'qp_mu0']
         string_fields = ['globalization']

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -1063,16 +1063,6 @@ class AcadosOcpSolver:
         elif field_ == 'residuals':
             return self.get_residuals()
 
-        elif field_ == 'residuals':
-            if self.acados_ocp.solver_options.nlp_solver_type == 'SQP':
-                full_stats = self.get_stats('statistics')
-                if self.status != 2:
-                    out = (full_stats.T)[-1][1:5]
-                else: # when exiting with max_iter, residuals are computed for second last iterate only
-                    out = (full_stats.T)[-2][1:5]
-            else:
-                Exception("residuals are not computed for SQP_RTI")
-
         else:
             raise Exception(f'AcadosOcpSolver.get_stats(): \'{field}\' is not a valid argument.'
                     + f'\n Possible values are {fields}.')

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -1478,9 +1478,10 @@ class AcadosOcpSolver:
             - qp_mu0: for HPIPM QP solvers: initial value for complementarity slackness
             - warm_start_first_qp: indicates if first QP in SQP is warm_started
             - rti_phase: phase of the real-time iteration algorithm (0: preparation+feedback, 1: feedback, 2: preparation, 3: advanced step preparation)
+            - as_rti_iter: number of iterations in the AS RTI algorithm
         """
         int_fields = ['print_level', 'rti_phase', 'initialize_t_slacks', 'qp_warm_start',
-                      'line_search_use_sufficient_descent', 'full_step_dual', 'globalization_use_SOC', 'warm_start_first_qp']
+                      'line_search_use_sufficient_descent', 'full_step_dual', 'globalization_use_SOC', 'warm_start_first_qp', "as_rti_iter", "as_rti_level"]
         double_fields = ['step_length', 'tol_eq', 'tol_stat', 'tol_ineq', 'tol_comp', 'alpha_min', 'alpha_reduction',
                          'eps_sufficient_descent', 'qp_tol_stat', 'qp_tol_eq', 'qp_tol_ineq', 'qp_tol_comp', 'qp_tau_min', 'qp_mu0']
         string_fields = ['globalization']

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -1477,6 +1477,7 @@ class AcadosOcpSolver:
             - qp_tau_min: for HPIPM QP solvers: minimum value of barrier parameter in HPIPM
             - qp_mu0: for HPIPM QP solvers: initial value for complementarity slackness
             - warm_start_first_qp: indicates if first QP in SQP is warm_started
+            - rti_phase: phase of the real-time iteration algorithm (0: preparation+feedback, 1: feedback, 2: preparation, 3: advanced step preparation)
         """
         int_fields = ['print_level', 'rti_phase', 'initialize_t_slacks', 'qp_warm_start',
                       'line_search_use_sufficient_descent', 'full_step_dual', 'globalization_use_SOC', 'warm_start_first_qp']
@@ -1509,9 +1510,9 @@ class AcadosOcpSolver:
 
 
         if field_ == 'rti_phase':
-            if value_ < 0 or value_ > 2:
+            if value_ < 0 or value_ > 3:
                 raise Exception('AcadosOcpSolver.options_set(): argument \'rti_phase\' can '
-                    'take only values 0, 1, 2 for SQP-RTI-type solvers')
+                    'take only values 0, 1, 2, 3 for SQP-RTI-type solvers')
             if self.solver_options['nlp_solver_type'] != 'SQP_RTI' and value_ > 0:
                 raise Exception('AcadosOcpSolver.options_set(): argument \'rti_phase\' can '
                     'take only value 0 for SQP-type solvers')

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.c
@@ -2160,6 +2160,9 @@ void {{ name }}_acados_create_6_set_opts({{ name }}_solver_capsule* capsule)
     int as_rti_iter = {{ solver_options.as_rti_iter }};
     ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "as_rti_iter", &as_rti_iter);
 
+    int as_rti_level = {{ solver_options.as_rti_level }};
+    ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "as_rti_level", &as_rti_level);
+
     int rti_log_residuals = {{ solver_options.rti_log_residuals }};
     ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "rti_log_residuals", &rti_log_residuals);
 {%- endif %}

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.c
@@ -2156,6 +2156,12 @@ void {{ name }}_acados_create_6_set_opts({{ name }}_solver_capsule* capsule)
 
     int initialize_t_slacks = {{ solver_options.initialize_t_slacks }};
     ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "initialize_t_slacks", &initialize_t_slacks);
+{%- elif solver_options.nlp_solver_type == "SQP_RTI" %}
+    int as_rti_iter = {{ solver_options.as_rti_iter }};
+    ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "as_rti_iter", &as_rti_iter);
+
+    int rti_log_residuals = {{ solver_options.rti_log_residuals }};
+    ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "rti_log_residuals", &rti_log_residuals);
 {%- endif %}
 
     int qp_solver_iter_max = {{ solver_options.qp_solver_iter_max }};

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -2131,6 +2131,9 @@ void {{ model.name }}_acados_create_6_set_opts({{ model.name }}_solver_capsule* 
     int as_rti_iter = {{ solver_options.as_rti_iter }};
     ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "as_rti_iter", &as_rti_iter);
 
+    int as_rti_level = {{ solver_options.as_rti_level }};
+    ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "as_rti_level", &as_rti_level);
+
     int rti_log_residuals = {{ solver_options.rti_log_residuals }};
     ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "rti_log_residuals", &rti_log_residuals);
 {%- endif %}

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -2126,6 +2126,10 @@ void {{ model.name }}_acados_create_6_set_opts({{ model.name }}_solver_capsule* 
 
     int initialize_t_slacks = {{ solver_options.initialize_t_slacks }};
     ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "initialize_t_slacks", &initialize_t_slacks);
+
+{%- elif solver_options.nlp_solver_type == "SQP_RTI" %}
+    int as_rti_iter = {{ solver_options.as_rti_iter }};
+    ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "as_rti_iter", &as_rti_iter);
 {%- endif %}
 
     int qp_solver_iter_max = {{ solver_options.qp_solver_iter_max }};

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -2130,6 +2130,9 @@ void {{ model.name }}_acados_create_6_set_opts({{ model.name }}_solver_capsule* 
 {%- elif solver_options.nlp_solver_type == "SQP_RTI" %}
     int as_rti_iter = {{ solver_options.as_rti_iter }};
     ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "as_rti_iter", &as_rti_iter);
+
+    int rti_log_residuals = {{ solver_options.rti_log_residuals }};
+    ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "rti_log_residuals", &rti_log_residuals);
 {%- endif %}
 
     int qp_solver_iter_max = {{ solver_options.qp_solver_iter_max }};


### PR DESCRIPTION
This pull request implements the advanced-step real-time iteration (AS-RTI)

It is implemented as a feature within the `RTI` module.
In order to use it, set the new options:
- `as_rti_level`
- `as_rti_iter`

The feedback phase of RTI and AS-RTI is the same.
The AS-RTI preparation phase is used instead of the "standard" RTI preparation phase, when the options above are set.

Additionally, this adds the flag:
- `rti_log_residuals`: which allows to log the residuals within (AS-)RTI. This was needed for the experiment in the paper, which reports the residuals of the inner iterations. Limited to convex-over-nonlinear and external cost modules for now.

The work in this PR is presented in the publication
"Advanced-Step Real-time Iterations with Four Levels -- New Error Bounds and Fast Implementation in acados" by Jonathan Frey, Armin Nurkanovic, Moritz Diehl
https://arxiv.org/abs/2403.07101

Limitations:
- AS-RTI-B not implemented for ns > 0.
- AS-RTI-C only implemented for linear inequality constraints.