### PR TITLE
add idxsh_0 to layout

### DIFF
--- a/interfaces/acados_matlab_octave/acados_template_mex/+acados_template_mex/acados_ocp_layout.json
+++ b/interfaces/acados_matlab_octave/acados_template_mex/+acados_template_mex/acados_ocp_layout.json
@@ -364,6 +364,12 @@
                 "nsh"
             ]
         ],
+        "idxsh_0": [
+            "ndarray",
+            [
+                "nsh_0"
+            ]
+        ],
         "lsh_e": [
             "ndarray",
             [


### PR DESCRIPTION
This was missing in https://github.com/acados/acados/pull/1059 to make this work in matlab for nsh_0 > 0.
https://github.com/acados/acados/issues/1056