### PR TITLE
Matlab Interface: Add ztraj to sfunction output

### DIFF
--- a/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_solver_sfun.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_solver_sfun.in.c
@@ -356,6 +356,11 @@ static void mdlInitializeSizes (SimStruct *S)
     ssSetOutputPortVectorDimension(S, {{ i_output }}, {{ dims.nx * (dims.N+1) }} );
   {%- endif %}
 
+  {%- if simulink_opts.outputs.ztraj == 1 %}
+    {%- set i_output = i_output + 1 %}
+    ssSetOutputPortVectorDimension(S, {{ i_output }}, {{ dims.nz * dims.N }} );
+  {%- endif %}
+
   {%- if simulink_opts.outputs.solver_status == 1 %}
     {%- set i_output = i_output + 1 %}
     ssSetOutputPortVectorDimension(S, {{ i_output }}, 1 );
@@ -815,7 +820,7 @@ static void mdlOutputs(SimStruct *S, int_T tid)
 
     /* set outputs */
     // assign pointers to output signals
-    real_t *out_u0, *out_utraj, *out_xtraj, *out_status, *out_sqp_iter, *out_KKT_res, *out_KKT_residuals, *out_x1, *out_cpu_time, *out_cpu_time_sim, *out_cpu_time_qp, *out_cpu_time_lin, *out_cost_value;
+    real_t *out_u0, *out_utraj, *out_xtraj, *out_ztraj, *out_status, *out_sqp_iter, *out_KKT_res, *out_KKT_residuals, *out_x1, *out_cpu_time, *out_cpu_time_sim, *out_cpu_time_qp, *out_cpu_time_lin, *out_cost_value;
     int tmp_int;
 
     {%- set i_output = -1 -%}{# note here i_output is 0-based #}
@@ -840,6 +845,15 @@ static void mdlOutputs(SimStruct *S, int_T tid)
     for (int ii = 0; ii < {{ dims.N + 1 }}; ii++)
         ocp_nlp_out_get(nlp_config, nlp_dims, nlp_out, ii,
                         "x", (void *) (out_xtraj + ii * {{ dims.nx }}));
+  {%- endif %}
+
+  {% if simulink_opts.outputs.ztraj == 1 %}
+    {%- set i_output = i_output + 1 %}
+
+    out_ztraj = ssGetOutputPortRealSignal(S, {{ i_output }});
+    for (int ii = 0; ii < N; ii++)
+        ocp_nlp_out_get(nlp_config, nlp_dims, nlp_out, ii,
+                        "z", (void *) (out_ztraj + ii * {{ dims.nz }}));
   {%- endif %}
 
   {%- if simulink_opts.outputs.solver_status == 1 %}

--- a/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/make_sfun.in.m
+++ b/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/make_sfun.in.m
@@ -382,6 +382,12 @@ output_note = strcat(output_note, num2str(i_out), ') xtraj, state concatenated f
 sfun_output_names = [sfun_output_names; 'xtraj [{{ dims.nx * (dims.N + 1) }}]'];
 {%- endif %}
 
+{%- if simulink_opts.outputs.ztraj == 1 %}
+i_out = i_out + 1;
+output_note = strcat(output_note, num2str(i_out), ') ztraj, algebraic states concatenated for nodes 0 to N-1, size [{{ dims.nz * dims.N }}]\n ');
+sfun_output_names = [sfun_output_names; 'ztraj [{{ dims.nz * dims.N }}]'];
+{%- endif %}
+
 {%- if simulink_opts.outputs.solver_status == 1 %}
 i_out = i_out + 1;
 output_note = strcat(output_note, num2str(i_out), ') acados solver status (0 = SUCCESS)\n ');

--- a/interfaces/acados_template/acados_template/simulink_default_opts.json
+++ b/interfaces/acados_template/acados_template/simulink_default_opts.json
@@ -3,6 +3,7 @@
         "u0": 1,
         "utraj": 0,
         "xtraj": 0,
+        "ztraj": 0,
         "solver_status": 1,
         "cost_value": 0,
         "KKT_residual": 1,


### PR DESCRIPTION
Added an output port in the acados_ocp S-function block for the algebraic states' trajectory, `ztraj`, equivalent to `xtraj`.