### PR TITLE
Add functionality in `ocp_nlp_solver_destroy`

### DIFF
--- a/acados/dense_qp/dense_qp_common.h
+++ b/acados/dense_qp/dense_qp_common.h
@@ -69,6 +69,7 @@ typedef struct
     void (*solver_get)(void *config_, void *qp_in_, void *qp_out_, void *opts_, void *mem_, const char *field, int stage, void* value, int size1, int size2);
     void (*memory_reset)(void *config, void *qp_in, void *qp_out, void *opts, void *mem, void *work);
     void (*eval_sens)(void *config, void *qp_in, void *qp_out, void *opts, void *mem, void *work);
+    void (*terminate)(void *config, void *mem, void *work);
 } qp_solver_config;
 #endif
 

--- a/acados/dense_qp/dense_qp_daqp.c
+++ b/acados/dense_qp/dense_qp_daqp.c
@@ -759,6 +759,15 @@ void dense_qp_daqp_solver_get(void *config_, void *qp_in_, void *qp_out_, void *
 }
 
 
+
+void dense_qp_daqp_terminate(void *config_, void *mem_, void *work_)
+{
+    return;
+}
+
+
+
+
 void dense_qp_daqp_config_initialize_default(void *config_)
 {
     qp_solver_config *config = config_;
@@ -780,6 +789,7 @@ void dense_qp_daqp_config_initialize_default(void *config_)
     config->evaluate = (int (*)(void *, void *, void *, void *, void *, void *)) & dense_qp_daqp;
     config->memory_reset = &dense_qp_daqp_memory_reset;
     config->solver_get = &dense_qp_daqp_solver_get;
+    config->terminate = &dense_qp_daqp_terminate;
 
     return;
 }

--- a/acados/dense_qp/dense_qp_hpipm.c
+++ b/acados/dense_qp/dense_qp_hpipm.c
@@ -335,6 +335,12 @@ void dense_qp_hpipm_solver_get(void *config_, void *qp_in_, void *qp_out_, void 
 }
 
 
+void dense_qp_hpipm_terminate(void *config_, void *mem_, void *work_)
+{
+    return;
+}
+
+
 void dense_qp_hpipm_config_initialize_default(void *config_)
 {
     qp_solver_config *config = config_;
@@ -353,6 +359,7 @@ void dense_qp_hpipm_config_initialize_default(void *config_)
     config->eval_sens = &dense_qp_hpipm_eval_sens;
     config->memory_reset = &dense_qp_hpipm_memory_reset;
     config->solver_get = &dense_qp_hpipm_solver_get;
+    config->terminate = &dense_qp_hpipm_terminate;
 
     return;
 }

--- a/acados/dense_qp/dense_qp_ooqp.c
+++ b/acados/dense_qp/dense_qp_ooqp.c
@@ -633,6 +633,12 @@ void dense_qp_ooqp_solver_get(void *config_, void *qp_in_, void *qp_out_, void *
     exit(1);
 }
 
+
+void dense_qp_ooqp_terminate(void *config_, void *mem_, void *work_)
+{
+    return;
+}
+
 void dense_qp_ooqp_config_initialize_default(void *config_)
 {
     qp_solver_config *config = config_;
@@ -654,4 +660,5 @@ void dense_qp_ooqp_config_initialize_default(void *config_)
     config->eval_sens = &dense_qp_ooqp_eval_sens;
     config->memory_reset = &dense_qp_ooqp_memory_reset;
     config->solver_get = &dense_qp_ooqp_solver_get;
+    config->terminate = &dense_qp_ooqp_terminate;
 }

--- a/acados/dense_qp/dense_qp_qore.c
+++ b/acados/dense_qp/dense_qp_qore.c
@@ -568,6 +568,11 @@ void dense_qp_qore_solver_get(void *config_, void *qp_in_, void *qp_out_, void *
     exit(1);
 }
 
+void dense_qp_qore_terminate(void *config_, void *mem_, void *work_)
+{
+    return;
+}
+
 void dense_qp_qore_config_initialize_default(void *config_)
 {
     qp_solver_config *config = config_;
@@ -589,6 +594,7 @@ void dense_qp_qore_config_initialize_default(void *config_)
     config->eval_sens = &dense_qp_qore_eval_sens;
     config->memory_reset = &dense_qp_qore_memory_reset;
     config->solver_get = &dense_qp_qore_solver_get;
+    config->terminate = &dense_qp_qore_terminate;
 
     return;
 }

--- a/acados/dense_qp/dense_qp_qpoases.c
+++ b/acados/dense_qp/dense_qp_qpoases.c
@@ -786,6 +786,12 @@ void dense_qp_qpoases_solver_get(void *config_, void *qp_in_, void *qp_out_, voi
 }
 
 
+
+void dense_qp_qpoases_terminate(void *config_, void *mem_, void *work_)
+{
+    return;
+}
+
 void dense_qp_qpoases_config_initialize_default(void *config_)
 {
     qp_solver_config *config = config_;
@@ -808,6 +814,7 @@ void dense_qp_qpoases_config_initialize_default(void *config_)
     config->evaluate = (int (*)(void *, void *, void *, void *, void *, void *)) & dense_qp_qpoases;
     config->memory_reset = &dense_qp_qpoases_memory_reset;
     config->solver_get = &dense_qp_qpoases_solver_get;
+    config->terminate = &dense_qp_qpoases_terminate;
 
     return;
 }

--- a/acados/ocp_nlp/ocp_nlp_common.h
+++ b/acados/ocp_nlp/ocp_nlp_common.h
@@ -99,6 +99,8 @@ typedef struct ocp_nlp_config
     void (*get)(void *config_, void *dims, void *mem_, const char *field, void *return_value_);
     void (*opts_get)(void *config_, void *dims, void *opts_, const char *field, void *return_value_);
     void (*work_get)(void *config_, void *dims, void *work_, const char *field, void *return_value_);
+    //
+    void (*terminate)(void *config, void *mem, void *work);
     // config structs of submodules
     ocp_qp_xcond_solver_config *qp_solver; // TODO rename xcond_solver
     ocp_nlp_dynamics_config **dynamics;

--- a/acados/ocp_nlp/ocp_nlp_ddp.c
+++ b/acados/ocp_nlp/ocp_nlp_ddp.c
@@ -1474,6 +1474,17 @@ void ocp_nlp_ddp_work_get(void *config_, void *dims_, void *work_,
     }
 }
 
+
+void ocp_nlp_ddp_terminate(void *config_, void *mem_, void *work_)
+{
+    ocp_nlp_config *config = config_;
+    ocp_nlp_ddp_memory *mem = mem_;
+    ocp_nlp_ddp_workspace *work = work_;
+
+    config->qp_solver->terminate(config->qp_solver, mem->nlp_mem->qp_solver_mem, work->nlp_work->qp_work);
+}
+
+
 void ocp_nlp_ddp_config_initialize_default(void *config_)
 {
     ocp_nlp_config *config = (ocp_nlp_config *) config_;
@@ -1496,6 +1507,7 @@ void ocp_nlp_ddp_config_initialize_default(void *config_)
     config->get = &ocp_nlp_ddp_get;
     config->opts_get = &ocp_nlp_ddp_opts_get;
     config->work_get = &ocp_nlp_ddp_work_get;
+    config->terminate = &ocp_nlp_ddp_terminate;
 
     return;
 }

--- a/acados/ocp_nlp/ocp_nlp_sqp.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp.c
@@ -1260,6 +1260,17 @@ void ocp_nlp_sqp_work_get(void *config_, void *dims_, void *work_,
 }
 
 
+
+void ocp_nlp_sqp_terminate(void *config_, void *mem_, void *work_)
+{
+    ocp_nlp_config *config = config_;
+    ocp_nlp_sqp_memory *mem = mem_;
+    ocp_nlp_sqp_workspace *work = work_;
+
+    config->qp_solver->terminate(config->qp_solver, mem->nlp_mem->qp_solver_mem, work->nlp_work->qp_work);
+}
+
+
 void ocp_nlp_sqp_config_initialize_default(void *config_)
 {
     ocp_nlp_config *config = (ocp_nlp_config *) config_;
@@ -1282,6 +1293,7 @@ void ocp_nlp_sqp_config_initialize_default(void *config_)
     config->get = &ocp_nlp_sqp_get;
     config->opts_get = &ocp_nlp_sqp_opts_get;
     config->work_get = &ocp_nlp_sqp_work_get;
+    config->terminate = &ocp_nlp_sqp_terminate;
 
     return;
 }

--- a/acados/ocp_nlp/ocp_nlp_sqp_rti.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp_rti.c
@@ -1548,6 +1548,17 @@ void ocp_nlp_sqp_rti_work_get(void *config_, void *dims_, void *work_,
     }
 }
 
+
+void ocp_nlp_sqp_rti_terminate(void *config_, void *mem_, void *work_)
+{
+    ocp_nlp_config *config = config_;
+    ocp_nlp_sqp_rti_memory *mem = mem_;
+    ocp_nlp_sqp_rti_workspace *work = work_;
+
+    config->qp_solver->terminate(config->qp_solver, mem->nlp_mem->qp_solver_mem, work->nlp_work->qp_work);
+}
+
+
 void ocp_nlp_sqp_rti_config_initialize_default(void *config_)
 {
     ocp_nlp_config *config = (ocp_nlp_config *) config_;
@@ -1570,6 +1581,7 @@ void ocp_nlp_sqp_rti_config_initialize_default(void *config_)
     config->get = &ocp_nlp_sqp_rti_get;
     config->opts_get = &ocp_nlp_sqp_rti_opts_get;
     config->work_get = &ocp_nlp_sqp_rti_work_get;
+    config->terminate = &ocp_nlp_sqp_rti_terminate;
 
     return;
 }

--- a/acados/ocp_qp/ocp_qp_common.h
+++ b/acados/ocp_qp/ocp_qp_common.h
@@ -72,6 +72,7 @@ typedef struct
     void (*solver_get)(void *config_, void *qp_in_, void *qp_out_, void *opts_, void *mem_, const char *field, int stage, void* value, int size1, int size2);
     void (*memory_reset)(void *config, void *qp_in, void *qp_out, void *opts, void *mem, void *work);
     void (*eval_sens)(void *config, void *qp_in, void *qp_out, void *opts, void *mem, void *work);
+    void (*terminate)(void *config, void *mem, void *work);
 } qp_solver_config;
 #endif
 

--- a/acados/ocp_qp/ocp_qp_hpipm.c
+++ b/acados/ocp_qp/ocp_qp_hpipm.c
@@ -415,6 +415,12 @@ void ocp_qp_hpipm_eval_sens(void *config_, void *param_qp_in_, void *sens_qp_out
 }
 
 
+void ocp_qp_hpipm_terminate(void *config_, void *mem_, void *work_)
+{
+    return;
+}
+
+
 
 void ocp_qp_hpipm_config_initialize_default(void *config_)
 {
@@ -434,6 +440,7 @@ void ocp_qp_hpipm_config_initialize_default(void *config_)
     config->solver_get = &ocp_qp_hpipm_solver_get;
     config->memory_reset = &ocp_qp_hpipm_memory_reset;
     config->eval_sens = &ocp_qp_hpipm_eval_sens;
+    config->terminate = &ocp_qp_hpipm_terminate;
 
     return;
 }

--- a/acados/ocp_qp/ocp_qp_hpmpc.c
+++ b/acados/ocp_qp/ocp_qp_hpmpc.c
@@ -578,6 +578,12 @@ void ocp_qp_hpmpc_eval_sens(void *config_, void *qp_in, void *qp_out, void *opts
 
 
 
+void ocp_qp_hpmpc_terminate(void *config_, void *mem_, void *work_)
+{
+    return;
+}
+
+
 void ocp_qp_hpmpc_config_initialize_default(void *config_)
 {
     qp_solver_config *config = config_;
@@ -600,6 +606,7 @@ void ocp_qp_hpmpc_config_initialize_default(void *config_)
     config->eval_sens = &ocp_qp_hpmpc_eval_sens;
     config->memory_reset = &ocp_qp_hpmpc_memory_reset;
     config->solver_get = &ocp_qp_hpmpc_solver_get;
+    config->terminate = &ocp_qp_hpmpc_terminate;
 
 
     return;

--- a/acados/ocp_qp/ocp_qp_ooqp.c
+++ b/acados/ocp_qp/ocp_qp_ooqp.c
@@ -1173,6 +1173,11 @@ void ocp_qp_ooqp_eval_sens(void *config_, void *qp_in, void *qp_out, void *opts_
 }
 
 
+void ocp_qp_ooqp_terminate(void *config_, void *mem_, void *work_)
+{
+    return;
+}
+
 
 void ocp_qp_ooqp_config_initialize_default(void *config_)
 {
@@ -1196,5 +1201,6 @@ void ocp_qp_ooqp_config_initialize_default(void *config_)
     config->eval_sens = &ocp_qp_ooqp_eval_sens;
     config->memory_reset = &ocp_qp_ooqp_memory_reset;
     config->solver_get = &ocp_qp_ooqp_solver_get;
+    config->terminate = &ocp_qp_ooqp_terminate;
 
 }

--- a/acados/ocp_qp/ocp_qp_osqp.c
+++ b/acados/ocp_qp/ocp_qp_osqp.c
@@ -1063,7 +1063,7 @@ static int osqp_init_data(OSQPData *data, OSQPSettings *settings, OSQPWorkspace 
     }
 
     // Initialize linear system solver structure
-    // NOTE: mallocs
+    // NOTE: mallocs, memory is freed in ocp_qp_osqp_terminate
     if(init_linsys_solver(&(work->linsys_solver), work->data->P, work->data->A, work->settings->sigma,
                                              work->rho_vec, work->settings->linsys_solver, 0)){
         c_eprint("Failed to initialize %s linear system solver",
@@ -1308,6 +1308,15 @@ static void fill_in_qp_out(const ocp_qp_in *in, ocp_qp_out *out, ocp_qp_osqp_mem
 }
 
 
+void ocp_qp_osqp_terminate(void *config_, void *mem_, void *work_)
+{
+    ocp_qp_osqp_memory *mem = (ocp_qp_osqp_memory *) mem_;
+    OSQPWorkspace *work = mem->osqp_work;
+    work->linsys_solver->free(work->linsys_solver);
+}
+
+
+
 
 int ocp_qp_osqp(void *config_, void *qp_in_, void *qp_out_, void *opts_, void *mem_, void *work_)
 {
@@ -1423,6 +1432,7 @@ void ocp_qp_osqp_config_initialize_default(void *config_)
     config->memory_get = &ocp_qp_osqp_memory_get;
     config->workspace_calculate_size = &ocp_qp_osqp_workspace_calculate_size;
     config->evaluate = &ocp_qp_osqp;
+    config->terminate = &ocp_qp_osqp_terminate;
     config->eval_sens = &ocp_qp_osqp_eval_sens;
     config->memory_reset = &ocp_qp_osqp_memory_reset;
     config->solver_get = &ocp_qp_osqp_solver_get;

--- a/acados/ocp_qp/ocp_qp_qpdunes.c
+++ b/acados/ocp_qp/ocp_qp_qpdunes.c
@@ -928,6 +928,11 @@ void ocp_qp_qpdunes_solver_get(void *config_, void *qp_in_, void *qp_out_, void 
 }
 
 
+void ocp_qp_qpdunes_terminate(void *config_, void *mem_, void *work_)
+{
+    return;
+}
+
 void ocp_qp_qpdunes_config_initialize_default(void *config_)
 {
     qp_solver_config *config = config_;
@@ -950,5 +955,6 @@ void ocp_qp_qpdunes_config_initialize_default(void *config_)
     config->evaluate = (int (*)(void *, void *, void *, void *, void *, void *)) & ocp_qp_qpdunes;
     config->eval_sens = &ocp_qp_qpdunes_eval_sens;
     config->solver_get = &ocp_qp_qpdunes_solver_get;
+    config->terminate = &ocp_qp_qpdunes_terminate;
     return;
 }

--- a/acados/ocp_qp/ocp_qp_xcond_solver.c
+++ b/acados/ocp_qp/ocp_qp_xcond_solver.c
@@ -664,6 +664,18 @@ void ocp_qp_xcond_solver_eval_sens(void *config_, ocp_qp_xcond_solver_dims *dims
 }
 
 
+void ocp_qp_xcond_solver_terminate(void *config_, void *mem_, void *work_)
+{
+    ocp_qp_xcond_solver_config *config = config_;
+    qp_solver_config *qp_solver = config->qp_solver;
+
+    ocp_qp_xcond_solver_memory *memory = mem_;
+    ocp_qp_xcond_solver_workspace *work = work_;
+
+    qp_solver->terminate(config->qp_solver, memory->solver_memory, work->qp_solver_work);
+}
+
+
 
 void ocp_qp_xcond_solver_config_initialize_default(void *config_)
 {
@@ -688,6 +700,7 @@ void ocp_qp_xcond_solver_config_initialize_default(void *config_)
     config->condense_lhs = &ocp_qp_xcond_condense_lhs;
     config->condense_rhs_and_solve = &ocp_qp_xcond_condense_rhs_and_solve;
     config->eval_sens = &ocp_qp_xcond_solver_eval_sens;
+    config->terminate = &ocp_qp_xcond_solver_terminate;
 
     return;
 }

--- a/acados/ocp_qp/ocp_qp_xcond_solver.h
+++ b/acados/ocp_qp/ocp_qp_xcond_solver.h
@@ -97,6 +97,7 @@ typedef struct
     int (*condense_lhs)(void *config, ocp_qp_xcond_solver_dims *dims, ocp_qp_in *qp_in, ocp_qp_out *qp_out, void *opts, void *mem, void *work);
     int (*condense_rhs_and_solve)(void *config, ocp_qp_xcond_solver_dims *dims, ocp_qp_in *qp_in, ocp_qp_out *qp_out, void *opts, void *mem, void *work);
     void (*eval_sens)(void *config, ocp_qp_xcond_solver_dims *dims, ocp_qp_in *param_qp_in, ocp_qp_out *sens_qp_out, void *opts, void *mem, void *work);
+    void (*terminate)(void *config, void *mem, void *work);
     qp_solver_config *qp_solver;  // either ocp_qp_solver or dense_solver
     ocp_qp_xcond_config *xcond;
 } ocp_qp_xcond_solver_config;  // pcond - partial condensing or fcond - full condensing

--- a/interfaces/acados_c/ocp_nlp_interface.c
+++ b/interfaces/acados_c/ocp_nlp_interface.c
@@ -1043,8 +1043,9 @@ ocp_nlp_solver *ocp_nlp_solver_create(ocp_nlp_config *config, ocp_nlp_dims *dims
 }
 
 
-void ocp_nlp_solver_destroy(void *solver)
+void ocp_nlp_solver_destroy(ocp_nlp_solver *solver)
 {
+    solver->config->terminate(solver->config, solver->mem, solver->work);
     free(solver);
 }
 

--- a/interfaces/acados_c/ocp_nlp_interface.h
+++ b/interfaces/acados_c/ocp_nlp_interface.h
@@ -342,7 +342,7 @@ ACADOS_SYMBOL_EXPORT ocp_nlp_solver *ocp_nlp_solver_create(ocp_nlp_config *confi
 /// Destructor of the solver.
 ///
 /// \param solver The solver struct.
-ACADOS_SYMBOL_EXPORT void ocp_nlp_solver_destroy(void *solver);
+ACADOS_SYMBOL_EXPORT void ocp_nlp_solver_destroy(ocp_nlp_solver *solver);
 
 /// Solves the optimal control problem. Call ocp_nlp_precompute before
 /// calling this functions (TBC).


### PR DESCRIPTION
Add functionality in `ocp_nlp_solver_destroy` to allow freeing memory in submodules, such as external QP solvers.

Fix OSQP memory leak by adding: `qp_solver->terminate`.