### PR TITLE
Add `rti_phase` as possible Simulink input

### DIFF
--- a/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_solver_sfun.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_solver_sfun.in.c
@@ -816,7 +816,7 @@ static void mdlOutputs(SimStruct *S, int_T tid)
   {%- elif simulink_opts.inputs.rti_phase %}{# SPLIT RTI PHASE#}
     {% if solver_options.nlp_solver_type != "SQP_RTI" %}
     rti_phase input only supported for nlp_solver_type == "SQP_RTI"!
-    {% elif solver_options.custom_update_filename != "" %}
+    {% elif custom_update_filename != "" %}
     rti_phase input only supported for custom_update_filename == ""!
     {% else %}
     ocp_nlp_solver_opts_set(nlp_config, capsule->nlp_opts, "rti_phase", &rti_phase);

--- a/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_solver_sfun.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_solver_sfun.in.c
@@ -172,6 +172,10 @@ static void mdlInitializeSizes (SimStruct *S)
     {%- set n_inputs = n_inputs + 1 -%}
   {%- endif -%}
 
+  {%- if simulink_opts.inputs.rti_phase -%}  {#- rti_phase #}
+    {%- set n_inputs = n_inputs + 1 -%}
+  {%- endif -%}
+
     // specify the number of input ports
     if ( !ssSetNumInputPorts(S, {{ n_inputs }}) )
         return;
@@ -337,6 +341,12 @@ static void mdlInitializeSizes (SimStruct *S)
     {%- set i_input = i_input + 1 %}
     // u_init
     ssSetInputPortVectorDimension(S, {{ i_input }}, {{ dims.nu * (dims.N) }});
+  {%- endif -%}
+
+  {%- if simulink_opts.inputs.rti_phase -%}  {#- rti_phase #}
+    {%- set i_input = i_input + 1 %}
+    // rti_phase
+    ssSetInputPortVectorDimension(S, {{ i_input }}, 1);
   {%- endif -%}
 
     /* specify dimension information for the OUTPUT ports */
@@ -784,15 +794,38 @@ static void mdlOutputs(SimStruct *S, int_T tid)
     }
   {%- endif %}
 
+  {%- if simulink_opts.inputs.rti_phase %}  {#- rti_phase #}
+    {%- set i_input = i_input + 1 %}
+    in_sign = ssGetInputPortRealSignalPtrs(S, {{ i_input }});
+    double rti_phase_double = (double)(*in_sign[0]);
+    int rti_phase = (int) rti_phase_double;
+
+    ocp_nlp_solver_opts_set(nlp_config, capsule->nlp_opts, "rti_phase", &rti_phase);
+  {%- endif %}
+
+
     /* call solver */
-  {%- if custom_update_filename == "" %}
+  {%- if custom_update_filename == "" and not simulink_opts.inputs.rti_phase %}
     int rti_phase = 0;
     ocp_nlp_solver_opts_set(nlp_config, capsule->nlp_opts, "rti_phase", &rti_phase);
     int acados_status = {{ model.name }}_acados_solve(capsule);
     // get time
     ocp_nlp_get(nlp_config, capsule->nlp_solver, "time_tot", (void *) buffer);
     tmp_cpu_time = buffer[0];
-  {%- elif solver_options.nlp_solver_type == "SQP_RTI" %}
+
+  {%- elif simulink_opts.inputs.rti_phase %}{# SPLIT RTI PHASE#}
+    {% if solver_options.nlp_solver_type != "SQP_RTI" %}
+    rti_phase input only supported for nlp_solver_type == "SQP_RTI"!
+    {% elif solver_options.custom_update_filename != "" %}
+    rti_phase input only supported for custom_update_filename == ""!
+    {% else %}
+    ocp_nlp_solver_opts_set(nlp_config, capsule->nlp_opts, "rti_phase", &rti_phase);
+    int acados_status = {{ model.name }}_acados_solve(capsule);
+    // get time
+    ocp_nlp_get(nlp_config, capsule->nlp_solver, "time_tot", (void *) buffer);
+    tmp_cpu_time = buffer[0];
+    {%- endif %}
+  {%- elif solver_options.nlp_solver_type == "SQP_RTI" %}{# if custom_update_filename != "" #}
     // preparation
     int rti_phase = 1;
     ocp_nlp_solver_opts_set(nlp_config, capsule->nlp_opts, "rti_phase", &rti_phase);

--- a/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/make_sfun.in.m
+++ b/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/make_sfun.in.m
@@ -354,6 +354,12 @@ sfun_input_names = [sfun_input_names; 'u_init [{{ dims.nu * (dims.N) }}]'];
 i_in = i_in + 1;
 {%- endif %}
 
+{%- if simulink_opts.inputs.rti_phase %}  {#- rti_phase #}
+input_note = strcat(input_note, num2str(i_in), ') rti_phase, size [1]\n ');
+sfun_input_names = [sfun_input_names; 'rti_phase [1]'];
+i_in = i_in + 1;
+{%- endif %}
+
 fprintf(input_note)
 
 disp(' ')

--- a/interfaces/acados_template/acados_template/simulink_default_opts.json
+++ b/interfaces/acados_template/acados_template/simulink_default_opts.json
@@ -41,7 +41,8 @@
         "cost_W_e": 0,
         "reset_solver": 0,
         "x_init": 0,
-        "u_init": 0
+        "u_init": 0,
+        "rti_phase": 0
     },
     "samplingtime": "t0"
 }


### PR DESCRIPTION
allows to split the computations of an OCP solve into preparation and feedback phase.