### PR TITLE
Remove local `CMAKE_PREFIX_PATH` adjustments

### DIFF
--- a/cmake/acadosConfig.cmake.in
+++ b/cmake/acadosConfig.cmake.in
@@ -40,7 +40,6 @@ set(ACADOS_WITH_DAQP @ACADOS_WITH_DAQP@)
 
 # Add acados CMake folder to CMake prefix and module path
 set(CMAKE_MODULE_PATH_save "${CMAKE_MODULE_PATH}")
-list(APPEND CMAKE_PREFIX_PATH "${CMAKE_CURRENT_LIST_DIR}/../") # for *Config.cmake
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")     # for FindOpenBLAS, FindFortranLibs
 
 include(CMakeFindDependencyMacro)


### PR DESCRIPTION
Adjusting CMAKE_PREFIX_PATH in acadosConfig.cmake breaks dependency handling by catkin when building a ROS package that depends on acados.

## Details

ROS's buildtool `catkin` controls `CMAKE_PREFIX_PATH` in the environment to [handle "workspaces"](https://catkin-tools.readthedocs.io/en/latest/verbs/catkin_config.html#explicitly-specifying-workspace-chaining), which collides with `acadosConfig.cmake`'s own path adjustments.

Instead of replicating  #971's means of reverting path adjustment at exit, I simply deleted the path adjustment command as it seems to serve no purpose. The associated comment suggests an absurd thing - no `*Config.cmake` files could exist in the parent of the `cmake` folder, which could either be root `acados` in case of default install or `/usr/local` in case of global install