### PR TITLE
Revert "Remove local `CMAKE_PREFIX_PATH` adjustments (#1083)"

### DIFF
--- a/cmake/acadosConfig.cmake.in
+++ b/cmake/acadosConfig.cmake.in
@@ -40,6 +40,7 @@ set(ACADOS_WITH_DAQP @ACADOS_WITH_DAQP@)
 
 # Add acados CMake folder to CMake prefix and module path
 set(CMAKE_MODULE_PATH_save "${CMAKE_MODULE_PATH}")
+list(APPEND CMAKE_PREFIX_PATH "${CMAKE_CURRENT_LIST_DIR}/../") # for *Config.cmake
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")     # for FindOpenBLAS, FindFortranLibs
 
 include(CMakeFindDependencyMacro)


### PR DESCRIPTION
This reverts commit 3594673f36022ab7d57f58014d83509c0b76d7fd.

After two people experienced failing builds with ROS2 after #1083 let's revert this change.
See https://github.com/acados/acados/commit/3594673f36022ab7d57f58014d83509c0b76d7fd
