### PR TITLE
Batch integrator and OCP solver for parallel solves

### DIFF
--- a/examples/acados_python/pendulum_on_cart/ocp/minimal_example_batch_ocp_solver.py
+++ b/examples/acados_python/pendulum_on_cart/ocp/minimal_example_batch_ocp_solver.py
@@ -1,0 +1,150 @@
+# -*- coding: future_fstrings -*-
+#
+# Copyright (c) The acados authors.
+#
+# This file is part of acados.
+#
+# The 2-Clause BSD License
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.;
+#
+
+import sys
+sys.path.insert(0, '../common')
+
+from acados_template import AcadosOcp,  AcadosOcpSolver, AcadosOcpSolverBatch
+from pendulum_model import export_pendulum_ode_model
+import numpy as np
+import time
+import scipy
+import casadi as ca
+
+
+def setup_ocp(with_parallel_batch_solve=False, tol=1e-7):
+
+    ocp = AcadosOcp()
+
+    ocp.model = export_pendulum_ode_model()
+
+    Tf = 1.0
+    N = 20
+
+    # set dimensions
+    ocp.dims.N = N
+
+    Q_mat = 2*np.diag([1e3, 1e3, 1e-2, 1e-2])
+    R_mat = 2*np.diag([1e-2])
+    cost_W = scipy.linalg.block_diag(Q_mat, R_mat)
+
+    ocp.cost.cost_type = 'NONLINEAR_LS'
+    ocp.cost.cost_type_e = 'NONLINEAR_LS'
+
+    ocp.cost.W_e = Q_mat
+    ocp.cost.W = cost_W
+    ocp.model.cost_y_expr = ca.vertcat(ocp.model.x, ocp.model.u)
+    ocp.model.cost_y_expr_e = ocp.model.x
+    ocp.cost.yref = np.zeros(ocp.model.cost_y_expr.shape).flatten()
+    ocp.cost.yref_e = np.zeros(ocp.model.cost_y_expr_e.shape).flatten()
+
+    # set constraints
+    Fmax = 80
+    ocp.constraints.lbu = np.array([-Fmax])
+    ocp.constraints.ubu = np.array([+Fmax])
+    ocp.constraints.idxbu = np.array([0])
+
+    ocp.constraints.x0 = np.array([0.0, np.pi, 0.0, 0.0])
+
+    ocp.solver_options.qp_solver = 'PARTIAL_CONDENSING_HPIPM' # FULL_CONDENSING_QPOASES
+    ocp.solver_options.hessian_approx = 'GAUSS_NEWTON' # 'GAUSS_NEWTON', 'EXACT'
+    ocp.solver_options.integrator_type = 'IRK'
+    ocp.solver_options.nlp_solver_type = 'SQP' # SQP_RTI, SQP
+    ocp.solver_options.nlp_solver_tol_stat = tol
+    ocp.solver_options.nlp_solver_tol_eq = tol
+    ocp.solver_options.nlp_solver_tol_ineq = tol
+    ocp.solver_options.nlp_solver_tol_comp = tol
+    ocp.solver_options.with_parallel_batch_solve = with_parallel_batch_solve
+
+    ocp.solver_options.tf = Tf
+
+    return ocp
+
+
+def main_sequential(x0, N_sim, tol):
+
+    ocp = setup_ocp(tol=tol)
+    solver = AcadosOcpSolver(ocp, verbose=False)
+
+    nx = ocp.dims.nx
+    nu = ocp.dims.nu
+
+    simU = np.zeros((N_sim, nu))
+    simX = np.zeros((N_sim+1, nx))
+    simX[0,:] = x0
+
+    for i in range(N_sim):
+        simU[i,:] = solver.solve_for_x0(x0_bar=simX[i, :])
+        simX[i+1,:] = solver.get(1, "x")
+
+    return simX, simU
+
+
+def main_batch(Xinit, simU, tol, with_parallel_batch_solve=True):
+
+    N_batch = Xinit.shape[0] - 1
+    ocp = setup_ocp(with_parallel_batch_solve, tol)
+    batch_solver = AcadosOcpSolverBatch(ocp, N_batch, verbose=False)
+
+    for n in range(N_batch):
+        batch_solver.ocp_solvers[n].constraints_set(0, "lbx", Xinit[n])
+        batch_solver.ocp_solvers[n].constraints_set(0, "ubx", Xinit[n])
+
+        # set initial guess
+        for i in range(ocp.dims.N):
+            batch_solver.ocp_solvers[n].set(i, "x", Xinit[n])
+
+    t0 = time.time()
+    batch_solver.solve()
+    t_elapsed = time.time() - t0
+    t_elapsed *= 1000
+
+    print("parallel:  " if with_parallel_batch_solve else "sequential:", f"{t_elapsed:.3f}ms")
+
+    for n in range(N_batch):
+        u = batch_solver.ocp_solvers[n].get(0, "u")
+        if not np.linalg.norm(u-simU[n]) < tol*10:
+            print(np.linalg.norm(u-simU[n]))
+            breakpoint()
+
+
+if __name__ == "__main__":
+
+    tol = 1e-7
+    N_batch = 256
+    x0 = np.array([0.0, np.pi, 0.0, 0.0])
+    u0 = np.array([0.0])
+
+    simX, simU = main_sequential(x0=x0, N_sim=N_batch, tol=tol)
+
+    main_batch(Xinit=simX, simU=simU, tol=tol, with_parallel_batch_solve=False)
+    main_batch(Xinit=simX, simU=simU, tol=tol, with_parallel_batch_solve=True)
+

--- a/examples/acados_python/pendulum_on_cart/sim/minimal_example_batch_sim_solver.py
+++ b/examples/acados_python/pendulum_on_cart/sim/minimal_example_batch_sim_solver.py
@@ -90,8 +90,6 @@ def main_batch(Xinit, u0, with_parallel_batch_solve=True):
         x = batch_integrator.sim_solvers[n].get("x")
         assert np.linalg.norm(x-Xinit[n+1]) < 1e-10
 
-    return simX, u0
-
 
 if __name__ == "__main__":
 

--- a/interfaces/acados_template/acados_template/__init__.py
+++ b/interfaces/acados_template/acados_template/__init__.py
@@ -42,6 +42,7 @@ from .acados_multiphase_ocp import AcadosMultiphaseOcp
 
 from .acados_ocp_solver import AcadosOcpSolver
 from .acados_sim_solver import AcadosSimSolver
+from .acados_sim_solver_batch import AcadosSimSolverBatch
 from .utils import print_casadi_expression, get_acados_path, get_python_interface_path, \
     get_tera_exec_path, get_tera, check_casadi_version, acados_dae_model_json_dump, \
     casadi_length, make_object_json_dumpable, J_to_idx, get_default_simulink_opts, \

--- a/interfaces/acados_template/acados_template/__init__.py
+++ b/interfaces/acados_template/acados_template/__init__.py
@@ -36,6 +36,7 @@ from .acados_ocp import AcadosOcp
 from .acados_ocp_cost import AcadosOcpCost
 from .acados_ocp_constraints import AcadosOcpConstraints
 from .acados_ocp_options import AcadosOcpOptions
+from .acados_ocp_solver_batch import AcadosOcpSolverBatch
 
 from .acados_sim import AcadosSim, AcadosSimOpts
 from .acados_multiphase_ocp import AcadosMultiphaseOcp

--- a/interfaces/acados_template/acados_template/acados_ocp_options.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_options.py
@@ -94,6 +94,7 @@ class AcadosOcpOptions:
         self.__hpipm_mode = 'BALANCE'
         self.__with_solution_sens_wrt_params = False
         self.__with_value_sens_wrt_params = False
+        self.__with_parallel_batch_solve: bool = False
         # TODO: move those out? they are more about generation than about the acados OCP solver.
         self.__ext_fun_compile_flags = '-O2'
         self.__model_external_shared_lib_dir = None
@@ -682,6 +683,15 @@ class AcadosOcpOptions:
         """
         return self.__with_value_sens_wrt_params
 
+    @property
+    def with_parallel_batch_solve(self):
+        """
+        Flag indicating whether the sim solver should be compiled with openmp.
+        Default: False.
+        """
+        return self.__with_parallel_batch_solve
+
+
     @qp_solver.setter
     def qp_solver(self, qp_solver):
         qp_solvers = ('PARTIAL_CONDENSING_HPIPM', \
@@ -693,6 +703,7 @@ class AcadosOcpOptions:
         else:
             raise Exception('Invalid qp_solver value. Possible values are:\n\n' \
                     + ',\n'.join(qp_solvers) + '.\n\nYou have: ' + qp_solver + '.\n\n')
+
 
     @regularize_method.setter
     def regularize_method(self, regularize_method):
@@ -1150,6 +1161,13 @@ class AcadosOcpOptions:
             self.__ext_cost_num_hess = ext_cost_num_hess
         else:
             raise Exception('Invalid ext_cost_num_hess value. ext_cost_num_hess takes one of the values 0, 1.')
+
+    @with_parallel_batch_solve.setter
+    def with_parallel_batch_solve(self, with_parallel_batch_solve):
+        if with_parallel_batch_solve in (True, False):
+            self.__with_parallel_batch_solve = with_parallel_batch_solve
+        else:
+            raise Exception('Invalid with_parallel_batch_solve value. with_parallel_batch_solve must be a Boolean.')
 
     def set(self, attr, value):
         setattr(self, attr, value)

--- a/interfaces/acados_template/acados_template/acados_ocp_solver_batch.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver_batch.py
@@ -1,0 +1,54 @@
+from .acados_ocp_solver import AcadosOcpSolver
+from .acados_ocp import AcadosOcp
+from typing import List
+from ctypes import (POINTER, c_int, c_void_p)
+
+
+class AcadosOcpSolverBatch():
+    """
+    Batch Integrator for parallel integration.
+
+        :param sim: type :py:class:`~acados_template.acados_sim.AcadosOcp`
+        :param N_batch: batch size, positive integer
+        :param json_file: Default: 'acados_sim.json'
+        :verbose: bool, default: True
+    """
+
+    __ocp_solvers : List[AcadosOcpSolver]
+
+    def __init__(self, ocp: AcadosOcp, N_batch: int, json_file: str = 'acados_ocp.json', verbose: bool=True):
+
+        if not isinstance(N_batch, int) or N_batch <= 0:
+            raise Exception("AcadosOcpSolverBatch: argument N_batch should be a positive integer.")
+
+        self.__N_batch = N_batch
+        self.__ocp_solvers = [AcadosOcpSolver(ocp, json_file=json_file, build=n==0, generate=n==0, verbose=verbose) for n in range(self.N_batch)]
+
+        self.__shared_lib = self.ocp_solvers[0].shared_lib
+        self.__name = self.ocp_solvers[0].name
+        self.__ocp_solvers_pointer = (c_void_p * self.N_batch)()
+
+        for i in range(self.N_batch):
+            self.__ocp_solvers_pointer[i] = self.ocp_solvers[i].capsule
+
+        getattr(self.__shared_lib, f"{self.__name}_acados_batch_solve").argtypes = [POINTER(c_void_p), c_int]
+        getattr(self.__shared_lib, f"{self.__name}_acados_batch_solve").restype = c_void_p
+
+
+    def solve(self):
+        """
+        Call solve for all `N_batch` solvers.
+        """
+        getattr(self.__shared_lib, f"{self.__name}_acados_batch_solve")(self.__ocp_solvers_pointer, self.__N_batch)
+
+
+    @property
+    def ocp_solvers(self):
+        """List of AcadosOcpSolvers."""
+        return self.__ocp_solvers
+
+    @property
+    def N_batch(self):
+        """Batch size."""
+        return self.__N_batch
+

--- a/interfaces/acados_template/acados_template/acados_sim.py
+++ b/interfaces/acados_template/acados_template/acados_sim.py
@@ -57,6 +57,7 @@ class AcadosSimOpts:
         self.__output_z = True
         self.__sim_method_jac_reuse = 0
         self.__ext_fun_compile_flags = '-O2'
+        self.__with_parallel_batch_solve: bool = False
 
     @property
     def integrator_type(self):
@@ -138,6 +139,15 @@ class AcadosSimOpts:
         Default: '-O2'.
         """
         return self.__ext_fun_compile_flags
+
+    @property
+    def with_parallel_batch_solve(self):
+        """
+        Flag indicating whether the sim solver should be compiled with openmp.
+        Default: False.
+        """
+        return self.__with_parallel_batch_solve
+
 
     @ext_fun_compile_flags.setter
     def ext_fun_compile_flags(self, ext_fun_compile_flags):
@@ -237,6 +247,13 @@ class AcadosSimOpts:
             self.__sim_method_jac_reuse = sim_method_jac_reuse
         else:
             raise Exception('Invalid sim_method_jac_reuse value. sim_method_jac_reuse must be 0 or 1.')
+
+    @with_parallel_batch_solve.setter
+    def with_parallel_batch_solve(self, with_parallel_batch_solve):
+        if with_parallel_batch_solve in (True, False):
+            self.__with_parallel_batch_solve = with_parallel_batch_solve
+        else:
+            raise Exception('Invalid with_parallel_batch_solve value. with_parallel_batch_solve must be a Boolean.')
 
 class AcadosSim:
     """

--- a/interfaces/acados_template/acados_template/acados_sim_solver.py
+++ b/interfaces/acados_template/acados_template/acados_sim_solver.py
@@ -55,7 +55,6 @@ from .casadi_function_generation import (generate_c_code_explicit_ode,
 from .gnsf.detect_gnsf_structure import detect_gnsf_structure
 from .utils import (check_casadi_version, format_class_dict,
                     get_shared_lib_ext, get_shared_lib_prefix, get_shared_lib_dir,
-                    get_python_interface_path,
                     make_object_json_dumpable,
                     render_template, set_up_imported_gnsf_model,
                     verbose_system_call)

--- a/interfaces/acados_template/acados_template/acados_sim_solver_batch.py
+++ b/interfaces/acados_template/acados_template/acados_sim_solver_batch.py
@@ -1,0 +1,24 @@
+from .acados_sim_solver import AcadosSimSolver
+from typing import List
+from ctypes import (POINTER, c_int, c_void_p)
+
+class AcadosSimSolverBatch():
+
+    def __init__(self, sim_solvers: List[AcadosSimSolver]):
+
+        self.sim_solvers = sim_solvers
+        self.N_batch = len(sim_solvers)
+        self.shared_lib = sim_solvers[0].shared_lib
+        self.model_name = sim_solvers[0].model_name
+        self.sim_solvers_pointer = (c_void_p * self.N_batch)()
+
+        for i in range(self.N_batch):
+            self.sim_solvers_pointer[i] = self.sim_solvers[i].capsule
+
+        getattr(self.shared_lib, f"{self.model_name}_acados_sim_solve").argtypes = [POINTER(c_void_p), c_int]
+        getattr(self.shared_lib, f"{self.model_name}_acados_sim_solve").restype = c_void_p
+
+
+    def solve(self):
+        getattr(self.shared_lib, f"{self.model_name}_acados_sim_batch_solve")(self.sim_solvers_pointer, self.N_batch)
+

--- a/interfaces/acados_template/acados_template/c_templates_tera/CMakeLists.in.txt
+++ b/interfaces/acados_template/acados_template/c_templates_tera/CMakeLists.in.txt
@@ -384,7 +384,7 @@ set(CMAKE_C_FLAGS "-fPIC -std=c99 {{ openmp_flag }}
     -DACADOS_WITH_QPDUNES
 {%- endif -%}
 {%- if solver_options.with_parallel_batch_solve -%}
-CFLAGS += -fopenmp
+    -fopenmp
 {%- endif -%}
 ")
 #-fno-diagnostics-show-line-numbers -g

--- a/interfaces/acados_template/acados_template/c_templates_tera/CMakeLists.in.txt
+++ b/interfaces/acados_template/acados_template/c_templates_tera/CMakeLists.in.txt
@@ -383,6 +383,9 @@ set(CMAKE_C_FLAGS "-fPIC -std=c99 {{ openmp_flag }}
 {%- if qp_solver == "PARTIAL_CONDENSING_QPDUNES" -%}
     -DACADOS_WITH_QPDUNES
 {%- endif -%}
+{%- if solver_options.with_parallel_batch_solve -%}
+CFLAGS += -fopenmp
+{%- endif -%}
 ")
 #-fno-diagnostics-show-line-numbers -g
 

--- a/interfaces/acados_template/acados_template/c_templates_tera/Makefile.in
+++ b/interfaces/acados_template/acados_template/c_templates_tera/Makefile.in
@@ -366,12 +366,15 @@ CPPFLAGS+= -I $(INCLUDE_PATH)/daqp/include
 CFLAGS = -fPIC -std=c99 {{ openmp_flag }} {{ solver_options.ext_fun_compile_flags }}#-fno-diagnostics-show-line-numbers -g
 {% if solver_options.with_parallel_batch_solve %}
 CFLAGS += -fopenmp
-{%- endif -%}
+{%- endif %}
 # # Debugging
 # CFLAGS += -g3
 
 # linker flags
 LDFLAGS+= -L$(LIB_PATH)
+{% if solver_options.with_parallel_batch_solve %}
+LDFLAGS += -fopenmp
+{%- endif %}
 
 # link to libraries
 LDLIBS+= -lacados

--- a/interfaces/acados_template/acados_template/c_templates_tera/Makefile.in
+++ b/interfaces/acados_template/acados_template/c_templates_tera/Makefile.in
@@ -364,6 +364,9 @@ CPPFLAGS+= -I $(INCLUDE_PATH)/daqp/include
 {# c-compiler flags #}
 # define the c-compiler flags for make's implicit rules
 CFLAGS = -fPIC -std=c99 {{ openmp_flag }} {{ solver_options.ext_fun_compile_flags }}#-fno-diagnostics-show-line-numbers -g
+{% if solver_options.with_parallel_batch_solve %}
+CFLAGS += -fopenmp
+{%- endif -%}
 # # Debugging
 # CFLAGS += -g3
 

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_sim_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_sim_solver.in.c
@@ -412,6 +412,19 @@ int {{ model.name }}_acados_sim_solve({{ model.name }}_sim_solver_capsule *capsu
 }
 
 
+void {{ model.name }}_acados_sim_batch_solve({{ model.name }}_sim_solver_capsule ** capsules, int N_batch)
+{
+{% if solver_options.with_parallel_batch_solve %}
+    #pragma omp parallel for
+{%- endif %}
+    for (int i = 0; i < N_batch; i++)
+    {
+        sim_solve(capsules[i]->acados_sim_solver, capsules[i]->acados_sim_in, capsules[i]->acados_sim_out);
+    }
+    return;
+}
+
+
 int {{ model.name }}_acados_sim_free({{ model.name }}_sim_solver_capsule *capsule)
 {
     // free memory

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_sim_solver.in.h
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_sim_solver.in.h
@@ -80,6 +80,7 @@ typedef struct {{ model.name }}_sim_solver_capsule
 
 ACADOS_SYMBOL_EXPORT int {{ model.name }}_acados_sim_create({{ model.name }}_sim_solver_capsule *capsule);
 ACADOS_SYMBOL_EXPORT int {{ model.name }}_acados_sim_solve({{ model.name }}_sim_solver_capsule *capsule);
+ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_sim_batch_solve({{ model.name }}_sim_solver_capsule **capsules, int N_batch);
 ACADOS_SYMBOL_EXPORT int {{ model.name }}_acados_sim_free({{ model.name }}_sim_solver_capsule *capsule);
 ACADOS_SYMBOL_EXPORT int {{ model.name }}_acados_sim_update_params({{ model.name }}_sim_solver_capsule *capsule, double *value, int np);
 

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -2866,6 +2866,19 @@ int {{ model.name }}_acados_solve({{ model.name }}_solver_capsule* capsule)
 }
 
 
+void {{ model.name }}_acados_batch_solve({{ model.name }}_solver_capsule ** capsules, int N_batch)
+{
+{% if solver_options.with_parallel_batch_solve %}
+    #pragma omp parallel for
+{%- endif %}
+    for (int i = 0; i < N_batch; i++)
+    {
+        ocp_nlp_solve(capsules[i]->nlp_solver, capsules[i]->nlp_in, capsules[i]->nlp_out);
+    }
+    return;
+}
+
+
 int {{ model.name }}_acados_free({{ model.name }}_solver_capsule* capsule)
 {
     // before destroying, keep some info

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.h
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.h
@@ -260,6 +260,7 @@ ACADOS_SYMBOL_EXPORT int {{ model.name }}_acados_update_params({{ model.name }}_
 ACADOS_SYMBOL_EXPORT int {{ model.name }}_acados_update_params_sparse({{ model.name }}_solver_capsule * capsule, int stage, int *idx, double *p, int n_update);
 
 ACADOS_SYMBOL_EXPORT int {{ model.name }}_acados_solve({{ model.name }}_solver_capsule * capsule);
+ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_solve({{ model.name }}_solver_capsule ** capsules, int N_batch);
 ACADOS_SYMBOL_EXPORT int {{ model.name }}_acados_free({{ model.name }}_solver_capsule * capsule);
 ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_print_stats({{ model.name }}_solver_capsule * capsule);
 ACADOS_SYMBOL_EXPORT int {{ model.name }}_acados_custom_update({{ model.name }}_solver_capsule* capsule, double* data, int data_len);

--- a/interfaces/acados_template/acados_template/c_templates_tera/multi_Makefile.in
+++ b/interfaces/acados_template/acados_template/c_templates_tera/multi_Makefile.in
@@ -303,11 +303,17 @@ CPPFLAGS+= -I $(INCLUDE_PATH)/daqp/include
 
 # define the c-compiler flags for make's implicit rules
 CFLAGS = -fPIC -std=c99 {{ openmp_flag }} {{ solver_options.ext_fun_compile_flags }}#-fno-diagnostics-show-line-numbers -g
+{% if solver_options.with_parallel_batch_solve %}
+CFLAGS += -fopenmp
+{%- endif %}
 # # Debugging
 # CFLAGS += -g3
 
 # linker flags
 LDFLAGS+= -L$(LIB_PATH)
+{% if solver_options.with_parallel_batch_solve %}
+LDFLAGS += -fopenmp
+{%- endif %}
 
 # link to libraries
 LDLIBS+= -lacados


### PR DESCRIPTION
This PR implements a parallelizable batch solve for acados integrators and OCP solvers. The batch solve is interfaced from python with `AcadosOcpSolverBatch` and `AcadosSimSolverBatch`. Parallelization via openmp can be switched on/off via the option `with_parallel_batch_solve` which has been added to the solver options.

These classes hold `N_batch` identical solvers and provide a parallelizable solve function. All other operations have to be called individually for each of the solvers via their standard interface.

Limitations:
* number of openmp threads cannot be set at the moment.