### PR TITLE
Follow up to #1087

### DIFF
--- a/examples/acados_python/pendulum_on_cart/ocp/minimal_example_batch_ocp_solver.py
+++ b/examples/acados_python/pendulum_on_cart/ocp/minimal_example_batch_ocp_solver.py
@@ -39,6 +39,13 @@ import time
 import scipy
 import casadi as ca
 
+"""
+This example shows how the AcadosOcpBatchSolver can be used to parallelize mulitple OCP solves.
+
+If you want to use the batch solver, make sure to compile acados with openmp and num_threads set to 1,
+i.e. with the flags -DACADOS_WITH_OPENMP=ON -DACADOS_NUM_THREADS=1
+The number of threads for the batch solver is then set via the option `num_threads_in_batch_solve`, see below.
+"""
 
 def setup_ocp(num_threads_in_batch_solve=1, tol=1e-7):
 

--- a/examples/acados_python/pendulum_on_cart/sim/minimal_example_batch_sim_solver.py
+++ b/examples/acados_python/pendulum_on_cart/sim/minimal_example_batch_sim_solver.py
@@ -38,6 +38,15 @@ import numpy as np
 import time
 
 
+"""
+This example shows how the AcadosSimBatchSolver can be used to parallelize mulitple integrators.
+
+If you want to use the batch solver, make sure to compile acados with openmp and num_threads set to 1,
+i.e. with the flags -DACADOS_WITH_OPENMP=ON -DACADOS_NUM_THREADS=1
+The number of threads for the batch solver is then set via the option `num_threads_in_batch_solve`, see below.
+"""
+
+
 def setup_integrator(num_threads_in_batch_solve=1):
 
     sim = AcadosSim()

--- a/interfaces/CMakeLists.txt
+++ b/interfaces/CMakeLists.txt
@@ -379,4 +379,8 @@ set_tests_properties(python_pendulum_ocp_IRK PROPERTIES DEPENDS python_pendulum_
 set_tests_properties(python_pendulum_ocp_ERK PROPERTIES DEPENDS python_pendulum_ocp_GNSF)
 set_tests_properties(python_pendulum_ocp_GNSF PROPERTIES DEPENDS python_example_ocp_dynamics_formulations_cmake)
 
+if(ACADOS_WITH_QPDUNES)
+        set_tests_properties(python_example_ocp_dynamics_formulations_cmake PROPERTIES DEPENDS python_qpDUNES_test)
+endif()
+
 endif()

--- a/interfaces/CMakeLists.txt
+++ b/interfaces/CMakeLists.txt
@@ -282,10 +282,6 @@ add_test(NAME python_pendulum_ext_sim_example
         COMMAND "${CMAKE_COMMAND}" -E chdir ${PROJECT_SOURCE_DIR}/examples/acados_python/pendulum_on_cart/sim
         python extensive_example_sim.py
         )
-add_test(NAME python_batch_sim
-        COMMAND "${CMAKE_COMMAND}" -E chdir ${PROJECT_SOURCE_DIR}/examples/acados_python/pendulum_on_cart/sim
-        python minimal_example_batch_sim_solver.py
-        )
 
 add_test(NAME cython_pendulum_closed_loop_example
         COMMAND "${CMAKE_COMMAND}" -E chdir ${PROJECT_SOURCE_DIR}/examples/acados_python/pendulum_on_cart
@@ -307,10 +303,6 @@ add_test(NAME python_pendulum_ocp_ERK
 add_test(NAME python_pendulum_ocp_GNSF
         COMMAND "${CMAKE_COMMAND}" -E chdir ${PROJECT_SOURCE_DIR}/examples/acados_python/pendulum_on_cart/ocp
         python example_ocp_dynamics_formulations.py --INTEGRATOR_TYPE=GNSF)
-
-add_test(NAME python_batch_ocp
-        COMMAND "${CMAKE_COMMAND}" -E chdir ${PROJECT_SOURCE_DIR}/examples/acados_python/pendulum_on_cart/ocp
-        python minimal_example_batch_ocp_solver.py)
 
 # CMake and solver=DISCRETE test
 add_test(NAME python_example_ocp_dynamics_formulations_cmake
@@ -362,7 +354,6 @@ set_tests_properties(python_chain_ocp PROPERTIES DEPENDS python_chain_sim)
 
 # Directory pendulum_on_cart/sim
 set_tests_properties(python_pendulum_ext_sim_example PROPERTIES DEPENDS python_pendulum_sim_example_cmake)
-set_tests_properties(python_pendulum_sim_example_cmake PROPERTIES DEPENDS python_batch_sim)
 
 # Directory pendulum_on_cart/mhe
 set_tests_properties(python_pendulum_mhe_example_minimal PROPERTIES DEPENDS python_pendulum_mhe_example_noisy_param)
@@ -387,8 +378,6 @@ set_tests_properties(pendulum_optimal_value_gradient PROPERTIES DEPENDS python_p
 set_tests_properties(python_pendulum_ocp_IRK PROPERTIES DEPENDS python_pendulum_ocp_ERK)
 set_tests_properties(python_pendulum_ocp_ERK PROPERTIES DEPENDS python_pendulum_ocp_GNSF)
 set_tests_properties(python_pendulum_ocp_GNSF PROPERTIES DEPENDS python_example_ocp_dynamics_formulations_cmake)
-set_tests_properties(python_example_ocp_dynamics_formulations_cmake PROPERTIES DEPENDS python_batch_ocp)
-if(ACADOS_WITH_QPDUNES)
-        set_tests_properties(python_batch_ocp PROPERTIES DEPENDS python_qpDUNES_test)
+
 endif()
 endif()

--- a/interfaces/CMakeLists.txt
+++ b/interfaces/CMakeLists.txt
@@ -380,4 +380,3 @@ set_tests_properties(python_pendulum_ocp_ERK PROPERTIES DEPENDS python_pendulum_
 set_tests_properties(python_pendulum_ocp_GNSF PROPERTIES DEPENDS python_example_ocp_dynamics_formulations_cmake)
 
 endif()
-endif()

--- a/interfaces/acados_template/acados_template/acados_ocp_batch_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_batch_solver.py
@@ -35,8 +35,10 @@ class AcadosOcpBatchSolver():
         getattr(self.__shared_lib, f"{self.__name}_acados_batch_solve").restype = c_void_p
 
         if self.ocp_solvers[0].acados_lib_uses_omp:
-            print("Warning: The acados shared library is already compiled with OpenMP, which allows to parallelize within a single OCP solver call.")
-            print("It is not recommended to use the AcadosOcpBatchSolver, which allows calling multiple OCP solvers in parallel, while also parallelizing each solver individually.")
+            print("Note: Please make sure that the acados shared library is compiled with the number of threads set to 1, i.e. with the flags -DACADOS_WITH_OPENMP=ON -DACADOS_NUM_THREADS=1.")
+        else:
+            print("Warning: Please compile the acados shared library with openmp and the number of threads set to 1, i.e. with the flags -DACADOS_WITH_OPENMP=ON -DACADOS_NUM_THREADS=1.")
+
 
     def solve(self):
         """

--- a/interfaces/acados_template/acados_template/acados_ocp_batch_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_batch_solver.py
@@ -35,9 +35,13 @@ class AcadosOcpBatchSolver():
         getattr(self.__shared_lib, f"{self.__name}_acados_batch_solve").restype = c_void_p
 
         if self.ocp_solvers[0].acados_lib_uses_omp:
-            print("Note: Please make sure that the acados shared library is compiled with the number of threads set to 1, i.e. with the flags -DACADOS_WITH_OPENMP=ON -DACADOS_NUM_THREADS=1.")
+            msg = "Note: Please make sure that the acados shared library is compiled with the number of threads set to 1,\n"
         else:
-            print("Warning: Please compile the acados shared library with openmp and the number of threads set to 1, i.e. with the flags -DACADOS_WITH_OPENMP=ON -DACADOS_NUM_THREADS=1.")
+            msg = "Warning: Please compile the acados shared library with openmp and the number of threads set to 1,\n"
+
+        msg += "i.e. with the flags -DACADOS_WITH_OPENMP=ON -DACADOS_NUM_THREADS=1.\n" + \
+                   "See https://github.com/acados/acados/pull/1089 for more details."
+        print(msg)
 
 
     def solve(self):

--- a/interfaces/acados_template/acados_template/acados_sim_batch_solver.py
+++ b/interfaces/acados_template/acados_template/acados_sim_batch_solver.py
@@ -34,6 +34,9 @@ class AcadosSimBatchSolver():
         getattr(self.__shared_lib, f"{self.__model_name}_acados_sim_batch_solve").argtypes = [POINTER(c_void_p), c_int]
         getattr(self.__shared_lib, f"{self.__model_name}_acados_sim_batch_solve").restype = c_void_p
 
+        if not self.ocp_solvers[0].acados_lib_uses_omp:
+            print("Warning: Please compile the acados shared library with openmp and the number of threads set to 1, i.e. with the flags -DACADOS_WITH_OPENMP=ON -DACADOS_NUM_THREADS=1.")
+
 
     def solve(self):
         """


### PR DESCRIPTION
Apparently, shared libraries with and without openmp cannot easily be combined.  If the acados batch solvers introduced in #1087  should be used, it is thus recommended to compile the acados shared library with openmp and set the number of threads to 1.
This problem seems to be related to:
* https://github.com/JuliaLang/julia/issues/10938
* https://github.com/casadi/casadi/issues/2447

This PR implements corresponding warnings in `AcadosOcpBatchSolver` and `AcadosSimBatchSolver` and removes the examples from the tests (as we do not want to compile acados with openmp for all tests). 