### PR TITLE
Octave works

### DIFF
--- a/interfaces/acados_matlab_octave/check_casadi_version.m
+++ b/interfaces/acados_matlab_octave/check_casadi_version.m
@@ -32,6 +32,6 @@ function check_casadi_version()
     import casadi.*
     casadi_version = CasadiMeta.version();
     if ~(strcmp(casadi_version(1:3),'3.4') || strcmp(casadi_version(1:3),'3.5') || strcmp(casadi_version(1:3),'3.6'))
-        warning('Tested CasADi versions are 3.4 and 3.5, you are using: %s.', casadi_version);
+        warning('Tested CasADi versions are 3.4, 3.5 and 3.6 you are using: %s.', casadi_version);
     end
 end

--- a/interfaces/acados_matlab_octave/detect_gnsf_structure.m
+++ b/interfaces/acados_matlab_octave/detect_gnsf_structure.m
@@ -33,7 +33,7 @@
 function model = detect_gnsf_structure(model, transcribe_opts)
 
 %% Description
-% This function takes a CasADi implicit ODE or index-1 DAE model "model" 
+% This function takes a CasADi implicit ODE or index-1 DAE model "model"
 % consisting of a CasADi expression f_impl in the symbolic CasADi
 % variables x, xdot, u, z, (and possibly parameters p), which are also part
 % of the model, as well as a model name.


### PR DESCRIPTION
Managed to run some examples with Octave 6.4.0 and CasADi 3.6.5, see https://github.com/acados/acados/issues/992
Made some small changes to the CasADi automatic download / instructions.