### PR TITLE
Feasibility Problem Reformulation enhancement

### DIFF
--- a/examples/acados_python/unconstrained_ocps/chen_allgoewer_unconstrained_ocp/chen_allgoewer_ocp.py
+++ b/examples/acados_python/unconstrained_ocps/chen_allgoewer_unconstrained_ocp/chen_allgoewer_ocp.py
@@ -128,7 +128,7 @@ def main(plot_solution = False):
             ocp_solver.set(i, "u", U_init[:,i])
         ocp_solver.set(N, "x", X_init[:,N])
 
-        ocp_solver.set(0, 'p', np.concatenate((initial_condition,initial_condition)))
+        ocp_solver.set(0, 'p', initial_condition)
 
         status = ocp_solver.solve()
 

--- a/examples/acados_python/unconstrained_ocps/chen_allgoewer_unconstrained_ocp/chen_allgoewer_ocp.py
+++ b/examples/acados_python/unconstrained_ocps/chen_allgoewer_unconstrained_ocp/chen_allgoewer_ocp.py
@@ -38,116 +38,120 @@ def main(plot_solution = False):
     # The flag denotes, if the problem should be transformed into a feasibility
     # problem, or if the unconstrained OCP should be solved.
     SOLVE_FEASIBILITY_PROBLEM = True
+    for TEST_X0 in [True, False]:
+        # create ocp object to formulate the OCP
+        ocp = AcadosOcp()
 
-    # create ocp object to formulate the OCP
-    ocp = AcadosOcp()
+        # set model
+        model = export_chen_allgoewer_model(use_SX=False)
+        ocp.model = model
 
-    # set model
-    model = export_chen_allgoewer_model(use_SX=False)
-    ocp.model = model
+        Tf = 5.0
+        nx = model.x.rows()
+        nu = model.u.rows()
+        N = 20
+        M = 10 # Needed for integrator
 
-    Tf = 5.0
-    nx = model.x.rows()
-    nu = model.u.rows()
-    N = 20
-    M = 10 # Needed for integrator
+        # set dimensions
+        ocp.dims.N = N
 
-    # set dimensions
-    ocp.dims.N = N
+        # set cost
+        Q_mat = np.array([[0.5, 0], [0, 0.5]])
+        R_mat = np.array([[0.8]])
+        P_mat = np.array([[10.0, 0], [0, 10.0]])
 
-    # set cost
-    Q_mat = np.array([[0.5, 0], [0, 0.5]])
-    R_mat = np.array([[0.8]])
-    P_mat = np.array([[10.0, 0], [0, 10.0]])
+        u_max = 1
+        tau = 100
+        # the 'EXTERNAL' cost type can be used to define general cost terms
+        # NOTE: This leads to additional (exact) hessian contributions when using GAUSS_NEWTON hessian.
 
-    u_max = 1
-    tau = 100
-    # the 'EXTERNAL' cost type can be used to define general cost terms
-    # NOTE: This leads to additional (exact) hessian contributions when using GAUSS_NEWTON hessian.
+        if not SOLVE_FEASIBILITY_PROBLEM:
+            ocp.cost.cost_type = 'EXTERNAL'
+            ocp.cost.cost_type_e = 'EXTERNAL'
+            tau_beta = tau * np.fmax(0, model.u-u_max)**2 + tau * np.fmin(0, model.u + u_max)**2
+            ocp.model.cost_expr_ext_cost = 0.5 * model.x.T @ Q_mat @ model.x + 0.5 * model.u.T @ R_mat @ model.u + tau_beta
+            ocp.model.cost_expr_ext_cost_e = 0.5 * model.x.T @ P_mat @ model.x
 
-    if not SOLVE_FEASIBILITY_PROBLEM:
-        ocp.cost.cost_type = 'EXTERNAL'
-        ocp.cost.cost_type_e = 'EXTERNAL'
-        tau_beta = tau * np.fmax(0, model.u-u_max)**2 + tau * np.fmin(0, model.u + u_max)**2
-        ocp.model.cost_expr_ext_cost = 0.5 * model.x.T @ Q_mat @ model.x + 0.5 * model.u.T @ R_mat @ model.u + tau_beta
-        ocp.model.cost_expr_ext_cost_e = 0.5 * model.x.T @ P_mat @ model.x
+        # set constraints
+        if TEST_X0:
+            ocp.constraints.x0 = np.array([0.42, 0.45]) 
+        else: # alternatively set the 
+            ocp.constraints.lbx_0 = np.array([0.42, 0.45])
+            ocp.constraints.ubx_0 = np.array([0.42, 0.45])
+            ocp.constraints.idxbx_0 = np.array([0, 1])
 
-    # set constraints
-    ocp.constraints.x0 = np.array([0.42, 0.45])
+        if SOLVE_FEASIBILITY_PROBLEM:
+            # Path constraints on control
+            u_max = 1.5
+            ocp.constraints.lbu = np.array([-u_max])
+            ocp.constraints.ubu = np.array([+u_max])
+            ocp.constraints.idxbu = np.array([0])
 
-    if SOLVE_FEASIBILITY_PROBLEM:
-        # Path constraints on control
-        u_max = 1.5
-        ocp.constraints.lbu = np.array([-u_max])
-        ocp.constraints.ubu = np.array([+u_max])
-        ocp.constraints.idxbu = np.array([0])
+            # Terminal constraints
+            ocp.constraints.lbx_e = np.array([0.0, 0.03])
+            ocp.constraints.ubx_e  = np.array([0.0, 0.03])
+            ocp.constraints.idxbx_e = np.arange(nx)
 
-        # Terminal constraints
-        ocp.constraints.lbx_e = np.array([0.0, 0.03])
-        ocp.constraints.ubx_e  = np.array([0.0, 0.03])
-        ocp.constraints.idxbx_e = np.arange(nx)
+        # set options
+        ocp.solver_options.qp_solver = 'PARTIAL_CONDENSING_HPIPM'
+        ocp.solver_options.qp_solver_cond_N = N
+        ocp.solver_options.hessian_approx = 'GAUSS_NEWTON'
+        ocp.solver_options.integrator_type = 'ERK'
+        ocp.solver_options.sim_method_num_steps = M
+        ocp.solver_options.print_level = 1
+        ocp.solver_options.nlp_solver_type = 'DDP'
+        ocp.solver_options.nlp_solver_max_iter = 10
+        ocp.solver_options.globalization = 'MERIT_BACKTRACKING'
+        ocp.solver_options.with_adaptive_levenberg_marquardt = True
 
+        # set prediction horizon
+        ocp.solver_options.tf = Tf
 
-    # set options
-    ocp.solver_options.qp_solver = 'PARTIAL_CONDENSING_HPIPM'
-    ocp.solver_options.qp_solver_cond_N = N
-    ocp.solver_options.hessian_approx = 'GAUSS_NEWTON'
-    ocp.solver_options.integrator_type = 'ERK'
-    ocp.solver_options.sim_method_num_steps = M
-    ocp.solver_options.print_level = 1
-    ocp.solver_options.nlp_solver_type = 'DDP'
-    ocp.solver_options.nlp_solver_max_iter = 10
-    ocp.solver_options.globalization = 'MERIT_BACKTRACKING'
-    ocp.solver_options.with_adaptive_levenberg_marquardt = True
+        if SOLVE_FEASIBILITY_PROBLEM:
+            ocp.translate_to_feasibility_problem(parametric_x0=True)
 
-    # set prediction horizon
-    ocp.solver_options.tf = Tf
+        ocp_solver = AcadosOcpSolver(ocp, json_file = 'chen_allgoewer_acados.json')
 
-    if SOLVE_FEASIBILITY_PROBLEM:
-        ocp.translate_to_feasibility_problem(parametric_x0=True)
-
-    ocp_solver = AcadosOcpSolver(ocp, json_file = 'chen_allgoewer_acados.json')
-
-    for i in range(N):
-        ocp_solver.cost_set(i, "scaling", 1.0)
-
-    sol_X = np.zeros((N+1, nx))
-    sol_U = np.zeros((N, nu))
-
-    # Load and set the initial guess
-    with open('chen_allgoewer_initial_guess.npy', 'rb') as f:
-        X_init = np.load(f)
-        U_init = np.load(f)
-
-    initial_conditions = [np.array([0.42, 0.45]), np.array([0.42, 0.5])]
-    for initial_condition in initial_conditions:
-
-        # Initial guess
         for i in range(N):
-            ocp_solver.set(i, "x", X_init[:,i])
-            ocp_solver.set(i, "u", U_init[:,i])
-        ocp_solver.set(N, "x", X_init[:,N])
+            ocp_solver.cost_set(i, "scaling", 1.0)
 
-        ocp_solver.set(0, 'p', initial_condition)
+        sol_X = np.zeros((N+1, nx))
+        sol_U = np.zeros((N, nu))
 
-        status = ocp_solver.solve()
+        # Load and set the initial guess
+        with open('chen_allgoewer_initial_guess.npy', 'rb') as f:
+            X_init = np.load(f)
+            U_init = np.load(f)
 
-        if status != 0:
-            raise Exception(f'acados returned status {status}.')
+        initial_conditions = [np.array([0.42, 0.45]), np.array([0.42, 0.5])]
+        for initial_condition in initial_conditions:
 
-        iter = ocp_solver.get_stats('nlp_iter')
-        assert iter == 4, "DDP Solver should converge within 4 iterations!"
+            # Initial guess
+            for i in range(N):
+                ocp_solver.set(i, "x", X_init[:,i])
+                ocp_solver.set(i, "u", U_init[:,i])
+            ocp_solver.set(N, "x", X_init[:,N])
 
-        # get solution
-        for i in range(N):
-            sol_X[i,:] = ocp_solver.get(i, "x")
-            sol_U[i,:] = ocp_solver.get(i, "u")
-        sol_X[N,:] = ocp_solver.get(N, "x")
+            ocp_solver.set(0, 'p', initial_condition)
 
-        assert np.allclose(sol_X[0,:].squeeze(), initial_condition), "Initial condition does not coincide with parameter!"
+            status = ocp_solver.solve()
 
-        if plot_solution:
-            plot_trajectory([X_init, sol_X.T], ["Initial guess", "Solution"])
+            if status != 0:
+                raise Exception(f'acados returned status {status}.')
+
+            iter = ocp_solver.get_stats('nlp_iter')
+            assert iter == 4, "DDP Solver should converge within 4 iterations!"
+
+            # get solution
+            for i in range(N):
+                sol_X[i,:] = ocp_solver.get(i, "x")
+                sol_U[i,:] = ocp_solver.get(i, "u")
+            sol_X[N,:] = ocp_solver.get(N, "x")
+
+            assert np.allclose(sol_X[0,:].squeeze(), initial_condition), "Initial condition does not coincide with parameter!"
+
+            if plot_solution:
+                plot_trajectory([X_init, sol_X.T], ["Initial guess", "Solution"])
 
 if __name__ == '__main__':
     main(plot_solution = False)

--- a/examples/acados_python/unconstrained_ocps/chen_allgoewer_unconstrained_ocp/chen_allgoewer_ocp.py
+++ b/examples/acados_python/unconstrained_ocps/chen_allgoewer_unconstrained_ocp/chen_allgoewer_ocp.py
@@ -38,120 +38,116 @@ def main(plot_solution = False):
     # The flag denotes, if the problem should be transformed into a feasibility
     # problem, or if the unconstrained OCP should be solved.
     SOLVE_FEASIBILITY_PROBLEM = True
-    for TEST_X0 in [True, False]:
-        # create ocp object to formulate the OCP
-        ocp = AcadosOcp()
 
-        # set model
-        model = export_chen_allgoewer_model(use_SX=False)
-        ocp.model = model
+    # create ocp object to formulate the OCP
+    ocp = AcadosOcp()
 
-        Tf = 5.0
-        nx = model.x.rows()
-        nu = model.u.rows()
-        N = 20
-        M = 10 # Needed for integrator
+    # set model
+    model = export_chen_allgoewer_model(use_SX=False)
+    ocp.model = model
 
-        # set dimensions
-        ocp.dims.N = N
+    Tf = 5.0
+    nx = model.x.rows()
+    nu = model.u.rows()
+    N = 20
+    M = 10 # Needed for integrator
 
-        # set cost
-        Q_mat = np.array([[0.5, 0], [0, 0.5]])
-        R_mat = np.array([[0.8]])
-        P_mat = np.array([[10.0, 0], [0, 10.0]])
+    # set dimensions
+    ocp.dims.N = N
 
-        u_max = 1
-        tau = 100
-        # the 'EXTERNAL' cost type can be used to define general cost terms
-        # NOTE: This leads to additional (exact) hessian contributions when using GAUSS_NEWTON hessian.
+    # set cost
+    Q_mat = np.array([[0.5, 0], [0, 0.5]])
+    R_mat = np.array([[0.8]])
+    P_mat = np.array([[10.0, 0], [0, 10.0]])
 
-        if not SOLVE_FEASIBILITY_PROBLEM:
-            ocp.cost.cost_type = 'EXTERNAL'
-            ocp.cost.cost_type_e = 'EXTERNAL'
-            tau_beta = tau * np.fmax(0, model.u-u_max)**2 + tau * np.fmin(0, model.u + u_max)**2
-            ocp.model.cost_expr_ext_cost = 0.5 * model.x.T @ Q_mat @ model.x + 0.5 * model.u.T @ R_mat @ model.u + tau_beta
-            ocp.model.cost_expr_ext_cost_e = 0.5 * model.x.T @ P_mat @ model.x
+    u_max = 1
+    tau = 100
+    # the 'EXTERNAL' cost type can be used to define general cost terms
+    # NOTE: This leads to additional (exact) hessian contributions when using GAUSS_NEWTON hessian.
 
-        # set constraints
-        if TEST_X0:
-            ocp.constraints.x0 = np.array([0.42, 0.45]) 
-        else: # alternatively set the 
-            ocp.constraints.lbx_0 = np.array([0.42, 0.45])
-            ocp.constraints.ubx_0 = np.array([0.42, 0.45])
-            ocp.constraints.idxbx_0 = np.array([0, 1])
+    if not SOLVE_FEASIBILITY_PROBLEM:
+        ocp.cost.cost_type = 'EXTERNAL'
+        ocp.cost.cost_type_e = 'EXTERNAL'
+        tau_beta = tau * np.fmax(0, model.u-u_max)**2 + tau * np.fmin(0, model.u + u_max)**2
+        ocp.model.cost_expr_ext_cost = 0.5 * model.x.T @ Q_mat @ model.x + 0.5 * model.u.T @ R_mat @ model.u + tau_beta
+        ocp.model.cost_expr_ext_cost_e = 0.5 * model.x.T @ P_mat @ model.x
 
-        if SOLVE_FEASIBILITY_PROBLEM:
-            # Path constraints on control
-            u_max = 1.5
-            ocp.constraints.lbu = np.array([-u_max])
-            ocp.constraints.ubu = np.array([+u_max])
-            ocp.constraints.idxbu = np.array([0])
+    # set constraints
+    ocp.constraints.x0 = np.array([0.42, 0.45])
 
-            # Terminal constraints
-            ocp.constraints.lbx_e = np.array([0.0, 0.03])
-            ocp.constraints.ubx_e  = np.array([0.0, 0.03])
-            ocp.constraints.idxbx_e = np.arange(nx)
+    if SOLVE_FEASIBILITY_PROBLEM:
+        # Path constraints on control
+        u_max = 1.5
+        ocp.constraints.lbu = np.array([-u_max])
+        ocp.constraints.ubu = np.array([+u_max])
+        ocp.constraints.idxbu = np.array([0])
 
-        # set options
-        ocp.solver_options.qp_solver = 'PARTIAL_CONDENSING_HPIPM'
-        ocp.solver_options.qp_solver_cond_N = N
-        ocp.solver_options.hessian_approx = 'GAUSS_NEWTON'
-        ocp.solver_options.integrator_type = 'ERK'
-        ocp.solver_options.sim_method_num_steps = M
-        ocp.solver_options.print_level = 1
-        ocp.solver_options.nlp_solver_type = 'DDP'
-        ocp.solver_options.nlp_solver_max_iter = 10
-        ocp.solver_options.globalization = 'MERIT_BACKTRACKING'
-        ocp.solver_options.with_adaptive_levenberg_marquardt = True
+        # Terminal constraints
+        ocp.constraints.lbx_e = np.array([0.0, 0.03])
+        ocp.constraints.ubx_e  = np.array([0.0, 0.03])
+        ocp.constraints.idxbx_e = np.arange(nx)
 
-        # set prediction horizon
-        ocp.solver_options.tf = Tf
 
-        if SOLVE_FEASIBILITY_PROBLEM:
-            ocp.translate_to_feasibility_problem(parametric_x0=True)
+    # set options
+    ocp.solver_options.qp_solver = 'PARTIAL_CONDENSING_HPIPM'
+    ocp.solver_options.qp_solver_cond_N = N
+    ocp.solver_options.hessian_approx = 'GAUSS_NEWTON'
+    ocp.solver_options.integrator_type = 'ERK'
+    ocp.solver_options.sim_method_num_steps = M
+    ocp.solver_options.print_level = 1
+    ocp.solver_options.nlp_solver_type = 'DDP'
+    ocp.solver_options.nlp_solver_max_iter = 10
+    ocp.solver_options.globalization = 'MERIT_BACKTRACKING'
+    ocp.solver_options.with_adaptive_levenberg_marquardt = True
 
-        ocp_solver = AcadosOcpSolver(ocp, json_file = 'chen_allgoewer_acados.json')
+    # set prediction horizon
+    ocp.solver_options.tf = Tf
 
+    if SOLVE_FEASIBILITY_PROBLEM:
+        ocp.translate_to_feasibility_problem(parametric_x0=True)
+
+    ocp_solver = AcadosOcpSolver(ocp, json_file = 'chen_allgoewer_acados.json')
+
+    for i in range(N):
+        ocp_solver.cost_set(i, "scaling", 1.0)
+
+    sol_X = np.zeros((N+1, nx))
+    sol_U = np.zeros((N, nu))
+
+    # Load and set the initial guess
+    with open('chen_allgoewer_initial_guess.npy', 'rb') as f:
+        X_init = np.load(f)
+        U_init = np.load(f)
+
+    initial_conditions = [np.array([0.42, 0.45]), np.array([0.42, 0.5])]
+    for initial_condition in initial_conditions:
+
+        # Initial guess
         for i in range(N):
-            ocp_solver.cost_set(i, "scaling", 1.0)
+            ocp_solver.set(i, "x", X_init[:,i])
+            ocp_solver.set(i, "u", U_init[:,i])
+        ocp_solver.set(N, "x", X_init[:,N])
 
-        sol_X = np.zeros((N+1, nx))
-        sol_U = np.zeros((N, nu))
+        ocp_solver.set(0, 'p', initial_condition)
 
-        # Load and set the initial guess
-        with open('chen_allgoewer_initial_guess.npy', 'rb') as f:
-            X_init = np.load(f)
-            U_init = np.load(f)
+        status = ocp_solver.solve()
 
-        initial_conditions = [np.array([0.42, 0.45]), np.array([0.42, 0.5])]
-        for initial_condition in initial_conditions:
+        if status != 0:
+            raise Exception(f'acados returned status {status}.')
 
-            # Initial guess
-            for i in range(N):
-                ocp_solver.set(i, "x", X_init[:,i])
-                ocp_solver.set(i, "u", U_init[:,i])
-            ocp_solver.set(N, "x", X_init[:,N])
+        iter = ocp_solver.get_stats('nlp_iter')
+        assert iter == 4, "DDP Solver should converge within 4 iterations!"
 
-            ocp_solver.set(0, 'p', initial_condition)
+        # get solution
+        for i in range(N):
+            sol_X[i,:] = ocp_solver.get(i, "x")
+            sol_U[i,:] = ocp_solver.get(i, "u")
+        sol_X[N,:] = ocp_solver.get(N, "x")
 
-            status = ocp_solver.solve()
+        assert np.allclose(sol_X[0,:].squeeze(), initial_condition), "Initial condition does not coincide with parameter!"
 
-            if status != 0:
-                raise Exception(f'acados returned status {status}.')
-
-            iter = ocp_solver.get_stats('nlp_iter')
-            assert iter == 4, "DDP Solver should converge within 4 iterations!"
-
-            # get solution
-            for i in range(N):
-                sol_X[i,:] = ocp_solver.get(i, "x")
-                sol_U[i,:] = ocp_solver.get(i, "u")
-            sol_X[N,:] = ocp_solver.get(N, "x")
-
-            assert np.allclose(sol_X[0,:].squeeze(), initial_condition), "Initial condition does not coincide with parameter!"
-
-            if plot_solution:
-                plot_trajectory([X_init, sol_X.T], ["Initial guess", "Solution"])
+        if plot_solution:
+            plot_trajectory([X_init, sol_X.T], ["Initial guess", "Solution"])
 
 if __name__ == '__main__':
     main(plot_solution = False)

--- a/examples/acados_python/unconstrained_ocps/chen_allgoewer_unconstrained_ocp/chen_allgoewer_ocp.py
+++ b/examples/acados_python/unconstrained_ocps/chen_allgoewer_unconstrained_ocp/chen_allgoewer_ocp.py
@@ -33,7 +33,7 @@ from chen_allgoewer_system_model import export_chen_allgoewer_model
 import numpy as np
 from utils import plot_trajectory
 
-def main():
+def main(plot_solution = False):
 
     # The flag denotes, if the problem should be transformed into a feasibility
     # problem, or if the unconstrained OCP should be solved.
@@ -119,7 +119,6 @@ def main():
         X_init = np.load(f)
         U_init = np.load(f)
 
-    wanted = False
     initial_conditions = [np.array([0.42, 0.45]), np.array([0.42, 0.5])]
     for initial_condition in initial_conditions:
 
@@ -147,8 +146,8 @@ def main():
 
         assert np.allclose(sol_X[0,:].squeeze(), initial_condition), "Initial condition does not coincide with parameter!"
 
-        if wanted:
+        if plot_solution:
             plot_trajectory([X_init, sol_X.T], ["Initial guess", "Solution"])
 
 if __name__ == '__main__':
-    main()
+    main(plot_solution = False)

--- a/examples/acados_python/unconstrained_ocps/chen_allgoewer_unconstrained_ocp/chen_allgoewer_system_model.py
+++ b/examples/acados_python/unconstrained_ocps/chen_allgoewer_unconstrained_ocp/chen_allgoewer_system_model.py
@@ -29,9 +29,9 @@
 #
 
 from acados_template import AcadosModel
-from casadi import SX, vertcat
+from casadi import SX, MX, vertcat
 
-def export_chen_allgoewer_model() -> AcadosModel:
+def export_chen_allgoewer_model(use_SX=True) -> AcadosModel:
 
     model_name = 'chen_allgoewer_ode'
 
@@ -39,17 +39,24 @@ def export_chen_allgoewer_model() -> AcadosModel:
     mu = 0.7
 
     # set up states & controls
-    x1 = SX.sym('x1')
-    x2 = SX.sym('x2')
+    if use_SX:
+        x1 = SX.sym('x1')
+        x2 = SX.sym('x2')
+
+        u = SX.sym('u')
+        # xdot
+        x1_dot = SX.sym('x1_dot')
+        x2_dot = SX.sym('x2_dot')
+    else:
+        x1 = MX.sym('x1')
+        x2 = MX.sym('x2')
+
+        u = MX.sym('u')
+        # xdot
+        x1_dot = MX.sym('x1_dot')
+        x2_dot = MX.sym('x2_dot')
 
     x = vertcat(x1, x2)
-
-    u = SX.sym('u')
-
-    # xdot
-    x1_dot = SX.sym('x1_dot')
-    x2_dot = SX.sym('x2_dot')
-
     xdot = vertcat(x1_dot, x2_dot)
 
     # dynamics

--- a/interfaces/acados_template/acados_template/acados_model.py
+++ b/interfaces/acados_template/acados_template/acados_model.py
@@ -270,6 +270,14 @@ class AcadosModel():
             return SX.sym
         else:
             raise Exception(f"model.x must be casadi.SX or casadi.MX, got {type(self.x)}")
+        
+    def get_casadi_zeros(self):
+        if isinstance(self.x, MX):
+            return MX.zeros
+        elif isinstance(self.x, SX):
+            return SX.zeros
+        else:
+            raise Exception(f"model.x must be casadi.SX or casadi.MX, got {type(self.x)}")
 
     def make_consistent(self, dims: Union[AcadosOcpDims, AcadosSimDims]) -> None:
 

--- a/interfaces/acados_template/acados_template/acados_model.py
+++ b/interfaces/acados_template/acados_template/acados_model.py
@@ -270,7 +270,7 @@ class AcadosModel():
             return SX.sym
         else:
             raise Exception(f"model.x must be casadi.SX or casadi.MX, got {type(self.x)}")
-        
+
     def get_casadi_zeros(self):
         if isinstance(self.x, MX):
             return MX.zeros

--- a/interfaces/acados_template/acados_template/acados_ocp.py
+++ b/interfaces/acados_template/acados_template/acados_ocp.py
@@ -1333,14 +1333,13 @@ class AcadosOcp:
 
         # Define initial condition expression
         if keep_x0:
-            if constraints.has_x0:
-                if parametric_x0:
-                    # define parameter
-                    new_constraints.x0 = param_lbx0
-                else:
-                    new_constraints.x0 = constraints.lbx_0
-            else:
+            if not constraints.has_x0:
                 raise NotImplementedError("translate_to_feasibility_problem: keep_x0 not defined for problems without x0 constraints.")
+            if parametric_x0:
+                # define parameter
+                new_constraints.x0 = param_lbx0
+            else:
+                new_constraints.x0 = constraints.lbx_0
         else:
             if parametric_x0:
                 expr_bound_list_0.append((model.x[constraints.idxbx_0], param_lbx0, param_ubx0))

--- a/interfaces/acados_template/acados_template/acados_ocp.py
+++ b/interfaces/acados_template/acados_template/acados_ocp.py
@@ -1255,9 +1255,10 @@ class AcadosOcp:
             cost.yref_0 = np.array([])
             cost.yref_e = np.array([])
 
-            model.cost_y_expr = ca.SX.zeros((0, 0))
-            model.cost_y_expr_e = ca.SX.zeros((0, 0))
-            model.cost_y_expr_0 = ca.SX.zeros((0, 0))
+            zeros = model.get_casadi_zeros()
+            model.cost_y_expr = zeros((0, 0))
+            model.cost_y_expr_e = zeros((0, 0))
+            model.cost_y_expr_0 = zeros((0, 0))
 
             cost.W = np.zeros((0, 0))
             cost.W_e = np.zeros((0, 0))

--- a/interfaces/acados_template/acados_template/acados_ocp.py
+++ b/interfaces/acados_template/acados_template/acados_ocp.py
@@ -1226,12 +1226,19 @@ class AcadosOcp:
 
         return
 
-    def translate_to_feasibility_problem(self, keep_x0=False, keep_cost=False, parametric_x0=False) -> None:
+    def translate_to_feasibility_problem(self,
+                                        keep_x0: bool=False,
+                                        keep_cost: bool=False,
+                                        parametric_x0: bool=False) -> None:
         """
         Translate an OCP to a feasibility problem by removing all cost term and then formulating all constraints as L2 penalties.
 
         Note: all weights are set to 1.0 for now.
         Options to specify weights should be implemented later for advanced use cases.
+
+        :param keep_x0: if True, x0 constraint is kept as a constraint
+        :param keep_cost: if True, cost is not removed before formulating constraints as penalties
+        :param parametric_x0: if True, replace the value of the initial state constraint with a parameter that is append to the model parameters.
         """
 
         self.model.make_consistent(self.dims) # sets the correct MX/SX defaults
@@ -1309,7 +1316,7 @@ class AcadosOcp:
             (model.u[constraints.idxbu], constraints.lbu, constraints.ubu),
             (model.con_h_expr_0, constraints.lh_0, constraints.uh_0),
         ]
-        
+
         # Define parameter symbols and values
         if parametric_x0:
             symbol = model.get_casadi_symbol()
@@ -1320,7 +1327,7 @@ class AcadosOcp:
             else:
                 param_ubx0 = symbol('ubx0', len(constraints.idxbx_0))
                 new_params = np.concatenate((constraints.lbx_0, constraints.ubx_0))
-            
+
             model.p = ca.vertcat(model.p, param_lbx0, param_ubx0)
             self.parameter_values = np.concatenate((self.parameter_values, new_params))
 

--- a/interfaces/acados_template/acados_template/acados_ocp.py
+++ b/interfaces/acados_template/acados_template/acados_ocp.py
@@ -1226,8 +1226,15 @@ class AcadosOcp:
 
         return
 
+    def get_casadi_symbol(self, x):
+        if isinstance(x, ca.MX):
+            return ca.MX.sym
+        elif isinstance(x, ca.SX):
+            return ca.SX.sym
+        else:
+            raise TypeError("Expected casadi SX or MX.")
 
-    def translate_to_feasibility_problem(self, keep_x0=False, keep_cost=False) -> None:
+    def translate_to_feasibility_problem(self, keep_x0=False, keep_cost=False, parametric_x0=False) -> None:
         """
         Translate an OCP to a feasibility problem by removing all cost term and then formulating all constraints as L2 penalties.
 
@@ -1304,18 +1311,44 @@ class AcadosOcp:
         model.con_r_expr_e = None
         model.con_r_in_phi_e = None
 
+        # Convert initial conditions to l2 penalty
+        if parametric_x0:
+            symbol = self.get_casadi_symbol(self.model.x)
+            param_lbx0 = symbol('x0', len(constraints.idxbx_0))
+            if keep_x0:
+                param_ubx0 = []
+            else:
+                param_ubx0 = symbol('x0', len(constraints.idxbx_0))
+            model.p = ca.vertcat(model.p, param_lbx0, param_ubx0)
+
+            # Set parameters
+            if keep_x0:
+                self.parameter_values = constraints.lbx_0
+            else:
+                self.parameter_values = np.concatenate((constraints.lbx_0, constraints.ubx_0))
+
+
         expr_bound_list_0 = [
             (model.u[constraints.idxbu], constraints.lbu, constraints.ubu),
             (model.con_h_expr_0, constraints.lh_0, constraints.uh_0),
         ]
 
+
+
         if keep_x0:
             if constraints.has_x0:
-                new_constraints.x0 = constraints.lbx_0
+                if parametric_x0 and constraints.has_x0:
+                    # define parameter
+                    new_constraints.x0 = param_lbx0
+                else:
+                    new_constraints.x0 = constraints.lbx_0
             else:
                 raise NotImplementedError("translate_to_feasibility_problem: keep_x0 not defined for problems without x0 constraints.")
         else:
-            expr_bound_list_0.append((model.x[constraints.idxbx_0], constraints.lbx_0, constraints.ubx_0))
+            if parametric_x0 and constraints.has_x0:
+                expr_bound_list_0.append((model.x[constraints.idxbx_0], param_lbx0, param_ubx0))
+            else:
+                expr_bound_list_0.append((model.x[constraints.idxbx_0], constraints.lbx_0, constraints.ubx_0))
 
         if casadi_length(model.con_phi_expr_0) > 0:
             phi_o_r_expr_0 = ca.substitute(model.con_phi_expr_0, model.con_r_in_phi_0, model.con_r_expr_0)

--- a/interfaces/acados_template/acados_template/acados_ocp.py
+++ b/interfaces/acados_template/acados_template/acados_ocp.py
@@ -1331,8 +1331,7 @@ class AcadosOcp:
             if not constraints.has_x0:
                 raise NotImplementedError("translate_to_feasibility_problem: keep_x0 not defined for problems without x0 constraints.")
             if parametric_x0:
-                # define parameter
-                new_constraints.x0 = param_x0
+                raise NotImplementedError("translate_to_feasibility_problem: parametric_x0 cannot be chosen together with keep_x0. x0 can be updated manually without a parameter.")
             else:
                 new_constraints.x0 = constraints.lbx_0
         else:

--- a/interfaces/acados_template/acados_template/acados_ocp.py
+++ b/interfaces/acados_template/acados_template/acados_ocp.py
@@ -1238,7 +1238,7 @@ class AcadosOcp:
 
         :param keep_x0: if True, x0 constraint is kept as a constraint
         :param keep_cost: if True, cost is not removed before formulating constraints as penalties
-        :param parametric_x0: if True, replace the value of the initial state constraint with a parameter that is append to the model parameters.
+        :param parametric_x0: if True, replace the value of the initial state constraint with a parameter that is appended to the model parameters.
         """
 
         self.model.make_consistent(self.dims) # sets the correct MX/SX defaults
@@ -1320,15 +1320,10 @@ class AcadosOcp:
         # Define parameter symbols and values
         if parametric_x0:
             symbol = model.get_casadi_symbol()
-            param_lbx0 = symbol('lbx0', len(constraints.idxbx_0))
-            if keep_x0:
-                param_ubx0 = []
-                new_params = constraints.lbx_0
-            else:
-                param_ubx0 = symbol('ubx0', len(constraints.idxbx_0))
-                new_params = np.concatenate((constraints.lbx_0, constraints.ubx_0))
+            param_x0 = symbol('lbx0', len(constraints.idxbx_0))
+            new_params = constraints.lbx_0
 
-            model.p = ca.vertcat(model.p, param_lbx0, param_ubx0)
+            model.p = ca.vertcat(model.p, param_x0)
             self.parameter_values = np.concatenate((self.parameter_values, new_params))
 
         # Define initial condition expression
@@ -1337,12 +1332,12 @@ class AcadosOcp:
                 raise NotImplementedError("translate_to_feasibility_problem: keep_x0 not defined for problems without x0 constraints.")
             if parametric_x0:
                 # define parameter
-                new_constraints.x0 = param_lbx0
+                new_constraints.x0 = param_x0
             else:
                 new_constraints.x0 = constraints.lbx_0
         else:
             if parametric_x0:
-                expr_bound_list_0.append((model.x[constraints.idxbx_0], param_lbx0, param_ubx0))
+                expr_bound_list_0.append((model.x[constraints.idxbx_0], param_x0, param_x0))
             else:
                 expr_bound_list_0.append((model.x[constraints.idxbx_0], constraints.lbx_0, constraints.ubx_0))
 


### PR DESCRIPTION
Handle the initial state constraint in `translate_to_feasibility_problem` in 3 different ways:
- 1. (default): bake in x0 constraint as part of the penalty formulation
- 2. `keep_x0`: initial state constraint is formulated as upper and lower bound on x at 0 (standard in acados), values can be updated as for standard problems
- 3. replace the value of the initial state constraint with a parameter that is appended to the model parameters. Initial state constraint can then be updated by setting the parameter.

Example update:
- The Chen Allgoewer problem tests two problems now. One problem has a changed x0 parameter
- In the Chen Allgoewer model you can choose if you want SX or MX variables