### PR TITLE
Add missing external function for convex-over-nonlinear constraints

### DIFF
--- a/interfaces/acados_template/acados_template/c_templates_tera/CMakeLists.in.txt
+++ b/interfaces/acados_template/acados_template/c_templates_tera/CMakeLists.in.txt
@@ -236,13 +236,16 @@ add_library(${MODEL_OBJ} OBJECT ${MODEL_SRC} )
 if(${BUILD_ACADOS_SOLVER_LIB} OR ${BUILD_ACADOS_OCP_SOLVER_LIB} OR ${BUILD_EXAMPLE})
     set(OCP_SRC
 {%- if constr_type == "BGP" and dims_nphi > 0 %}
-        {{ model.name }}_constraints/{{ model.name }}_phi_constraint.c
+        {{ model.name }}_constraints/{{ model.name }}_phi_constraint_fun.c
+        {{ model.name }}_constraints/{{ model.name }}_phi_constraint_fun_jac_hess.c
 {%- endif %}
 {%- if constr_type_e == "BGP" and dims_nphi_e > 0 %}
-        {{ model.name }}_constraints/{{ model.name }}_phi_e_constraint.c
+        {{ model.name }}_constraints/{{ model.name }}_phi_e_constraint_fun.c
+        {{ model.name }}_constraints/{{ model.name }}_phi_e_constraint_fun_jac_hess.c
 {%- endif %}
 {%- if constr_type_0 == "BGP" and dims_nphi_0 > 0 %}
-        {{ model.name }}_constraints/{{ model.name }}_phi_0_constraint.c
+        {{ model.name }}_constraints/{{ model.name }}_phi_0_constraint_fun.c
+        {{ model.name }}_constraints/{{ model.name }}_phi_0_constraint_fun_jac_hess.c
 {%- endif %}
 
 {%- if constr_type == "BGH" and dims_nh > 0 %}

--- a/interfaces/acados_template/acados_template/c_templates_tera/Makefile.in
+++ b/interfaces/acados_template/acados_template/c_templates_tera/Makefile.in
@@ -206,7 +206,8 @@ OCP_SRC+= {{ model.name }}_constraints/{{ model.name }}_constr_h_0_fun.c
 OCP_SRC+= {{ model.name }}_constraints/{{ model.name }}_constr_h_0_fun_jac_uxt_zt_hess.c
 	{%- endif %}
 {%- elif constr_type_0 == "BGP" and dims_nphi_0 > 0 %}
-OCP_SRC+= {{ model.name }}_constraints/{{ model.name }}_phi_0_constraint.c
+OCP_SRC+= {{ model.name }}_constraints/{{ model.name }}_phi_0_constraint_fun_jac_hess.c
+OCP_SRC+= {{ model.name }}_constraints/{{ model.name }}_phi_0_constraint_fun.c
 {%- endif %}
 
 {%- if constr_type == "BGH" and dims_nh > 0 %}
@@ -216,7 +217,8 @@ OCP_SRC+= {{ model.name }}_constraints/{{ model.name }}_constr_h_fun.c
 OCP_SRC+= {{ model.name }}_constraints/{{ model.name }}_constr_h_fun_jac_uxt_zt_hess.c
 	{%- endif %}
 {%- elif constr_type == "BGP" and dims_nphi > 0 %}
-OCP_SRC+= {{ model.name }}_constraints/{{ model.name }}_phi_constraint.c
+OCP_SRC+= {{ model.name }}_constraints/{{ model.name }}_phi_constraint_fun.c
+OCP_SRC+= {{ model.name }}_constraints/{{ model.name }}_phi_constraint_fun_jac_hess.c
 {%- endif %}
 
 {%- if constr_type_e == "BGH" and dims_nh_e > 0 %}
@@ -226,7 +228,8 @@ OCP_SRC+= {{ model.name }}_constraints/{{ model.name }}_constr_h_e_fun.c
 OCP_SRC+= {{ model.name }}_constraints/{{ model.name }}_constr_h_e_fun_jac_uxt_zt_hess.c
 	{%- endif %}
 {%- elif constr_type_e == "BGP" and dims_nphi_e > 0 %}
-OCP_SRC+= {{ model.name }}_constraints/{{ model.name }}_phi_e_constraint.c
+OCP_SRC+= {{ model.name }}_constraints/{{ model.name }}_phi_e_constraint_fun.c
+OCP_SRC+= {{ model.name }}_constraints/{{ model.name }}_phi_e_constraint_fun_jac_hess.c
 {%- endif %}
 
 {%- if cost_type_0 == "NONLINEAR_LS" %}

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.h
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.h
@@ -107,7 +107,8 @@ typedef struct {{ name }}_solver_capsule
 
     // constraints
 {%- if constraints[jj].constr_type == "BGP" %}
-    external_function_param_casadi *phi_constraint_{{ jj }};
+    external_function_param_casadi *phi_constraint_fun_{{ jj }};
+    external_function_param_casadi *phi_constraint_fun_jac_hess_{{ jj }};
 {% elif constraints[jj].constr_type == "BGH" and phases_dims[jj].nh > 0 %}
     external_function_param_casadi *nl_constr_h_fun_jac_{{ jj }};
     external_function_param_casadi *nl_constr_h_fun_{{ jj }};
@@ -154,7 +155,8 @@ typedef struct {{ name }}_solver_capsule
 
 
 {% if constraints[0].constr_type_0 == "BGP" %}
-    external_function_param_casadi phi_0_constraint;
+    external_function_param_casadi phi_0_constraint_fun;
+    external_function_param_casadi phi_0_constraint_fun_jac_hess;
 {% elif constraints[0].constr_type_0 == "BGH" and dims_0.nh_0 > 0 %}
     external_function_param_casadi nl_constr_h_0_fun_jac;
     external_function_param_casadi nl_constr_h_0_fun;
@@ -181,7 +183,8 @@ typedef struct {{ name }}_solver_capsule
 
 
 {% if constraints_e.constr_type_e == "BGP" %}
-    external_function_param_casadi phi_e_constraint;
+    external_function_param_casadi phi_e_constraint_fun;
+    external_function_param_casadi phi_e_constraint_fun_jac_hess;
 {% elif constraints_e.constr_type_e == "BGH" and dims_e.nh_e > 0 %}
     external_function_param_casadi nl_constr_h_e_fun_jac;
     external_function_param_casadi nl_constr_h_e_fun;

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -2792,6 +2792,7 @@ int {{ model.name }}_acados_update_params_sparse({{ model.name }}_solver_capsule
         if (stage == 0)
         {
         {%- if constraints.constr_type_0 == "BGP" %}
+            capsule->phi_0_constraint_fun.set_param_sparse(&capsule->phi_0_constraint_fun, n_update, idx, p);
             capsule->phi_0_constraint_fun_jac_hess.set_param_sparse(&capsule->phi_0_constraint_fun_jac_hess, n_update, idx, p);
         {%- elif constraints.constr_type_0 == "BGH" and dims.nh_0 > 0 %}
             capsule->nl_constr_h_0_fun_jac.set_param_sparse(&capsule->nl_constr_h_0_fun_jac, n_update, idx, p);
@@ -2804,7 +2805,8 @@ int {{ model.name }}_acados_update_params_sparse({{ model.name }}_solver_capsule
         else
         {
         {%- if constraints.constr_type == "BGP" %}
-            capsule->phi_constraint[stage-1].set_param_sparse(capsule->phi_constraint+stage-1, n_update, idx, p);
+            capsule->phi_constraint_fun[stage-1].set_param_sparse(capsule->phi_constraint_fun+stage-1, n_update, idx, p);
+            capsule->phi_constraint_fun_jac_hess[stage-1].set_param_sparse(capsule->phi_constraint_fun_jac_hess+stage-1, n_update, idx, p);
         {%- elif constraints.constr_type == "BGH" and dims.nh > 0 %}
             capsule->nl_constr_h_fun_jac[stage-1].set_param_sparse(capsule->nl_constr_h_fun_jac+stage-1, n_update, idx, p);
             capsule->nl_constr_h_fun[stage-1].set_param_sparse(capsule->nl_constr_h_fun+stage-1, n_update, idx, p);
@@ -2883,6 +2885,7 @@ int {{ model.name }}_acados_update_params_sparse({{ model.name }}_solver_capsule
     {%- endif %}
         // constraints
     {%- if constraints.constr_type_e == "BGP" %}
+        capsule->phi_e_constraint_fun.set_param_sparse(&capsule->phi_e_constraint_fun, n_update, idx, p);
         capsule->phi_e_constraint_fun_jac_hess.set_param_sparse(&capsule->phi_e_constraint_fun_jac_hess, n_update, idx, p);
     {%- elif constraints.constr_type_e == "BGH" and dims.nh_e > 0 %}
         capsule->nl_constr_h_e_fun_jac.set_param_sparse(&capsule->nl_constr_h_e_fun_jac, n_update, idx, p);

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -416,7 +416,8 @@ void {{ model.name }}_acados_create_3_create_and_set_functions({{ model.name }}_
     {% endif %}
 {%- elif constraints.constr_type_0 == "BGP" %}
     // convex-over-nonlinear constraint
-    MAP_CASADI_FNC(phi_0_constraint, {{ model.name }}_phi_0_constraint);
+    MAP_CASADI_FNC(phi_0_constraint_fun_jac_hess, {{ model.name }}_phi_0_constraint_fun_jac_hess);
+    MAP_CASADI_FNC(phi_0_constraint_fun, {{ model.name }}_phi_0_constraint_fun);
 {%- endif %}
 
 
@@ -438,11 +439,13 @@ void {{ model.name }}_acados_create_3_create_and_set_functions({{ model.name }}_
     }
     {% endif %}
 {% elif constraints.constr_type == "BGP" %}
-    capsule->phi_constraint = (external_function_param_casadi *) malloc(sizeof(external_function_param_casadi)*(N-1));
+    capsule->phi_constraint_fun_jac_hess = (external_function_param_casadi *) malloc(sizeof(external_function_param_casadi)*(N-1));
+    capsule->phi_constraint_fun = (external_function_param_casadi *) malloc(sizeof(external_function_param_casadi)*(N-1));
     for (int i = 0; i < N-1; i++)
     {
         // convex-over-nonlinear constraint
-        MAP_CASADI_FNC(phi_constraint[i], {{ model.name }}_phi_constraint);
+        MAP_CASADI_FNC(phi_constraint_fun_jac_hess[i], {{ model.name }}_phi_constraint_fun_jac_hess);
+        MAP_CASADI_FNC(phi_constraint_fun[i], {{ model.name }}_phi_constraint_fun);
     }
 {%- endif %}
 
@@ -456,7 +459,8 @@ void {{ model.name }}_acados_create_3_create_and_set_functions({{ model.name }}_
     {% endif %}
 {%- elif constraints.constr_type_e == "BGP" %}
     // convex-over-nonlinear constraint
-    MAP_CASADI_FNC(phi_e_constraint, {{ model.name }}_phi_e_constraint);
+    MAP_CASADI_FNC(phi_e_constraint_fun_jac_hess, {{ model.name }}_phi_e_constraint_fun_jac_hess);
+    MAP_CASADI_FNC(phi_e_constraint_fun, {{ model.name }}_phi_e_constraint_fun);
 {%- endif %}
 
 {% if solver_options.integrator_type == "ERK" %}
@@ -1455,7 +1459,9 @@ void {{ model.name }}_acados_create_5_set_nlp_in({{ model.name }}_solver_capsule
     ocp_nlp_constraints_model_set(nlp_config, nlp_dims, nlp_in, 0, "lphi", lphi_0);
     ocp_nlp_constraints_model_set(nlp_config, nlp_dims, nlp_in, 0, "uphi", uphi_0);
     ocp_nlp_constraints_model_set(nlp_config, nlp_dims, nlp_in, 0,
-                                  "nl_constr_phi_o_r_fun_phi_jac_ux_z_phi_hess_r_jac_ux", &capsule->phi_0_constraint);
+                                  "nl_constr_phi_o_r_fun", &capsule->phi_0_constraint_fun);
+    ocp_nlp_constraints_model_set(nlp_config, nlp_dims, nlp_in, 0,
+                                  "nl_constr_phi_o_r_fun_phi_jac_ux_z_phi_hess_r_jac_ux", &capsule->phi_0_constraint_fun_jac_hess);
     free(luphi_0);
 {% endif %}
 
@@ -1814,7 +1820,9 @@ void {{ model.name }}_acados_create_5_set_nlp_in({{ model.name }}_solver_capsule
     for (int i = 1; i < N; i++)
     {
         ocp_nlp_constraints_model_set(nlp_config, nlp_dims, nlp_in, i,
-                                      "nl_constr_phi_o_r_fun_phi_jac_ux_z_phi_hess_r_jac_ux", &capsule->phi_constraint[i-1]);
+                                      "nl_constr_phi_o_r_fun", &capsule->phi_constraint_fun[i-1]);
+        ocp_nlp_constraints_model_set(nlp_config, nlp_dims, nlp_in, i,
+                                      "nl_constr_phi_o_r_fun_phi_jac_ux_z_phi_hess_r_jac_ux", &capsule->phi_constraint_fun_jac_hess[i-1]);
         ocp_nlp_constraints_model_set(nlp_config, nlp_dims, nlp_in, i, "lphi", lphi);
         ocp_nlp_constraints_model_set(nlp_config, nlp_dims, nlp_in, i, "uphi", uphi);
     }
@@ -2021,7 +2029,9 @@ void {{ model.name }}_acados_create_5_set_nlp_in({{ model.name }}_solver_capsule
     ocp_nlp_constraints_model_set(nlp_config, nlp_dims, nlp_in, N, "lphi", lphi_e);
     ocp_nlp_constraints_model_set(nlp_config, nlp_dims, nlp_in, N, "uphi", uphi_e);
     ocp_nlp_constraints_model_set(nlp_config, nlp_dims, nlp_in, N,
-                                  "nl_constr_phi_o_r_fun_phi_jac_ux_z_phi_hess_r_jac_ux", &capsule->phi_e_constraint);
+                                  "nl_constr_phi_o_r_fun", &capsule->phi_e_constraint_fun);
+    ocp_nlp_constraints_model_set(nlp_config, nlp_dims, nlp_in, N,
+                                  "nl_constr_phi_o_r_fun_phi_jac_ux_z_phi_hess_r_jac_ux", &capsule->phi_e_constraint_fun_jac_hess);
     free(luphi_e);
 {% endif %}
 }
@@ -2605,7 +2615,8 @@ int {{ model.name }}_acados_update_params({{ model.name }}_solver_capsule* capsu
         if (stage == 0)
         {
         {%- if constraints.constr_type_0 == "BGP" %}
-            capsule->phi_0_constraint.set_param(&capsule->phi_0_constraint, p);
+            capsule->phi_0_constraint_fun_jac_hess.set_param(&capsule->phi_0_constraint_fun_jac_hess, p);
+            capsule->phi_0_constraint_fun.set_param(&capsule->phi_0_constraint_fun, p);
         {%- elif constraints.constr_type_0 == "BGH" and dims.nh_0 > 0 %}
             capsule->nl_constr_h_0_fun_jac.set_param(&capsule->nl_constr_h_0_fun_jac, p);
             capsule->nl_constr_h_0_fun.set_param(&capsule->nl_constr_h_0_fun, p);
@@ -2617,7 +2628,8 @@ int {{ model.name }}_acados_update_params({{ model.name }}_solver_capsule* capsu
         else
         {
         {%- if constraints.constr_type == "BGP" %}
-            capsule->phi_constraint[stage-1].set_param(capsule->phi_constraint+stage-1, p);
+            capsule->phi_constraint_fun[stage-1].set_param(capsule->phi_constraint_fun+stage-1, p);
+            capsule->phi_constraint_fun_jac_hess[stage-1].set_param(capsule->phi_constraint_fun_jac_hess+stage-1, p);
         {%- elif constraints.constr_type == "BGH" and dims.nh > 0 %}
             capsule->nl_constr_h_fun_jac[stage-1].set_param(capsule->nl_constr_h_fun_jac+stage-1, p);
             capsule->nl_constr_h_fun[stage-1].set_param(capsule->nl_constr_h_fun+stage-1, p);
@@ -2696,7 +2708,8 @@ int {{ model.name }}_acados_update_params({{ model.name }}_solver_capsule* capsu
     {%- endif %}
         // constraints
     {%- if constraints.constr_type_e == "BGP" %}
-        capsule->phi_e_constraint.set_param(&capsule->phi_e_constraint, p);
+        capsule->phi_e_constraint_fun_jac_hess.set_param(&capsule->phi_e_constraint_fun_jac_hess, p);
+        capsule->phi_e_constraint_fun.set_param(&capsule->phi_e_constraint_fun, p);
     {%- elif constraints.constr_type_e == "BGH" and dims.nh_e > 0 %}
         capsule->nl_constr_h_e_fun_jac.set_param(&capsule->nl_constr_h_e_fun_jac, p);
         capsule->nl_constr_h_e_fun.set_param(&capsule->nl_constr_h_e_fun, p);
@@ -2779,7 +2792,7 @@ int {{ model.name }}_acados_update_params_sparse({{ model.name }}_solver_capsule
         if (stage == 0)
         {
         {%- if constraints.constr_type_0 == "BGP" %}
-            capsule->phi_0_constraint.set_param_sparse(&capsule->phi_0_constraint, n_update, idx, p);
+            capsule->phi_0_constraint_fun_jac_hess.set_param_sparse(&capsule->phi_0_constraint_fun_jac_hess, n_update, idx, p);
         {%- elif constraints.constr_type_0 == "BGH" and dims.nh_0 > 0 %}
             capsule->nl_constr_h_0_fun_jac.set_param_sparse(&capsule->nl_constr_h_0_fun_jac, n_update, idx, p);
             capsule->nl_constr_h_0_fun.set_param_sparse(&capsule->nl_constr_h_0_fun, n_update, idx, p);
@@ -2870,7 +2883,7 @@ int {{ model.name }}_acados_update_params_sparse({{ model.name }}_solver_capsule
     {%- endif %}
         // constraints
     {%- if constraints.constr_type_e == "BGP" %}
-        capsule->phi_e_constraint.set_param_sparse(&capsule->phi_e_constraint, n_update, idx, p);
+        capsule->phi_e_constraint_fun_jac_hess.set_param_sparse(&capsule->phi_e_constraint_fun_jac_hess, n_update, idx, p);
     {%- elif constraints.constr_type_e == "BGH" and dims.nh_e > 0 %}
         capsule->nl_constr_h_e_fun_jac.set_param_sparse(&capsule->nl_constr_h_e_fun_jac, n_update, idx, p);
         capsule->nl_constr_h_e_fun.set_param_sparse(&capsule->nl_constr_h_e_fun, n_update, idx, p);
@@ -3122,9 +3135,11 @@ int {{ model.name }}_acados_free({{ model.name }}_solver_capsule* capsule)
 {%- elif constraints.constr_type == "BGP" and dims.nphi > 0 %}
     for (int i = 0; i < N-1; i++)
     {
-        external_function_param_casadi_free(&capsule->phi_constraint[i]);
+        external_function_param_casadi_free(&capsule->phi_constraint_fun_jac_hess[i]);
+        external_function_param_casadi_free(&capsule->phi_constraint_fun[i]);
     }
-    free(capsule->phi_constraint);
+    free(capsule->phi_constraint_fun);
+    free(capsule->phi_constraint_fun_jac_hess);
 {%- endif %}
 
 {%- if constraints.constr_type_0 == "BGH" and dims.nh_0 > 0 %}
@@ -3134,7 +3149,8 @@ int {{ model.name }}_acados_free({{ model.name }}_solver_capsule* capsule)
     external_function_param_casadi_free(&capsule->nl_constr_h_0_fun_jac_hess);
 {%- endif %}
 {%- elif constraints.constr_type_0 == "BGP" and dims.nphi_0 > 0 %}
-    external_function_param_casadi_free(&capsule->phi_0_constraint);
+    external_function_param_casadi_free(&capsule->phi_0_constraint_fun);
+    external_function_param_casadi_free(&capsule->phi_0_constraint_fun_jac_hess);
 {%- endif %}
 
 {%- if constraints.constr_type_e == "BGH" and dims.nh_e > 0 %}
@@ -3144,7 +3160,8 @@ int {{ model.name }}_acados_free({{ model.name }}_solver_capsule* capsule)
     external_function_param_casadi_free(&capsule->nl_constr_h_e_fun_jac_hess);
 {%- endif %}
 {%- elif constraints.constr_type_e == "BGP" and dims.nphi_e > 0 %}
-    external_function_param_casadi_free(&capsule->phi_e_constraint);
+    external_function_param_casadi_free(&capsule->phi_e_constraint_fun);
+    external_function_param_casadi_free(&capsule->phi_e_constraint_fun_jac_hess);
 {%- endif %}
 
     return 0;

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.h
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.h
@@ -197,7 +197,8 @@ typedef struct {{ model.name }}_solver_capsule
 
     // constraints
 {%- if constraints.constr_type == "BGP" %}
-    external_function_param_casadi *phi_constraint;
+    external_function_param_casadi *phi_constraint_fun_jac_hess;
+    external_function_param_casadi *phi_constraint_fun;
 {% elif constraints.constr_type == "BGH" and dims.nh > 0 %}
     external_function_param_casadi *nl_constr_h_fun_jac;
     external_function_param_casadi *nl_constr_h_fun;
@@ -208,7 +209,8 @@ typedef struct {{ model.name }}_solver_capsule
 
 
 {% if constraints.constr_type_0 == "BGP" %}
-    external_function_param_casadi phi_0_constraint;
+    external_function_param_casadi phi_0_constraint_fun_jac_hess;
+    external_function_param_casadi phi_0_constraint_fun;
 {% elif constraints.constr_type_0 == "BGH" and dims.nh_0 > 0 %}
     external_function_param_casadi nl_constr_h_0_fun_jac;
     external_function_param_casadi nl_constr_h_0_fun;
@@ -219,7 +221,8 @@ typedef struct {{ model.name }}_solver_capsule
 
 
 {% if constraints.constr_type_e == "BGP" %}
-    external_function_param_casadi phi_e_constraint;
+    external_function_param_casadi phi_e_constraint_fun_jac_hess;
+    external_function_param_casadi phi_e_constraint_fun;
 {% elif constraints.constr_type_e == "BGH" and dims.nh_e > 0 %}
     external_function_param_casadi nl_constr_h_e_fun_jac;
     external_function_param_casadi nl_constr_h_e_fun;

--- a/interfaces/acados_template/acados_template/c_templates_tera/constraints.in.h
+++ b/interfaces/acados_template/acados_template/c_templates_tera/constraints.in.h
@@ -68,7 +68,7 @@ int {{ model.name }}_phi_e_constraint_fun_jac_hess_n_out(void);
 {% endif %}
 
 {% if dims.nphi_0 > 0 %}
-int {{ model.name }}_phi_0_constraint_fun_jac_hess(const real_t** arg, real_t** res, int* iw, real_t* w, void *mem);
+int {{ model.name }}_phi_0_constraint_fun(const real_t** arg, real_t** res, int* iw, real_t* w, void *mem);
 int {{ model.name }}_phi_0_constraint_fun_work(int *, int *, int *, int *);
 const int *{{ model.name }}_phi_0_constraint_fun_sparsity_in(int);
 const int *{{ model.name }}_phi_0_constraint_fun_sparsity_out(int);

--- a/interfaces/acados_template/acados_template/c_templates_tera/constraints.in.h
+++ b/interfaces/acados_template/acados_template/c_templates_tera/constraints.in.h
@@ -36,30 +36,51 @@ extern "C" {
 #endif
 
 {% if dims.nphi > 0 %}
-int {{ model.name }}_phi_constraint(const real_t** arg, real_t** res, int* iw, real_t* w, void *mem);
-int {{ model.name }}_phi_constraint_work(int *, int *, int *, int *);
-const int *{{ model.name }}_phi_constraint_sparsity_in(int);
-const int *{{ model.name }}_phi_constraint_sparsity_out(int);
-int {{ model.name }}_phi_constraint_n_in(void);
-int {{ model.name }}_phi_constraint_n_out(void);
+int {{ model.name }}_phi_constraint_fun(const real_t** arg, real_t** res, int* iw, real_t* w, void *mem);
+int {{ model.name }}_phi_constraint_fun_work(int *, int *, int *, int *);
+const int *{{ model.name }}_phi_constraint_fun_sparsity_in(int);
+const int *{{ model.name }}_phi_constraint_fun_sparsity_out(int);
+int {{ model.name }}_phi_constraint_fun_n_in(void);
+int {{ model.name }}_phi_constraint_fun_n_out(void);
+
+int {{ model.name }}_phi_constraint_fun_jac_hess(const real_t** arg, real_t** res, int* iw, real_t* w, void *mem);
+int {{ model.name }}_phi_constraint_fun_jac_hess_work(int *, int *, int *, int *);
+const int *{{ model.name }}_phi_constraint_fun_jac_hess_sparsity_in(int);
+const int *{{ model.name }}_phi_constraint_fun_jac_hess_sparsity_out(int);
+int {{ model.name }}_phi_constraint_fun_jac_hess_n_in(void);
+int {{ model.name }}_phi_constraint_fun_jac_hess_n_out(void);
 {% endif %}
 
 {% if dims.nphi_e > 0 %}
-int {{ model.name }}_phi_e_constraint(const real_t** arg, real_t** res, int* iw, real_t* w, void *mem);
-int {{ model.name }}_phi_e_constraint_work(int *, int *, int *, int *);
-const int *{{ model.name }}_phi_e_constraint_sparsity_in(int);
-const int *{{ model.name }}_phi_e_constraint_sparsity_out(int);
-int {{ model.name }}_phi_e_constraint_n_in(void);
-int {{ model.name }}_phi_e_constraint_n_out(void);
+int {{ model.name }}_phi_e_constraint_fun(const real_t** arg, real_t** res, int* iw, real_t* w, void *mem);
+int {{ model.name }}_phi_e_constraint_fun_work(int *, int *, int *, int *);
+const int *{{ model.name }}_phi_e_constraint_fun_sparsity_in(int);
+const int *{{ model.name }}_phi_e_constraint_fun_sparsity_out(int);
+int {{ model.name }}_phi_e_constraint_fun_n_in(void);
+int {{ model.name }}_phi_e_constraint_fun_n_out(void);
+
+int {{ model.name }}_phi_e_constraint_fun_jac_hess(const real_t** arg, real_t** res, int* iw, real_t* w, void *mem);
+int {{ model.name }}_phi_e_constraint_fun_jac_hess_work(int *, int *, int *, int *);
+const int *{{ model.name }}_phi_e_constraint_fun_jac_hess_sparsity_in(int);
+const int *{{ model.name }}_phi_e_constraint_fun_jac_hess_sparsity_out(int);
+int {{ model.name }}_phi_e_constraint_fun_jac_hess_n_in(void);
+int {{ model.name }}_phi_e_constraint_fun_jac_hess_n_out(void);
 {% endif %}
 
 {% if dims.nphi_0 > 0 %}
-int {{ model.name }}_phi_0_constraint(const real_t** arg, real_t** res, int* iw, real_t* w, void *mem);
-int {{ model.name }}_phi_0_constraint_work(int *, int *, int *, int *);
-const int *{{ model.name }}_phi_0_constraint_sparsity_in(int);
-const int *{{ model.name }}_phi_0_constraint_sparsity_out(int);
-int {{ model.name }}_phi_0_constraint_n_in(void);
-int {{ model.name }}_phi_0_constraint_n_out(void);
+int {{ model.name }}_phi_0_constraint_fun_jac_hess(const real_t** arg, real_t** res, int* iw, real_t* w, void *mem);
+int {{ model.name }}_phi_0_constraint_fun_work(int *, int *, int *, int *);
+const int *{{ model.name }}_phi_0_constraint_fun_sparsity_in(int);
+const int *{{ model.name }}_phi_0_constraint_fun_sparsity_out(int);
+int {{ model.name }}_phi_0_constraint_fun_n_in(void);
+int {{ model.name }}_phi_0_constraint_fun_n_out(void);
+
+int {{ model.name }}_phi_0_constraint_fun_jac_hess(const real_t** arg, real_t** res, int* iw, real_t* w, void *mem);
+int {{ model.name }}_phi_0_constraint_fun_jac_hess_work(int *, int *, int *, int *);
+const int *{{ model.name }}_phi_0_constraint_fun_jac_hess_sparsity_in(int);
+const int *{{ model.name }}_phi_0_constraint_fun_jac_hess_sparsity_out(int);
+int {{ model.name }}_phi_0_constraint_fun_jac_hess_n_in(void);
+int {{ model.name }}_phi_0_constraint_fun_jac_hess_n_out(void);
 {% endif %}
 
 

--- a/interfaces/acados_template/acados_template/c_templates_tera/multi_Makefile.in
+++ b/interfaces/acados_template/acados_template/c_templates_tera/multi_Makefile.in
@@ -173,7 +173,8 @@ OCP_SRC+= {{ model[jj].name }}_constraints/{{ model[jj].name }}_constr_h_fun.c
 OCP_SRC+= {{ model[jj].name }}_constraints/{{ model[jj].name }}_constr_h_fun_jac_uxt_zt_hess.c
 	{%- endif %}
 {%- elif constraints[jj].constr_type == "BGP" and phases_dims[jj].nphi > 0 %}
-OCP_SRC+= {{ model[jj].name }}_constraints/{{ model[jj].name }}_phi_constraint.c
+OCP_SRC+= {{ model[jj].name }}_constraints/{{ model[jj].name }}_phi_constraint_fun.c
+OCP_SRC+= {{ model[jj].name }}_constraints/{{ model[jj].name }}_phi_constraint_fun_jac_hess.c
 {%- endif %}
 
 {% endfor %}
@@ -210,7 +211,8 @@ OCP_SRC+= {{ model_0.name }}_constraints/{{ model_0.name }}_constr_h_0_fun.c
 OCP_SRC+= {{ model_0.name }}_constraints/{{ model_0.name }}_constr_h_0_fun_jac_uxt_zt_hess.c
 	{%- endif %}
 {%- elif constraints_0.constr_type_0 == "BGP" and dims_0.nphi_0 > 0 %}
-OCP_SRC+= {{ model_0.name }}_constraints/{{ model_0.name }}_phi_0_constraint.c
+OCP_SRC+= {{ model_0.name }}_constraints/{{ model_0.name }}_phi_0_constraint_fun.c
+OCP_SRC+= {{ model_0.name }}_constraints/{{ model_0.name }}_phi_0_constraint_fun_jac_hess.c
 {%- endif %}
 
 
@@ -223,7 +225,8 @@ OCP_SRC+= {{ model_e.name }}_constraints/{{ model_e.name }}_constr_h_e_fun.c
 OCP_SRC+= {{ model_e.name }}_constraints/{{ model_e.name }}_constr_h_e_fun_jac_uxt_zt_hess.c
 	{%- endif %}
 {%- elif constraints_e.constr_type_e == "BGP" and dims_e.nphi_e > 0 %}
-OCP_SRC+= {{ model_e.name }}_constraints/{{ model_e.name }}_phi_e_constraint.c
+OCP_SRC+= {{ model_e.name }}_constraints/{{ model_e.name }}_phi_e_constraint_fun.c
+OCP_SRC+= {{ model_e.name }}_constraints/{{ model_e.name }}_phi_e_constraint_fun_jac_hess.c
 {%- endif %}
 
 {%- if cost_e.cost_type_e == "NONLINEAR_LS" %}


### PR DESCRIPTION
The function `nl_constr_phi_o_r_fun` which is used in `ocp_nlp_constraints_bgp_compute_fun` hasn't been generated and set in the templates.

This PR adds the additional external function, `phi_constraint_fun`,  and renames the existing one from `phi_constraint` to `phi_constraint_fun_jac_hess` within the templates.

TODO: Test multi-phase solver with CONL constraints and globalization