### PR TITLE
Windows, MATLAB - Fix timing with MinGW

### DIFF
--- a/acados/utils/timing.c
+++ b/acados/utils/timing.c
@@ -32,7 +32,7 @@
 #include "acados/utils/timing.h"
 
 
-#if (defined _WIN32 || defined _WIN64) && !(defined __MINGW32__ || defined __MINGW64__)
+#if (defined _WIN32 || defined _WIN64)
 
 void acados_tic(acados_timer* t)
 {

--- a/acados/utils/timing.h
+++ b/acados/utils/timing.h
@@ -38,7 +38,7 @@
 extern "C" {
 #endif
 
-#if (defined _WIN32 || defined _WIN64) && !(defined __MINGW32__ || defined __MINGW64__)
+#if (defined _WIN32 || defined _WIN64)
 
 /* Use Windows QueryPerformanceCounter for timing. */
 #include <Windows.h>


### PR DESCRIPTION
This PR implements the fix suggested [here](https://discourse.acados.org/t/error-during-runing-the-example-in-matlab-2019b/1579/6).
Now the native Windows timing functionality is used also when compiling with MinGW.

This was tested on two machines (one had the original issue) and it works in both cases.
The difference in timing when running the `linear_mpc` example is ca. 0.002 ms (0.178 ms total solve time).