### PR TITLE
Python cleanup

### DIFF
--- a/examples/acados_python/pendulum_on_cart/ocp/nonuniform_discretization_example.py
+++ b/examples/acados_python/pendulum_on_cart/ocp/nonuniform_discretization_example.py
@@ -32,7 +32,7 @@
 import sys, json, os
 sys.path.insert(0, '../common')
 
-from acados_template import AcadosOcp, AcadosOcpSolver, acados_dae_model_json_dump, get_acados_path
+from acados_template import AcadosOcp, AcadosOcpSolver, acados_dae_model_json_dump, get_acados_path, get_simulink_default_opts
 from pendulum_model import export_pendulum_ode_model
 import numpy as np
 import scipy.linalg
@@ -141,10 +141,7 @@ def main(discretization='shooting_nodes'):
     ocp.solver_options.initialize_t_slacks = 1
 
     # Set additional options for Simulink interface:
-    acados_path = get_acados_path()
-    json_path = os.path.join(acados_path, 'interfaces/acados_template/acados_template')
-    with open(json_path + '/simulink_default_opts.json', 'r') as f:
-        simulink_opts = json.load(f)
+    simulink_opts = get_simulink_default_opts()
     ocp_solver = AcadosOcpSolver(ocp, json_file = 'acados_ocp.json', simulink_opts = simulink_opts, verbose=False)
 
     # ocp_solver = AcadosOcpSolver(ocp, json_file = 'acados_ocp.json')

--- a/examples/acados_python/pendulum_on_cart/ocp/simulink_example.py
+++ b/examples/acados_python/pendulum_on_cart/ocp/simulink_example.py
@@ -31,7 +31,7 @@
 import sys
 sys.path.insert(0, '../common')
 
-from acados_template import AcadosOcp, AcadosOcpSolver, get_default_simulink_opts
+from acados_template import AcadosOcp, AcadosOcpSolver, get_simulink_default_opts
 from pendulum_model import export_pendulum_ode_model
 import numpy as np
 # from utils import plot_pendulum
@@ -84,7 +84,7 @@ def main():
     ocp.solver_options.tf = Tf
 
     # to generate Simulink wrapper for solver
-    simulink_opts = get_default_simulink_opts() # modify those options, if you like.
+    simulink_opts = get_simulink_default_opts() # modify those options, if you like.
 
     # create solver
     ocp_solver = AcadosOcpSolver(ocp, json_file = 'acados_ocp.json', simulink_opts=simulink_opts)

--- a/examples/acados_python/zoRO_example/pendulum_on_cart/minimal_example_zoro.py
+++ b/examples/acados_python/zoRO_example/pendulum_on_cart/minimal_example_zoro.py
@@ -31,7 +31,7 @@ import os
 
 import numpy as np
 import scipy.linalg
-from acados_template import AcadosOcp, AcadosOcpSolver, ZoroDescription, get_default_simulink_opts
+from acados_template import AcadosOcp, AcadosOcpSolver, ZoroDescription, get_simulink_default_opts
 
 # same as in normal pendulum model
 local_path = os.path.dirname(os.path.abspath(__file__))
@@ -136,7 +136,7 @@ def main():
     ocp.zoro_description = zoro_description
 
     # to export Simulink block
-    simulink_opts = get_default_simulink_opts()
+    simulink_opts = get_simulink_default_opts()
     simulink_opts['inputs']['lbx'] = 0
     simulink_opts['inputs']['ubx'] = 0
     simulink_opts['inputs']['lbx_e'] = 0

--- a/interfaces/acados_template/acados_template/acados_ocp_constraints.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_constraints.py
@@ -743,17 +743,28 @@ class AcadosOcpConstraints:
 
     @property
     def x0(self):
-        """:math:`x_0 \\in \mathbb{R}^{n_x}` - initial state --
-        Translated internally to :py:attr:`idxbx_0`, :py:attr:`lbx_0`, :py:attr:`ubx_0`, :py:attr:`idxbxe_0` """
-        print("x0 is converted to lbx_0, ubx_0, idxbx_0")
-        print("idxbx_0: ", self.__idxbx_0)
-        print("lbx_0: ", self.__lbx_0)
-        print("ubx_0: ", self.__ubx_0)
-        print("idxbxe_0: ", self.__idxbxe_0)
-        return None
+        """
+        :math:`x_0 \\in \mathbb{R}^{n_x}` - initial state --
+        Translated internally to :py:attr:`idxbx_0`, :py:attr:`lbx_0`, :py:attr:`ubx_0`, :py:attr:`idxbxe_0`
+        """
+        if self.has_x0:
+            return self.lbx_0
+        else:
+            print("x0 is not set. You can set it or specify lbx_0, ubx_0, idxbx_0, idxbxe_0 to implement general bounds on x0.")
+            print("")
+            print("idxbx_0: ", self.__idxbx_0)
+            print("lbx_0: ", self.__lbx_0)
+            print("ubx_0: ", self.__ubx_0)
+            print("idxbxe_0: ", self.__idxbxe_0)
+            return None
 
     @property
     def has_x0(self):
+        """
+        Internal variable to check if x0 is set.
+        Cannot be set from outside.
+        :bool: True if x0 is set, False otherwise.
+        """
         return self.__has_x0
 
     # SETTERS

--- a/interfaces/acados_template/acados_template/utils.py
+++ b/interfaces/acados_template/acados_template/utils.py
@@ -335,11 +335,9 @@ def format_class_dict(d):
     return out
 
 def get_default_simulink_opts() -> dict:
-    python_interface_path = get_python_interface_path()
-    abs_path = os.path.join(python_interface_path, 'simulink_default_opts.json')
-    with open(abs_path, 'r') as f:
-        simulink_opts = json.load(f)
-    return simulink_opts
+    print("get_default_simulink_opts is deprecated, use get_simulink_default_opts instead."
+          + " This function will be removed in a future release.")
+    return get_simulink_default_opts()
 
 
 def J_to_idx(J):


### PR DESCRIPTION
- deprecate `get_default_simulink_opts`, use `get_simulink_default_opts` instead
- return `x0` if set