### PR TITLE
Remove `t` slacks from `ocp_nlp_out`

### DIFF
--- a/acados/ocp_nlp/ocp_nlp_common.c
+++ b/acados/ocp_nlp/ocp_nlp_common.c
@@ -2154,32 +2154,6 @@ void ocp_nlp_initialize_submodules(ocp_nlp_config *config, ocp_nlp_dims *dims, o
 }
 
 
-void ocp_nlp_initialize_t_slacks(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in,
-         ocp_nlp_out *out, ocp_nlp_opts *opts, ocp_nlp_memory *mem, ocp_nlp_workspace *work)
-{
-    struct blasfeo_dvec *ineq_fun;
-    int N = dims->N;
-    int *ni = dims->ni;
-    // int *ns = dims->ns;
-    // int *nx = dims->nx;
-    // int *nu = dims->nu;
-
-#if defined(ACADOS_WITH_OPENMP)
-    #pragma omp parallel for
-#endif
-    for (int i = 0; i <= N; i++)
-    {
-        // evaluate inequalities
-        config->constraints[i]->compute_fun(config->constraints[i], dims->constraints[i],
-                                             in->constraints[i], opts->constraints[i],
-                                             mem->constraints[i], work->constraints[i]);
-        ineq_fun = config->constraints[i]->memory_get_fun_ptr(mem->constraints[i]);
-        // t = -ineq_fun
-        blasfeo_dveccpsc(2 * ni[i], -1.0, ineq_fun, 0, out->t + i, 0);
-    }
-
-    return;
-}
 
 static void adaptive_levenberg_marquardt_update_mu(double iter, double step_size, ocp_nlp_opts *opts, ocp_nlp_memory *mem)
 {

--- a/acados/ocp_nlp/ocp_nlp_common.c
+++ b/acados/ocp_nlp/ocp_nlp_common.c
@@ -3180,7 +3180,6 @@ void ocp_nlp_res_compute(ocp_nlp_dims *dims, ocp_nlp_in *in, ocp_nlp_out *out, o
     res->inf_norm_res_ineq = 0.0;
     for (int i = 0; i <= N; i++)
     {
-        // TODO: do we need to get the ineq_fun value before this? or is it always done?
         for (int j=0; j<2*ni[i]; j++)
         {
             tmp = BLASFEO_DVECEL(mem->ineq_fun+i, j);

--- a/acados/ocp_nlp/ocp_nlp_common.c
+++ b/acados/ocp_nlp/ocp_nlp_common.c
@@ -834,8 +834,6 @@ ocp_nlp_out *ocp_nlp_out_assign(ocp_nlp_config *config, ocp_nlp_dims *dims, void
     assign_and_advance_blasfeo_dvec_structs(N, &out->pi, &c_ptr);
     // lam
     assign_and_advance_blasfeo_dvec_structs(N + 1, &out->lam, &c_ptr);
-    // t
-    assign_and_advance_blasfeo_dvec_structs(N + 1, &out->t, &c_ptr);
 
     // blasfeo_mem align
     align_char_to(64, &c_ptr);
@@ -861,11 +859,6 @@ ocp_nlp_out *ocp_nlp_out_assign(ocp_nlp_config *config, ocp_nlp_dims *dims, void
     {
         assign_and_advance_blasfeo_dvec_mem(2 * ni[i], out->lam + i, &c_ptr);
     }
-    // t
-    for (int i = 0; i <= N; ++i)
-    {
-        assign_and_advance_blasfeo_dvec_mem(2 * ni[i], out->t + i, &c_ptr);
-    }
 
     // zero solution
     for(int i=0; i<N; i++)
@@ -874,12 +867,10 @@ ocp_nlp_out *ocp_nlp_out_assign(ocp_nlp_config *config, ocp_nlp_dims *dims, void
         blasfeo_dvecse(nz[i], 0.0, out->z+i, 0);
         blasfeo_dvecse(nx[i+1], 0.0, out->pi+i, 0);
         blasfeo_dvecse(2*ni[i], 0.0, out->lam+i, 0);
-        blasfeo_dvecse(2*ni[i], 0.0, out->t+i, 0);
     }
     blasfeo_dvecse(nv[N], 0.0, out->ux+N, 0);
     blasfeo_dvecse(nz[N], 0.0, out->z+N, 0);
     blasfeo_dvecse(2*ni[N], 0.0, out->lam+N, 0);
-    blasfeo_dvecse(2*ni[N], 0.0, out->t+N, 0);
 
     assert((char *) raw_memory + ocp_nlp_out_calculate_size(config, dims) >= c_ptr);
 
@@ -2982,10 +2973,6 @@ void ocp_nlp_update_variables_sqp(ocp_nlp_config *config, ocp_nlp_dims *dims, oc
             }
         }
 
-        // update slack values
-        blasfeo_dvecsc(2*ni[i], 1.0-alpha, out->t+i, 0);
-        blasfeo_daxpy(2*ni[i], alpha, mem->qp_out->t+i, 0, out->t+i, 0, out->t+i, 0);
-
         // linear update of algebraic variables using state and input sensitivity
         if (i < N)
         {
@@ -3166,6 +3153,7 @@ void ocp_nlp_res_compute(ocp_nlp_dims *dims, ocp_nlp_in *in, ocp_nlp_out *out, o
     int *ni = dims->ni;
 
     double tmp_res;
+    double tmp;
 
     // res_stat
     for (int i = 0; i <= N; i++)
@@ -3192,17 +3180,22 @@ void ocp_nlp_res_compute(ocp_nlp_dims *dims, ocp_nlp_in *in, ocp_nlp_out *out, o
     res->inf_norm_res_ineq = 0.0;
     for (int i = 0; i <= N; i++)
     {
-        blasfeo_daxpy(2 * ni[i], 1.0, out->t + i, 0, mem->ineq_fun + i, 0, res->res_ineq + i, 0);
-        blasfeo_dvecnrm_inf(2 * ni[i], res->res_ineq + i, 0, &tmp_res);
-        blasfeo_dvecse(1, tmp_res, &res->tmp, i);
+        // TODO: do we need to get the ineq_fun value before this? or is it always done?
+        for (int j=0; j<2*ni[i]; j++)
+        {
+            tmp = BLASFEO_DVECEL(mem->ineq_fun+i, j);
+            if (tmp > res->inf_norm_res_ineq)
+            {
+                res->inf_norm_res_ineq = tmp;
+            }
+        }
     }
-    blasfeo_dvecnrm_inf(N+1, &res->tmp, 0, &res->inf_norm_res_ineq);
 
     // res_comp
     res->inf_norm_res_comp = 0.0;
     for (int i = 0; i <= N; i++)
     {
-        blasfeo_dvecmul(2 * ni[i], out->lam + i, 0, out->t + i, 0, res->res_comp + i, 0);
+        blasfeo_dvecmul(2 * ni[i], out->lam + i, 0, mem->ineq_fun+i, 0, res->res_comp + i, 0);
         blasfeo_dvecnrm_inf(2 * ni[i], res->res_comp + i, 0, &tmp_res);
         blasfeo_dvecse(1, tmp_res, &res->tmp, i);
     }
@@ -3240,7 +3233,6 @@ void copy_ocp_nlp_out(ocp_nlp_dims *dims, ocp_nlp_out *from, ocp_nlp_out *to)
         blasfeo_dveccp(nv[i], from->ux+i, 0, to->ux+i, 0);
         blasfeo_dveccp(nz[i], from->z+i, 0, to->z+i, 0);
         blasfeo_dveccp(2*ni[i], from->lam+i, 0, to->lam+i, 0);
-        blasfeo_dveccp(2*ni[i], from->t+i, 0, to->t+i, 0);
     }
 
     for (int i = 0; i < N; i++)
@@ -3387,7 +3379,6 @@ void ocp_nlp_common_eval_param_sens(ocp_nlp_config *config, ocp_nlp_dims *dims,
             blasfeo_dveccp(nx[i + 1], tmp_qp_out->pi + i, 0, sens_nlp_out->pi + i, 0);
 
         blasfeo_dveccp(2 * ni[i], tmp_qp_out->lam + i, 0, sens_nlp_out->lam + i, 0);
-        blasfeo_dveccp(2 * ni[i], tmp_qp_out->t + i, 0, sens_nlp_out->t + i, 0);
     }
 }
 

--- a/acados/ocp_nlp/ocp_nlp_common.c
+++ b/acados/ocp_nlp/ocp_nlp_common.c
@@ -779,19 +779,19 @@ acados_size_t ocp_nlp_out_calculate_size(ocp_nlp_config *config, ocp_nlp_dims *d
 
     acados_size_t size = sizeof(ocp_nlp_out);
 
-    size += 4 * (N + 1) * sizeof(struct blasfeo_dvec);  // ux, lam, t, z
+    size += 3 * (N + 1) * sizeof(struct blasfeo_dvec);  // ux, lam, z
     size += 1 * N * sizeof(struct blasfeo_dvec);        // pi
 
     for (int i = 0; i < N; i++)
     {
         size += 1 * blasfeo_memsize_dvec(nv[i]);      // ux
         size += 1 * blasfeo_memsize_dvec(nz[i]);      // z
-        size += 2 * blasfeo_memsize_dvec(2 * ni[i]);  // lam, t
+        size += 1 * blasfeo_memsize_dvec(2 * ni[i]);  // lam
         size += 1 * blasfeo_memsize_dvec(nx[i + 1]);  // pi
     }
     size += 1 * blasfeo_memsize_dvec(nv[N]);      // ux
     size += 1 * blasfeo_memsize_dvec(nz[N]);     // z
-    size += 2 * blasfeo_memsize_dvec(2 * ni[N]);  // lam, t
+    size += 1 * blasfeo_memsize_dvec(2 * ni[N]);  // lam
 
     size += 8;   // initial align
     size += 8;   // blasfeo_struct align

--- a/acados/ocp_nlp/ocp_nlp_common.h
+++ b/acados/ocp_nlp/ocp_nlp_common.h
@@ -233,7 +233,6 @@ typedef struct ocp_nlp_out
     struct blasfeo_dvec *z;  // algebraic variables
     struct blasfeo_dvec *pi;  // multipliers for dynamics
     struct blasfeo_dvec *lam;  // inequality multipliers
-    struct blasfeo_dvec *t;  // slack variables corresponding to evaluation of all inequalities (at the solution)
 
     // NOTE: the inequalities are internally organized in the following order:
     // [ lbu lbx lg lh lphi ubu ubx ug uh uphi; lsbu lsbx lsg lsh lsphi usbu usbx usg ush usphi]

--- a/acados/ocp_nlp/ocp_nlp_common.h
+++ b/acados/ocp_nlp/ocp_nlp_common.h
@@ -463,9 +463,6 @@ double ocp_nlp_line_search(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_i
 double ocp_nlp_evaluate_merit_fun(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in,
           ocp_nlp_out *out, ocp_nlp_opts *opts, ocp_nlp_memory *mem, ocp_nlp_workspace *work);
 //
-void ocp_nlp_initialize_t_slacks(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in,
-            ocp_nlp_out *out, ocp_nlp_opts *opts, ocp_nlp_memory *mem, ocp_nlp_workspace *work);
-//
 void ocp_nlp_res_compute(ocp_nlp_dims *dims, ocp_nlp_in *in, ocp_nlp_out *out,
                          ocp_nlp_res *res, ocp_nlp_memory *mem);
 //

--- a/acados/ocp_nlp/ocp_nlp_ddp.c
+++ b/acados/ocp_nlp/ocp_nlp_ddp.c
@@ -545,10 +545,6 @@ static void ocp_nlp_ddp_compute_trial_iterate(ocp_nlp_config *config, ocp_nlp_di
             }
         }
 
-        // // update slack values
-        // blasfeo_dvecsc(2*ni[i], 1.0-alpha, tmp_nlp_out->t+i, 0);
-        // blasfeo_daxpy(2*ni[i], alpha, mem->qp_out->t+i, 0, tmp_nlp_out->t+i, 0, tmp_nlp_out->t+i, 0);
-
         // linear update of algebraic variables using state and input sensitivity
         if (i < N)
         {

--- a/acados/ocp_nlp/ocp_nlp_ddp.c
+++ b/acados/ocp_nlp/ocp_nlp_ddp.c
@@ -123,7 +123,6 @@ void ocp_nlp_ddp_opts_initialize_default(void *config_, void *dims_, void *opts_
     opts->qp_warm_start = 0;
     opts->warm_start_first_qp = false;
     opts->rti_phase = 0;
-    opts->initialize_t_slacks = 0;
 
     opts->linesearch_eta = 1e-6;
     opts->linesearch_minimum_step_size = 1e-17;
@@ -245,16 +244,6 @@ void ocp_nlp_ddp_opts_set(void *config_, void *opts_, const char *field, void* v
                 exit(1);
             }
             opts->rti_phase = *rti_phase;
-        }
-        else if (!strcmp(field, "initialize_t_slacks"))
-        {
-            int* initialize_t_slacks = (int *) value;
-            if (*initialize_t_slacks != 0 && *initialize_t_slacks != 1)
-            {
-                printf("\nerror: ocp_nlp_ddp_opts_set: invalid value for initialize_t_slacks field, need int 0 or 1, got %d.", *initialize_t_slacks);
-                exit(1);
-            }
-            opts->initialize_t_slacks = *initialize_t_slacks;
         }
         else
         {
@@ -732,9 +721,6 @@ int ocp_nlp_ddp(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
     // approximate_qp_matrices is parallelized
     omp_set_num_threads(opts->nlp_opts->num_threads);
 #endif
-
-    if (opts->initialize_t_slacks > 0)
-        ocp_nlp_initialize_t_slacks(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work);
 
     ocp_nlp_initialize_submodules(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work);
 

--- a/acados/ocp_nlp/ocp_nlp_ddp.h
+++ b/acados/ocp_nlp/ocp_nlp_ddp.h
@@ -66,7 +66,6 @@ typedef struct
     int qp_warm_start;   // qp_warm_start in all but the first ddp iterations
     bool warm_start_first_qp; // to set qp_warm_start in first iteration
     int rti_phase;       // only phase 0 at the moment
-    int initialize_t_slacks;  // 0-false or 1-true
 
     // Line search
     double linesearch_eta;

--- a/acados/ocp_nlp/ocp_nlp_sqp.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp.c
@@ -124,7 +124,6 @@ void ocp_nlp_sqp_opts_initialize_default(void *config_, void *dims_, void *opts_
     opts->qp_warm_start = 0;
     opts->warm_start_first_qp = false;
     opts->rti_phase = 0;
-    opts->initialize_t_slacks = 0;
 
     // overwrite default submodules opts
 
@@ -241,16 +240,6 @@ void ocp_nlp_sqp_opts_set(void *config_, void *opts_, const char *field, void* v
                 exit(1);
             }
             opts->rti_phase = *rti_phase;
-        }
-        else if (!strcmp(field, "initialize_t_slacks"))
-        {
-            int* initialize_t_slacks = (int *) value;
-            if (*initialize_t_slacks != 0 && *initialize_t_slacks != 1)
-            {
-                printf("\nerror: ocp_nlp_sqp_opts_set: invalid value for initialize_t_slacks field, need int 0 or 1, got %d.", *initialize_t_slacks);
-                exit(1);
-            }
-            opts->initialize_t_slacks = *initialize_t_slacks;
         }
         else
         {
@@ -707,9 +696,6 @@ int ocp_nlp_sqp(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
     // set number of threads
     omp_set_num_threads(opts->nlp_opts->num_threads);
 #endif
-
-    if (opts->initialize_t_slacks > 0)
-        ocp_nlp_initialize_t_slacks(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work);
 
     ocp_nlp_initialize_submodules(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work);
 

--- a/acados/ocp_nlp/ocp_nlp_sqp.h
+++ b/acados/ocp_nlp/ocp_nlp_sqp.h
@@ -66,7 +66,6 @@ typedef struct
     int qp_warm_start;   // qp_warm_start in all but the first sqp iterations
     bool warm_start_first_qp; // to set qp_warm_start in first iteration
     int rti_phase;       // only phase 0 at the moment
-    int initialize_t_slacks;  // 0-false or 1-true
 
 } ocp_nlp_sqp_opts;
 

--- a/acados/ocp_nlp/ocp_nlp_sqp_rti.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp_rti.c
@@ -1097,12 +1097,6 @@ static void ocp_nlp_sqp_rti_preparation_advanced_step(ocp_nlp_config *config, oc
         // perform k full SQP iterations
         for (; mem->sqp_iter < opts->as_rti_iter; mem->sqp_iter++)
         {
-            if (opts->rti_log_residuals)
-            {
-                // TODO: evaluate what is needed!!
-                ocp_nlp_res_compute(dims, nlp_in, nlp_out, nlp_mem->nlp_res, nlp_mem);
-                rti_store_residuals_in_stats(opts, mem);
-            }
             acados_tic(&timer1);
             // linearize NLP
             ocp_nlp_approximate_qp_matrices(config, dims, nlp_in,
@@ -1111,6 +1105,13 @@ static void ocp_nlp_sqp_rti_preparation_advanced_step(ocp_nlp_config *config, oc
             ocp_nlp_approximate_qp_vectors_sqp(config, dims, nlp_in,
                 nlp_out, nlp_opts, nlp_mem, nlp_work);
             mem->time_lin += acados_toc(&timer1);
+
+            if (opts->rti_log_residuals)
+            {
+                ocp_nlp_res_compute(dims, nlp_in, nlp_out, nlp_mem->nlp_res, nlp_mem);
+                rti_store_residuals_in_stats(opts, mem);
+            }
+
             // full regularization
             acados_tic(&timer1);
             config->regularize->regularize(config->regularize,

--- a/acados/utils/print.c
+++ b/acados/utils/print.c
@@ -464,10 +464,6 @@ void ocp_nlp_out_print(ocp_nlp_dims *dims, ocp_nlp_out *nlp_out)
         blasfeo_print_tran_dvec(2 * ni[ii], &nlp_out->lam[ii], 0);
     }
 
-// printf("t =\n");
-// for (ii=0; ii<=N; ii++)
-//        blasfeo_print_exp_tran_dvec(2*nb[ii]+2*ng[ii], &nlp_out->t[ii], 0);
-
 #else
 
     for (ii = 0; ii < N + 1; ii++)

--- a/examples/acados_matlab_octave/getting_started/extensive_example_ocp.m
+++ b/examples/acados_matlab_octave/getting_started/extensive_example_ocp.m
@@ -282,7 +282,6 @@ end
 for i = 0:N-1
     sl = ocp.get('sl', i);
     su = ocp.get('su', i);
-    t = ocp.get('t', i);
 end
 sl = ocp.get('sl', N);
 su = ocp.get('su', N);
@@ -293,7 +292,7 @@ cost_val_ocp = ocp.get_cost();
 
 %% get QP matrices:
 % See https://docs.acados.org/problem_formulation
-%        |----- dynamics -----|------ cost --------|---------------------------- constraints ------------------------|        
+%        |----- dynamics -----|------ cost --------|---------------------------- constraints ------------------------|
 fields = {'qp_A','qp_B','qp_b','qp_R','qp_Q','qp_r','qp_C','qp_D','qp_lg','qp_ug','qp_lbx','qp_ubx','qp_lbu','qp_ubu'};
 % either stage wise
 for stage = [0,N-1]

--- a/examples/acados_matlab_octave/test/test_ocp_wtnx6.m
+++ b/examples/acados_matlab_octave/test/test_ocp_wtnx6.m
@@ -462,7 +462,6 @@ for i = 0:N-1
     % test setters
     ocp.set('sl', sl, i);
     ocp.set('su', su, i);
-    t = ocp.get('t', i);
 end
 sl = ocp.get('sl', N);
 su = ocp.get('su', N);

--- a/examples/acados_python/linear_mass_model/linear_mass_test_problem.py
+++ b/examples/acados_python/linear_mass_model/linear_mass_test_problem.py
@@ -165,7 +165,6 @@ def solve_marathos_ocp(setting):
     ocp.solver_options.nlp_solver_type = 'SQP' # SQP_RTI, SQP
     ocp.solver_options.globalization = globalization
     ocp.solver_options.alpha_min = 0.01
-    # ocp.solver_options.__initialize_t_slacks = 0
     # ocp.solver_options.levenberg_marquardt = 1e-2
     ocp.solver_options.qp_solver_cond_N = 0
     ocp.solver_options.print_level = 1

--- a/examples/acados_python/non_ocp_nlp/marathos_test_problem.py
+++ b/examples/acados_python/non_ocp_nlp/marathos_test_problem.py
@@ -122,7 +122,6 @@ def solve_marathos_problem_with_setting(setting):
     ocp.solver_options.nlp_solver_type = 'SQP' # SQP_RTI, SQP
     ocp.solver_options.globalization = globalization
     ocp.solver_options.alpha_min = 1e-2
-    # ocp.solver_options.__initialize_t_slacks = 0
     # ocp.solver_options.regularize_method = 'CONVEXIFY'
     ocp.solver_options.levenberg_marquardt = 1e-1
     # ocp.solver_options.print_level = 2

--- a/examples/acados_python/pendulum_on_cart/ocp/nonuniform_discretization_example.py
+++ b/examples/acados_python/pendulum_on_cart/ocp/nonuniform_discretization_example.py
@@ -206,14 +206,11 @@ def main(discretization='shooting_nodes'):
 
     print("inequality multipliers at stage 1")
     print(ocp_solver.get(1, "lam")) # inequality multipliers at stage 1
-    print("slack values at stage 1")
-    print(ocp_solver.get(1, "t")) # slack values at stage 1
     print("multipliers of dynamic conditions between stage 1 and 2")
     print(ocp_solver.get(1, "pi")) # multipliers of dynamic conditions between stage 1 and 2
 
-    # initialize ineq multipliers and slacks at stage 1
+    # initialize ineq multipliers at stage 1
     ocp_solver.set(1, "lam", np.zeros(2,))
-    ocp_solver.set(1, "t", np.zeros(2,))
 
     ocp_solver.print_statistics() # encapsulates: stat = ocp_solver.get_stats("statistics")
 

--- a/examples/acados_python/pendulum_on_cart/ocp/nonuniform_discretization_example.py
+++ b/examples/acados_python/pendulum_on_cart/ocp/nonuniform_discretization_example.py
@@ -142,7 +142,6 @@ def main(discretization='shooting_nodes'):
 
     # set prediction horizon
     ocp.solver_options.tf = Tf
-    ocp.solver_options.initialize_t_slacks = 1
 
     # Set additional options for Simulink interface:
     simulink_opts = get_simulink_default_opts()

--- a/interfaces/acados_c/ocp_nlp_interface.c
+++ b/interfaces/acados_c/ocp_nlp_interface.c
@@ -622,7 +622,7 @@ int ocp_nlp_dims_get_from_attr(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_n
     {
         return dims->np[stage];
     }
-    else if (!strcmp(field, "lam") || !strcmp(field, "t"))
+    else if (!strcmp(field, "lam"))
     {
         return 2*dims->ni[stage];
     }

--- a/interfaces/acados_c/ocp_nlp_interface.c
+++ b/interfaces/acados_c/ocp_nlp_interface.c
@@ -528,11 +528,6 @@ void ocp_nlp_out_set(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_out *ou
         double *double_values = value;
         blasfeo_pack_dvec(2*dims->ni[stage], double_values, 1, &out->lam[stage], 0);
     }
-    else if (!strcmp(field, "t"))
-    {
-        double *double_values = value;
-        blasfeo_pack_dvec(2*dims->ni[stage], double_values, 1, &out->t[stage], 0);
-    }
     else if (!strcmp(field, "z"))
     {
         double *double_values = value;
@@ -586,11 +581,6 @@ void ocp_nlp_out_get(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_out *ou
     {
         double *double_values = value;
         blasfeo_unpack_dvec(2*dims->ni[stage], &out->lam[stage], 0, double_values, 1);
-    }
-    else if (!strcmp(field, "t"))
-    {
-        double *double_values = value;
-        blasfeo_unpack_dvec(2*dims->ni[stage], &out->t[stage], 0, double_values, 1);
     }
     else if ((!strcmp(field, "kkt_norm_inf")) || (!strcmp(field, "kkt_norm")))
     {

--- a/interfaces/acados_matlab_octave/acados_template_mex/+acados_template_mex/acados_ocp_layout.json
+++ b/interfaces/acados_matlab_octave/acados_template_mex/+acados_template_mex/acados_ocp_layout.json
@@ -875,9 +875,6 @@
         "print_level": [
             "int"
         ],
-        "initialize_t_slacks": [
-            "int"
-        ],
         "exact_hess_cost": [
             "int"
         ],

--- a/interfaces/acados_matlab_octave/acados_template_mex/+acados_template_mex/ocp_nlp_solver_options_json.m
+++ b/interfaces/acados_matlab_octave/acados_template_mex/+acados_template_mex/ocp_nlp_solver_options_json.m
@@ -60,7 +60,6 @@ classdef ocp_nlp_solver_options_json < handle
         qp_solver_tol_comp
         qp_solver_warm_start
         print_level
-        initialize_t_slacks
         levenberg_marquardt
         regularize_method
         exact_hess_cost
@@ -113,7 +112,6 @@ classdef ocp_nlp_solver_options_json < handle
             obj.reg_epsilon = 1e-4;
             obj.print_level = 0;
             obj.time_steps = [];
-            obj.initialize_t_slacks = 0;
             obj.levenberg_marquardt = 0.0;
             obj.regularize_method = 'NO_REGULARIZE';
             obj.exact_hess_cost = 1;

--- a/interfaces/acados_matlab_octave/ocp_get.c
+++ b/interfaces/acados_matlab_octave/ocp_get.c
@@ -96,7 +96,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
             sprintf(buffer, "\nocp_get: invalid stage index, got %d\n", stage);
             mexErrMsgTxt(buffer);
         }
-        else if (stage == N && strcmp(field, "x") && strcmp(field, "lam") && strcmp(field, "t") && strcmp(field, "sens_x") && strcmp(field, "sl") && strcmp(field, "su") && strcmp(field, "qp_Q") && strcmp(field, "qp_R") && strcmp(field, "qp_S") && strcmp(field, "qp_q") )
+        else if (stage == N && strcmp(field, "x") && strcmp(field, "lam") && strcmp(field, "sens_x") && strcmp(field, "sl") && strcmp(field, "su") && strcmp(field, "qp_Q") && strcmp(field, "qp_R") && strcmp(field, "qp_S") && strcmp(field, "qp_q") )
         {
             sprintf(buffer, "\nocp_get: invalid stage index, got stage = %d = N, field = %s, only x, lam, t, slacks available at this stage\n", stage, field);
             mexErrMsgTxt(buffer);
@@ -150,26 +150,6 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         }
     }
     else if (!strcmp(field, "sl") || !strcmp(field, "su"))
-    {
-        if (nrhs==2)
-        {
-            sprintf(buffer, "\nocp_get: values %s can only be accessed stagewise\n", field);
-            mexErrMsgTxt(buffer);
-        }
-        else if (nrhs==3)
-        {
-            length = ocp_nlp_dims_get_from_attr(config, dims, out, stage, field);
-            plhs[0] = mxCreateNumericMatrix(length, 1, mxDOUBLE_CLASS, mxREAL);
-            double *value = mxGetPr( plhs[0] );
-            ocp_nlp_out_get(config, dims, out, stage, field, value);
-        }
-        else
-        {
-            sprintf(buffer, "\nocp_get: wrong nrhs: %d\n", nrhs);
-            mexErrMsgTxt(buffer);
-        }
-    }
-    else if (!strcmp(field, "t"))
     {
         if (nrhs==2)
         {

--- a/interfaces/acados_template/acados_template/acados_model.py
+++ b/interfaces/acados_template/acados_template/acados_model.py
@@ -66,13 +66,13 @@ class AcadosModel():
         """CasADi variable describing parameters of the DAE; Default: :code:`[]`"""
         self.t = []
         """
-        CasADi variable representing time t in functions; Default: :code:`[]
+        CasADi variable representing time t in functions; Default: :code:`[]`
         NOTE:
         - For integrators, the start time has to be explicitly set via :py:attr:`acados_template.AcadosSimSolver.set`('t0').
         - For OCPs, the start time is set to 0. on each stage.
         The time dependency can be used within cost formulations and is relevant when cost integration is used.
         Start times of shooting intervals can be added using parameters.
-        `"""
+        """
 
         ## dynamics
         self.f_impl_expr = None

--- a/interfaces/acados_template/acados_template/acados_ocp_options.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_options.py
@@ -75,7 +75,6 @@ class AcadosOcpOptions:
         self.__rti_log_residuals = 0
         self.__Tsim = None
         self.__print_level = 0
-        self.__initialize_t_slacks = 0
         self.__cost_discretization = 'EULER'
         self.__regularize_method = 'NO_REGULARIZE'
         self.__reg_epsilon = 1e-4

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -1392,8 +1392,7 @@ class AcadosOcpSolver:
 
         Note:
         - additional supported fields are ['P', 'K', 'Lr'], which can be extracted form QP solver PARTIAL_CONDENSING_HPIPM.
-        - for PARTIAL_CONDENSING_* QP solvers, the following additional fields are available:
-            ['pcond_Q', 'pcond_R', 'pcond_S']
+        - for PARTIAL_CONDENSING_* QP solvers, the following additional fields are available: ['pcond_Q', 'pcond_R', 'pcond_S']
         """
         # idx* should be added too..
         if not isinstance(stage_, int):

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -719,7 +719,7 @@ class AcadosOcpSolver:
             :param stage: integer corresponding to shooting node
             :param field: string in ['x', 'u', 'z', 'pi', 'lam', 'sl', 'su', 'sens_u', 'sens_x']
 
-            .. note:: regarding lam, t: \n
+            .. note:: regarding lam: \n
                     the inequalities are internally organized in the following order: \n
                     [ lbu lbx lg lh lphi ubu ubx ug uh uphi; \n
                       lsbu lsbx lsg lsh lsphi usbu usbx usg ush usphi]
@@ -1163,7 +1163,7 @@ class AcadosOcpSolver:
             :param stage: integer corresponding to shooting node
             :param field: string in ['x', 'u', 'pi', 'lam', 'p', 'xdot_guess', 'z_guess']
 
-            .. note:: regarding lam, t: \n
+            .. note:: regarding lam: \n
                     the inequalities are internally organized in the following order: \n
                     [ lbu lbx lg lh lphi ubu ubx ug uh uphi; \n
                       lsbu lsbx lsg lsh lsphi usbu usbx usg ush usphi]

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -717,7 +717,7 @@ class AcadosOcpSolver:
         Get the last solution of the solver:
 
             :param stage: integer corresponding to shooting node
-            :param field: string in ['x', 'u', 'z', 'pi', 'lam', 't', 'sl', 'su', 'sens_u', 'sens_x']
+            :param field: string in ['x', 'u', 'z', 'pi', 'lam', 'sl', 'su', 'sens_u', 'sens_x']
 
             .. note:: regarding lam, t: \n
                     the inequalities are internally organized in the following order: \n
@@ -731,7 +731,7 @@ class AcadosOcpSolver:
                       su: slack variables of soft upper inequality constraints \n
         """
 
-        out_fields = ['x', 'u', 'z', 'pi', 'lam', 't', 'sl', 'su']
+        out_fields = ['x', 'u', 'z', 'pi', 'lam', 'sl', 'su']
         sens_fields = ['sens_u', 'sens_x']
         all_fields = out_fields + sens_fields
 
@@ -867,7 +867,6 @@ class AcadosOcpSolver:
             solution['u_'+i_string] = self.get(i,'u')
             solution['z_'+i_string] = self.get(i,'z')
             solution['lam_'+i_string] = self.get(i,'lam')
-            solution['t_'+i_string] = self.get(i, 't')
             solution['sl_'+i_string] = self.get(i, 'sl')
             solution['su_'+i_string] = self.get(i, 'su')
             if i < self.N:
@@ -1162,7 +1161,7 @@ class AcadosOcpSolver:
         Set numerical data inside the solver.
 
             :param stage: integer corresponding to shooting node
-            :param field: string in ['x', 'u', 'pi', 'lam', 't', 'p', 'xdot_guess', 'z_guess']
+            :param field: string in ['x', 'u', 'pi', 'lam', 'p', 'xdot_guess', 'z_guess']
 
             .. note:: regarding lam, t: \n
                     the inequalities are internally organized in the following order: \n
@@ -1177,7 +1176,7 @@ class AcadosOcpSolver:
         """
         cost_fields = ['y_ref', 'yref']
         constraints_fields = ['lbx', 'ubx', 'lbu', 'ubu']
-        out_fields = ['x', 'u', 'pi', 'lam', 't', 'z', 'sl', 'su']
+        out_fields = ['x', 'u', 'pi', 'lam', 'z', 'sl', 'su']
         mem_fields = ['xdot_guess', 'z_guess']
 
         if not isinstance(stage_, int):

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -1440,7 +1440,7 @@ class AcadosOcpSolver:
         """
         Set options of the solver.
 
-            :param field: string, e.g. 'print_level', 'rti_phase', 'initialize_t_slacks', 'step_length', 'alpha_min', 'alpha_reduction', 'qp_warm_start', 'line_search_use_sufficient_descent', 'full_step_dual', 'globalization_use_SOC', 'qp_tol_stat', 'qp_tol_eq', 'qp_tol_ineq', 'qp_tol_comp', 'qp_tau_min', 'qp_mu0'
+            :param field: string, e.g. 'print_level', 'rti_phase', 'step_length', 'alpha_min', 'alpha_reduction', 'qp_warm_start', 'line_search_use_sufficient_descent', 'full_step_dual', 'globalization_use_SOC', 'qp_tol_stat', 'qp_tol_eq', 'qp_tol_ineq', 'qp_tol_comp', 'qp_tau_min', 'qp_mu0'
 
             :param value: of type int, float, string
 
@@ -1453,7 +1453,7 @@ class AcadosOcpSolver:
             - warm_start_first_qp: indicates if first QP in SQP is warm_started
             - rti_phase: 0: PREPARATION_AND_FEEDBACK, 1: PREPARATION, 2: FEEDBACK
         """
-        int_fields = ['print_level', 'rti_phase', 'initialize_t_slacks', 'qp_warm_start',
+        int_fields = ['print_level', 'rti_phase', 'qp_warm_start',
                       'line_search_use_sufficient_descent', 'full_step_dual', 'globalization_use_SOC', 'warm_start_first_qp', "as_rti_level", "max_iter"]
         double_fields = ['step_length', 'tol_eq', 'tol_stat', 'tol_ineq', 'tol_comp', 'alpha_min', 'alpha_reduction',
                          'eps_sufficient_descent', 'qp_tol_stat', 'qp_tol_eq', 'qp_tol_ineq', 'qp_tol_comp', 'qp_tau_min', 'qp_mu0']

--- a/interfaces/acados_template/acados_template/acados_ocp_solver_pyx.pyx
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver_pyx.pyx
@@ -874,7 +874,7 @@ cdef class AcadosOcpSolverCython:
         """
         Set options of the solver.
 
-            :param field: string, e.g. 'print_level', 'rti_phase', 'initialize_t_slacks', 'step_length', 'alpha_min', 'alpha_reduction', 'qp_warm_start', 'line_search_use_sufficient_descent', 'full_step_dual', 'globalization_use_SOC', 'qp_tol_stat', 'qp_tol_eq', 'qp_tol_ineq', 'qp_tol_comp', 'qp_tau_min', 'qp_mu0'
+            :param field: string, e.g. 'print_level', 'rti_phase', 'step_length', 'alpha_min', 'alpha_reduction', 'qp_warm_start', 'line_search_use_sufficient_descent', 'full_step_dual', 'globalization_use_SOC', 'qp_tol_stat', 'qp_tol_eq', 'qp_tol_ineq', 'qp_tol_comp', 'qp_tau_min', 'qp_mu0'
 
             :param value: of type int, float, string
 
@@ -886,7 +886,7 @@ cdef class AcadosOcpSolverCython:
             - qp_mu0: for HPIPM QP solvers: initial value for complementarity slackness
             - warm_start_first_qp: indicates if first QP in SQP is warm_started
         """
-        int_fields = ['print_level', 'rti_phase', 'initialize_t_slacks', 'qp_warm_start', 'line_search_use_sufficient_descent', 'full_step_dual', 'globalization_use_SOC', 'warm_start_first_qp']
+        int_fields = ['print_level', 'rti_phase', 'qp_warm_start', 'line_search_use_sufficient_descent', 'full_step_dual', 'globalization_use_SOC', 'warm_start_first_qp']
         double_fields = ['step_length', 'tol_eq', 'tol_stat', 'tol_ineq', 'tol_comp', 'alpha_min', 'alpha_reduction', 'eps_sufficient_descent',
         'qp_tol_stat', 'qp_tol_eq', 'qp_tol_ineq', 'qp_tol_comp', 'qp_tau_min', 'qp_mu0']
         string_fields = ['globalization']

--- a/interfaces/acados_template/acados_template/acados_ocp_solver_pyx.pyx
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver_pyx.pyx
@@ -434,7 +434,7 @@ cdef class AcadosOcpSolverCython:
         Get the last solution of the solver:
 
             :param stage: integer corresponding to shooting node
-            :param field: string in ['x', 'u', 'z', 'pi', 'lam', 't', 'sl', 'su',]
+            :param field: string in ['x', 'u', 'z', 'pi', 'lam', 'sl', 'su',]
 
             .. note:: regarding lam, t: \n
                     the inequalities are internally organized in the following order: \n
@@ -448,7 +448,7 @@ cdef class AcadosOcpSolverCython:
                       su: slack variables of soft upper inequality constraints \n
         """
 
-        out_fields = ['x', 'u', 'z', 'pi', 'lam', 't', 'sl', 'su']
+        out_fields = ['x', 'u', 'z', 'pi', 'lam', 'sl', 'su']
         sens_fields = ['sens_u', 'sens_x']
         all_fields = out_fields + sens_fields
 
@@ -527,7 +527,6 @@ cdef class AcadosOcpSolverCython:
             solution['u_'+i_string] = self.get(i,'u')
             solution['z_'+i_string] = self.get(i,'z')
             solution['lam_'+i_string] = self.get(i,'lam')
-            solution['t_'+i_string] = self.get(i, 't')
             solution['sl_'+i_string] = self.get(i, 'sl')
             solution['su_'+i_string] = self.get(i, 'su')
             if i < self.N:
@@ -710,12 +709,11 @@ cdef class AcadosOcpSolverCython:
 
     # Note: this function should not be used anymore, better use cost_set, constraints_set
     def set(self, int stage, str field_, value_):
-
         """
         Set numerical data inside the solver.
 
             :param stage: integer corresponding to shooting node
-            :param field: string in ['x', 'u', 'pi', 'lam', 't', 'p']
+            :param field: string in ['x', 'u', 'pi', 'lam', 'p']
 
             .. note:: regarding lam, t: \n
                     the inequalities are internally organized in the following order: \n
@@ -732,7 +730,7 @@ cdef class AcadosOcpSolverCython:
             raise Exception(f"set: value must be numpy array, got {type(value_)}.")
         cost_fields = ['y_ref', 'yref']
         constraints_fields = ['lbx', 'ubx', 'lbu', 'ubu']
-        out_fields = ['x', 'u', 'pi', 'lam', 't', 'z', 'sl', 'su']
+        out_fields = ['x', 'u', 'pi', 'lam', 'z', 'sl', 'su']
         mem_fields = ['xdot_guess', 'z_guess']
 
         field = field_.encode('utf-8')

--- a/interfaces/acados_template/acados_template/acados_ocp_solver_pyx.pyx
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver_pyx.pyx
@@ -436,7 +436,7 @@ cdef class AcadosOcpSolverCython:
             :param stage: integer corresponding to shooting node
             :param field: string in ['x', 'u', 'z', 'pi', 'lam', 'sl', 'su',]
 
-            .. note:: regarding lam, t: \n
+            .. note:: regarding lam: \n
                     the inequalities are internally organized in the following order: \n
                     [ lbu lbx lg lh lphi ubu ubx ug uh uphi; \n
                       lsbu lsbx lsg lsh lsphi usbu usbx usg ush usphi]
@@ -715,7 +715,7 @@ cdef class AcadosOcpSolverCython:
             :param stage: integer corresponding to shooting node
             :param field: string in ['x', 'u', 'pi', 'lam', 'p']
 
-            .. note:: regarding lam, t: \n
+            .. note:: regarding lam: \n
                     the inequalities are internally organized in the following order: \n
                     [ lbu lbx lg lh lphi ubu ubx ug uh uphi; \n
                       lsbu lsbx lsg lsh lsphi usbu usbx usg ush usphi]

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.c
@@ -2175,8 +2175,6 @@ void {{ name }}_acados_create_6_set_opts({{ name }}_solver_capsule* capsule)
     int nlp_solver_max_iter = {{ solver_options.nlp_solver_max_iter }};
     ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "max_iter", &nlp_solver_max_iter);
 
-    int initialize_t_slacks = {{ solver_options.initialize_t_slacks }};
-    ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "initialize_t_slacks", &initialize_t_slacks);
 {%- elif solver_options.nlp_solver_type == "SQP_RTI" %}
     int as_rti_iter = {{ solver_options.as_rti_iter }};
     ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "as_rti_iter", &as_rti_iter);

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.c
@@ -2493,7 +2493,6 @@ int {{ name }}_acados_reset({{ name }}_solver_capsule* capsule, int reset_qp_sol
         ocp_nlp_out_set(nlp_config, nlp_dims, nlp_out, i, "sl", buffer);
         ocp_nlp_out_set(nlp_config, nlp_dims, nlp_out, i, "su", buffer);
         ocp_nlp_out_set(nlp_config, nlp_dims, nlp_out, i, "lam", buffer);
-        ocp_nlp_out_set(nlp_config, nlp_dims, nlp_out, i, "t", buffer);
         ocp_nlp_out_set(nlp_config, nlp_dims, nlp_out, i, "z", buffer);
         if (i<N)
         {

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -2277,9 +2277,6 @@ void {{ model.name }}_acados_create_6_set_opts({{ model.name }}_solver_capsule* 
     int nlp_solver_max_iter = {{ solver_options.nlp_solver_max_iter }};
     ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "max_iter", &nlp_solver_max_iter);
 
-    int initialize_t_slacks = {{ solver_options.initialize_t_slacks }};
-    ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "initialize_t_slacks", &initialize_t_slacks);
-
 {%- elif solver_options.nlp_solver_type == "SQP_RTI" %}
     int as_rti_iter = {{ solver_options.as_rti_iter }};
     ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "as_rti_iter", &as_rti_iter);

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -2528,7 +2528,6 @@ int {{ model.name }}_acados_reset({{ model.name }}_solver_capsule* capsule, int 
         ocp_nlp_out_set(nlp_config, nlp_dims, nlp_out, i, "sl", buffer);
         ocp_nlp_out_set(nlp_config, nlp_dims, nlp_out, i, "su", buffer);
         ocp_nlp_out_set(nlp_config, nlp_dims, nlp_out, i, "lam", buffer);
-        ocp_nlp_out_set(nlp_config, nlp_dims, nlp_out, i, "t", buffer);
         ocp_nlp_out_set(nlp_config, nlp_dims, nlp_out, i, "z", buffer);
         if (i<N)
         {

--- a/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_mex_set.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_mex_set.in.c
@@ -523,19 +523,6 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
             ocp_nlp_out_set(config, dims, out, s0, "lam", value);
         }
     }
-    else if (!strcmp(field, "init_t")||!strcmp(field, "t"))
-    {
-        if (nrhs==min_nrhs)
-        {
-            MEX_SETTER_NO_ALL_STAGES_SUPPORT(fun_name, field)
-        }
-        else //(nrhs==min_nrhs+1)
-        {
-            acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, s0, "t");
-            MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
-            ocp_nlp_out_set(config, dims, out, s0, "t", value);
-        }
-    }
     else if (!strcmp(field, "init_sl")||!strcmp(field, "sl"))
     {
         if (nrhs==min_nrhs)

--- a/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/mex_solver.in.m
+++ b/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/mex_solver.in.m
@@ -165,7 +165,6 @@ classdef {{ model.name }}_mex_solver < handle
             for i=0:obj.N
                 solution.(['x_' num2str(i)]) = obj.get('x', i);
                 solution.(['lam_' num2str(i)]) = obj.get('lam', i);
-                solution.(['t_' num2str(i)]) = obj.get('t', i);
                 solution.(['sl_' num2str(i)]) = obj.get('sl', i);
                 solution.(['su_' num2str(i)]) = obj.get('su', i);
             end


### PR DESCRIPTION
The slacks `t` that were used to slack the inequality constraint values are actually not needed in an NLP solver and are thus removed in this PR.
Instead of using `t`, we now directly evaluate inequality residual using the function evaluations.
This results in consistent inequality residuals and will help future work on globalization.
Related interface functionality such as getters and setters for `t` and `initialize_t_slacks` have been removed.