### PR TITLE
Fix small typo in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,13 +137,13 @@ endif
 ifeq ($(ACADOS_WITH_QORE), 1)
 STATIC_DEPS += qore_static
 CLEAN_DEPS += qore_clean
-LINK_FLAG_QPDUNES = -lqore
+LINK_FLAG_QORE = -lqore
 endif
 ifeq ($(ACADOS_WITH_OSQP), 1)
 STATIC_DEPS += osqp_static
 SHARED_DEPS += osqp_shared
 CLEAN_DEPS += osqp_clean
-LINK_FLAG_QPDUNES = -losqp
+LINK_FLAG_OSQP = -losqp
 endif
 
 ifeq ($(ACADOS_WITH_OPENMP), 1)


### PR DESCRIPTION
Hi, I noticed two small typos in the Makefile.
Also, I was wondering if something similar to [this section](https://github.com/acados/acados/blob/master/Makefile#L71-L73) should be added for [DAQP](https://github.com/acados/acados/blob/master/acados/dense_qp/dense_qp_daqp.c)?

EDIT: I see now that DAQP is not included in the Makefile, not sure if it's relevant in that case.