### PR TITLE
Python interface: default for `sim_method_num_stages`

### DIFF
--- a/interfaces/acados_template/acados_template/acados_sim.py
+++ b/interfaces/acados_template/acados_template/acados_sim.py
@@ -44,7 +44,7 @@ class AcadosSimOpts:
         self.__collocation_type = 'GAUSS_LEGENDRE'
         self.__Tsim = None
         # ints
-        self.__sim_method_num_stages = 1
+        self.__sim_method_num_stages = 4
         self.__sim_method_num_steps = 1
         self.__sim_method_newton_iter = 3
         # doubles


### PR DESCRIPTION
BREAKING: change default for `sim_method_num_stages` to 4 in `AcadosSim` to be consistent with the default in `AcadosOcp`