### PR TITLE
Fix external casadi functions with sparse parameter definitions, remove unused memory, add tests

### DIFF
--- a/acados/utils/external_function_generic.c
+++ b/acados/utils/external_function_generic.c
@@ -1121,7 +1121,6 @@ acados_size_t external_function_param_casadi_calculate_size(external_function_pa
     size += fun->args_size_tot * sizeof(double);  // args
     size += fun->res_size_tot * sizeof(double);   // res
     size += fun->w_size * sizeof(double);         // w
-    size += fun->np * sizeof(double);             // p
 
     size += 8;  // initial align
     size += 8;  // align to double

--- a/acados/utils/external_function_generic.c
+++ b/acados/utils/external_function_generic.c
@@ -1044,10 +1044,9 @@ static void external_function_param_casadi_set_param(void *self, double *p)
     external_function_param_casadi *fun = self;
 
     // set value for all parameters
-    for (int ii = 0; ii < fun->np; ii++)
-    {
-        fun->args[fun->in_num-1][ii] = p[ii];
-    }
+    int idx_arg_p = fun->args_num-1;
+    d_cvt_colmaj_to_casadi(p, (double *) fun->args[idx_arg_p],
+                                       (int *) fun->casadi_sparsity_in(idx_arg_p), fun->args_dense[idx_arg_p]);
     return;
 }
 
@@ -1055,11 +1054,21 @@ static void external_function_param_casadi_set_param(void *self, double *p)
 static void external_function_param_casadi_set_param_sparse(void *self, int n_update,
                                                             int *idx, double *p)
 {
+    // TODO: fix!!!
     external_function_param_casadi *fun = self;
 
-    for (int ii = 0; ii < n_update; ii++)
+    int idx_arg_p = fun->args_num-1;
+
+    if (fun->args_dense[idx_arg_p])
     {
-        fun->args[fun->in_num-1][idx[ii]] = p[ii];
+        for (int ii = 0; ii < n_update; ii++)
+        {
+            fun->args[idx_arg_p][idx[ii]] = p[ii];
+        }
+    }
+    else
+    {
+        printf("sparse update not implemented yet\n");
     }
 
     return;

--- a/acados/utils/external_function_generic.c
+++ b/acados/utils/external_function_generic.c
@@ -1054,8 +1054,6 @@ static void external_function_param_casadi_set_param(void *self, double *p)
 static void external_function_param_casadi_set_param_sparse(void *self, int n_update,
                                                             int *idx_p_update, double *p)
 {
-    // TODO: fix!!!
-    // TODO: assert p is vector!!!
     external_function_param_casadi *fun = self;
 
     int idx_arg_p = fun->args_num-1;
@@ -1069,40 +1067,8 @@ static void external_function_param_casadi_set_param_sparse(void *self, int n_up
     }
     else
     {
-        int *sparsity = fun->casadi_sparsity_in(idx_arg_p);
-        int nrow = sparsity[0];
-        int ncol = sparsity[1];
-        int *idxcol = sparsity + 2;
-        int *row = sparsity + ncol + 3;
-
-        int i_idx = 0;
-        int ip;
-        int ip_prev = -1;
-        int nnz_p = casadi_nnz(sparsity);
-        int jj = 0;
-        double *out = fun->args[idx_arg_p]
-        for (int ii = 0; ii < n_update; ii++)
-        {
-            ip = idx_p_update[ii];
-            if (ip < ip_prev)
-            {
-                printf("external_function_param_casadi_set_param_sparse: idx_p_update must be in ascending order\n");
-                exit(1);
-            }
-            while (jj < nnz_p)
-            {
-                if (row[jj] == ip)
-                {
-                    out[jj] = p[ii];
-                    jj++;
-                    break;
-                }
-                else
-                {
-                    jj++;
-                }
-            }
-        }
+        printf("\nexternal_function_param_casadi_set_param_sparse: sparse parameter update for sparse parameter vector not supported!\n");
+        exit(1);
     }
 
     return;

--- a/acados/utils/external_function_generic.c
+++ b/acados/utils/external_function_generic.c
@@ -1052,9 +1052,10 @@ static void external_function_param_casadi_set_param(void *self, double *p)
 
 
 static void external_function_param_casadi_set_param_sparse(void *self, int n_update,
-                                                            int *idx, double *p)
+                                                            int *idx_p_update, double *p)
 {
     // TODO: fix!!!
+    // TODO: assert p is vector!!!
     external_function_param_casadi *fun = self;
 
     int idx_arg_p = fun->args_num-1;
@@ -1063,12 +1064,45 @@ static void external_function_param_casadi_set_param_sparse(void *self, int n_up
     {
         for (int ii = 0; ii < n_update; ii++)
         {
-            fun->args[idx_arg_p][idx[ii]] = p[ii];
+            fun->args[idx_arg_p][idx_p_update[ii]] = p[ii];
         }
     }
     else
     {
-        printf("sparse update not implemented yet\n");
+        int *sparsity = fun->casadi_sparsity_in(idx_arg_p);
+        int nrow = sparsity[0];
+        int ncol = sparsity[1];
+        int *idxcol = sparsity + 2;
+        int *row = sparsity + ncol + 3;
+
+        int i_idx = 0;
+        int ip;
+        int ip_prev = -1;
+        int nnz_p = casadi_nnz(sparsity);
+        int jj = 0;
+        double *out = fun->args[idx_arg_p]
+        for (int ii = 0; ii < n_update; ii++)
+        {
+            ip = idx_p_update[ii];
+            if (ip < ip_prev)
+            {
+                printf("external_function_param_casadi_set_param_sparse: idx_p_update must be in ascending order\n");
+                exit(1);
+            }
+            while (jj < nnz_p)
+            {
+                if (row[jj] == ip)
+                {
+                    out[jj] = p[ii];
+                    jj++;
+                    break;
+                }
+                else
+                {
+                    jj++;
+                }
+            }
+        }
     }
 
     return;

--- a/acados/utils/external_function_generic.c
+++ b/acados/utils/external_function_generic.c
@@ -1046,10 +1046,11 @@ static void external_function_param_casadi_set_param(void *self, double *p)
     external_function_param_casadi *fun = self;
 
     // set value for all parameters
-    int idx_arg_p = fun->args_num-1;
-    int* sparsity = (int *) fun->casadi_sparsity_in(idx_arg_p);
-    d_cvt_colmaj_to_casadi(p, (double *) fun->args[idx_arg_p],
-                            sparsity, fun->args_dense[idx_arg_p]);
+    int idx_in_p = fun->in_num-1;
+    int* sparsity = (int *) fun->casadi_sparsity_in(idx_in_p);
+    d_cvt_colmaj_to_casadi(p, (double *) fun->args[idx_in_p],
+                            sparsity, fun->args_dense[idx_in_p]);
+
     return;
 }
 
@@ -1059,13 +1060,13 @@ static void external_function_param_casadi_set_param_sparse(void *self, int n_up
 {
     external_function_param_casadi *fun = self;
 
-    int idx_arg_p = fun->args_num-1;
+    int idx_in_p = fun->in_num-1;
 
-    if (fun->args_dense[idx_arg_p])
+    if (fun->args_dense[idx_in_p])
     {
         for (int ii = 0; ii < n_update; ii++)
         {
-            fun->args[idx_arg_p][idx_p_update[ii]] = p[ii];
+            fun->args[idx_in_p][idx_p_update[ii]] = p[ii];
         }
     }
     else

--- a/acados/utils/external_function_generic.c
+++ b/acados/utils/external_function_generic.c
@@ -735,6 +735,45 @@ static int d_cvt_casadi_to_ext_fun_arg(ext_fun_arg_t type, double *in, int *spar
     return 0;
 }
 
+static int d_cvt_ext_fun_arg_to_casadi(ext_fun_arg_t type, void *in, double *out, int *sparsity, int is_dense)
+{
+    switch (type)
+    {
+        case COLMAJ:
+            d_cvt_colmaj_to_casadi(in, out, sparsity, is_dense);
+            break;
+
+        case BLASFEO_DMAT:
+            d_cvt_dmat_to_casadi(in, out, sparsity, is_dense);
+            break;
+
+        case BLASFEO_DVEC:
+            d_cvt_dvec_to_casadi(in, out, sparsity, is_dense);
+            break;
+
+        case COLMAJ_ARGS:
+            d_cvt_colmaj_args_to_casadi(in, out, sparsity, is_dense);
+            break;
+
+        case BLASFEO_DMAT_ARGS:
+            d_cvt_dmat_args_to_casadi(in, out, sparsity, is_dense);
+            break;
+
+        case BLASFEO_DVEC_ARGS:
+            d_cvt_dvec_args_to_casadi(in, out, sparsity, is_dense);
+            break;
+
+        case IGNORE_ARGUMENT:
+            // do nothing
+            break;
+
+        default:
+            return 1;
+    }
+    return 0;
+}
+
+
 
 
 /************************************************
@@ -913,52 +952,12 @@ void external_function_casadi_wrapper(void *self, ext_fun_arg_t *type_in, void *
     // in as args
     for (ii = 0; ii < fun->in_num; ii++)
     {
-        switch (type_in[ii])
+        status = d_cvt_ext_fun_arg_to_casadi(type_in[ii], in[ii], (double *) fun->args[ii],
+                                    (int *) fun->casadi_sparsity_in(ii), fun->args_dense[ii]);
+        if (status)
         {
-            case COLMAJ:
-                d_cvt_colmaj_to_casadi(in[ii], (double *) fun->args[ii],
-                                       (int *) fun->casadi_sparsity_in(ii),
-                                       fun->args_dense[ii]);
-                break;
-
-            case BLASFEO_DMAT:
-                d_cvt_dmat_to_casadi(in[ii], (double *) fun->args[ii],
-                                     (int *) fun->casadi_sparsity_in(ii),
-                                     fun->args_dense[ii]);
-                break;
-
-            case BLASFEO_DVEC:
-                d_cvt_dvec_to_casadi(in[ii], (double *) fun->args[ii],
-                                     (int *) fun->casadi_sparsity_in(ii),
-                                     fun->args_dense[ii]);
-                break;
-
-            case COLMAJ_ARGS:
-                d_cvt_colmaj_args_to_casadi(in[ii], (double *) fun->args[ii],
-                                            (int *) fun->casadi_sparsity_in(ii),
-                                            fun->args_dense[ii]);
-                break;
-
-            case BLASFEO_DMAT_ARGS:
-                d_cvt_dmat_args_to_casadi(in[ii], (double *) fun->args[ii],
-                                          (int *) fun->casadi_sparsity_in(ii),
-                                          fun->args_dense[ii]);
-                break;
-
-            case BLASFEO_DVEC_ARGS:
-                d_cvt_dvec_args_to_casadi(in[ii], (double *) fun->args[ii],
-                                          (int *) fun->casadi_sparsity_in(ii),
-                                          fun->args_dense[ii]);
-                break;
-
-            case IGNORE_ARGUMENT:
-                // do nothing
-                break;
-
-            default:
-                printf("\ntype in %d\n", type_in[ii]);
-                printf("\nUnknown external function argument type for argument %i\n\n", ii);
-                exit(1);
+            printf("\nexternal_function_casadi_wrapper: Unknown external function argument type %d for output %d\n\n", type_out[ii], ii);
+            exit(1);
         }
     }
 
@@ -1200,44 +1199,12 @@ void external_function_param_casadi_wrapper(void *self, ext_fun_arg_t *type_in, 
     // skip last argument (that is the parameters vector)
     for (ii = 0; ii < fun->in_num - 1; ii++)
     {
-        switch (type_in[ii])
+        status = d_cvt_ext_fun_arg_to_casadi(type_in[ii], in[ii], (double *) fun->args[ii],
+                                    (int *) fun->casadi_sparsity_in(ii), fun->args_dense[ii]);
+        if (status)
         {
-            case COLMAJ:
-                d_cvt_colmaj_to_casadi(in[ii], (double *) fun->args[ii],
-                                       (int *) fun->casadi_sparsity_in(ii), fun->args_dense[ii]);
-                break;
-
-            case BLASFEO_DMAT:
-                d_cvt_dmat_to_casadi(in[ii], (double *) fun->args[ii],
-                                     (int *) fun->casadi_sparsity_in(ii), fun->args_dense[ii]);
-                break;
-
-            case BLASFEO_DVEC:
-                d_cvt_dvec_to_casadi(in[ii], (double *) fun->args[ii],
-                                     (int *) fun->casadi_sparsity_in(ii), fun->args_dense[ii]);
-                break;
-            case COLMAJ_ARGS:
-                d_cvt_colmaj_args_to_casadi(in[ii], (double *) fun->args[ii],
-                                            (int *) fun->casadi_sparsity_in(ii), fun->args_dense[ii]);
-                break;
-
-            case BLASFEO_DMAT_ARGS:
-                d_cvt_dmat_args_to_casadi(in[ii], (double *) fun->args[ii],
-                                          (int *) fun->casadi_sparsity_in(ii), fun->args_dense[ii]);
-                break;
-
-            case BLASFEO_DVEC_ARGS:
-                d_cvt_dvec_args_to_casadi(in[ii], (double *) fun->args[ii],
-                                          (int *) fun->casadi_sparsity_in(ii), fun->args_dense[ii]);
-                break;
-
-            case IGNORE_ARGUMENT:
-                // do nothing
-                break;
-
-            default:
-                printf("\nexternal_function_param_casadi_wrapper: Unknown external function argument type %d for input %d\n\n", type_in[ii], ii);
-                exit(1);
+            printf("\nexternal_function_casadi_wrapper: Unknown external function argument type %d for output %d\n\n", type_out[ii], ii);
+            exit(1);
         }
     }
     // parameters are last argument and set via external_function_param_casadi_set_param

--- a/acados/utils/external_function_generic.c
+++ b/acados/utils/external_function_generic.c
@@ -284,8 +284,6 @@ static void d_cvt_colmaj_to_casadi(double *in, double *out, int *sparsity_out, i
 {
     int ii, jj, idx;
 
-    if (sparsity_out == NULL)
-        return;
     int nrow = sparsity_out[0];
     int ncol = sparsity_out[1];
 

--- a/acados/utils/external_function_generic.c
+++ b/acados/utils/external_function_generic.c
@@ -284,6 +284,8 @@ static void d_cvt_colmaj_to_casadi(double *in, double *out, int *sparsity_out, i
 {
     int ii, jj, idx;
 
+    if (sparsity_out == NULL)
+        return;
     int nrow = sparsity_out[0];
     int ncol = sparsity_out[1];
 
@@ -1045,8 +1047,9 @@ static void external_function_param_casadi_set_param(void *self, double *p)
 
     // set value for all parameters
     int idx_arg_p = fun->args_num-1;
+    int* sparsity = (int *) fun->casadi_sparsity_in(idx_arg_p);
     d_cvt_colmaj_to_casadi(p, (double *) fun->args[idx_arg_p],
-                                       (int *) fun->casadi_sparsity_in(idx_arg_p), fun->args_dense[idx_arg_p]);
+                            sparsity, fun->args_dense[idx_arg_p]);
     return;
 }
 

--- a/acados/utils/external_function_generic.c
+++ b/acados/utils/external_function_generic.c
@@ -762,7 +762,6 @@ acados_size_t external_function_casadi_calculate_size(external_function_casadi *
     // casadi wrapper as evaluate
     fun->evaluate = &external_function_casadi_wrapper;
 
-    // loop index
     int ii;
 
     fun->casadi_work(&fun->args_num, &fun->res_num, &fun->iw_size, &fun->w_size);
@@ -808,7 +807,6 @@ acados_size_t external_function_casadi_calculate_size(external_function_casadi *
 
 void external_function_casadi_assign(external_function_casadi *fun, void *raw_memory)
 {
-    // loop index
     int ii;
 
     // save initial pointer to external memory
@@ -871,7 +869,6 @@ void external_function_casadi_wrapper(void *self, ext_fun_arg_t *type_in, void *
     // cast into external casadi function
     external_function_casadi *fun = self;
 
-    // loop index
     int ii;
 
     // in as args
@@ -1081,7 +1078,6 @@ static void external_function_param_casadi_set_param_sparse(void *self, int n_up
 
 acados_size_t external_function_param_casadi_calculate_size(external_function_param_casadi *fun, int np)
 {
-    // loop index
     int ii;
 
     // casadi wrapper as evaluate function
@@ -1138,7 +1134,6 @@ acados_size_t external_function_param_casadi_calculate_size(external_function_pa
 
 void external_function_param_casadi_assign(external_function_param_casadi *fun, void *raw_memory)
 {
-    // loop index
     int ii;
 
     // save initial pointer to external memory
@@ -1201,8 +1196,6 @@ void external_function_param_casadi_wrapper(void *self, ext_fun_arg_t *type_in, 
 {
     // cast into external casadi function
     external_function_param_casadi *fun = self;
-
-    // loop index
     int ii;
 
     // in as args

--- a/acados/utils/external_function_generic.c
+++ b/acados/utils/external_function_generic.c
@@ -138,7 +138,7 @@ void external_function_param_generic_get_nparam(void *self, int *np)
     // cast into external generic function
     external_function_param_generic *fun = self;
 
-	*np = fun->np;
+    *np = fun->np;
 
     return;
 }
@@ -1301,7 +1301,7 @@ void external_function_param_casadi_get_nparam(void *self, int *np)
     // cast into external casadi function
     external_function_param_casadi *fun = self;
 
-	*np = fun->np;
+    *np = fun->np;
 
     return;
 }

--- a/examples/acados_python/pendulum_on_cart/sim/sparse_param_test.py
+++ b/examples/acados_python/pendulum_on_cart/sim/sparse_param_test.py
@@ -1,0 +1,196 @@
+# -*- coding: future_fstrings -*-
+#
+# Copyright (c) The acados authors.
+#
+# This file is part of acados.
+#
+# The 2-Clause BSD License
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.;
+#
+
+import sys, json
+sys.path.insert(0, '../common')
+
+from acados_template import AcadosSim, AcadosSimSolver, AcadosModel, sim_get_default_cmake_builder
+from pendulum_model import export_pendulum_ode_model
+from utils import plot_pendulum
+
+import casadi as ca
+import numpy as np
+
+
+def export_pendulum_ode_model() -> AcadosModel:
+
+    model_name = 'pendulum'
+
+    # constants
+    m_cart = 1. # mass of the cart [kg]
+    m = 0.1 # mass of the ball [kg]
+    g = 9.81 # gravity constant [m/s^2]
+    l = 0.8 # length of the rod [m]
+
+    # set up states & controls
+    x1      = ca.SX.sym('x1')
+    theta   = ca.SX.sym('theta')
+    v1      = ca.SX.sym('v1')
+    dtheta  = ca.SX.sym('dtheta')
+
+    x = ca.vertcat(x1, theta, v1, dtheta)
+
+    F = ca.SX.sym('F')
+    u = ca.vertcat(F)
+
+    # xdot
+    x1_dot      = ca.SX.sym('x1_dot')
+    theta_dot   = ca.SX.sym('theta_dot')
+    v1_dot      = ca.SX.sym('v1_dot')
+    dtheta_dot  = ca.SX.sym('dtheta_dot')
+
+    xdot = ca.vertcat(x1_dot, theta_dot, v1_dot, dtheta_dot)
+
+    # parameters
+    p = ca.SX.zeros(1000, 1)
+    p[-1] = ca.SX.sym('p')
+    m_cart = p[-1]
+    p = ca.sparsify(p)
+    # dynamics
+    cos_theta = ca.cos(theta)
+    sin_theta = ca.sin(theta)
+    denominator = m_cart + m - m*cos_theta*cos_theta
+    f_expl = ca.vertcat(v1,
+                     dtheta,
+                     (-m*l*sin_theta*dtheta*dtheta + m*g*cos_theta*sin_theta+F)/denominator,
+                     (-m*l*cos_theta*sin_theta*dtheta*dtheta + F*cos_theta+(m_cart+m)*g*sin_theta)/(l*denominator)
+                     )
+
+    f_impl = xdot - f_expl
+
+    model = AcadosModel()
+
+    model.f_impl_expr = f_impl
+    model.f_expl_expr = f_expl
+    model.x = x
+    model.xdot = xdot
+    model.u = u
+    # model.z = z
+    model.p = p
+    model.name = model_name
+
+    return model
+
+
+def sparse_param_test():
+    sim = AcadosSim()
+
+    # model
+    model = export_pendulum_ode_model()
+    sim.model = model
+
+    Tf = 0.1
+    nx = model.x.rows()
+    nu = model.u.rows()
+    N = 200
+
+    # set simulation time
+    sim.solver_options.T = Tf
+    # set options
+    sim.solver_options.num_stages = 7
+    sim.solver_options.num_steps = 3
+    sim.solver_options.newton_iter = 10 # for implicit integrator
+    sim.solver_options.collocation_type = "GAUSS_RADAU_IIA"
+    sim.solver_options.integrator_type = "IRK" # ERK, IRK, GNSF
+    sim.solver_options.sens_forw = True
+    sim.solver_options.sens_adj = True
+    sim.solver_options.sens_hess = False
+    sim.solver_options.sens_algebraic = False
+    sim.solver_options.output_z = False
+    sim.solver_options.sim_method_jac_reuse = False
+    sim.parameter_values = np.zeros(model.p.shape).flatten()
+    sim.parameter_values[-1] = 1.0
+
+
+    # create
+    cmake_builder = sim_get_default_cmake_builder()
+    acados_integrator = AcadosSimSolver(sim)
+
+    simX = np.zeros((N+1, nx))
+    x0 = np.array([0.0, np.pi+1, 0.0, 0.0])
+    u0 = np.array([0.0])
+    acados_integrator.set("u", u0)
+
+    simX[0,:] = x0
+
+    ## Single test call
+    import time
+
+    t0 = time.time()
+    acados_integrator.set("seed_adj", np.ones((nx, 1)))
+    acados_integrator.set("x", x0)
+    acados_integrator.set("u", u0)
+    status = acados_integrator.solve()
+    time_external = time.time() - t0
+
+    S_forw = acados_integrator.get("S_forw")
+    Sx = acados_integrator.get("Sx")
+    Su = acados_integrator.get("Su")
+    S_hess = acados_integrator.get("S_hess")
+    S_adj = acados_integrator.get("S_adj")
+    print(f"\ntimings of last call to acados_integrator: with Python interface, set and get {time_external*1e3:.4f}ms")
+
+
+    # get timings (of last call)
+    CPUtime = acados_integrator.get("CPUtime")
+    LAtime = acados_integrator.get("LAtime")
+    ADtime = acados_integrator.get("ADtime")
+    print(f"\ntimings of last call to acados_integrator: overall CPU: {CPUtime*1e3:.4f} ms, linear algebra {LAtime*1e3:.4f} ms, external functions {ADtime*1e3:.4f} ms")
+
+    print("S_forw, sensitivities of simulation result wrt x,u:\n", S_forw)
+    print("Sx, sensitivities of simulation result wrt x:\n", Sx)
+    print("Su, sensitivities of simulation result wrt u:\n", Su)
+    print("S_adj, adjoint sensitivities:\n", S_adj)
+    print("S_hess, second order sensitivities:\n", S_hess)
+
+    # turn off sensitivity propagation when not needed
+    acados_integrator.options_set('sens_forw', False)
+    acados_integrator.options_set('sens_adj', False)
+    acados_integrator.options_set('sens_hess', False)
+
+    # call in loop:
+    for i in range(N):
+        # set initial state
+        acados_integrator.set("x", simX[i,:])
+        # solve
+        status = acados_integrator.solve()
+        # get solution
+        simX[i+1,:] = acados_integrator.get("x")
+
+    if status != 0:
+        raise Exception(f'acados returned status {status}.')
+
+    # plot results
+    plot_pendulum(np.linspace(0, N*Tf, N+1), 10, np.zeros((N, nu)), simX, latexify=False)
+
+
+if __name__ == '__main__':
+    sparse_param_test()

--- a/examples/acados_python/tests/sparse_param_test.py
+++ b/examples/acados_python/tests/sparse_param_test.py
@@ -29,11 +29,10 @@
 # POSSIBILITY OF SUCH DAMAGE.;
 #
 
-import sys, json
-sys.path.insert(0, '../common')
+import sys
+sys.path.insert(0, '../pendulum_on_cart/common')
 
 from acados_template import AcadosSim, AcadosSimSolver, AcadosModel, sim_get_default_cmake_builder
-from pendulum_model import export_pendulum_ode_model
 from utils import plot_pendulum
 
 import casadi as ca
@@ -41,7 +40,6 @@ import numpy as np
 
 
 def export_pendulum_ode_model() -> AcadosModel:
-
     model_name = 'pendulum'
 
     # constants
@@ -70,6 +68,7 @@ def export_pendulum_ode_model() -> AcadosModel:
     xdot = ca.vertcat(x1_dot, theta_dot, v1_dot, dtheta_dot)
 
     # parameters
+    # NOTE: such sparse parameter formulations are not recommended to use in acados!
     p = ca.SX.zeros(1000, 1)
     p[-1] = ca.SX.sym('p')
     m_cart = p[-1]
@@ -187,6 +186,9 @@ def sparse_param_test():
 
     if status != 0:
         raise Exception(f'acados returned status {status}.')
+
+    if not np.allclose(S_adj, np.array([1., 0.32978441, 1.1, 1.0644604, 0.03091267])):
+        raise Exception("adjoint sensitivities should match reference solution.")
 
     # plot results
     plot_pendulum(np.linspace(0, N*Tf, N+1), 10, np.zeros((N, nu)), simX, latexify=False)

--- a/examples/acados_python/tests/test_parametric_nonlinear_constraint_h.py
+++ b/examples/acados_python/tests/test_parametric_nonlinear_constraint_h.py
@@ -70,7 +70,7 @@ def main():
     y_param = p[1:nx+nu+1]
     ocp.model.p = p
 
-    # defeine cost with parametric reference
+    # define cost with parametric reference
     ocp.cost.cost_type = 'EXTERNAL'
     ocp.cost.cost_type_e = 'EXTERNAL'
 

--- a/examples/acados_python/tests/test_parametric_nonlinear_constraint_h.py
+++ b/examples/acados_python/tests/test_parametric_nonlinear_constraint_h.py
@@ -151,7 +151,7 @@ else:
 
 for i in range(N):
     ## Two equivalent ways to set parameters
-    if i < N/2:
+    if i < 3:
         # set all parameters
         ocp_solver.set(i, "p", p_0)
     else:
@@ -173,6 +173,15 @@ for i in range(N):
     simU[i,:] = ocp_solver.get(i, "u")
 simX[N,:] = ocp_solver.get(N, "x")
 
-ocp_solver.print_statistics() # encapsulates: stat = ocp_solver.get_stats("statistics")
+ocp_solver.print_statistics()
+
+
+if np.any(simU > Fmax) or np.any(simU < -Fmax):
+    raise Exception(f"control bounds should be respected by solution, got u: {simU}")
+
+if not np.allclose(np.max(simU), Fmax):
+    raise Exception(f"control should go to bounds, got u: {simU}")
+if not np.allclose(np.min(simU), -Fmax):
+    raise Exception(f"control should go to bounds, got u: {simU}")
 
 plot_pendulum(np.linspace(0, Tf, N+1), Fmax, simU, simX, latexify=False)

--- a/examples/acados_python/tests/test_parametric_nonlinear_constraint_h.py
+++ b/examples/acados_python/tests/test_parametric_nonlinear_constraint_h.py
@@ -120,6 +120,10 @@ ocp.constraints.lh = np.array([-Fmax])
 ocp.constraints.uh = np.array([+Fmax])
 ocp.model.con_h_expr = model.u / constraint_quotient
 
+ocp.constraints.lh_0 = np.array([-Fmax])
+ocp.constraints.uh_0 = np.array([+Fmax])
+ocp.model.con_h_expr_0 = model.u / constraint_quotient
+
 p_0 = np.zeros(n_param)
 p_0[0] = 1.0
 p_0[1] = 1.0

--- a/examples/acados_python/tests/test_parametric_nonlinear_constraint_h.py
+++ b/examples/acados_python/tests/test_parametric_nonlinear_constraint_h.py
@@ -39,67 +39,38 @@ from utils import plot_pendulum
 from casadi import SX, vertcat
 
 
-COST_MODULE = 'EXTERNAL'
 
-# create ocp object to formulate the OCP
-ocp = AcadosOcp()
+def main():
+    ocp = AcadosOcp()
 
-# set model
-model = export_pendulum_ode_model()
-ocp.model = model
-x = model.x
-u = model.u
+    # set model
+    model = export_pendulum_ode_model()
+    ocp.model = model
+    x = model.x
+    u = model.u
 
-Tf = 1.0
-nx = x.rows()
-nu = u.rows()
-ny = nx + nu
-ny_e = nx
-N = 20
+    Tf = 1.0
+    nx = x.rows()
+    nu = u.rows()
+    N = 20
 
-# set dimensions
-ocp.dims.N = N
+    # set dimensions
+    ocp.dims.N = N
 
-# set cost
-Q = 2*np.diag([1e3, 1e3, 1e-2, 1e-2])
-R = 2*np.diag([1e-2])
-cost_W = scipy.linalg.block_diag(Q, R)
+    # set cost
+    Q = 2*np.diag([1e3, 1e3, 1e-2, 1e-2])
+    R = 2*np.diag([1e-2])
+    cost_W = scipy.linalg.block_diag(Q, R)
 
 
-#
-n_param = 42
-p = SX.sym('p', n_param)
-constraint_quotient = p[0]
-y_param = p[1:nx+nu+1]
-ocp.model.p = p
+    #
+    n_param = 42
+    p = SX.sym('p', n_param)
+    constraint_quotient = p[0]
+    y_param = p[1:nx+nu+1]
+    ocp.model.p = p
 
-if COST_MODULE == 'LS':
-    ocp.cost.W_e = Q
-    ocp.cost.W = cost_W
-
-    ocp.cost.cost_type = 'LINEAR_LS'
-    ocp.cost.cost_type_e = 'LINEAR_LS'
-
-    ocp.cost.Vx = np.zeros((ny, nx))
-    ocp.cost.Vx[:nx,:nx] = np.eye(nx)
-
-    Vu = np.zeros((ny, nu))
-    Vu[4,0] = 1.0
-    ocp.cost.Vu = Vu
-
-    ocp.cost.Vx_e = np.eye(nx)
-
-    ocp.cost.yref = np.zeros((ny, ))
-    ocp.cost.yref_e = np.zeros((ny_e, ))
-
-# elif COST_MODULE == 'NLS':
-#     ocp.cost.cost_type = 'NONLINEAR_LS'
-#     ocp.cost.cost_type_e = 'NONLINEAR_LS'
-
-#     ocp.model.cost_y_expr = vertcat(x, u)
-#     ocp.model.cost_y_expr_e = x
-
-elif COST_MODULE == 'EXTERNAL':
+    # defeine cost with parametric reference
     ocp.cost.cost_type = 'EXTERNAL'
     ocp.cost.cost_type_e = 'EXTERNAL'
 
@@ -108,80 +79,84 @@ elif COST_MODULE == 'EXTERNAL':
     res_e = y_param[0:nx] - x
     ocp.model.cost_expr_ext_cost_e = res_e.T @ Q @ res_e
 
-# set constraints
+    # set constraints
 
-Fmax = 80
-# use equivalent formulation with h constraint
-# ocp.constraints.lbu = np.array([-Fmax])
-# ocp.constraints.ubu = np.array([+Fmax])
-# ocp.constraints.idxbu = np.array([0])
+    Fmax = 80
+    # use equivalent formulation with h constraint
+    # ocp.constraints.lbu = np.array([-Fmax])
+    # ocp.constraints.ubu = np.array([+Fmax])
+    # ocp.constraints.idxbu = np.array([0])
 
-ocp.constraints.lh = np.array([-Fmax])
-ocp.constraints.uh = np.array([+Fmax])
-ocp.model.con_h_expr = model.u / constraint_quotient
+    ocp.constraints.lh = np.array([-Fmax])
+    ocp.constraints.uh = np.array([+Fmax])
+    ocp.model.con_h_expr = model.u / constraint_quotient
 
-ocp.constraints.lh_0 = np.array([-Fmax])
-ocp.constraints.uh_0 = np.array([+Fmax])
-ocp.model.con_h_expr_0 = model.u / constraint_quotient
+    ocp.constraints.lh_0 = np.array([-Fmax])
+    ocp.constraints.uh_0 = np.array([+Fmax])
+    ocp.model.con_h_expr_0 = model.u / constraint_quotient
 
-p_0 = np.zeros(n_param)
-p_0[0] = 1.0
-p_0[1] = 1.0
-ocp.parameter_values = p_0
+    p_0 = np.zeros(n_param)
+    p_0[0] = 1.0
+    p_0[1] = 1.0
+    ocp.parameter_values = p_0
 
-ocp.constraints.x0 = np.array([0.0, np.pi, 0.0, 0.0])
+    ocp.constraints.x0 = np.array([0.0, np.pi, 0.0, 0.0])
 
-ocp.solver_options.qp_solver = 'PARTIAL_CONDENSING_HPIPM' # FULL_CONDENSING_QPOASES
-ocp.solver_options.hessian_approx = 'EXACT' # GAUSS_NEWTON, EXACT
-ocp.solver_options.regularize_method = 'CONVEXIFY' # GAUSS_NEWTON, EXACT
-ocp.solver_options.integrator_type = 'ERK'
-ocp.solver_options.print_level = 0
-ocp.solver_options.nlp_solver_type = 'SQP' # SQP_RTI, SQP
+    ocp.solver_options.qp_solver = 'PARTIAL_CONDENSING_HPIPM' # FULL_CONDENSING_QPOASES
+    ocp.solver_options.hessian_approx = 'EXACT' # GAUSS_NEWTON, EXACT
+    ocp.solver_options.regularize_method = 'CONVEXIFY' # GAUSS_NEWTON, EXACT
+    ocp.solver_options.integrator_type = 'ERK'
+    ocp.solver_options.print_level = 0
+    ocp.solver_options.nlp_solver_type = 'SQP' # SQP_RTI, SQP
 
-# set prediction horizon
-ocp.solver_options.tf = Tf
+    # set prediction horizon
+    ocp.solver_options.tf = Tf
 
-# Cython
-if 0:
-    AcadosOcpSolver.generate(ocp, json_file='acados_ocp.json')
-    AcadosOcpSolver.build(ocp.code_export_directory, with_cython=True)
-    ocp_solver = AcadosOcpSolver.create_cython_solver('acados_ocp.json')
-else:
-    ocp_solver = AcadosOcpSolver(ocp, json_file = 'acados_ocp.json')
-
-for i in range(N):
-    ## Two equivalent ways to set parameters
-    if i < 3:
-        # set all parameters
-        ocp_solver.set(i, "p", p_0)
+    # Cython
+    if 0:
+        AcadosOcpSolver.generate(ocp, json_file='acados_ocp.json')
+        AcadosOcpSolver.build(ocp.code_export_directory, with_cython=True)
+        ocp_solver = AcadosOcpSolver.create_cython_solver('acados_ocp.json')
     else:
-        # set subset of parameters
-        ocp_solver.set_params_sparse(i, np.array(range(n_param)), np.zeros(n_param))
-        ocp_solver.set_params_sparse(i, np.ascontiguousarray([0, 1]), np.array([1.0, 1.0]))
+        ocp_solver = AcadosOcpSolver(ocp, json_file = 'acados_ocp.json')
 
-simX = np.zeros((N+1, nx))
-simU = np.zeros((N, nu))
+    for i in range(N):
+        ## Two equivalent ways to set parameters
+        if i < 3:
+            # set all parameters
+            ocp_solver.set(i, "p", p_0)
+        else:
+            # set subset of parameters
+            ocp_solver.set_params_sparse(i, np.array(range(n_param)), np.zeros(n_param))
+            ocp_solver.set_params_sparse(i, np.ascontiguousarray([0, 1]), np.array([1.0, 1.0]))
 
-status = ocp_solver.solve()
+    solX = np.zeros((N+1, nx))
+    solU = np.zeros((N, nu))
 
-if status != 0:
-    raise Exception(f'acados returned status {status}.')
+    status = ocp_solver.solve()
 
-# get solution
-for i in range(N):
-    simX[i,:] = ocp_solver.get(i, "x")
-    simU[i,:] = ocp_solver.get(i, "u")
-simX[N,:] = ocp_solver.get(N, "x")
+    if status != 0:
+        raise Exception(f'acados returned status {status}.')
 
-ocp_solver.print_statistics()
+    # get solution
+    for i in range(N):
+        solX[i,:] = ocp_solver.get(i, "x")
+        solU[i,:] = ocp_solver.get(i, "u")
+    solX[N,:] = ocp_solver.get(N, "x")
+
+    ocp_solver.print_statistics()
 
 
-if np.any(simU > Fmax) or np.any(simU < -Fmax):
-    raise Exception(f"control bounds should be respected by solution, got u: {simU}")
+    if np.any(solU > Fmax) or np.any(solU < -Fmax):
+        raise Exception(f"control bounds should be respected by solution, got u: {solU}")
 
-if not np.allclose(np.max(simU), Fmax):
-    raise Exception(f"control should go to bounds, got u: {simU}")
-if not np.allclose(np.min(simU), -Fmax):
-    raise Exception(f"control should go to bounds, got u: {simU}")
+    if not np.allclose(np.max(solU), Fmax):
+        raise Exception(f"control should go to bounds, got u: {solU}")
+    if not np.allclose(np.min(solU), -Fmax):
+        raise Exception(f"control should go to bounds, got u: {solU}")
 
-plot_pendulum(np.linspace(0, Tf, N+1), Fmax, simU, simX, latexify=False)
+    plot_pendulum(np.linspace(0, Tf, N+1), Fmax, solU, solX, latexify=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/interfaces/CMakeLists.txt
+++ b/interfaces/CMakeLists.txt
@@ -343,6 +343,10 @@ add_test(NAME python_pendulum_ocp_example_cmake
     add_test(NAME python_test_sim_dae
         COMMAND "${CMAKE_COMMAND}" -E chdir ${PROJECT_SOURCE_DIR}/examples/acados_python/tests
         python test_sim_dae.py)
+    add_test(NAME python_sparse_param_test
+        COMMAND "${CMAKE_COMMAND}" -E chdir ${PROJECT_SOURCE_DIR}/examples/acados_python/tests
+        python sparse_param_test.py)
+
 
     add_test(NAME python_pmsm_example
         COMMAND "${CMAKE_COMMAND}" -E chdir ${PROJECT_SOURCE_DIR}/examples/acados_python/pmsm_example
@@ -372,9 +376,10 @@ add_test(NAME python_pendulum_ocp_example_cmake
     set_tests_properties(python_armijo_test PROPERTIES DEPENDS python_pendulum_soft_constraints_example)
     set_tests_properties(python_pendulum_soft_constraints_example PROPERTIES DEPENDS python_pendulum_parametric_nonlinear_constraint_h_test)
     set_tests_properties(python_pendulum_parametric_nonlinear_constraint_h_test PROPERTIES DEPENDS python_test_sim_dae)
+    set_tests_properties(python_test_sim_dae PROPERTIES DEPENDS python_sparse_param_test)
 
     if(ACADOS_WITH_OSQP)
-        set_tests_properties(python_test_sim_dae PROPERTIES DEPENDS python_OSQP_test)
+        set_tests_properties(python_sparse_param_test PROPERTIES DEPENDS python_OSQP_test)
     endif()
 
     # Directory acados_python/chain_mass


### PR DESCRIPTION
- fix: `external_function_param_casadi` class for the case when the parameters are not a dense vector. This is still not recommended
- removed unused memory requirement of `np` in `external_function_param_casadi`.
- added static functions `d_cvt_ext_fun_arg_to_casadi`, `d_cvt_casadi_to_ext_fun_arg` to avoid code duplication

Tests:
- added `examples/acados_python/tests/sparse_param_test.py`
- improved test of parametric OCP formulation