### PR TITLE
Stagewise parameter values for OCP NLP solver

### DIFF
--- a/acados/ocp_nlp/ocp_nlp_common.c
+++ b/acados/ocp_nlp/ocp_nlp_common.c
@@ -719,6 +719,10 @@ static ocp_nlp_in *ocp_nlp_in_assign_self(ocp_nlp_dims *dims, void *raw_memory)
     for (int i = 0; i <= N; i++)
     {
         assign_and_advance_double(dims->np[i], &in->parameter_values[i], &c_ptr);
+        for (int ip = 0; ip < dims->np[i]; ip++)
+        {
+            in->parameter_values[i][ip] = 0.0;
+        }
     }
 
     // dynamics

--- a/acados/ocp_nlp/ocp_nlp_common.c
+++ b/acados/ocp_nlp/ocp_nlp_common.c
@@ -633,11 +633,18 @@ void ocp_nlp_dims_set_dynamics(void *config_, void *dims_, int stage,
  * in
  ************************************************/
 
-acados_size_t ocp_nlp_in_calculate_size_self(int N)
+static acados_size_t ocp_nlp_in_calculate_size_self(ocp_nlp_dims *dims)
 {
+    int N = dims->N;
     acados_size_t size = sizeof(ocp_nlp_in);
 
     size += N * sizeof(double);  // Ts
+    // parameter values
+    for (int i = 0; i <= N; i++)
+    {
+        size += dims->np[i] * sizeof(double);
+    }
+    size += (N + 1) * sizeof(double *);
 
     size += N * sizeof(void *);  // dynamics
 
@@ -645,7 +652,7 @@ acados_size_t ocp_nlp_in_calculate_size_self(int N)
 
     size += (N + 1) * sizeof(void *);  // constraints
 
-    size += 3*8;  // aligns
+    size += 4*8;  // aligns
     return size;
 }
 
@@ -655,7 +662,7 @@ acados_size_t ocp_nlp_in_calculate_size(ocp_nlp_config *config, ocp_nlp_dims *di
 {
     int N = dims->N;
 
-    acados_size_t size = ocp_nlp_in_calculate_size_self(N);
+    acados_size_t size = ocp_nlp_in_calculate_size_self(dims);
 
     // dynamics
     for (int i = 0; i < N; i++)
@@ -676,15 +683,17 @@ acados_size_t ocp_nlp_in_calculate_size(ocp_nlp_config *config, ocp_nlp_dims *di
         size += config->constraints[i]->model_calculate_size(config->constraints[i],
                                                               dims->constraints[i]);
     }
-    //  make_int_multiple_of(64, &size);
+
+    make_int_multiple_of(8, &size);
 
     return size;
 }
 
 
 
-ocp_nlp_in *ocp_nlp_in_assign_self(int N, void *raw_memory)
+static ocp_nlp_in *ocp_nlp_in_assign_self(ocp_nlp_dims *dims, void *raw_memory)
 {
+    int N = dims->N;
     char *c_ptr = (char *) raw_memory;
 
     // initial align
@@ -697,8 +706,20 @@ ocp_nlp_in *ocp_nlp_in_assign_self(int N, void *raw_memory)
     // align
     align_char_to(8, &c_ptr);
 
+    // double pointers
+    assign_and_advance_double_ptrs(N+1, &in->parameter_values, &c_ptr);
+
+    align_char_to(8, &c_ptr);
+
+    // doubles
     // Ts
     assign_and_advance_double(N, &in->Ts, &c_ptr);
+
+    // parameter values
+    for (int i = 0; i <= N; i++)
+    {
+        assign_and_advance_double(dims->np[i], &in->parameter_values[i], &c_ptr);
+    }
 
     // dynamics
     in->dynamics = (void **) c_ptr;
@@ -714,7 +735,7 @@ ocp_nlp_in *ocp_nlp_in_assign_self(int N, void *raw_memory)
 
     align_char_to(8, &c_ptr);
 
-    assert((char *) raw_memory + ocp_nlp_in_calculate_size_self(N) >= c_ptr);
+    assert((char *) raw_memory + ocp_nlp_in_calculate_size_self(dims) >= c_ptr);
 
     return in;
 }
@@ -728,8 +749,8 @@ ocp_nlp_in *ocp_nlp_in_assign(ocp_nlp_config *config, ocp_nlp_dims *dims, void *
     char *c_ptr = (char *) raw_memory;
 
     // struct
-    ocp_nlp_in *in = ocp_nlp_in_assign_self(N, c_ptr);
-    c_ptr += ocp_nlp_in_calculate_size_self(N);
+    ocp_nlp_in *in = ocp_nlp_in_assign_self(dims, c_ptr);
+    c_ptr += ocp_nlp_in_calculate_size_self(dims);
 
     // dynamics
     for (int i = 0; i < N; i++)

--- a/acados/ocp_nlp/ocp_nlp_common.h
+++ b/acados/ocp_nlp/ocp_nlp_common.h
@@ -199,6 +199,9 @@ typedef struct ocp_nlp_in
     /// Timesteps.
     double *Ts;
 
+    /// Parameter values.
+    double **parameter_values;
+
     /// Pointers to cost functions (TBC).
     void **cost;
 
@@ -214,11 +217,7 @@ typedef struct ocp_nlp_in
 } ocp_nlp_in;
 
 //
-acados_size_t ocp_nlp_in_calculate_size_self(int N);
-//
 acados_size_t ocp_nlp_in_calculate_size(ocp_nlp_config *config, ocp_nlp_dims *dims);
-//
-ocp_nlp_in *ocp_nlp_in_assign_self(int N, void *raw_memory);
 //
 ocp_nlp_in *ocp_nlp_in_assign(ocp_nlp_config *config, ocp_nlp_dims *dims, void *raw_memory);
 

--- a/acados/utils/external_function_generic.c
+++ b/acados/utils/external_function_generic.c
@@ -35,11 +35,6 @@
 #include "acados/utils/external_function_generic.h"
 #include "acados/utils/mem.h"
 
-/************************************************
- * generic external function
- ************************************************/
-
-
 
 /************************************************
  * generic external parametric function
@@ -125,7 +120,6 @@ void external_function_param_generic_wrapper(void *self, ext_fun_arg_t *type_in,
     // cast into external generic function
     external_function_param_generic *fun = self;
 
-    // call casadi function
     fun->fun(in, out, fun->p);
 
     return;
@@ -1241,6 +1235,81 @@ void external_function_param_casadi_get_nparam(void *self, int *np)
 
 
 /************************************************
+ * generic external parametric function
+ ************************************************/
+
+acados_size_t external_function_external_param_generic_struct_size()
+{
+    return sizeof(external_function_external_param_generic);
+}
+
+
+
+void external_function_external_param_generic_set_fun(external_function_external_param_generic *fun, void *value)
+{
+    fun->fun = value;
+    return;
+}
+
+
+static void external_function_external_param_generic_set_param_pointer(void *self, double *p)
+{
+    external_function_external_param_generic *fun = self;
+
+    fun->p = p;
+    fun->param_mem_is_set = true;
+
+    return;
+}
+
+
+acados_size_t external_function_external_param_generic_calculate_size(external_function_external_param_generic *fun, int np)
+{
+    // wrapper as evaluate function
+    fun->evaluate = &external_function_external_param_generic_wrapper;
+
+    // set param function
+    fun->set_param_pointer = &external_function_external_param_generic_set_param_pointer;
+
+    // set number of parameters
+    fun->param_mem_is_set = false;
+
+    acados_size_t size = 0;
+
+    make_int_multiple_of(8, &size);
+
+    return size;
+}
+
+
+
+void external_function_external_param_generic_assign(external_function_external_param_generic *fun, void *raw_memory)
+{
+    // save initial pointer to external memory
+    fun->ptr_ext_mem = raw_memory;
+
+    // char pointer for byte advances
+    // char *c_ptr = raw_memory;
+    // assert((char *) raw_memory + external_function_external_param_generic_calculate_size(fun, fun->np) >= c_ptr);
+
+    return;
+}
+
+
+
+void external_function_external_param_generic_wrapper(void *self, ext_fun_arg_t *type_in, void **in, ext_fun_arg_t *type_out, void **out)
+{
+    // cast into external generic function
+    external_function_external_param_generic *fun = self;
+
+    fun->fun(in, out, fun->p);
+
+    return;
+}
+
+
+
+/************************************************
  * external_function_external_param_casadi
  ************************************************/
 
@@ -1296,7 +1365,6 @@ static void external_function_external_param_casadi_set_param_pointer(void *self
 {
     external_function_external_param_casadi *fun = self;
 
-    // set value for all parameters
     int idx_in_p = fun->in_num-1;
     if (!fun->args_dense[idx_in_p])
     {

--- a/acados/utils/external_function_generic.c
+++ b/acados/utils/external_function_generic.c
@@ -1263,7 +1263,7 @@ static void external_function_external_param_generic_set_param_pointer(void *sel
 }
 
 
-acados_size_t external_function_external_param_generic_calculate_size(external_function_external_param_generic *fun, int np)
+acados_size_t external_function_external_param_generic_calculate_size(external_function_external_param_generic *fun)
 {
     // wrapper as evaluate function
     fun->evaluate = &external_function_external_param_generic_wrapper;
@@ -1378,7 +1378,7 @@ static void external_function_external_param_casadi_set_param_pointer(void *self
 }
 
 
-acados_size_t external_function_external_param_casadi_calculate_size(external_function_external_param_casadi *fun, int np)
+acados_size_t external_function_external_param_casadi_calculate_size(external_function_external_param_casadi *fun)
 {
     int ii;
 
@@ -1387,9 +1387,6 @@ acados_size_t external_function_external_param_casadi_calculate_size(external_fu
 
     // set param function
     fun->set_param_pointer = &external_function_external_param_casadi_set_param_pointer;
-
-    // set number of parameters
-    fun->np = np;
 
     fun->casadi_work(&fun->args_num, &fun->res_num, &fun->iw_size, &fun->w_size);
 

--- a/acados/utils/external_function_generic.h
+++ b/acados/utils/external_function_generic.h
@@ -239,6 +239,69 @@ void external_function_param_casadi_wrapper(void *self, ext_fun_arg_t *type_in, 
 //
 void external_function_param_casadi_get_nparam(void *self, int *np);
 
+
+/************************************************
+ * casadi external parametric function
+ ************************************************/
+
+typedef struct
+{
+    // public members for core (have to be the same as in the prototype, and before the private ones)
+    void (*evaluate)(void *, ext_fun_arg_t *, void **, ext_fun_arg_t *, void **);
+	// public members for interfaces
+    void (*set_param_pointer)(void *, double *);
+    // private members
+    void *ptr_ext_mem;  // pointer to external memory
+    int (*casadi_fun)(const double **, double **, int *, double *, void *);
+    int (*casadi_work)(int *, int *, int *, int *);
+    const int *(*casadi_sparsity_in)(int);
+    const int *(*casadi_sparsity_out)(int);
+    int (*casadi_n_in)(void);
+    int (*casadi_n_out)(void);
+    double **args;
+    double **res;
+    double *w;
+    int *iw;
+    int *args_size;     // size of args[i]
+    int *res_size;      // size of res[i]
+    int *args_dense;    // indicates if args[i] is dense
+    int *res_dense;     // indicates if res[i] is dense
+    int args_num;       // number of args arrays
+    int args_size_tot;  // total size of args arrays
+    int res_num;        // number of res arrays
+    int res_size_tot;   // total size of res arrays
+    int in_num;         // number of input arrays
+    int out_num;        // number of output arrays
+    int iw_size;        // number of ints for worksapce
+    int w_size;         // number of doubles for workspace
+    int np;             // number of parameters
+
+    bool param_mem_is_set;  // indicates if param memory is set;
+} external_function_external_param_casadi;
+
+//
+acados_size_t external_function_external_param_casadi_struct_size();
+//
+void external_function_external_param_casadi_set_fun(external_function_external_param_casadi *fun, void *value);
+//
+void external_function_external_param_casadi_set_work(external_function_external_param_casadi *fun, void *value);
+//
+void external_function_external_param_casadi_set_sparsity_in(external_function_external_param_casadi *fun, void *value);
+//
+void external_function_external_param_casadi_set_sparsity_out(external_function_external_param_casadi *fun, void *value);
+//
+void external_function_external_param_casadi_set_n_in(external_function_external_param_casadi *fun, void *value);
+//
+void external_function_external_param_casadi_set_n_out(external_function_external_param_casadi *fun, void *value);
+//
+acados_size_t external_function_external_param_casadi_calculate_size(external_function_external_param_casadi *fun, int np);
+//
+void external_function_external_param_casadi_assign(external_function_external_param_casadi *fun, void *mem);
+//
+void external_function_external_param_casadi_wrapper(void *self, ext_fun_arg_t *type_in, void **in,
+                                            ext_fun_arg_t *type_out, void **out);
+
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/acados/utils/external_function_generic.h
+++ b/acados/utils/external_function_generic.h
@@ -241,7 +241,7 @@ void external_function_param_casadi_get_nparam(void *self, int *np);
 
 
 /************************************************
- * casadi external parametric function
+ * external_function_external_param_casadi
  ************************************************/
 
 typedef struct
@@ -300,6 +300,41 @@ void external_function_external_param_casadi_assign(external_function_external_p
 //
 void external_function_external_param_casadi_wrapper(void *self, ext_fun_arg_t *type_in, void **in,
                                             ext_fun_arg_t *type_out, void **out);
+
+
+
+/************************************************
+ * external_function_external_param_generic
+ ************************************************/
+
+// prototype of a parametric external function
+typedef struct
+{
+    // public members for core (have to be before private ones)
+    void (*evaluate)(void *, ext_fun_arg_t *, void **, ext_fun_arg_t *, void **);
+    // public members for interfaces
+    void (*set_param_pointer)(void *, double *);
+
+    // private members
+    void *ptr_ext_mem;  // pointer to external memory
+    int (*fun)(void **, void **, void *);
+    double *p;  // parameters
+    bool param_mem_is_set;
+
+} external_function_external_param_generic;
+
+//
+acados_size_t external_function_external_param_generic_struct_size();
+//
+void external_function_external_param_generic_set_fun(external_function_external_param_generic *fun, void *value);
+//
+acados_size_t external_function_external_param_generic_calculate_size(external_function_external_param_generic *fun, int np);
+//
+void external_function_external_param_generic_assign(external_function_external_param_generic *fun, void *mem);
+//
+void external_function_external_param_generic_wrapper(void *self, ext_fun_arg_t *type_in, void **in, ext_fun_arg_t *type_out, void **out);
+//
+void external_function_external_param_generic_set_param_ptr(void *self, double *p);
 
 
 #ifdef __cplusplus

--- a/acados/utils/external_function_generic.h
+++ b/acados/utils/external_function_generic.h
@@ -92,7 +92,7 @@ typedef struct
 {
     // public members for core (have to be before private ones)
     void (*evaluate)(void *, ext_fun_arg_t *, void **, ext_fun_arg_t *, void **);
-	// public members for interfaces
+    // public members for interfaces
     void (*get_nparam)(void *, int *);
     void (*set_param)(void *, double *);
     void (*set_param_sparse)(void *, int n_update, int *idx, double *);
@@ -184,7 +184,7 @@ typedef struct
 {
     // public members for core (have to be the same as in the prototype, and before the private ones)
     void (*evaluate)(void *, ext_fun_arg_t *, void **, ext_fun_arg_t *, void **);
-	// public members for interfaces
+    // public members for interfaces
     void (*get_nparam)(void *, int *);
     void (*set_param)(void *, double *);
     void (*set_param_sparse)(void *, int n_update, int *idx, double *);
@@ -248,7 +248,7 @@ typedef struct
 {
     // public members for core (have to be the same as in the prototype, and before the private ones)
     void (*evaluate)(void *, ext_fun_arg_t *, void **, ext_fun_arg_t *, void **);
-	// public members for interfaces
+    // public members for interfaces
     void (*set_param_pointer)(void *, double *);
     // private members
     void *ptr_ext_mem;  // pointer to external memory

--- a/acados/utils/external_function_generic.h
+++ b/acados/utils/external_function_generic.h
@@ -274,7 +274,6 @@ typedef struct
     int out_num;        // number of output arrays
     int iw_size;        // number of ints for worksapce
     int w_size;         // number of doubles for workspace
-    int np;             // number of parameters
 
     bool param_mem_is_set;  // indicates if param memory is set;
 } external_function_external_param_casadi;
@@ -294,7 +293,7 @@ void external_function_external_param_casadi_set_n_in(external_function_external
 //
 void external_function_external_param_casadi_set_n_out(external_function_external_param_casadi *fun, void *value);
 //
-acados_size_t external_function_external_param_casadi_calculate_size(external_function_external_param_casadi *fun, int np);
+acados_size_t external_function_external_param_casadi_calculate_size(external_function_external_param_casadi *fun);
 //
 void external_function_external_param_casadi_assign(external_function_external_param_casadi *fun, void *mem);
 //
@@ -328,7 +327,7 @@ acados_size_t external_function_external_param_generic_struct_size();
 //
 void external_function_external_param_generic_set_fun(external_function_external_param_generic *fun, void *value);
 //
-acados_size_t external_function_external_param_generic_calculate_size(external_function_external_param_generic *fun, int np);
+acados_size_t external_function_external_param_generic_calculate_size(external_function_external_param_generic *fun);
 //
 void external_function_external_param_generic_assign(external_function_external_param_generic *fun, void *mem);
 //

--- a/interfaces/acados_c/external_function_interface.c
+++ b/interfaces/acados_c/external_function_interface.c
@@ -216,9 +216,9 @@ void external_function_param_casadi_free_array(int size, external_function_param
 
 // external_function_external_param
 
-void external_function_external_param_casadi_create(external_function_external_param_casadi *fun, int np)
+void external_function_external_param_casadi_create(external_function_external_param_casadi *fun)
 {
-    acados_size_t fun_size = external_function_external_param_casadi_calculate_size(fun, np);
+    acados_size_t fun_size = external_function_external_param_casadi_calculate_size(fun);
     void *fun_mem = acados_malloc(1, fun_size);
     assert(fun_mem != 0);
     external_function_external_param_casadi_assign(fun, fun_mem);
@@ -237,9 +237,9 @@ void external_function_external_param_casadi_free(external_function_external_par
 
 // external_function_external_param
 
-void external_function_external_param_generic_create(external_function_external_param_generic *fun, int np)
+void external_function_external_param_generic_create(external_function_external_param_generic *fun)
 {
-    acados_size_t fun_size = external_function_external_param_generic_calculate_size(fun, np);
+    acados_size_t fun_size = external_function_external_param_generic_calculate_size(fun);
     void *fun_mem = acados_malloc(1, fun_size);
     assert(fun_mem != 0);
     external_function_external_param_generic_assign(fun, fun_mem);

--- a/interfaces/acados_c/external_function_interface.c
+++ b/interfaces/acados_c/external_function_interface.c
@@ -212,3 +212,24 @@ void external_function_param_casadi_free_array(int size, external_function_param
 
     return;
 }
+
+
+// external_function_external_param
+
+void external_function_external_param_casadi_create(external_function_external_param_casadi *fun, int np)
+{
+    acados_size_t fun_size = external_function_external_param_casadi_calculate_size(fun, np);
+    void *fun_mem = acados_malloc(1, fun_size);
+    assert(fun_mem != 0);
+    external_function_external_param_casadi_assign(fun, fun_mem);
+
+    return;
+}
+
+
+void external_function_external_param_casadi_free(external_function_external_param_casadi *fun)
+{
+    free(fun->ptr_ext_mem);
+
+    return;
+}

--- a/interfaces/acados_c/external_function_interface.c
+++ b/interfaces/acados_c/external_function_interface.c
@@ -233,3 +233,24 @@ void external_function_external_param_casadi_free(external_function_external_par
 
     return;
 }
+
+
+// external_function_external_param
+
+void external_function_external_param_generic_create(external_function_external_param_generic *fun, int np)
+{
+    acados_size_t fun_size = external_function_external_param_generic_calculate_size(fun, np);
+    void *fun_mem = acados_malloc(1, fun_size);
+    assert(fun_mem != 0);
+    external_function_external_param_generic_assign(fun, fun_mem);
+
+    return;
+}
+
+
+void external_function_external_param_generic_free(external_function_external_param_generic *fun)
+{
+    free(fun->ptr_ext_mem);
+
+    return;
+}

--- a/interfaces/acados_c/external_function_interface.h
+++ b/interfaces/acados_c/external_function_interface.h
@@ -91,6 +91,16 @@ void external_function_external_param_casadi_create(external_function_external_p
 //
 void external_function_external_param_casadi_free(external_function_external_param_casadi *fun);
 
+/************************************************
+ * external_function_external_param_generic
+ ************************************************/
+
+//
+void external_function_external_param_generic_create(external_function_external_param_generic *fun, int np);
+//
+void external_function_external_param_generic_free(external_function_external_param_generic *fun);
+
+
 
 
 

--- a/interfaces/acados_c/external_function_interface.h
+++ b/interfaces/acados_c/external_function_interface.h
@@ -82,6 +82,18 @@ void external_function_param_casadi_free_array(int size, external_function_param
 
 
 
+/************************************************
+ * external_function_external_param_casadi
+ ************************************************/
+
+//
+void external_function_external_param_casadi_create(external_function_external_param_casadi *fun, int np);
+//
+void external_function_external_param_casadi_free(external_function_external_param_casadi *fun);
+
+
+
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/interfaces/acados_c/external_function_interface.h
+++ b/interfaces/acados_c/external_function_interface.h
@@ -87,7 +87,7 @@ void external_function_param_casadi_free_array(int size, external_function_param
  ************************************************/
 
 //
-void external_function_external_param_casadi_create(external_function_external_param_casadi *fun, int np);
+void external_function_external_param_casadi_create(external_function_external_param_casadi *fun);
 //
 void external_function_external_param_casadi_free(external_function_external_param_casadi *fun);
 
@@ -96,7 +96,7 @@ void external_function_external_param_casadi_free(external_function_external_par
  ************************************************/
 
 //
-void external_function_external_param_generic_create(external_function_external_param_generic *fun, int np);
+void external_function_external_param_generic_create(external_function_external_param_generic *fun);
 //
 void external_function_external_param_generic_free(external_function_external_param_generic *fun);
 

--- a/interfaces/acados_c/ocp_nlp_interface.c
+++ b/interfaces/acados_c/ocp_nlp_interface.c
@@ -393,6 +393,16 @@ void ocp_nlp_in_set(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in, 
         double *Ts_value = value;
         in->Ts[stage] = Ts_value[0];
     }
+    else if (!strcmp(field, "parameter_values"))
+    {
+        double *parameter_values = value;
+        printf("setting parameter values at stage %d\n", stage);
+        for (int ii = 0; ii < dims->np[stage]; ii++)
+        {
+            in->parameter_values[stage][ii] = parameter_values[ii];
+        }
+        printf("done setting parameter values at stage %d\n", stage);
+    }
     else
     {
         printf("\nerror: ocp_nlp_in_set: field %s not available\n", field);
@@ -403,21 +413,26 @@ void ocp_nlp_in_set(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in, 
 
 
 
-// void ocp_nlp_in_get(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in, int stage,
-//         const char *field, void *value)
-// {
-//     if (!strcmp(field, "Ts"))
-//     {
-//         double *Ts_value = value;
-//         Ts_value[0] = in->Ts[stage];
-//     }
-//     else
-//     {
-//         printf("\nerror: ocp_nlp_in_get: field %s not available\n", field);
-//         exit(1);
-//     }
-//     return;
-// }
+void ocp_nlp_in_get(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in, int stage,
+        const char *field, void *value)
+{
+    if (!strcmp(field, "Ts"))
+    {
+        double *Ts_value = value;
+        Ts_value[0] = in->Ts[stage];
+    }
+    else if (!strcmp(field, "parameter_pointer"))
+    {
+        double **ptr = value;
+        ptr[0] = in->parameter_values[stage];
+    }
+    else
+    {
+        printf("\nerror: ocp_nlp_in_get: field %s not available\n", field);
+        exit(1);
+    }
+    return;
+}
 
 
 int ocp_nlp_dynamics_model_set(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in,

--- a/interfaces/acados_c/ocp_nlp_interface.c
+++ b/interfaces/acados_c/ocp_nlp_interface.c
@@ -479,6 +479,49 @@ int ocp_nlp_constraints_model_set(ocp_nlp_config *config, ocp_nlp_dims *dims,
 }
 
 
+int ocp_nlp_dynamics_model_set_external_param_fun(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in,
+        int stage, const char *field, void *ext_fun_)
+{
+    ocp_nlp_dynamics_config *dynamics_config = config->dynamics[stage];
+    external_function_external_param_generic * ext_fun = (external_function_external_param_generic *) ext_fun_;
+
+    ext_fun->set_param_pointer(ext_fun, in->parameter_values[stage]);
+
+    dynamics_config->model_set(dynamics_config, dims->dynamics[stage], in->dynamics[stage], field, ext_fun);
+
+    return ACADOS_SUCCESS;
+}
+
+
+
+int ocp_nlp_cost_model_set_external_param_fun(ocp_nlp_config *config, ocp_nlp_dims *dims,
+        ocp_nlp_in *in, int stage, const char *field, void *ext_fun_)
+{
+    ocp_nlp_cost_config *cost_config = config->cost[stage];
+    external_function_external_param_generic * ext_fun = (external_function_external_param_generic *) ext_fun_;
+
+    ext_fun->set_param_pointer(ext_fun, in->parameter_values[stage]);
+
+    return cost_config->model_set(cost_config, dims->cost[stage], in->cost[stage], field, ext_fun);
+
+}
+
+
+
+int ocp_nlp_constraints_model_set_external_param_fun(ocp_nlp_config *config, ocp_nlp_dims *dims,
+        ocp_nlp_in *in, int stage, const char *field, void *ext_fun_)
+{
+    ocp_nlp_constraints_config *constr_config = config->constraints[stage];
+    external_function_external_param_generic * ext_fun = (external_function_external_param_generic *) ext_fun_;
+
+    ext_fun->set_param_pointer(ext_fun, in->parameter_values[stage]);
+
+    return constr_config->model_set(constr_config, dims->constraints[stage],
+            in->constraints[stage], field, ext_fun);
+}
+
+
+
 void ocp_nlp_constraints_model_get(ocp_nlp_config *config, ocp_nlp_dims *dims,
         ocp_nlp_in *in, int stage, const char *field, void *value)
 {

--- a/interfaces/acados_c/ocp_nlp_interface.c
+++ b/interfaces/acados_c/ocp_nlp_interface.c
@@ -396,12 +396,10 @@ void ocp_nlp_in_set(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in, 
     else if (!strcmp(field, "parameter_values"))
     {
         double *parameter_values = value;
-        printf("setting parameter values at stage %d\n", stage);
         for (int ii = 0; ii < dims->np[stage]; ii++)
         {
             in->parameter_values[stage][ii] = parameter_values[ii];
         }
-        printf("done setting parameter values at stage %d\n", stage);
     }
     else
     {
@@ -410,6 +408,19 @@ void ocp_nlp_in_set(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in, 
     }
     return;
 }
+
+
+void ocp_nlp_in_set_params_sparse(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in, int stage,
+        int *idx, double *p, int n_update)
+{
+    for (int ii = 0; ii < n_update; ii++)
+    {
+        in->parameter_values[stage][idx[ii]] = p[ii];
+    }
+
+    return;
+}
+
 
 
 

--- a/interfaces/acados_c/ocp_nlp_interface.h
+++ b/interfaces/acados_c/ocp_nlp_interface.h
@@ -193,8 +193,12 @@ ACADOS_SYMBOL_EXPORT void ocp_nlp_in_destroy(void *in);
 ACADOS_SYMBOL_EXPORT void ocp_nlp_in_set(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in, int stage,
         const char *field, void *value);
 
+
+ACADOS_SYMBOL_EXPORT void ocp_nlp_in_set_params_sparse(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in, int stage,
+        int *idx, double *p, int n_update);
+
 ///
-void ocp_nlp_in_get(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in, int stage,
+ACADOS_SYMBOL_EXPORT void ocp_nlp_in_get(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in, int stage,
         const char *field, void *value);
 
 /// Sets the function pointers to the dynamics functions for the given stage.

--- a/interfaces/acados_c/ocp_nlp_interface.h
+++ b/interfaces/acados_c/ocp_nlp_interface.h
@@ -194,8 +194,8 @@ ACADOS_SYMBOL_EXPORT void ocp_nlp_in_set(ocp_nlp_config *config, ocp_nlp_dims *d
         const char *field, void *value);
 
 ///
-// void ocp_nlp_in_get(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in, int stage,
-//         const char *field, void *value);
+void ocp_nlp_in_get(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in, int stage,
+        const char *field, void *value);
 
 /// Sets the function pointers to the dynamics functions for the given stage.
 ///

--- a/interfaces/acados_c/ocp_nlp_interface.h
+++ b/interfaces/acados_c/ocp_nlp_interface.h
@@ -194,6 +194,18 @@ ACADOS_SYMBOL_EXPORT void ocp_nlp_in_set(ocp_nlp_config *config, ocp_nlp_dims *d
         const char *field, void *value);
 
 
+ACADOS_SYMBOL_EXPORT int ocp_nlp_dynamics_model_set_external_param_fun(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in,
+        int stage, const char *field, void *ext_fun);
+
+
+ACADOS_SYMBOL_EXPORT int ocp_nlp_cost_model_set_external_param_fun(ocp_nlp_config *config, ocp_nlp_dims *dims,
+        ocp_nlp_in *in, int stage, const char *field, void *ext_fun);
+
+
+ACADOS_SYMBOL_EXPORT int ocp_nlp_constraints_model_set_external_param_fun(ocp_nlp_config *config, ocp_nlp_dims *dims,
+        ocp_nlp_in *in, int stage, const char *field, void *ext_fun);
+
+
 ACADOS_SYMBOL_EXPORT void ocp_nlp_in_set_params_sparse(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in, int stage,
         int *idx, double *p, int n_update);
 

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.c
@@ -156,7 +156,7 @@ int {{ name }}_acados_update_time_steps({{ name }}_solver_capsule* capsule, int 
 /**
  * Internal function for {{ name }}_acados_create: step 1
  */
-void {{ name }}_acados_create_1_set_plan(ocp_nlp_plan_t* nlp_solver_plan, const int N)
+void {{ name }}_acados_create_set_plan(ocp_nlp_plan_t* nlp_solver_plan, const int N)
 {
     assert(N == nlp_solver_plan->N);
 
@@ -200,7 +200,7 @@ void {{ name }}_acados_create_1_set_plan(ocp_nlp_plan_t* nlp_solver_plan, const 
 /**
  * Internal function for {{ name }}_acados_create: step 2
  */
-ocp_nlp_dims* {{ name }}_acados_create_2_create_and_set_dimensions({{ name }}_solver_capsule* capsule)
+ocp_nlp_dims* {{ name }}_acados_create_setup_dimensions({{ name }}_solver_capsule* capsule)
 {
     ocp_nlp_plan_t* nlp_solver_plan = capsule->nlp_solver_plan;
     const int N = nlp_solver_plan->N;
@@ -410,7 +410,7 @@ ocp_nlp_dims* {{ name }}_acados_create_2_create_and_set_dimensions({{ name }}_so
 /**
  * Internal function for {{ name }}_acados_create: step 3
  */
-void {{ name }}_acados_create_3_create_and_set_functions({{ name }}_solver_capsule* capsule)
+void {{ name }}_acados_create_setup_functions({{ name }}_solver_capsule* capsule)
 {
     const int N = capsule->nlp_solver_plan->N;
 
@@ -783,7 +783,7 @@ void {{ name }}_acados_create_3_create_and_set_functions({{ name }}_solver_capsu
 /**
  * Internal function for {{ name }}_acados_create: step 4
  */
-void {{ name }}_acados_create_4_set_default_parameters({{ name }}_solver_capsule* capsule) {
+void {{ name }}_acados_create_set_default_parameters({{ name }}_solver_capsule* capsule) {
 
     double* p = calloc({{ np_max }}, sizeof(double));
 {%- for jj in range(end=n_phases) %}{# phases loop !#}
@@ -807,7 +807,7 @@ void {{ name }}_acados_create_4_set_default_parameters({{ name }}_solver_capsule
 /**
  * Internal function for {{ name }}_acados_create: step 5
  */
-void {{ name }}_acados_create_5_set_nlp_in({{ name }}_solver_capsule* capsule, int N)
+void {{ name }}_acados_create_setup_nlp_in({{ name }}_solver_capsule* capsule, int N)
 {
     assert(N == capsule->nlp_solver_plan->N);
     ocp_nlp_config* nlp_config = capsule->nlp_config;
@@ -2051,7 +2051,7 @@ void {{ name }}_acados_create_5_set_nlp_in({{ name }}_solver_capsule* capsule, i
 /**
  * Internal function for {{ name }}_acados_create: step 6
  */
-void {{ name }}_acados_create_6_set_opts({{ name }}_solver_capsule* capsule)
+void {{ name }}_acados_create_set_opts({{ name }}_solver_capsule* capsule)
 {
     const int N = capsule->nlp_solver_plan->N;
     ocp_nlp_config* nlp_config = capsule->nlp_config;
@@ -2343,7 +2343,7 @@ void {{ name }}_acados_create_6_set_opts({{ name }}_solver_capsule* capsule)
 /**
  * Internal function for {{ name }}_acados_create: step 7
  */
-void {{ name }}_acados_create_7_set_nlp_out({{ name }}_solver_capsule* capsule)
+void {{ name }}_acados_create_set_nlp_out({{ name }}_solver_capsule* capsule)
 {
     const int N = capsule->nlp_solver_plan->N;
     ocp_nlp_config* nlp_config = capsule->nlp_config;
@@ -2392,7 +2392,7 @@ void {{ name }}_acados_create_7_set_nlp_out({{ name }}_solver_capsule* capsule)
 /**
  * Internal function for {{ name }}_acados_create: step 9
  */
-int {{ name }}_acados_create_9_precompute({{ name }}_solver_capsule* capsule) {
+int {{ name }}_acados_create_precompute({{ name }}_solver_capsule* capsule) {
     int status = ocp_nlp_precompute(capsule->nlp_solver, capsule->nlp_in, capsule->nlp_out);
 
     if (status != ACADOS_SUCCESS) {
@@ -2421,37 +2421,36 @@ int {{ name }}_acados_create_with_discretization({{ name }}_solver_capsule* caps
 
     // 1) create and set nlp_solver_plan; create nlp_config
     capsule->nlp_solver_plan = ocp_nlp_plan_create(N);
-    {{ name }}_acados_create_1_set_plan(capsule->nlp_solver_plan, N);
+    {{ name }}_acados_create_set_plan(capsule->nlp_solver_plan, N);
     capsule->nlp_config = ocp_nlp_config_create(*capsule->nlp_solver_plan);
 
-    // 3) create and set dimensions
-    capsule->nlp_dims = {{ name }}_acados_create_2_create_and_set_dimensions(capsule);
-    {{ name }}_acados_create_3_create_and_set_functions(capsule);
+    // 2) create and set dimensions
+    capsule->nlp_dims = {{ name }}_acados_create_setup_dimensions(capsule);
 
-    // 4) set default parameters in functions
-    {{ name }}_acados_create_4_set_default_parameters(capsule);
-
-    // 5) create and set nlp_in
-    capsule->nlp_in = ocp_nlp_in_create(capsule->nlp_config, capsule->nlp_dims);
-    {{ name }}_acados_create_5_set_nlp_in(capsule, N);
-
-    // 6) create and set nlp_opts
+    // 3) create and set nlp_opts
     capsule->nlp_opts = ocp_nlp_solver_opts_create(capsule->nlp_config, capsule->nlp_dims);
-    {{ name }}_acados_create_6_set_opts(capsule);
+    {{ name }}_acados_create_set_opts(capsule);
+
+    // 4) create nlp_in
+    capsule->nlp_in = ocp_nlp_in_create(capsule->nlp_config, capsule->nlp_dims);
+
+    // 5) set default parameters in functions
+    {{ name }}_acados_create_setup_functions(capsule);
+    {{ name }}_acados_create_setup_nlp_in(capsule, N);
+    {{ name }}_acados_create_set_default_parameters(capsule);
+
+    // 6) create solver
+    capsule->nlp_solver = ocp_nlp_solver_create(capsule->nlp_config, capsule->nlp_dims, capsule->nlp_opts);
 
     // 7) create and set nlp_out
     // 7.1) nlp_out
     capsule->nlp_out = ocp_nlp_out_create(capsule->nlp_config, capsule->nlp_dims);
     // 7.2) sens_out
     capsule->sens_out = ocp_nlp_out_create(capsule->nlp_config, capsule->nlp_dims);
-    {{ name }}_acados_create_7_set_nlp_out(capsule);
+    {{ name }}_acados_create_set_nlp_out(capsule);
 
-    // 8) create solver
-    capsule->nlp_solver = ocp_nlp_solver_create(capsule->nlp_config, capsule->nlp_dims, capsule->nlp_opts);
-    //{{ name }}_acados_create_8_create_solver(capsule);
-
-    // 9) do precomputations
-    int status = {{ name }}_acados_create_9_precompute(capsule);
+    // 8) do precomputations
+    int status = {{ name }}_acados_create_precompute(capsule);
 
     {%- if custom_update_filename != "" %}
     // Initialize custom update function

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.c
@@ -418,66 +418,66 @@ void {{ name }}_acados_create_setup_functions({{ name }}_solver_capsule* capsule
     *  external functions
     ************************************************/
 
-#define MAP_CASADI_FNC(__CAPSULE_FNC__, __MODEL_BASE_FNC__, __NP__) do{ \
+#define MAP_CASADI_FNC(__CAPSULE_FNC__, __MODEL_BASE_FNC__) do{ \
         capsule->__CAPSULE_FNC__.casadi_fun = & __MODEL_BASE_FNC__ ;\
         capsule->__CAPSULE_FNC__.casadi_n_in = & __MODEL_BASE_FNC__ ## _n_in; \
         capsule->__CAPSULE_FNC__.casadi_n_out = & __MODEL_BASE_FNC__ ## _n_out; \
         capsule->__CAPSULE_FNC__.casadi_sparsity_in = & __MODEL_BASE_FNC__ ## _sparsity_in; \
         capsule->__CAPSULE_FNC__.casadi_sparsity_out = & __MODEL_BASE_FNC__ ## _sparsity_out; \
         capsule->__CAPSULE_FNC__.casadi_work = & __MODEL_BASE_FNC__ ## _work; \
-        external_function_param_casadi_create(&capsule->__CAPSULE_FNC__, __NP__); \
+        external_function_external_param_casadi_create(&capsule->__CAPSULE_FNC__); \
     } while(false)
 
 
 {# INITIAL #}
 {%- if constraints[0].constr_type_0 == "BGH" and phases_dims[0].nh_0 > 0 %}
-    MAP_CASADI_FNC(nl_constr_h_0_fun_jac, {{ model[0].name }}_constr_h_0_fun_jac_uxt_zt, {{ phases_dims[0].np }});
-    MAP_CASADI_FNC(nl_constr_h_0_fun, {{ model[0].name }}_constr_h_0_fun, {{ phases_dims[0].np }});
+    MAP_CASADI_FNC(nl_constr_h_0_fun_jac, {{ model[0].name }}_constr_h_0_fun_jac_uxt_zt);
+    MAP_CASADI_FNC(nl_constr_h_0_fun, {{ model[0].name }}_constr_h_0_fun);
 
     {%- if solver_options.hessian_approx == "EXACT" %}
-    MAP_CASADI_FNC(nl_constr_h_0_fun_jac_hess, {{ model[0].name }}_constr_h_0_fun_jac_uxt_zt_hess, {{ phases_dims[0].np }});
+    MAP_CASADI_FNC(nl_constr_h_0_fun_jac_hess, {{ model[0].name }}_constr_h_0_fun_jac_uxt_zt_hess);
     {% endif %}
 {%- elif constraints[0].constr_type_0 == "BGP" %}
     // convex-over-nonlinear constraint
-    MAP_CASADI_FNC(phi_0_constraint_fun, {{ model[0].name }}_phi_0_constraint_fun, {{ phases_dims[0].np }});
-    MAP_CASADI_FNC(phi_0_constraint_fun_jac_hess, {{ model[0].name }}_phi_0_constraint_fun_jac_hess, {{ phases_dims[0].np }});
+    MAP_CASADI_FNC(phi_0_constraint_fun, {{ model[0].name }}_phi_0_constraint_fun);
+    MAP_CASADI_FNC(phi_0_constraint_fun_jac_hess, {{ model[0].name }}_phi_0_constraint_fun_jac_hess);
 {%- endif %}
 
 
 {%- if cost[0].cost_type_0 == "NONLINEAR_LS" %}
     // nonlinear least squares function
-    MAP_CASADI_FNC(cost_y_0_fun, {{ model[0].name }}_cost_y_0_fun, {{ phases_dims[0].np }});
-    MAP_CASADI_FNC(cost_y_0_fun_jac_ut_xt, {{ model[0].name }}_cost_y_0_fun_jac_ut_xt, {{ phases_dims[0].np }});
-    MAP_CASADI_FNC(cost_y_0_hess, {{ model[0].name }}_cost_y_0_hess, {{ phases_dims[0].np }});
+    MAP_CASADI_FNC(cost_y_0_fun, {{ model[0].name }}_cost_y_0_fun);
+    MAP_CASADI_FNC(cost_y_0_fun_jac_ut_xt, {{ model[0].name }}_cost_y_0_fun_jac_ut_xt);
+    MAP_CASADI_FNC(cost_y_0_hess, {{ model[0].name }}_cost_y_0_hess);
 
 {%- elif cost[0].cost_type_0 == "CONVEX_OVER_NONLINEAR" %}
     // convex-over-nonlinear cost
-    MAP_CASADI_FNC(conl_cost_0_fun, {{ model[0].name }}_conl_cost_0_fun, {{ phases_dims[0].np }});
-    MAP_CASADI_FNC(conl_cost_0_fun_jac_hess, {{ model[0].name }}_conl_cost_0_fun_jac_hess, {{ phases_dims[0].np }});
+    MAP_CASADI_FNC(conl_cost_0_fun, {{ model[0].name }}_conl_cost_0_fun);
+    MAP_CASADI_FNC(conl_cost_0_fun_jac_hess, {{ model[0].name }}_conl_cost_0_fun_jac_hess);
 
 {%- elif cost[0].cost_type_0 == "EXTERNAL" %}
     // external cost
     {%- if cost[0].cost_ext_fun_type_0 == "casadi" %}
-    MAP_CASADI_FNC(ext_cost_0_fun, {{ model[0].name }}_cost_ext_cost_0_fun, {{ phases_dims[0].np }});
+    MAP_CASADI_FNC(ext_cost_0_fun, {{ model[0].name }}_cost_ext_cost_0_fun);
     {%- else %}
     capsule->ext_cost_0_fun.fun = &{{ cost[0].cost_function_ext_cost_0 }};
-    external_function_param_{{ cost[0].cost_ext_fun_type_0 }}_create(&capsule->ext_cost_0_fun, {{ phases_dims[0].np }});
+    external_function_external_param_{{ cost[0].cost_ext_fun_type_0 }}_create(&capsule->ext_cost_0_fun);
     {%- endif %}
 
     // external cost
     {%- if cost[0].cost_ext_fun_type_0 == "casadi" %}
-    MAP_CASADI_FNC(ext_cost_0_fun_jac, {{ model[0].name }}_cost_ext_cost_0_fun_jac, {{ phases_dims[0].np }});
+    MAP_CASADI_FNC(ext_cost_0_fun_jac, {{ model[0].name }}_cost_ext_cost_0_fun_jac);
     {%- else %}
     capsule->ext_cost_0_fun_jac.fun = &{{ cost[0].cost_function_ext_cost_0 }};
-    external_function_param_{{ cost[0].cost_ext_fun_type_0 }}_create(&capsule->ext_cost_0_fun_jac, {{ phases_dims[0].np }});
+    external_function_external_param_{{ cost[0].cost_ext_fun_type_0 }}_create(&capsule->ext_cost_0_fun_jac);
     {%- endif %}
 
     // external cost
     {%- if cost[0].cost_ext_fun_type_0 == "casadi" %}
-    MAP_CASADI_FNC(ext_cost_0_fun_jac_hess, {{ model[0].name }}_cost_ext_cost_0_fun_jac_hess, {{ phases_dims[0].np }});
+    MAP_CASADI_FNC(ext_cost_0_fun_jac_hess, {{ model[0].name }}_cost_ext_cost_0_fun_jac_hess);
     {%- else %}
     capsule->ext_cost_0_fun_jac_hess.fun = &{{ cost[0].cost_function_ext_cost_0 }};
-    external_function_param_{{ cost[0].cost_ext_fun_type_0 }}_create(&capsule->ext_cost_0_fun_jac_hess, {{ phases_dims[0].np }});
+    external_function_external_param_{{ cost[0].cost_ext_fun_type_0 }}_create(&capsule->ext_cost_0_fun_jac_hess);
     {%- endif %}
 {%- endif %}
 
@@ -490,161 +490,161 @@ void {{ name }}_acados_create_setup_functions({{ name }}_solver_capsule* capsule
     n_path = {{ end_idx[jj] - start_idx[jj]}};
     n_cost_path = {{ end_idx[jj] - cost_start_idx[jj] }};
 {%- if constraints[jj].constr_type == "BGH" and phases_dims[jj].nh > 0  %}
-    capsule->nl_constr_h_fun_jac_{{ jj }} = (external_function_param_casadi *) malloc(sizeof(external_function_param_casadi)*n_cost_path);
+    capsule->nl_constr_h_fun_jac_{{ jj }} = (external_function_external_param_casadi *) malloc(sizeof(external_function_external_param_casadi)*n_cost_path);
     for (int i = 0; i < n_cost_path; i++) {
-        MAP_CASADI_FNC(nl_constr_h_fun_jac_{{ jj }}[i], {{ model[jj].name }}_constr_h_fun_jac_uxt_zt, {{ phases_dims[jj].np }});
+        MAP_CASADI_FNC(nl_constr_h_fun_jac_{{ jj }}[i], {{ model[jj].name }}_constr_h_fun_jac_uxt_zt);
     }
-    capsule->nl_constr_h_fun_{{ jj }} = (external_function_param_casadi *) malloc(sizeof(external_function_param_casadi)*n_cost_path);
+    capsule->nl_constr_h_fun_{{ jj }} = (external_function_external_param_casadi *) malloc(sizeof(external_function_external_param_casadi)*n_cost_path);
     for (int i = 0; i < n_cost_path; i++) {
-        MAP_CASADI_FNC(nl_constr_h_fun_{{ jj }}[i], {{ model[jj].name }}_constr_h_fun, {{ phases_dims[jj].np }});
+        MAP_CASADI_FNC(nl_constr_h_fun_{{ jj }}[i], {{ model[jj].name }}_constr_h_fun);
     }
     {% if solver_options.hessian_approx == "EXACT" %}
-    capsule->nl_constr_h_fun_jac_hess_{{ jj }} = (external_function_param_casadi *) malloc(sizeof(external_function_param_casadi)*n_cost_path);
+    capsule->nl_constr_h_fun_jac_hess_{{ jj }} = (external_function_external_param_casadi *) malloc(sizeof(external_function_external_param_casadi)*n_cost_path);
     for (int i = 0; i < n_cost_path; i++) {
-        MAP_CASADI_FNC(nl_constr_h_fun_jac_hess_{{ jj }}[i], {{ model[jj].name }}_constr_h_fun_jac_uxt_zt_hess, {{ phases_dims[jj].np }});
+        MAP_CASADI_FNC(nl_constr_h_fun_jac_hess_{{ jj }}[i], {{ model[jj].name }}_constr_h_fun_jac_uxt_zt_hess);
     }
     {% endif %}
 {% elif constraints[jj].constr_type == "BGP" %}
-    capsule->phi_constraint_fun_{{ jj }} = (external_function_param_casadi *) malloc(sizeof(external_function_param_casadi)*n_cost_path);
-    capsule->phi_constraint_fun_jac_hess_{{ jj }} = (external_function_param_casadi *) malloc(sizeof(external_function_param_casadi)*n_cost_path);
+    capsule->phi_constraint_fun_{{ jj }} = (external_function_external_param_casadi *) malloc(sizeof(external_function_external_param_casadi)*n_cost_path);
+    capsule->phi_constraint_fun_jac_hess_{{ jj }} = (external_function_external_param_casadi *) malloc(sizeof(external_function_external_param_casadi)*n_cost_path);
     for (int i = 0; i < n_cost_path; i++)
     {
         // convex-over-nonlinear constraint
-        MAP_CASADI_FNC(phi_constraint_fun_{{ jj }}[i], {{ model[jj].name }}_phi_constraint_fun, {{ phases_dims[jj].np }});
-        MAP_CASADI_FNC(phi_constraint_fun_jac_hess_{{ jj }}[i], {{ model[jj].name }}_phi_constraint_fun_jac_hess, {{ phases_dims[jj].np }});
+        MAP_CASADI_FNC(phi_constraint_fun_{{ jj }}[i], {{ model[jj].name }}_phi_constraint_fun);
+        MAP_CASADI_FNC(phi_constraint_fun_jac_hess_{{ jj }}[i], {{ model[jj].name }}_phi_constraint_fun_jac_hess);
     }
 {%- endif %}
 
 {% if mocp_opts.integrator_type[jj] == "ERK" %}
     // explicit ode
-    capsule->forw_vde_casadi_{{ jj }} = (external_function_param_casadi *) malloc(sizeof(external_function_param_casadi)*n_path);
+    capsule->forw_vde_casadi_{{ jj }} = (external_function_external_param_casadi *) malloc(sizeof(external_function_external_param_casadi)*n_path);
     for (int i = 0; i < n_path; i++) {
-        MAP_CASADI_FNC(forw_vde_casadi_{{ jj }}[i], {{ model[jj].name }}_expl_vde_forw, {{ phases_dims[jj].np }});
+        MAP_CASADI_FNC(forw_vde_casadi_{{ jj }}[i], {{ model[jj].name }}_expl_vde_forw);
     }
 
-    capsule->expl_ode_fun_{{ jj }} = (external_function_param_casadi *) malloc(sizeof(external_function_param_casadi)*n_path);
+    capsule->expl_ode_fun_{{ jj }} = (external_function_external_param_casadi *) malloc(sizeof(external_function_external_param_casadi)*n_path);
     for (int i = 0; i < n_path; i++) {
-        MAP_CASADI_FNC(expl_ode_fun_{{ jj }}[i], {{ model[jj].name }}_expl_ode_fun, {{ phases_dims[jj].np }});
+        MAP_CASADI_FNC(expl_ode_fun_{{ jj }}[i], {{ model[jj].name }}_expl_ode_fun);
     }
 
     {%- if solver_options.hessian_approx == "EXACT" %}
-    capsule->hess_vde_casadi_{{ jj }} = (external_function_param_casadi *) malloc(sizeof(external_function_param_casadi)*n_path);
+    capsule->hess_vde_casadi_{{ jj }} = (external_function_external_param_casadi *) malloc(sizeof(external_function_external_param_casadi)*n_path);
     for (int i = 0; i < n_path; i++) {
-        MAP_CASADI_FNC(hess_vde_casadi_{{ jj }}[i], {{ model[jj].name }}_expl_ode_hess, {{ phases_dims[jj].np }});
+        MAP_CASADI_FNC(hess_vde_casadi_{{ jj }}[i], {{ model[jj].name }}_expl_ode_hess);
     }
     {%- endif %}
 
 {% elif mocp_opts.integrator_type[jj] == "IRK" %}
     // implicit dae
-    capsule->impl_dae_fun_{{ jj }} = (external_function_param_{{ model[jj].dyn_ext_fun_type }} *) malloc(sizeof(external_function_param_{{ model[jj].dyn_ext_fun_type }})*n_path);
+    capsule->impl_dae_fun_{{ jj }} = (external_function_external_param_{{ model[jj].dyn_ext_fun_type }} *) malloc(sizeof(external_function_external_param_{{ model[jj].dyn_ext_fun_type }})*n_path);
     for (int i = 0; i < n_path; i++) {
     {%- if model[jj].dyn_ext_fun_type == "casadi" %}
-        MAP_CASADI_FNC(impl_dae_fun_{{ jj }}[i], {{ model[jj].name }}_impl_dae_fun, {{ phases_dims[jj].np }});
+        MAP_CASADI_FNC(impl_dae_fun_{{ jj }}[i], {{ model[jj].name }}_impl_dae_fun);
     {%- else %}
         capsule->impl_dae_fun_{{ jj }}[i].fun = &{{ model[jj].dyn_impl_dae_fun }};
-        external_function_param_{{ model[jj].dyn_ext_fun_type }}_create(&capsule->impl_dae_fun_{{ jj }}[i], {{ phases_dims[jj].np }});
+        external_function_external_param_{{ model[jj].dyn_ext_fun_type }}_create(&capsule->impl_dae_fun_{{ jj }}[i]);
     {%- endif %}
     }
 
-    capsule->impl_dae_fun_jac_x_xdot_z_{{ jj }} = (external_function_param_{{ model[jj].dyn_ext_fun_type }} *) malloc(sizeof(external_function_param_{{ model[jj].dyn_ext_fun_type }})*n_path);
+    capsule->impl_dae_fun_jac_x_xdot_z_{{ jj }} = (external_function_external_param_{{ model[jj].dyn_ext_fun_type }} *) malloc(sizeof(external_function_external_param_{{ model[jj].dyn_ext_fun_type }})*n_path);
     for (int i = 0; i < n_path; i++) {
     {%- if model[jj].dyn_ext_fun_type == "casadi" %}
-        MAP_CASADI_FNC(impl_dae_fun_jac_x_xdot_z_{{ jj }}[i], {{ model[jj].name }}_impl_dae_fun_jac_x_xdot_z, {{ phases_dims[jj].np }});
+        MAP_CASADI_FNC(impl_dae_fun_jac_x_xdot_z_{{ jj }}[i], {{ model[jj].name }}_impl_dae_fun_jac_x_xdot_z);
     {%- else %}
         capsule->impl_dae_fun_jac_x_xdot_z_{{ jj }}[i].fun = &{{ model[jj].dyn_impl_dae_fun_jac }};
-        external_function_param_{{ model[jj].dyn_ext_fun_type }}_create(&capsule->impl_dae_fun_jac_x_xdot_z_{{ jj }}[i], {{ phases_dims[jj].np }});
+        external_function_external_param_{{ model[jj].dyn_ext_fun_type }}_create(&capsule->impl_dae_fun_jac_x_xdot_z_{{ jj }}[i]);
     {%- endif %}
     }
 
-    capsule->impl_dae_jac_x_xdot_u_z_{{ jj }} = (external_function_param_{{ model[jj].dyn_ext_fun_type }} *) malloc(sizeof(external_function_param_{{ model[jj].dyn_ext_fun_type }})*n_path);
+    capsule->impl_dae_jac_x_xdot_u_z_{{ jj }} = (external_function_external_param_{{ model[jj].dyn_ext_fun_type }} *) malloc(sizeof(external_function_external_param_{{ model[jj].dyn_ext_fun_type }})*n_path);
     for (int i = 0; i < n_path; i++) {
     {%- if model[jj].dyn_ext_fun_type == "casadi" %}
-        MAP_CASADI_FNC(impl_dae_jac_x_xdot_u_z_{{ jj }}[i], {{ model[jj].name }}_impl_dae_jac_x_xdot_u_z, {{ phases_dims[jj].np }});
+        MAP_CASADI_FNC(impl_dae_jac_x_xdot_u_z_{{ jj }}[i], {{ model[jj].name }}_impl_dae_jac_x_xdot_u_z);
     {%- else %}
         capsule->impl_dae_jac_x_xdot_u_z_{{ jj }}[i].fun = &{{ model[jj].dyn_impl_dae_jac }};
-        external_function_param_{{ model[jj].dyn_ext_fun_type }}_create(&capsule->impl_dae_jac_x_xdot_u_z_{{ jj }}[i], {{ phases_dims[jj].np }});
+        external_function_external_param_{{ model[jj].dyn_ext_fun_type }}_create(&capsule->impl_dae_jac_x_xdot_u_z_{{ jj }}[i]);
     {%- endif %}
     }
 
     {%- if solver_options.hessian_approx == "EXACT" %}
-    capsule->impl_dae_hess_{{ jj }} = (external_function_param_{{ model[jj].dyn_ext_fun_type }} *) malloc(sizeof(external_function_param_{{ model[jj].dyn_ext_fun_type }})*n_path);
+    capsule->impl_dae_hess_{{ jj }} = (external_function_external_param_{{ model[jj].dyn_ext_fun_type }} *) malloc(sizeof(external_function_external_param_{{ model[jj].dyn_ext_fun_type }})*n_path);
     for (int i = 0; i < n_path; i++) {
-        MAP_CASADI_FNC(impl_dae_hess_{{ jj }}[i], {{ model[jj].name }}_impl_dae_hess, {{ phases_dims[jj].np }});
+        MAP_CASADI_FNC(impl_dae_hess_{{ jj }}[i], {{ model[jj].name }}_impl_dae_hess);
     }
     {%- endif %}
 {% elif mocp_opts.integrator_type[jj] == "LIFTED_IRK" %}
     // external functions (implicit model)
-    capsule->impl_dae_fun_{{ jj }} = (external_function_param_{{ model[jj].dyn_ext_fun_type }} *) malloc(sizeof(external_function_param_{{ model[jj].dyn_ext_fun_type }})*n_path);
+    capsule->impl_dae_fun_{{ jj }} = (external_function_external_param_{{ model[jj].dyn_ext_fun_type }} *) malloc(sizeof(external_function_external_param_{{ model[jj].dyn_ext_fun_type }})*n_path);
     for (int i = 0; i < n_path; i++) {
-        MAP_CASADI_FNC(impl_dae_fun_{{ jj }}[i], {{ model[jj].name }}_impl_dae_fun, {{ phases_dims[jj].np }});
+        MAP_CASADI_FNC(impl_dae_fun_{{ jj }}[i], {{ model[jj].name }}_impl_dae_fun);
     }
 
-    capsule->impl_dae_fun_jac_x_xdot_u_{{ jj }} = (external_function_param_{{ model[jj].dyn_ext_fun_type }} *) malloc(sizeof(external_function_param_{{ model[jj].dyn_ext_fun_type }})*n_path);
+    capsule->impl_dae_fun_jac_x_xdot_u_{{ jj }} = (external_function_external_param_{{ model[jj].dyn_ext_fun_type }} *) malloc(sizeof(external_function_external_param_{{ model[jj].dyn_ext_fun_type }})*n_path);
     for (int i = 0; i < n_path; i++) {
-        MAP_CASADI_FNC(impl_dae_fun_jac_x_xdot_u_{{ jj }}[i], {{ model[jj].name }}_impl_dae_fun_jac_x_xdot_u, {{ phases_dims[jj].np }});
+        MAP_CASADI_FNC(impl_dae_fun_jac_x_xdot_u_{{ jj }}[i], {{ model[jj].name }}_impl_dae_fun_jac_x_xdot_u);
     }
 
 {% elif mocp_opts.integrator_type[jj] == "GNSF" %}
     {% if model[jj].gnsf.purely_linear != 1 %}
-    capsule->gnsf_phi_fun_{{ jj }} = (external_function_param_casadi *) malloc(sizeof(external_function_param_casadi)*n_path);
+    capsule->gnsf_phi_fun_{{ jj }} = (external_function_external_param_casadi *) malloc(sizeof(external_function_external_param_casadi)*n_path);
     for (int i = 0; i < n_path; i++) {
-        MAP_CASADI_FNC(gnsf_phi_fun_{{ jj }}[i], {{ model[jj].name }}_gnsf_phi_fun, {{ phases_dims[jj].np }});
+        MAP_CASADI_FNC(gnsf_phi_fun_{{ jj }}[i], {{ model[jj].name }}_gnsf_phi_fun);
     }
 
-    capsule->gnsf_phi_fun_jac_y_{{ jj }} = (external_function_param_casadi *) malloc(sizeof(external_function_param_casadi)*n_path);
+    capsule->gnsf_phi_fun_jac_y_{{ jj }} = (external_function_external_param_casadi *) malloc(sizeof(external_function_external_param_casadi)*n_path);
     for (int i = 0; i < n_path; i++) {
-        MAP_CASADI_FNC(gnsf_phi_fun_jac_y_{{ jj }}[i], {{ model[jj].name }}_gnsf_phi_fun_jac_y, {{ phases_dims[jj].np }});
+        MAP_CASADI_FNC(gnsf_phi_fun_jac_y_{{ jj }}[i], {{ model[jj].name }}_gnsf_phi_fun_jac_y);
     }
 
-    capsule->gnsf_phi_jac_y_uhat_{{ jj }} = (external_function_param_casadi *) malloc(sizeof(external_function_param_casadi)*n_path);
+    capsule->gnsf_phi_jac_y_uhat_{{ jj }} = (external_function_external_param_casadi *) malloc(sizeof(external_function_external_param_casadi)*n_path);
     for (int i = 0; i < n_path; i++) {
-        MAP_CASADI_FNC(gnsf_phi_jac_y_uhat_{{ jj }}[i], {{ model[jj].name }}_gnsf_phi_jac_y_uhat, {{ phases_dims[jj].np }});
+        MAP_CASADI_FNC(gnsf_phi_jac_y_uhat_{{ jj }}[i], {{ model[jj].name }}_gnsf_phi_jac_y_uhat);
     }
 
     {% if model[jj].gnsf.nontrivial_f_LO == 1 %}
-    capsule->gnsf_f_lo_jac_x1_x1dot_u_z_{{ jj }} = (external_function_param_casadi *) malloc(sizeof(external_function_param_casadi)*n_path);
+    capsule->gnsf_f_lo_jac_x1_x1dot_u_z_{{ jj }} = (external_function_external_param_casadi *) malloc(sizeof(external_function_external_param_casadi)*n_path);
     for (int i = 0; i < n_path; i++) {
-        MAP_CASADI_FNC(gnsf_f_lo_jac_x1_x1dot_u_z_{{ jj }}[i], {{ model[jj].name }}_gnsf_f_lo_fun_jac_x1k1uz, {{ phases_dims[jj].np }});
+        MAP_CASADI_FNC(gnsf_f_lo_jac_x1_x1dot_u_z_{{ jj }}[i], {{ model[jj].name }}_gnsf_f_lo_fun_jac_x1k1uz);
     }
     {%- endif %}
     {%- endif %}
-    capsule->gnsf_get_matrices_fun_{{ jj }} = (external_function_param_casadi *) malloc(sizeof(external_function_param_casadi)*n_path);
+    capsule->gnsf_get_matrices_fun_{{ jj }} = (external_function_external_param_casadi *) malloc(sizeof(external_function_external_param_casadi)*n_path);
     for (int i = 0; i < n_path; i++) {
-        MAP_CASADI_FNC(gnsf_get_matrices_fun_{{ jj }}[i], {{ model[jj].name }}_gnsf_get_matrices_fun, {{ phases_dims[jj].np }});
+        MAP_CASADI_FNC(gnsf_get_matrices_fun_{{ jj }}[i], {{ model[jj].name }}_gnsf_get_matrices_fun);
     }
 {% elif mocp_opts.integrator_type[jj] == "DISCRETE" %}
     // discrete dynamics
-    capsule->discr_dyn_phi_fun_{{ jj }} = (external_function_param_{{ model[jj].dyn_ext_fun_type }} *) malloc(sizeof(external_function_param_{{ model[jj].dyn_ext_fun_type }})*n_path);
+    capsule->discr_dyn_phi_fun_{{ jj }} = (external_function_external_param_{{ model[jj].dyn_ext_fun_type }} *) malloc(sizeof(external_function_external_param_{{ model[jj].dyn_ext_fun_type }})*n_path);
     for (int i = 0; i < n_path; i++)
     {
         {%- if model[jj].dyn_ext_fun_type == "casadi" %}
-        MAP_CASADI_FNC(discr_dyn_phi_fun_{{ jj }}[i], {{ model[jj].name }}_dyn_disc_phi_fun, {{ phases_dims[jj].np }});
+        MAP_CASADI_FNC(discr_dyn_phi_fun_{{ jj }}[i], {{ model[jj].name }}_dyn_disc_phi_fun);
         {%- else %}
         capsule->discr_dyn_phi_fun_{{ jj }}[i].fun = &{{ model[jj].dyn_disc_fun }};
-        external_function_param_{{ model[jj].dyn_ext_fun_type }}_create(&capsule->discr_dyn_phi_fun_{{ jj }}[i], {{ phases_dims[jj].np }});
+        external_function_external_param_{{ model[jj].dyn_ext_fun_type }}_create(&capsule->discr_dyn_phi_fun_{{ jj }}[i]);
         {%- endif %}
     }
 
-    capsule->discr_dyn_phi_fun_jac_ut_xt_{{ jj }} = (external_function_param_{{ model[jj].dyn_ext_fun_type }} *) malloc(sizeof(external_function_param_{{ model[jj].dyn_ext_fun_type }})*n_path);
+    capsule->discr_dyn_phi_fun_jac_ut_xt_{{ jj }} = (external_function_external_param_{{ model[jj].dyn_ext_fun_type }} *) malloc(sizeof(external_function_external_param_{{ model[jj].dyn_ext_fun_type }})*n_path);
     for (int i = 0; i < n_path; i++)
     {
         {%- if model[jj].dyn_ext_fun_type == "casadi" %}
-        MAP_CASADI_FNC(discr_dyn_phi_fun_jac_ut_xt_{{ jj }}[i], {{ model[jj].name }}_dyn_disc_phi_fun_jac, {{ phases_dims[jj].np }});
+        MAP_CASADI_FNC(discr_dyn_phi_fun_jac_ut_xt_{{ jj }}[i], {{ model[jj].name }}_dyn_disc_phi_fun_jac);
         {%- else %}
         capsule->discr_dyn_phi_fun_jac_ut_xt_{{ jj }}[i].fun = &{{ model[jj].dyn_disc_fun_jac }};
-        external_function_param_{{ model[jj].dyn_ext_fun_type }}_create(&capsule->discr_dyn_phi_fun_jac_ut_xt_{{ jj }}[i], {{ phases_dims[jj].np }});
+        external_function_external_param_{{ model[jj].dyn_ext_fun_type }}_create(&capsule->discr_dyn_phi_fun_jac_ut_xt_{{ jj }}[i]);
         {%- endif %}
     }
 
   {%- if solver_options.hessian_approx == "EXACT" %}
-    capsule->discr_dyn_phi_fun_jac_ut_xt_hess_{{ jj }} = (external_function_param_{{ model[jj].dyn_ext_fun_type }} *) malloc(sizeof(external_function_param_{{ model[jj].dyn_ext_fun_type }})*n_path);
+    capsule->discr_dyn_phi_fun_jac_ut_xt_hess_{{ jj }} = (external_function_external_param_{{ model[jj].dyn_ext_fun_type }} *) malloc(sizeof(external_function_external_param_{{ model[jj].dyn_ext_fun_type }})*n_path);
     for (int i = 0; i < n_path; i++)
     {
         {%- if model[jj].dyn_ext_fun_type == "casadi" %}
-        MAP_CASADI_FNC(discr_dyn_phi_fun_jac_ut_xt_hess_{{ jj }}[i], {{ model[jj].name }}_dyn_disc_phi_fun_jac_hess, {{ phases_dims[jj].np }});
+        MAP_CASADI_FNC(discr_dyn_phi_fun_jac_ut_xt_hess_{{ jj }}[i], {{ model[jj].name }}_dyn_disc_phi_fun_jac_hess);
         {%- else %}
         capsule->discr_dyn_phi_fun_jac_ut_xt_hess_{{ jj }}[i].fun = &{{ model[jj].dyn_disc_fun_jac_hess }};
-        external_function_param_{{ model[jj].dyn_ext_fun_type }}_create(&capsule->discr_dyn_phi_fun_jac_ut_xt_hess_{{ jj }}[i], {{ phases_dims[jj].np }});
+        external_function_external_param_{{ model[jj].dyn_ext_fun_type }}_create(&capsule->discr_dyn_phi_fun_jac_ut_xt_hess_{{ jj }}[i]);
         {%- endif %}
     }
   {%- endif %}
@@ -654,69 +654,69 @@ void {{ name }}_acados_create_setup_functions({{ name }}_solver_capsule* capsule
 
 {%- if cost[jj].cost_type == "NONLINEAR_LS" %}
     // nonlinear least squares cost
-    capsule->cost_y_fun_{{ jj }} = (external_function_param_casadi *) malloc(sizeof(external_function_param_casadi)*n_cost_path);
+    capsule->cost_y_fun_{{ jj }} = (external_function_external_param_casadi *) malloc(sizeof(external_function_external_param_casadi)*n_cost_path);
     for (int i = 0; i < n_cost_path; i++)
     {
-        MAP_CASADI_FNC(cost_y_fun_{{ jj }}[i], {{ model[jj].name }}_cost_y_fun, {{ phases_dims[jj].np }});
+        MAP_CASADI_FNC(cost_y_fun_{{ jj }}[i], {{ model[jj].name }}_cost_y_fun);
     }
 
-    capsule->cost_y_fun_jac_ut_xt_{{ jj }} = (external_function_param_casadi *) malloc(sizeof(external_function_param_casadi)*n_cost_path);
+    capsule->cost_y_fun_jac_ut_xt_{{ jj }} = (external_function_external_param_casadi *) malloc(sizeof(external_function_external_param_casadi)*n_cost_path);
     for (int i = 0; i < n_cost_path; i++)
     {
-        MAP_CASADI_FNC(cost_y_fun_jac_ut_xt_{{ jj }}[i], {{ model[jj].name }}_cost_y_fun_jac_ut_xt, {{ phases_dims[jj].np }});
+        MAP_CASADI_FNC(cost_y_fun_jac_ut_xt_{{ jj }}[i], {{ model[jj].name }}_cost_y_fun_jac_ut_xt);
     }
 
-    capsule->cost_y_hess_{{ jj }} = (external_function_param_casadi *) malloc(sizeof(external_function_param_casadi)*n_cost_path);
+    capsule->cost_y_hess_{{ jj }} = (external_function_external_param_casadi *) malloc(sizeof(external_function_external_param_casadi)*n_cost_path);
     for (int i = 0; i < n_cost_path; i++)
     {
-        MAP_CASADI_FNC(cost_y_hess_{{ jj }}[i], {{ model[jj].name }}_cost_y_hess, {{ phases_dims[jj].np }});
+        MAP_CASADI_FNC(cost_y_hess_{{ jj }}[i], {{ model[jj].name }}_cost_y_hess);
     }
 
 {%- elif cost[jj].cost_type == "CONVEX_OVER_NONLINEAR" %}
     // convex-over-nonlinear cost
-    capsule->conl_cost_fun_{{ jj }} = (external_function_param_casadi *) malloc(sizeof(external_function_param_casadi)*n_cost_path);
+    capsule->conl_cost_fun_{{ jj }} = (external_function_external_param_casadi *) malloc(sizeof(external_function_external_param_casadi)*n_cost_path);
     for (int i = 0; i < n_cost_path; i++)
     {
-        MAP_CASADI_FNC(conl_cost_fun_{{ jj }}[i], {{ model[jj].name }}_conl_cost_fun, {{ phases_dims[jj].np }});
+        MAP_CASADI_FNC(conl_cost_fun_{{ jj }}[i], {{ model[jj].name }}_conl_cost_fun);
     }
-    capsule->conl_cost_fun_jac_hess_{{ jj }} = (external_function_param_casadi *) malloc(sizeof(external_function_param_casadi)*n_cost_path);
+    capsule->conl_cost_fun_jac_hess_{{ jj }} = (external_function_external_param_casadi *) malloc(sizeof(external_function_external_param_casadi)*n_cost_path);
     for (int i = 0; i < n_cost_path; i++)
     {
-        MAP_CASADI_FNC(conl_cost_fun_jac_hess_{{ jj }}[i], {{ model[jj].name }}_conl_cost_fun_jac_hess, {{ phases_dims[jj].np }});
+        MAP_CASADI_FNC(conl_cost_fun_jac_hess_{{ jj }}[i], {{ model[jj].name }}_conl_cost_fun_jac_hess);
     }
 
 {%- elif cost[jj].cost_type == "EXTERNAL" %}
     // external cost
-    capsule->ext_cost_fun_{{ jj }} = (external_function_param_{{ cost[jj].cost_ext_fun_type }} *) malloc(sizeof(external_function_param_{{ cost[jj].cost_ext_fun_type }})*n_cost_path);
+    capsule->ext_cost_fun_{{ jj }} = (external_function_external_param_{{ cost[jj].cost_ext_fun_type }} *) malloc(sizeof(external_function_external_param_{{ cost[jj].cost_ext_fun_type }})*n_cost_path);
     for (int i = 0; i < n_cost_path; i++)
     {
         {%- if cost[jj].cost_ext_fun_type == "casadi" %}
-        MAP_CASADI_FNC(ext_cost_fun_{{ jj }}[i], {{ model[jj].name }}_cost_ext_cost_fun, {{ phases_dims[jj].np }});
+        MAP_CASADI_FNC(ext_cost_fun_{{ jj }}[i], {{ model[jj].name }}_cost_ext_cost_fun);
         {%- else %}
         capsule->ext_cost_fun_{{ jj }}[i].fun = &{{ cost[jj].cost_function_ext_cost }};
-        external_function_param_{{ cost[jj].cost_ext_fun_type }}_create(&capsule->ext_cost_fun_{{ jj }}[i], {{ phases_dims[jj].np }});
+        external_function_external_param_{{ cost[jj].cost_ext_fun_type }}_create(&capsule->ext_cost_fun_{{ jj }}[i]);
         {%- endif %}
     }
 
-    capsule->ext_cost_fun_jac_{{ jj }} = (external_function_param_{{ cost[jj].cost_ext_fun_type }} *) malloc(sizeof(external_function_param_{{ cost[jj].cost_ext_fun_type }})*n_cost_path);
+    capsule->ext_cost_fun_jac_{{ jj }} = (external_function_external_param_{{ cost[jj].cost_ext_fun_type }} *) malloc(sizeof(external_function_external_param_{{ cost[jj].cost_ext_fun_type }})*n_cost_path);
     for (int i = 0; i < n_cost_path; i++)
     {
         {%- if cost[jj].cost_ext_fun_type == "casadi" %}
-        MAP_CASADI_FNC(ext_cost_fun_jac_{{ jj }}[i], {{ model[jj].name }}_cost_ext_cost_fun_jac, {{ phases_dims[jj].np }});
+        MAP_CASADI_FNC(ext_cost_fun_jac_{{ jj }}[i], {{ model[jj].name }}_cost_ext_cost_fun_jac);
         {%- else %}
         capsule->ext_cost_fun_jac_{{ jj }}[i].fun = &{{ cost[jj].cost_function_ext_cost }};
-        external_function_param_{{ cost[jj].cost_ext_fun_type }}_create(&capsule->ext_cost_fun_jac_{{ jj }}[i], {{ phases_dims[jj].np }});
+        external_function_external_param_{{ cost[jj].cost_ext_fun_type }}_create(&capsule->ext_cost_fun_jac_{{ jj }}[i]);
         {%- endif %}
     }
 
-    capsule->ext_cost_fun_jac_hess_{{ jj }} = (external_function_param_{{ cost[jj].cost_ext_fun_type }} *) malloc(sizeof(external_function_param_{{ cost[jj].cost_ext_fun_type }})*n_cost_path);
+    capsule->ext_cost_fun_jac_hess_{{ jj }} = (external_function_external_param_{{ cost[jj].cost_ext_fun_type }} *) malloc(sizeof(external_function_external_param_{{ cost[jj].cost_ext_fun_type }})*n_cost_path);
     for (int i = 0; i < n_cost_path; i++)
     {
         {%- if cost[jj].cost_ext_fun_type == "casadi" %}
-        MAP_CASADI_FNC(ext_cost_fun_jac_hess_{{ jj }}[i], {{ model[jj].name }}_cost_ext_cost_fun_jac_hess, {{ phases_dims[jj].np }});
+        MAP_CASADI_FNC(ext_cost_fun_jac_hess_{{ jj }}[i], {{ model[jj].name }}_cost_ext_cost_fun_jac_hess);
         {%- else %}
         capsule->ext_cost_fun_jac_hess_{{ jj }}[i].fun = &{{ cost[jj].cost_function_ext_cost }};
-        external_function_param_{{ cost[jj].cost_ext_fun_type }}_create(&capsule->ext_cost_fun_jac_hess_{{ jj }}[i], {{ phases_dims[jj].np }});
+        external_function_external_param_{{ cost[jj].cost_ext_fun_type }}_create(&capsule->ext_cost_fun_jac_hess_{{ jj }}[i]);
         {%- endif %}
     }
 {%- endif %}
@@ -726,52 +726,52 @@ void {{ name }}_acados_create_setup_functions({{ name }}_solver_capsule* capsule
 
 {# TERMINAL NODE #}
 {%- if constraints_e.constr_type_e == "BGH" and dims_e.nh_e > 0 %}
-    MAP_CASADI_FNC(nl_constr_h_e_fun_jac, {{ model_e.name }}_constr_h_e_fun_jac_uxt_zt, {{ dims_e.np }});
-    MAP_CASADI_FNC(nl_constr_h_e_fun, {{ model_e.name }}_constr_h_e_fun, {{ dims_e.np }});
+    MAP_CASADI_FNC(nl_constr_h_e_fun_jac, {{ model_e.name }}_constr_h_e_fun_jac_uxt_zt);
+    MAP_CASADI_FNC(nl_constr_h_e_fun, {{ model_e.name }}_constr_h_e_fun);
 
     {%- if solver_options.hessian_approx == "EXACT" %}
-    MAP_CASADI_FNC(nl_constr_h_e_fun_jac_hess, {{ model_e.name }}_constr_h_e_fun_jac_uxt_zt_hess, {{ dims_e.np }});
+    MAP_CASADI_FNC(nl_constr_h_e_fun_jac_hess, {{ model_e.name }}_constr_h_e_fun_jac_uxt_zt_hess);
     {% endif %}
 {%- elif constraints_e.constr_type_e == "BGP" %}
     // convex-over-nonlinear constraint
-    MAP_CASADI_FNC(phi_e_constraint_fun, {{ model_e.name }}_phi_e_constraint_fun, {{ dims_e.np }});
-    MAP_CASADI_FNC(phi_e_constraint_fun_jac_hess, {{ model_e.name }}_phi_e_constraint_fun_jac_hess, {{ dims_e.np }});
+    MAP_CASADI_FNC(phi_e_constraint_fun, {{ model_e.name }}_phi_e_constraint_fun);
+    MAP_CASADI_FNC(phi_e_constraint_fun_jac_hess, {{ model_e.name }}_phi_e_constraint_fun_jac_hess);
 {%- endif %}
 
 {%- if cost_e.cost_type_e == "NONLINEAR_LS" %}
     // nonlinear least square function
-    MAP_CASADI_FNC(cost_y_e_fun, {{ model_e.name }}_cost_y_e_fun, {{ dims_e.np }});
-    MAP_CASADI_FNC(cost_y_e_fun_jac_ut_xt, {{ model_e.name }}_cost_y_e_fun_jac_ut_xt, {{ dims_e.np }});
-    MAP_CASADI_FNC(cost_y_e_hess, {{ model_e.name }}_cost_y_e_hess, {{ dims_e.np }});
+    MAP_CASADI_FNC(cost_y_e_fun, {{ model_e.name }}_cost_y_e_fun);
+    MAP_CASADI_FNC(cost_y_e_fun_jac_ut_xt, {{ model_e.name }}_cost_y_e_fun_jac_ut_xt);
+    MAP_CASADI_FNC(cost_y_e_hess, {{ model_e.name }}_cost_y_e_hess);
 
 {%- elif cost_e.cost_type_e == "CONVEX_OVER_NONLINEAR" %}
     // convex-over-nonlinear cost
-    MAP_CASADI_FNC(conl_cost_e_fun, {{ model_e.name }}_conl_cost_e_fun, {{ dims_e.np }});
-    MAP_CASADI_FNC(conl_cost_e_fun_jac_hess, {{ model_e.name }}_conl_cost_e_fun_jac_hess, {{ dims_e.np }});
+    MAP_CASADI_FNC(conl_cost_e_fun, {{ model_e.name }}_conl_cost_e_fun);
+    MAP_CASADI_FNC(conl_cost_e_fun_jac_hess, {{ model_e.name }}_conl_cost_e_fun_jac_hess);
 
 {%- elif cost_e.cost_type_e == "EXTERNAL" %}
     // external cost - function
     {%- if cost_e.cost_ext_fun_type_e == "casadi" %}
-    MAP_CASADI_FNC(ext_cost_e_fun, {{ model_e.name }}_cost_ext_cost_e_fun, {{ dims_e.np }});
+    MAP_CASADI_FNC(ext_cost_e_fun, {{ model_e.name }}_cost_ext_cost_e_fun);
     {%- else %}
     capsule->ext_cost_e_fun.fun = &{{ cost_e.cost_function_ext_cost_e }};
-    external_function_param_{{ cost_e.cost_ext_fun_type_e }}_create(&capsule->ext_cost_e_fun, {{ dims_e.np }});
+    external_function_external_param_{{ cost_e.cost_ext_fun_type_e }}_create(&capsule->ext_cost_e_fun);
     {%- endif %}
 
     // external cost - jacobian
     {%- if cost_e.cost_ext_fun_type_e == "casadi" %}
-    MAP_CASADI_FNC(ext_cost_e_fun_jac, {{ model_e.name }}_cost_ext_cost_e_fun_jac, {{ dims_e.np }});
+    MAP_CASADI_FNC(ext_cost_e_fun_jac, {{ model_e.name }}_cost_ext_cost_e_fun_jac);
     {%- else %}
     capsule->ext_cost_e_fun_jac.fun = &{{ cost_e.cost_function_ext_cost_e }};
-    external_function_param_{{ cost_e.cost_ext_fun_type_e }}_create(&capsule->ext_cost_e_fun_jac, {{ dims_e.np }});
+    external_function_external_param_{{ cost_e.cost_ext_fun_type_e }}_create(&capsule->ext_cost_e_fun_jac);
     {%- endif %}
 
     // external cost - hessian
     {%- if cost_e.cost_ext_fun_type_e == "casadi" %}
-    MAP_CASADI_FNC(ext_cost_e_fun_jac_hess, {{ model_e.name }}_cost_ext_cost_e_fun_jac_hess, {{ dims_e.np }});
+    MAP_CASADI_FNC(ext_cost_e_fun_jac_hess, {{ model_e.name }}_cost_ext_cost_e_fun_jac_hess);
     {%- else %}
     capsule->ext_cost_e_fun_jac_hess.fun = &{{ cost_e.cost_function_ext_cost_e }};
-    external_function_param_{{ cost_e.cost_ext_fun_type_e }}_create(&capsule->ext_cost_e_fun_jac_hess, {{ dims_e.np }});
+    external_function_external_param_{{ cost_e.cost_ext_fun_type_e }}_create(&capsule->ext_cost_e_fun_jac_hess);
     {%- endif %}
 {%- endif %}
 
@@ -918,25 +918,25 @@ void {{ name }}_acados_create_setup_nlp_in({{ name }}_solver_capsule* capsule, i
 
 
 {%- if cost[0].cost_type_0 == "NONLINEAR_LS" %}
-    ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, 0, "nls_y_fun", &capsule->cost_y_0_fun);
-    ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, 0, "nls_y_fun_jac", &capsule->cost_y_0_fun_jac_ut_xt);
-    ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, 0, "nls_y_hess", &capsule->cost_y_0_hess);
+    ocp_nlp_cost_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, 0, "nls_y_fun", &capsule->cost_y_0_fun);
+    ocp_nlp_cost_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, 0, "nls_y_fun_jac", &capsule->cost_y_0_fun_jac_ut_xt);
+    ocp_nlp_cost_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, 0, "nls_y_hess", &capsule->cost_y_0_hess);
 {%- elif cost[0].cost_type_0 == "CONVEX_OVER_NONLINEAR" %}
-    ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, 0, "conl_cost_fun", &capsule->conl_cost_0_fun);
-    ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, 0, "conl_cost_fun_jac_hess", &capsule->conl_cost_0_fun_jac_hess);
+    ocp_nlp_cost_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, 0, "conl_cost_fun", &capsule->conl_cost_0_fun);
+    ocp_nlp_cost_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, 0, "conl_cost_fun_jac_hess", &capsule->conl_cost_0_fun_jac_hess);
 {%- elif cost[0].cost_type_0 == "EXTERNAL" %}
-    ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, 0, "ext_cost_fun", &capsule->ext_cost_0_fun);
-    ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, 0, "ext_cost_fun_jac", &capsule->ext_cost_0_fun_jac);
-    ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, 0, "ext_cost_fun_jac_hess", &capsule->ext_cost_0_fun_jac_hess);
+    ocp_nlp_cost_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, 0, "ext_cost_fun", &capsule->ext_cost_0_fun);
+    ocp_nlp_cost_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, 0, "ext_cost_fun_jac", &capsule->ext_cost_0_fun_jac);
+    ocp_nlp_cost_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, 0, "ext_cost_fun_jac_hess", &capsule->ext_cost_0_fun_jac_hess);
 {%- endif %}
 
 {%- if mocp_opts.cost_discretization[0] == "INTEGRATOR" %}
   {%- if cost[0].cost_type_0 == "NONLINEAR_LS" %}
-    ocp_nlp_dynamics_model_set(nlp_config, nlp_dims, nlp_in, 0, "nls_y_fun_jac", &capsule->cost_y_0_fun_jac_ut_xt);
-    ocp_nlp_dynamics_model_set(nlp_config, nlp_dims, nlp_in, 0, "nls_y_fun", &capsule->cost_y_0_fun);
+    ocp_nlp_dynamics_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, 0, "nls_y_fun_jac", &capsule->cost_y_0_fun_jac_ut_xt);
+    ocp_nlp_dynamics_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, 0, "nls_y_fun", &capsule->cost_y_0_fun);
   {%- elif cost[0].cost_type_0 == "CONVEX_OVER_NONLINEAR" %}
-    ocp_nlp_dynamics_model_set(nlp_config, nlp_dims, nlp_in, 0, "conl_cost_fun", &capsule->conl_cost_0_fun);
-    ocp_nlp_dynamics_model_set(nlp_config, nlp_dims, nlp_in, 0, "conl_cost_fun_jac_hess", &capsule->conl_cost_0_fun_jac_hess);
+    ocp_nlp_dynamics_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, 0, "conl_cost_fun", &capsule->conl_cost_0_fun);
+    ocp_nlp_dynamics_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, 0, "conl_cost_fun_jac_hess", &capsule->conl_cost_0_fun_jac_hess);
   {%- endif %}
 {%- endif %}
 
@@ -1038,10 +1038,10 @@ void {{ name }}_acados_create_setup_nlp_in({{ name }}_solver_capsule* capsule, i
         {%- endif %}
     {%- endfor %}
 
-    ocp_nlp_constraints_model_set(nlp_config, nlp_dims, nlp_in, 0, "nl_constr_h_fun_jac", &capsule->nl_constr_h_0_fun_jac);
-    ocp_nlp_constraints_model_set(nlp_config, nlp_dims, nlp_in, 0, "nl_constr_h_fun", &capsule->nl_constr_h_0_fun);
+    ocp_nlp_constraints_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, 0, "nl_constr_h_fun_jac", &capsule->nl_constr_h_0_fun_jac);
+    ocp_nlp_constraints_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, 0, "nl_constr_h_fun", &capsule->nl_constr_h_0_fun);
     {% if solver_options.hessian_approx == "EXACT" %}
-    ocp_nlp_constraints_model_set(nlp_config, nlp_dims, nlp_in, 0, "nl_constr_h_fun_jac_hess",
+    ocp_nlp_constraints_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, 0, "nl_constr_h_fun_jac_hess",
                                   &capsule->nl_constr_h_0_fun_jac_hess);
     {% endif %}
     ocp_nlp_constraints_model_set(nlp_config, nlp_dims, nlp_in, 0, "lh", lh_0);
@@ -1063,9 +1063,9 @@ void {{ name }}_acados_create_setup_nlp_in({{ name }}_solver_capsule* capsule, i
 
     ocp_nlp_constraints_model_set(nlp_config, nlp_dims, nlp_in, 0, "lphi", lphi_0);
     ocp_nlp_constraints_model_set(nlp_config, nlp_dims, nlp_in, 0, "uphi", uphi_0);
-    ocp_nlp_constraints_model_set(nlp_config, nlp_dims, nlp_in, 0,
+    ocp_nlp_constraints_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, 0,
                                   "nl_constr_phi_o_r_fun", &capsule->phi_0_constraint_fun);
-    ocp_nlp_constraints_model_set(nlp_config, nlp_dims, nlp_in, 0,
+    ocp_nlp_constraints_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, 0,
                                   "nl_constr_phi_o_r_fun_phi_jac_ux_z_phi_hess_r_jac_ux", &capsule->phi_0_constraint_fun_jac_hess);
     free(luphi_0);
 {% endif %}
@@ -1200,42 +1200,42 @@ void {{ name }}_acados_create_setup_nlp_in({{ name }}_solver_capsule* capsule, i
     {
         i_fun = i - {{ start_idx[jj] }};
     {%- if mocp_opts.integrator_type[jj] == "ERK" %}
-        ocp_nlp_dynamics_model_set(nlp_config, nlp_dims, nlp_in, i, "expl_vde_forw", &capsule->forw_vde_casadi_{{ jj }}[i_fun]);
-        ocp_nlp_dynamics_model_set(nlp_config, nlp_dims, nlp_in, i, "expl_ode_fun", &capsule->expl_ode_fun_{{ jj }}[i_fun]);
+        ocp_nlp_dynamics_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, i, "expl_vde_forw", &capsule->forw_vde_casadi_{{ jj }}[i_fun]);
+        ocp_nlp_dynamics_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, i, "expl_ode_fun", &capsule->expl_ode_fun_{{ jj }}[i_fun]);
         {%- if solver_options.hessian_approx == "EXACT" %}
-        ocp_nlp_dynamics_model_set(nlp_config, nlp_dims, nlp_in, i, "expl_ode_hess", &capsule->hess_vde_casadi_{{ jj }}[i_fun]);
+        ocp_nlp_dynamics_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, i, "expl_ode_hess", &capsule->hess_vde_casadi_{{ jj }}[i_fun]);
         {%- endif %}
     {%- elif mocp_opts.integrator_type[jj] == "IRK" %}
-        ocp_nlp_dynamics_model_set(nlp_config, nlp_dims, nlp_in, i, "impl_dae_fun", &capsule->impl_dae_fun_{{ jj }}[i_fun]);
-        ocp_nlp_dynamics_model_set(nlp_config, nlp_dims, nlp_in, i,
+        ocp_nlp_dynamics_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, i, "impl_dae_fun", &capsule->impl_dae_fun_{{ jj }}[i_fun]);
+        ocp_nlp_dynamics_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, i,
                                    "impl_dae_fun_jac_x_xdot_z", &capsule->impl_dae_fun_jac_x_xdot_z_{{ jj }}[i_fun]);
-        ocp_nlp_dynamics_model_set(nlp_config, nlp_dims, nlp_in, i,
+        ocp_nlp_dynamics_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, i,
                                    "impl_dae_jac_x_xdot_u", &capsule->impl_dae_jac_x_xdot_u_z_{{ jj }}[i_fun]);
         {%- if solver_options.hessian_approx == "EXACT" %}
-        ocp_nlp_dynamics_model_set(nlp_config, nlp_dims, nlp_in, i, "impl_dae_hess", &capsule->impl_dae_hess_{{ jj }}[i_fun]);
+        ocp_nlp_dynamics_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, i, "impl_dae_hess", &capsule->impl_dae_hess_{{ jj }}[i_fun]);
         {%- endif %}
     {%- elif mocp_opts.integrator_type[jj] == "LIFTED_IRK" %}
-        ocp_nlp_dynamics_model_set(nlp_config, nlp_dims, nlp_in, i, "impl_dae_fun", &capsule->impl_dae_fun_{{ jj }}[i_fun]);
-        ocp_nlp_dynamics_model_set(nlp_config, nlp_dims, nlp_in, i,
+        ocp_nlp_dynamics_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, i, "impl_dae_fun", &capsule->impl_dae_fun_{{ jj }}[i_fun]);
+        ocp_nlp_dynamics_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, i,
                                    "impl_dae_fun_jac_x_xdot_u", &capsule->impl_dae_fun_jac_x_xdot_u_{{ jj }}[i_fun]);
     {%- elif mocp_opts.integrator_type[jj] == "GNSF" %}
         {% if model[jj].gnsf.purely_linear != 1 %}
-        ocp_nlp_dynamics_model_set(nlp_config, nlp_dims, nlp_in, i, "phi_fun", &capsule->gnsf_phi_fun_{{ jj }}[i_fun]);
-        ocp_nlp_dynamics_model_set(nlp_config, nlp_dims, nlp_in, i, "phi_fun_jac_y", &capsule->gnsf_phi_fun_jac_y_{{ jj }}[i_fun]);
-        ocp_nlp_dynamics_model_set(nlp_config, nlp_dims, nlp_in, i, "phi_jac_y_uhat", &capsule->gnsf_phi_jac_y_uhat_{{ jj }}[i_fun]);
+        ocp_nlp_dynamics_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, i, "phi_fun", &capsule->gnsf_phi_fun_{{ jj }}[i_fun]);
+        ocp_nlp_dynamics_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, i, "phi_fun_jac_y", &capsule->gnsf_phi_fun_jac_y_{{ jj }}[i_fun]);
+        ocp_nlp_dynamics_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, i, "phi_jac_y_uhat", &capsule->gnsf_phi_jac_y_uhat_{{ jj }}[i_fun]);
             {% if model[jj].gnsf.nontrivial_f_LO == 1 %}
-        ocp_nlp_dynamics_model_set(nlp_config, nlp_dims, nlp_in, i, "f_lo_jac_x1_x1dot_u_z",
+        ocp_nlp_dynamics_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, i, "f_lo_jac_x1_x1dot_u_z",
                                    &capsule->gnsf_f_lo_jac_x1_x1dot_u_z_{{ jj }}[i_fun]);
             {%- endif %}
         {%- endif %}
-        ocp_nlp_dynamics_model_set(nlp_config, nlp_dims, nlp_in, i, "gnsf_get_matrices_fun",
+        ocp_nlp_dynamics_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, i, "gnsf_get_matrices_fun",
                                    &capsule->gnsf_get_matrices_fun_{{ jj }}[i_fun]);
     {%- elif mocp_opts.integrator_type[jj] == "DISCRETE" %}
-        ocp_nlp_dynamics_model_set(nlp_config, nlp_dims, nlp_in, i, "disc_dyn_fun", &capsule->discr_dyn_phi_fun_{{ jj }}[i_fun]);
-        ocp_nlp_dynamics_model_set(nlp_config, nlp_dims, nlp_in, i, "disc_dyn_fun_jac",
+        ocp_nlp_dynamics_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, i, "disc_dyn_fun", &capsule->discr_dyn_phi_fun_{{ jj }}[i_fun]);
+        ocp_nlp_dynamics_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, i, "disc_dyn_fun_jac",
                                    &capsule->discr_dyn_phi_fun_jac_ut_xt_{{ jj }}[i_fun]);
         {%- if solver_options.hessian_approx == "EXACT" %}
-        ocp_nlp_dynamics_model_set(nlp_config, nlp_dims, nlp_in, i, "disc_dyn_fun_jac_hess",
+        ocp_nlp_dynamics_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, i, "disc_dyn_fun_jac_hess",
                                    &capsule->discr_dyn_phi_fun_jac_ut_xt_hess_{{ jj }}[i_fun]);
         {%- endif %}
     {%- endif %}
@@ -1247,24 +1247,24 @@ void {{ name }}_acados_create_setup_nlp_in({{ name }}_solver_capsule* capsule, i
     {
         i_fun = i - {{ cost_start_idx[jj] }};
 
-        ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, i, "nls_y_fun", &capsule->cost_y_fun_{{ jj }}[i_fun]);
-        ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, i, "nls_y_fun_jac", &capsule->cost_y_fun_jac_ut_xt_{{ jj }}[i_fun]);
-        ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, i, "nls_y_hess", &capsule->cost_y_hess_{{ jj }}[i_fun]);
+        ocp_nlp_cost_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, i, "nls_y_fun", &capsule->cost_y_fun_{{ jj }}[i_fun]);
+        ocp_nlp_cost_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, i, "nls_y_fun_jac", &capsule->cost_y_fun_jac_ut_xt_{{ jj }}[i_fun]);
+        ocp_nlp_cost_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, i, "nls_y_hess", &capsule->cost_y_hess_{{ jj }}[i_fun]);
     }
 {%- elif cost[jj].cost_type == "CONVEX_OVER_NONLINEAR" %}
     for (int i = {{ cost_start_idx[jj] }}; i < {{ end_idx[jj] }}; i++)
     {
         i_fun = i - {{ cost_start_idx[jj] }};
-        ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, i, "conl_cost_fun", &capsule->conl_cost_fun_{{ jj }}[i_fun]);
-        ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, i, "conl_cost_fun_jac_hess", &capsule->conl_cost_fun_jac_hess_{{ jj }}[i_fun]);
+        ocp_nlp_cost_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, i, "conl_cost_fun", &capsule->conl_cost_fun_{{ jj }}[i_fun]);
+        ocp_nlp_cost_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, i, "conl_cost_fun_jac_hess", &capsule->conl_cost_fun_jac_hess_{{ jj }}[i_fun]);
     }
 {%- elif cost[jj].cost_type == "EXTERNAL" %}
     for (int i = {{ cost_start_idx[jj] }}; i < {{ end_idx[jj] }}; i++)
     {
         i_fun = i - {{ cost_start_idx[jj] }};
-        ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, i, "ext_cost_fun", &capsule->ext_cost_fun_{{ jj }}[i_fun]);
-        ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, i, "ext_cost_fun_jac", &capsule->ext_cost_fun_jac_{{ jj }}[i_fun]);
-        ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, i, "ext_cost_fun_jac_hess", &capsule->ext_cost_fun_jac_hess_{{ jj }}[i_fun]);
+        ocp_nlp_cost_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, i, "ext_cost_fun", &capsule->ext_cost_fun_{{ jj }}[i_fun]);
+        ocp_nlp_cost_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, i, "ext_cost_fun_jac", &capsule->ext_cost_fun_jac_{{ jj }}[i_fun]);
+        ocp_nlp_cost_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, i, "ext_cost_fun_jac_hess", &capsule->ext_cost_fun_jac_hess_{{ jj }}[i_fun]);
     }
 {%- endif %}
 
@@ -1275,11 +1275,11 @@ void {{ name }}_acados_create_setup_nlp_in({{ name }}_solver_capsule* capsule, i
     {
         i_fun = i - {{ cost_start_idx[jj] }};
   {%- if cost[jj].cost_type == "NONLINEAR_LS" %}
-        ocp_nlp_dynamics_model_set(nlp_config, nlp_dims, nlp_in, i, "nls_y_fun_jac", &capsule->cost_y_fun_jac_ut_xt_{{ jj }}[i_fun]);
-        ocp_nlp_dynamics_model_set(nlp_config, nlp_dims, nlp_in, i, "nls_y_fun", &capsule->cost_y_fun_{{ jj }}[i_fun]);
+        ocp_nlp_dynamics_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, i, "nls_y_fun_jac", &capsule->cost_y_fun_jac_ut_xt_{{ jj }}[i_fun]);
+        ocp_nlp_dynamics_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, i, "nls_y_fun", &capsule->cost_y_fun_{{ jj }}[i_fun]);
   {%- elif cost[jj].cost_type == "CONVEX_OVER_NONLINEAR" %}
-        ocp_nlp_dynamics_model_set(nlp_config, nlp_dims, nlp_in, i, "conl_cost_fun", &capsule->conl_cost_fun_{{ jj }}[i_fun]);
-        ocp_nlp_dynamics_model_set(nlp_config, nlp_dims, nlp_in, i, "conl_cost_fun_jac_hess", &capsule->conl_cost_fun_jac_hess_{{ jj }}[i_fun]);
+        ocp_nlp_dynamics_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, i, "conl_cost_fun", &capsule->conl_cost_fun_{{ jj }}[i_fun]);
+        ocp_nlp_dynamics_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, i, "conl_cost_fun_jac_hess", &capsule->conl_cost_fun_jac_hess_{{ jj }}[i_fun]);
   {%- endif %}
     }
 {%- endif %}
@@ -1690,12 +1690,12 @@ void {{ name }}_acados_create_setup_nlp_in({{ name }}_solver_capsule* capsule, i
     for (int i = {{ cost_start_idx[jj] }}; i < {{ end_idx[jj] }}; i++)
     {
         i_fun = i - {{ cost_start_idx[jj] }};
-        ocp_nlp_constraints_model_set(nlp_config, nlp_dims, nlp_in, i, "nl_constr_h_fun_jac",
+        ocp_nlp_constraints_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, i, "nl_constr_h_fun_jac",
                                       &capsule->nl_constr_h_fun_jac_{{ jj }}[i_fun]);
-        ocp_nlp_constraints_model_set(nlp_config, nlp_dims, nlp_in, i, "nl_constr_h_fun",
+        ocp_nlp_constraints_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, i, "nl_constr_h_fun",
                                       &capsule->nl_constr_h_fun_{{ jj }}[i_fun]);
         {% if solver_options.hessian_approx == "EXACT" %}
-        ocp_nlp_constraints_model_set(nlp_config, nlp_dims, nlp_in, i,
+        ocp_nlp_constraints_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, i,
                                       "nl_constr_h_fun_jac_hess", &capsule->nl_constr_h_fun_jac_hess_{{ jj }}[i_fun]);
         {% endif %}
         ocp_nlp_constraints_model_set(nlp_config, nlp_dims, nlp_in, i, "lh", lh);
@@ -1724,8 +1724,8 @@ void {{ name }}_acados_create_setup_nlp_in({{ name }}_solver_capsule* capsule, i
     for (int i = {{ cost_start_idx[jj] }}; i < {{ end_idx[jj] }}; i++)
     {
         i_fun = i - {{ cost_start_idx[jj] }};
-        ocp_nlp_constraints_model_set(nlp_config, nlp_dims, nlp_in, i, "nl_constr_phi_o_r_fun", &capsule->phi_constraint_fun[i_fun]);
-        ocp_nlp_constraints_model_set(nlp_config, nlp_dims, nlp_in, i,
+        ocp_nlp_constraints_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, i, "nl_constr_phi_o_r_fun", &capsule->phi_constraint_fun[i_fun]);
+        ocp_nlp_constraints_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, i,
                                       "nl_constr_phi_o_r_fun_phi_jac_ux_z_phi_hess_r_jac_ux", &capsule->phi_constraint_fun_jac_hess[i_fun]);
         ocp_nlp_constraints_model_set(nlp_config, nlp_dims, nlp_in, i, "lphi", lphi);
         ocp_nlp_constraints_model_set(nlp_config, nlp_dims, nlp_in, i, "uphi", uphi);
@@ -1781,18 +1781,18 @@ void {{ name }}_acados_create_setup_nlp_in({{ name }}_solver_capsule* capsule, i
 
 
 {%- if cost_e.cost_type_e == "NONLINEAR_LS" %}
-    ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, N, "nls_y_fun", &capsule->cost_y_e_fun);
-    ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, N, "nls_y_fun_jac", &capsule->cost_y_e_fun_jac_ut_xt);
-    ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, N, "nls_y_hess", &capsule->cost_y_e_hess);
+    ocp_nlp_cost_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, N, "nls_y_fun", &capsule->cost_y_e_fun);
+    ocp_nlp_cost_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, N, "nls_y_fun_jac", &capsule->cost_y_e_fun_jac_ut_xt);
+    ocp_nlp_cost_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, N, "nls_y_hess", &capsule->cost_y_e_hess);
 
 {%- elif cost_e.cost_type_e == "CONVEX_OVER_NONLINEAR" %}
-    ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, N, "conl_cost_fun", &capsule->conl_cost_e_fun);
-    ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, N, "conl_cost_fun_jac_hess", &capsule->conl_cost_e_fun_jac_hess);
+    ocp_nlp_cost_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, N, "conl_cost_fun", &capsule->conl_cost_e_fun);
+    ocp_nlp_cost_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, N, "conl_cost_fun_jac_hess", &capsule->conl_cost_e_fun_jac_hess);
 
 {%- elif cost_e.cost_type_e == "EXTERNAL" %}
-    ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, N, "ext_cost_fun", &capsule->ext_cost_e_fun);
-    ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, N, "ext_cost_fun_jac", &capsule->ext_cost_e_fun_jac);
-    ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, N, "ext_cost_fun_jac_hess", &capsule->ext_cost_e_fun_jac_hess);
+    ocp_nlp_cost_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, N, "ext_cost_fun", &capsule->ext_cost_e_fun);
+    ocp_nlp_cost_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, N, "ext_cost_fun_jac", &capsule->ext_cost_e_fun_jac);
+    ocp_nlp_cost_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, N, "ext_cost_fun_jac_hess", &capsule->ext_cost_e_fun_jac_hess);
 {%- endif %}
 
 
@@ -2015,10 +2015,10 @@ void {{ name }}_acados_create_setup_nlp_in({{ name }}_solver_capsule* capsule, i
         {%- endif %}
     {%- endfor %}
 
-    ocp_nlp_constraints_model_set(nlp_config, nlp_dims, nlp_in, N, "nl_constr_h_fun_jac", &capsule->nl_constr_h_e_fun_jac);
-    ocp_nlp_constraints_model_set(nlp_config, nlp_dims, nlp_in, N, "nl_constr_h_fun", &capsule->nl_constr_h_e_fun);
+    ocp_nlp_constraints_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, N, "nl_constr_h_fun_jac", &capsule->nl_constr_h_e_fun_jac);
+    ocp_nlp_constraints_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, N, "nl_constr_h_fun", &capsule->nl_constr_h_e_fun);
     {% if solver_options.hessian_approx == "EXACT" %}
-    ocp_nlp_constraints_model_set(nlp_config, nlp_dims, nlp_in, N, "nl_constr_h_fun_jac_hess",
+    ocp_nlp_constraints_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, N, "nl_constr_h_fun_jac_hess",
                                   &capsule->nl_constr_h_e_fun_jac_hess);
     {% endif %}
     ocp_nlp_constraints_model_set(nlp_config, nlp_dims, nlp_in, N, "lh", lh_e);
@@ -2040,8 +2040,8 @@ void {{ name }}_acados_create_setup_nlp_in({{ name }}_solver_capsule* capsule, i
 
     ocp_nlp_constraints_model_set(nlp_config, nlp_dims, nlp_in, N, "lphi", lphi_e);
     ocp_nlp_constraints_model_set(nlp_config, nlp_dims, nlp_in, N, "uphi", uphi_e);
-    ocp_nlp_constraints_model_set(nlp_config, nlp_dims, nlp_in, N, "nl_constr_phi_o_r_fun", &capsule->phi_e_constraint_fun);
-    ocp_nlp_constraints_model_set(nlp_config, nlp_dims, nlp_in, N,
+    ocp_nlp_constraints_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, N, "nl_constr_phi_o_r_fun", &capsule->phi_e_constraint_fun);
+    ocp_nlp_constraints_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, N,
                                   "nl_constr_phi_o_r_fun_phi_jac_ux_z_phi_hess_r_jac_ux", &capsule->phi_e_constraint_fun_jac_hess);
     free(luphi_e);
 {% endif %}
@@ -2551,8 +2551,6 @@ int {{ name }}_acados_reset({{ name }}_solver_capsule* capsule, int reset_qp_sol
 int {{ name }}_acados_update_params({{ name }}_solver_capsule* capsule, int stage, double *p, int np)
 {
     int solver_status = 0;
-    const int N = capsule->nlp_solver_plan->N;
-    int i_fun, i_cost_fun;
 
     {%- for jj in range(end=n_phases) %}{# phases loop !#}
     if (stage >= {{ start_idx[jj] }} && stage < {{ end_idx[jj] }})
@@ -2563,134 +2561,9 @@ int {{ name }}_acados_update_params({{ name }}_solver_capsule* capsule, int stag
                 " Parameters should be of length %i. Exiting.\n", np, stage, NP_{{ jj }});
             exit(1);
         }
-
-        i_fun = stage - {{ start_idx[jj] }};
-        i_cost_fun = stage - {{ cost_start_idx[jj] }};
-    {%- if mocp_opts.integrator_type[jj] == "IRK" %}
-        capsule->impl_dae_fun_{{ jj }}[i_fun].set_param(capsule->impl_dae_fun_{{ jj }}+i_fun, p);
-        capsule->impl_dae_fun_jac_x_xdot_z_{{ jj }}[i_fun].set_param(capsule->impl_dae_fun_jac_x_xdot_z_{{ jj }}+i_fun, p);
-        capsule->impl_dae_jac_x_xdot_u_z_{{ jj }}[i_fun].set_param(capsule->impl_dae_jac_x_xdot_u_z_{{ jj }}+i_fun, p);
-
-        {%- if solver_options.hessian_approx == "EXACT" %}
-        capsule->impl_dae_hess_{{ jj }}[i_fun].set_param(capsule->impl_dae_hess_{{ jj }}+i_fun, p);
-        {%- endif %}
-    {%- elif mocp_opts.integrator_type[jj] == "LIFTED_IRK" %}
-        capsule->impl_dae_fun_{{ jj }}[i_fun].set_param(capsule->impl_dae_fun_{{ jj }}+i_fun, p);
-        capsule->impl_dae_fun_jac_x_xdot_u_{{ jj }}[i_fun].set_param(capsule->impl_dae_fun_jac_x_xdot_u_{{ jj }}+i_fun, p);
-    {%- elif mocp_opts.integrator_type[jj] == "ERK" %}
-        capsule->forw_vde_casadi_{{ jj }}[i_fun].set_param(capsule->forw_vde_casadi_{{ jj }}+i_fun, p);
-        capsule->expl_ode_fun_{{ jj }}[i_fun].set_param(capsule->expl_ode_fun_{{ jj }}+i_fun, p);
-
-        {%- if solver_options.hessian_approx == "EXACT" %}
-        capsule->hess_vde_casadi_{{ jj }}[i_fun].set_param(capsule->hess_vde_casadi_{{ jj }}+i_fun, p);
-        {%- endif %}
-    {%- elif mocp_opts.integrator_type[jj] == "GNSF" %}
-    {% if model.gnsf.purely_linear != 1 %}
-        capsule->gnsf_phi_fun_{{ jj }}[i_fun].set_param(capsule->gnsf_phi_fun_{{ jj }}+i_fun, p);
-        capsule->gnsf_phi_fun_jac_y_{{ jj }}[i_fun].set_param(capsule->gnsf_phi_fun_jac_y_{{ jj }}+i_fun, p);
-        capsule->gnsf_phi_jac_y_uhat_{{ jj }}[i_fun].set_param(capsule->gnsf_phi_jac_y_uhat_{{ jj }}+i_fun, p);
-        {% if model.gnsf.nontrivial_f_LO == 1 %}
-            capsule->gnsf_f_lo_jac_x1_x1dot_u_z_{{ jj }}[i_fun].set_param(capsule->gnsf_f_lo_jac_x1_x1dot_u_z_{{ jj }}+i_fun, p);
-        {%- endif %}
-    {%- endif %}
-    {% elif mocp_opts.integrator_type[jj] == "DISCRETE" %}
-        capsule->discr_dyn_phi_fun_{{ jj }}[i_fun].set_param(capsule->discr_dyn_phi_fun_{{ jj }}+i_fun, p);
-        capsule->discr_dyn_phi_fun_jac_ut_xt_{{ jj }}[i_fun].set_param(capsule->discr_dyn_phi_fun_jac_ut_xt_{{ jj }}+i_fun, p);
-    {%- if solver_options.hessian_approx == "EXACT" %}
-        capsule->discr_dyn_phi_fun_jac_ut_xt_hess_{{ jj }}[i_fun].set_param(capsule->discr_dyn_phi_fun_jac_ut_xt_hess_{{ jj }}+i_fun, p);
-    {%- endif %}
-    {%- endif %}{# integrator_type #}
-        if (stage > 0)
-        {
-          {%- if constraints[jj].constr_type == "BGP" %}
-            capsule->phi_constraint_fun_{{ jj }}[i_cost_fun].set_param(capsule->phi_constraint_fun_{{ jj }}+i_cost_fun, p);
-            capsule->phi_constraint_fun_jac_hess_{{ jj }}[i_cost_fun].set_param(capsule->phi_constraint_fun_jac_hess_{{ jj }}+i_cost_fun, p);
-          {%- elif constraints[jj].constr_type == "BGH" and phases_dims[jj].nh > 0 %}
-            capsule->nl_constr_h_fun_jac_{{ jj }}[i_cost_fun].set_param(capsule->nl_constr_h_fun_jac_{{ jj }}+i_cost_fun, p);
-            capsule->nl_constr_h_fun_{{ jj }}[i_cost_fun].set_param(capsule->nl_constr_h_fun_{{ jj }}+i_cost_fun, p);
-          {%- if solver_options.hessian_approx == "EXACT" %}
-            capsule->nl_constr_h_fun_jac_hess_{{ jj }}[i_cost_fun].set_param(capsule->nl_constr_h_fun_jac_hess_{{ jj }}+i_cost_fun, p);
-          {%- endif %}
-          {%- endif %}
-
-          {%- if cost[jj].cost_type == "NONLINEAR_LS" %}
-            capsule->cost_y_fun_{{ jj }}[i_cost_fun].set_param(capsule->cost_y_fun_{{ jj }}+i_cost_fun, p);
-            capsule->cost_y_fun_jac_ut_xt_{{ jj }}[i_cost_fun].set_param(capsule->cost_y_fun_jac_ut_xt_{{ jj }}+i_cost_fun, p);
-            capsule->cost_y_hess_{{ jj }}[i_cost_fun].set_param(capsule->cost_y_hess_{{ jj }}+i_cost_fun, p);
-          {%- elif cost[jj].cost_type == "CONVEX_OVER_NONLINEAR" %}
-            capsule->conl_cost_fun_{{ jj }}[i_cost_fun].set_param(capsule->conl_cost_fun_{{ jj }}+i_cost_fun, p);
-            capsule->conl_cost_fun_jac_hess_{{ jj }}[i_cost_fun].set_param(capsule->conl_cost_fun_jac_hess_{{ jj }}+i_cost_fun, p);
-          {%- elif cost[jj].cost_type == "EXTERNAL" %}
-            capsule->ext_cost_fun_{{ jj }}[i_cost_fun].set_param(capsule->ext_cost_fun_{{ jj }}+i_cost_fun, p);
-            capsule->ext_cost_fun_jac_{{ jj }}[i_cost_fun].set_param(capsule->ext_cost_fun_jac_{{ jj }}+i_cost_fun, p);
-            capsule->ext_cost_fun_jac_hess_{{ jj }}[i_cost_fun].set_param(capsule->ext_cost_fun_jac_hess_{{ jj }}+i_cost_fun, p);
-          {%- endif %}
-        }
     }
-    {%- endfor %}{# for jj in range(end=n_phases) #}
-
-    if (stage == 0)
-    {
-        // constraints
-        {%- if constraints_0.constr_type_0 == "BGP" %}
-        capsule->phi_0_constraint_fun.set_param(&capsule->phi_0_constraint_fun, p);
-        capsule->phi_0_constraint_fun_jac_hess.set_param(&capsule->phi_0_constraint_fun_jac_hess, p);
-        {%- elif constraints_0.constr_type_0 == "BGH" and dims_0.nh_0 > 0 %}
-        capsule->nl_constr_h_0_fun_jac.set_param(&capsule->nl_constr_h_0_fun_jac, p);
-        capsule->nl_constr_h_0_fun.set_param(&capsule->nl_constr_h_0_fun, p);
-        {%- if solver_options.hessian_approx == "EXACT" %}
-        capsule->nl_constr_h_0_fun_jac_hess.set_param(&capsule->nl_constr_h_0_fun_jac_hess, p);
-        {%- endif %}
-        {%- endif %}
-        // cost
-        {%- if cost[0].cost_type_0 == "NONLINEAR_LS" %}
-        capsule->cost_y_0_fun.set_param(&capsule->cost_y_0_fun, p);
-        capsule->cost_y_0_fun_jac_ut_xt.set_param(&capsule->cost_y_0_fun_jac_ut_xt, p);
-        capsule->cost_y_0_hess.set_param(&capsule->cost_y_0_hess, p);
-        {%- elif cost[0].cost_type_0 == "CONVEX_OVER_NONLINEAR" %}
-        capsule->conl_cost_0_fun.set_param(&capsule->conl_cost_0_fun, p);
-        capsule->conl_cost_0_fun_jac_hess.set_param(&capsule->conl_cost_0_fun_jac_hess, p);
-        {%- elif cost[0].cost_type_0 == "EXTERNAL" %}
-        capsule->ext_cost_0_fun.set_param(&capsule->ext_cost_0_fun, p);
-        capsule->ext_cost_0_fun_jac.set_param(&capsule->ext_cost_0_fun_jac, p);
-        capsule->ext_cost_0_fun_jac_hess.set_param(&capsule->ext_cost_0_fun_jac_hess, p);
-        {%- endif %}
-    }
-
-    if (stage == N)
-    {
-        if ({{ dims_e.np }} != np)
-        {
-            printf("acados_update_params: trying to set %i parameters at stage %i."
-                " Parameters should be of length %i. Exiting.\n", stage, np, {{ dims_e.np }});
-            exit(1);
-        }
-        // terminal shooting node has no dynamics
-        // cost
-      {%- if cost_e.cost_type_e == "NONLINEAR_LS" %}
-        capsule->cost_y_e_fun.set_param(&capsule->cost_y_e_fun, p);
-        capsule->cost_y_e_fun_jac_ut_xt.set_param(&capsule->cost_y_e_fun_jac_ut_xt, p);
-        capsule->cost_y_e_hess.set_param(&capsule->cost_y_e_hess, p);
-      {%- elif cost_e.cost_type_e == "CONVEX_OVER_NONLINEAR" %}
-        capsule->conl_cost_e_fun.set_param(&capsule->conl_cost_e_fun, p);
-        capsule->conl_cost_e_fun_jac_hess.set_param(&capsule->conl_cost_e_fun_jac_hess, p);
-      {%- elif cost_e.cost_type_e == "EXTERNAL" %}
-        capsule->ext_cost_e_fun.set_param(&capsule->ext_cost_e_fun, p);
-        capsule->ext_cost_e_fun_jac.set_param(&capsule->ext_cost_e_fun_jac, p);
-        capsule->ext_cost_e_fun_jac_hess.set_param(&capsule->ext_cost_e_fun_jac_hess, p);
-      {%- endif %}
-        // constraints
-      {%- if constraints_e.constr_type_e == "BGP" %}
-        capsule->phi_e_constraint_fun.set_param(&capsule->phi_e_constraint_fun, p);
-        capsule->phi_e_constraint_fun_jac_hess.set_param(&capsule->phi_e_constraint_fun_jac_hess, p);
-      {%- elif constraints_e.constr_type_e == "BGH" and dims_e.nh_e > 0 %}
-        capsule->nl_constr_h_e_fun_jac.set_param(&capsule->nl_constr_h_e_fun_jac, p);
-        capsule->nl_constr_h_e_fun.set_param(&capsule->nl_constr_h_e_fun, p);
-      {%- if solver_options.hessian_approx == "EXACT" %}
-        capsule->nl_constr_h_e_fun_jac_hess.set_param(&capsule->nl_constr_h_e_fun_jac_hess, p);
-      {%- endif %}
-      {%- endif %}
-    }
+    {% endfor %}
+    ocp_nlp_in_set(capsule->nlp_config, capsule->nlp_dims, capsule->nlp_in, stage, "parameter_values", p);
 
     return solver_status;
 }
@@ -2698,134 +2571,9 @@ int {{ name }}_acados_update_params({{ name }}_solver_capsule* capsule, int stag
 
 int {{ name }}_acados_update_params_sparse({{ name }}_solver_capsule * capsule, int stage, int *idx, double *p, int n_update)
 {
-    int solver_status = 0;
-    const int N = capsule->nlp_solver_plan->N;
-    int i_fun, i_cost_fun;
+    ocp_nlp_in_set_params_sparse(capsule->nlp_config, capsule->nlp_dims, capsule->nlp_in, stage, idx, p, n_update);
 
-    {%- for jj in range(end=n_phases) %}{# phases loop !#}
-    if (stage >= {{ start_idx[jj] }} && stage < {{ end_idx[jj] }})
-    {
-        i_fun = stage - {{ start_idx[jj] }};
-        i_cost_fun = stage - {{ cost_start_idx[jj] }};
-    {%- if mocp_opts.integrator_type[jj] == "IRK" %}
-        capsule->impl_dae_fun_{{ jj }}[i_fun].set_param_sparse(capsule->impl_dae_fun_{{ jj }}+i_fun, n_update, idx, p);
-        capsule->impl_dae_fun_jac_x_xdot_z_{{ jj }}[i_fun].set_param_sparse(capsule->impl_dae_fun_jac_x_xdot_z_{{ jj }}+i_fun, n_update, idx, p);
-        capsule->impl_dae_jac_x_xdot_u_z_{{ jj }}[i_fun].set_param_sparse(capsule->impl_dae_jac_x_xdot_u_z_{{ jj }}+i_fun, n_update, idx, p);
-
-        {%- if solver_options.hessian_approx == "EXACT" %}
-        capsule->impl_dae_hess_{{ jj }}[i_fun].set_param_sparse(capsule->impl_dae_hess_{{ jj }}+i_fun, n_update, idx, p);
-        {%- endif %}
-    {%- elif mocp_opts.integrator_type[jj] == "LIFTED_IRK" %}
-        capsule->impl_dae_fun_{{ jj }}[i_fun].set_param_sparse(capsule->impl_dae_fun_{{ jj }}+i_fun, n_update, idx, p);
-        capsule->impl_dae_fun_jac_x_xdot_u_{{ jj }}[i_fun].set_param_sparse(capsule->impl_dae_fun_jac_x_xdot_u_{{ jj }}+i_fun, n_update, idx, p);
-    {%- elif mocp_opts.integrator_type[jj] == "ERK" %}
-        capsule->forw_vde_casadi_{{ jj }}[i_fun].set_param_sparse(capsule->forw_vde_casadi_{{ jj }}+i_fun, n_update, idx, p);
-        capsule->expl_ode_fun_{{ jj }}[i_fun].set_param_sparse(capsule->expl_ode_fun_{{ jj }}+i_fun, n_update, idx, p);
-
-        {%- if solver_options.hessian_approx == "EXACT" %}
-        capsule->hess_vde_casadi_{{ jj }}[i_fun].set_param_sparse(capsule->hess_vde_casadi_{{ jj }}+i_fun, n_update, idx, p);
-        {%- endif %}
-    {%- elif mocp_opts.integrator_type[jj] == "GNSF" %}
-    {% if model.gnsf.purely_linear != 1 %}
-        capsule->gnsf_phi_fun_{{ jj }}[i_fun].set_param_sparse(capsule->gnsf_phi_fun_{{ jj }}+i_fun, n_update, idx, p);
-        capsule->gnsf_phi_fun_jac_y_{{ jj }}[i_fun].set_param_sparse(capsule->gnsf_phi_fun_jac_y_{{ jj }}+i_fun, n_update, idx, p);
-        capsule->gnsf_phi_jac_y_uhat_{{ jj }}[i_fun].set_param_sparse(capsule->gnsf_phi_jac_y_uhat_{{ jj }}+i_fun, n_update, idx, p);
-        {% if model.gnsf.nontrivial_f_LO == 1 %}
-            capsule->gnsf_f_lo_jac_x1_x1dot_u_z_{{ jj }}[i_fun].set_param_sparse(capsule->gnsf_f_lo_jac_x1_x1dot_u_z_{{ jj }}+i_fun, n_update, idx, p);
-        {%- endif %}
-    {%- endif %}
-    {% elif mocp_opts.integrator_type[jj] == "DISCRETE" %}
-        capsule->discr_dyn_phi_fun_{{ jj }}[i_fun].set_param_sparse(capsule->discr_dyn_phi_fun_{{ jj }}+i_fun, n_update, idx, p);
-        capsule->discr_dyn_phi_fun_jac_ut_xt_{{ jj }}[i_fun].set_param_sparse(capsule->discr_dyn_phi_fun_jac_ut_xt_{{ jj }}+i_fun, n_update, idx, p);
-    {%- if solver_options.hessian_approx == "EXACT" %}
-        capsule->discr_dyn_phi_fun_jac_ut_xt_hess_{{ jj }}[i_fun].set_param_sparse(capsule->discr_dyn_phi_fun_jac_ut_xt_hess_{{ jj }}+i_fun, n_update, idx, p);
-    {%- endif %}
-    {%- endif %}{# integrator_type #}
-        if (stage > 0)
-        {
-          {%- if constraints[jj].constr_type == "BGP" %}
-            capsule->phi_constraint_fun_{{ jj }}[i_cost_fun].set_param_sparse(capsule->phi_constraint_fun_{{ jj }}+i_cost_fun, n_update, idx, p);
-            capsule->phi_constraint_fun_jac_hess_{{ jj }}[i_cost_fun].set_param_sparse(capsule->phi_constraint_fun_jac_hess_{{ jj }}+i_cost_fun, n_update, idx, p);
-          {%- elif constraints[jj].constr_type == "BGH" and phases_dims[jj].nh > 0 %}
-            capsule->nl_constr_h_fun_jac_{{ jj }}[i_cost_fun].set_param_sparse(capsule->nl_constr_h_fun_jac_{{ jj }}+i_cost_fun, n_update, idx, p);
-            capsule->nl_constr_h_fun_{{ jj }}[i_cost_fun].set_param_sparse(capsule->nl_constr_h_fun_{{ jj }}+i_cost_fun, n_update, idx, p);
-          {%- if solver_options.hessian_approx == "EXACT" %}
-            capsule->nl_constr_h_fun_jac_hess_{{ jj }}[i_cost_fun].set_param_sparse(capsule->nl_constr_h_fun_jac_hess_{{ jj }}+i_cost_fun, n_update, idx, p);
-          {%- endif %}
-          {%- endif %}
-
-          {%- if cost[jj].cost_type == "NONLINEAR_LS" %}
-            capsule->cost_y_fun_{{ jj }}[i_cost_fun].set_param_sparse(capsule->cost_y_fun_{{ jj }}+i_cost_fun, n_update, idx, p);
-            capsule->cost_y_fun_jac_ut_xt_{{ jj }}[i_cost_fun].set_param_sparse(capsule->cost_y_fun_jac_ut_xt_{{ jj }}+i_cost_fun, n_update, idx, p);
-            capsule->cost_y_hess_{{ jj }}[i_cost_fun].set_param_sparse(capsule->cost_y_hess_{{ jj }}+i_cost_fun, n_update, idx, p);
-          {%- elif cost[jj].cost_type == "CONVEX_OVER_NONLINEAR" %}
-            capsule->conl_cost_fun_{{ jj }}[i_cost_fun].set_param_sparse(capsule->conl_cost_fun_{{ jj }}+i_cost_fun, n_update, idx, p);
-            capsule->conl_cost_fun_jac_hess_{{ jj }}[i_cost_fun].set_param_sparse(capsule->conl_cost_fun_jac_hess_{{ jj }}+i_cost_fun, n_update, idx, p);
-          {%- elif cost[jj].cost_type == "EXTERNAL" %}
-            capsule->ext_cost_fun_{{ jj }}[i_cost_fun].set_param_sparse(capsule->ext_cost_fun_{{ jj }}+i_cost_fun, n_update, idx, p);
-            capsule->ext_cost_fun_jac_{{ jj }}[i_cost_fun].set_param_sparse(capsule->ext_cost_fun_jac_{{ jj }}+i_cost_fun, n_update, idx, p);
-            capsule->ext_cost_fun_jac_hess_{{ jj }}[i_cost_fun].set_param_sparse(capsule->ext_cost_fun_jac_hess_{{ jj }}+i_cost_fun, n_update, idx, p);
-          {%- endif %}
-        }
-    }
-    {%- endfor %}{# for jj in range(end=n_phases) #}
-
-    if (stage == 0)
-    {
-        // constraints
-        {%- if constraints_0.constr_type_0 == "BGP" %}
-        capsule->phi_0_constraint_fun.set_param_sparse(&capsule->phi_0_constraint_fun, n_update, idx, p);
-        capsule->phi_0_constraint_fun_jac_hess.set_param_sparse(&capsule->phi_0_constraint_fun_jac_hess, n_update, idx, p);
-        {%- elif constraints_0.constr_type_0 == "BGH" and dims_0.nh_0 > 0 %}
-        capsule->nl_constr_h_0_fun_jac.set_param_sparse(&capsule->nl_constr_h_0_fun_jac, n_update, idx, p);
-        capsule->nl_constr_h_0_fun.set_param_sparse(&capsule->nl_constr_h_0_fun, n_update, idx, p);
-        {%- if solver_options.hessian_approx == "EXACT" %}
-        capsule->nl_constr_h_0_fun_jac_hess.set_param_sparse(&capsule->nl_constr_h_0_fun_jac_hess, n_update, idx, p);
-        {%- endif %}
-        {%- endif %}
-        // cost
-        {%- if cost[0].cost_type_0 == "NONLINEAR_LS" %}
-        capsule->cost_y_0_fun.set_param_sparse(&capsule->cost_y_0_fun, n_update, idx, p);
-        capsule->cost_y_0_fun_jac_ut_xt.set_param_sparse(&capsule->cost_y_0_fun_jac_ut_xt, n_update, idx, p);
-        capsule->cost_y_0_hess.set_param_sparse(&capsule->cost_y_0_hess, n_update, idx, p);
-        {%- elif cost[0].cost_type_0 == "CONVEX_OVER_NONLINEAR" %}
-        capsule->conl_cost_0_fun.set_param_sparse(&capsule->conl_cost_0_fun, n_update, idx, p);
-        capsule->conl_cost_0_fun_jac_hess.set_param_sparse(&capsule->conl_cost_0_fun_jac_hess, n_update, idx, p);
-        {%- elif cost[0].cost_type_0 == "EXTERNAL" %}
-        capsule->ext_cost_0_fun.set_param_sparse(&capsule->ext_cost_0_fun, n_update, idx, p);
-        capsule->ext_cost_0_fun_jac.set_param_sparse(&capsule->ext_cost_0_fun_jac, n_update, idx, p);
-        capsule->ext_cost_0_fun_jac_hess.set_param_sparse(&capsule->ext_cost_0_fun_jac_hess, n_update, idx, p);
-        {%- endif %}
-    }
-
-    if (stage == N)
-    {
-        // terminal shooting node has no dynamics
-        // cost
-      {%- if cost_e.cost_type_e == "NONLINEAR_LS" %}
-        capsule->cost_y_e_fun.set_param_sparse(&capsule->cost_y_e_fun, n_update, idx, p);
-        capsule->cost_y_e_fun_jac_ut_xt.set_param_sparse(&capsule->cost_y_e_fun_jac_ut_xt, n_update, idx, p);
-        capsule->cost_y_e_hess.set_param_sparse(&capsule->cost_y_e_hess, n_update, idx, p);
-      {%- elif cost_e.cost_type_e == "CONVEX_OVER_NONLINEAR" %}
-        capsule->conl_cost_e_fun.set_param_sparse(&capsule->conl_cost_e_fun, n_update, idx, p);
-        capsule->conl_cost_e_fun_jac_hess.set_param_sparse(&capsule->conl_cost_e_fun_jac_hess, n_update, idx, p);
-      {%- elif cost_e.cost_type_e == "EXTERNAL" %}
-        capsule->ext_cost_e_fun.set_param_sparse(&capsule->ext_cost_e_fun, n_update, idx, p);
-        capsule->ext_cost_e_fun_jac.set_param_sparse(&capsule->ext_cost_e_fun_jac, n_update, idx, p);
-        capsule->ext_cost_e_fun_jac_hess.set_param_sparse(&capsule->ext_cost_e_fun_jac_hess, n_update, idx, p);
-      {%- endif %}
-        // constraints
-      {%- if constraints_e.constr_type_e == "BGP" %}
-        capsule->phi_e_constraint_fun.set_param_sparse(&capsule->phi_e_constraint_fun, n_update, idx, p);
-        capsule->phi_e_constraint_fun_jac_hess.set_param_sparse(&capsule->phi_e_constraint_fun_jac_hess, n_update, idx, p);
-      {%- elif constraints_e.constr_type_e == "BGH" and dims_e.nh_e > 0 %}
-        capsule->nl_constr_h_e_fun_jac.set_param_sparse(&capsule->nl_constr_h_e_fun_jac, n_update, idx, p);
-        capsule->nl_constr_h_e_fun.set_param_sparse(&capsule->nl_constr_h_e_fun, n_update, idx, p);
-      {%- if solver_options.hessian_approx == "EXACT" %}
-        capsule->nl_constr_h_e_fun_jac_hess.set_param_sparse(&capsule->nl_constr_h_e_fun_jac_hess, n_update, idx, p);
-      {%- endif %}
-      {%- endif %}
-    }
+    return 0;
 }
 
 
@@ -2915,27 +2663,27 @@ int {{ name }}_acados_free({{ name }}_solver_capsule* capsule)
     /* free external function */
     // initial node
 {%- if cost[0].cost_type_0 == "NONLINEAR_LS" %}
-    external_function_param_casadi_free(&capsule->cost_y_0_fun);
-    external_function_param_casadi_free(&capsule->cost_y_0_fun_jac_ut_xt);
-    external_function_param_casadi_free(&capsule->cost_y_0_hess);
+    external_function_external_param_casadi_free(&capsule->cost_y_0_fun);
+    external_function_external_param_casadi_free(&capsule->cost_y_0_fun_jac_ut_xt);
+    external_function_external_param_casadi_free(&capsule->cost_y_0_hess);
 {%- elif cost[0].cost_type_0 == "CONVEX_OVER_NONLINEAR" %}
-    external_function_param_casadi_free(&capsule->conl_cost_0_fun);
-    external_function_param_casadi_free(&capsule->conl_cost_0_fun_jac_hess);
+    external_function_external_param_casadi_free(&capsule->conl_cost_0_fun);
+    external_function_external_param_casadi_free(&capsule->conl_cost_0_fun_jac_hess);
 {%- elif cost[0].cost_type_0 == "EXTERNAL" %}
-    external_function_param_{{ cost[0].cost_ext_fun_type_0 }}_free(&capsule->ext_cost_0_fun);
-    external_function_param_{{ cost[0].cost_ext_fun_type_0 }}_free(&capsule->ext_cost_0_fun_jac);
-    external_function_param_{{ cost[0].cost_ext_fun_type_0 }}_free(&capsule->ext_cost_0_fun_jac_hess);
+    external_function_external_param_{{ cost[0].cost_ext_fun_type_0 }}_free(&capsule->ext_cost_0_fun);
+    external_function_external_param_{{ cost[0].cost_ext_fun_type_0 }}_free(&capsule->ext_cost_0_fun_jac);
+    external_function_external_param_{{ cost[0].cost_ext_fun_type_0 }}_free(&capsule->ext_cost_0_fun_jac_hess);
 {%- endif %}
 
 {%- if constraints_0.constr_type_0 == "BGH" and dims_0.nh_0 > 0 %}
-    external_function_param_casadi_free(&capsule->nl_constr_h_0_fun_jac);
-    external_function_param_casadi_free(&capsule->nl_constr_h_0_fun);
+    external_function_external_param_casadi_free(&capsule->nl_constr_h_0_fun_jac);
+    external_function_external_param_casadi_free(&capsule->nl_constr_h_0_fun);
 {%- if solver_options.hessian_approx == "EXACT" %}
-    external_function_param_casadi_free(&capsule->nl_constr_h_0_fun_jac_hess);
+    external_function_external_param_casadi_free(&capsule->nl_constr_h_0_fun_jac_hess);
 {%- endif %}
 {%- elif constraints_0.constr_type_0 == "BGP" and dims_0.nphi_0 > 0 %}
-    external_function_param_casadi_free(&capsule->phi_0_constraint_fun);
-    external_function_param_casadi_free(&capsule->phi_0_constraint_fun_jac_hess);
+    external_function_external_param_casadi_free(&capsule->phi_0_constraint_fun);
+    external_function_external_param_casadi_free(&capsule->phi_0_constraint_fun_jac_hess);
 {%- endif %}
 
 
@@ -2947,11 +2695,11 @@ int {{ name }}_acados_free({{ name }}_solver_capsule* capsule)
 {%- if mocp_opts.integrator_type[jj] == "IRK" %}
     for (int i_fun = 0; i_fun < {{ end_idx[jj] - start_idx[jj] }}; i_fun++)
     {
-        external_function_param_{{ model[jj].dyn_ext_fun_type }}_free(&capsule->impl_dae_fun_{{ jj }}[i_fun]);
-        external_function_param_{{ model[jj].dyn_ext_fun_type }}_free(&capsule->impl_dae_fun_jac_x_xdot_z_{{ jj }}[i_fun]);
-        external_function_param_{{ model[jj].dyn_ext_fun_type }}_free(&capsule->impl_dae_jac_x_xdot_u_z_{{ jj }}[i_fun]);
+        external_function_external_param_{{ model[jj].dyn_ext_fun_type }}_free(&capsule->impl_dae_fun_{{ jj }}[i_fun]);
+        external_function_external_param_{{ model[jj].dyn_ext_fun_type }}_free(&capsule->impl_dae_fun_jac_x_xdot_z_{{ jj }}[i_fun]);
+        external_function_external_param_{{ model[jj].dyn_ext_fun_type }}_free(&capsule->impl_dae_jac_x_xdot_u_z_{{ jj }}[i_fun]);
     {%- if solver_options.hessian_approx == "EXACT" %}
-        external_function_param_{{ model[jj].dyn_ext_fun_type }}_free(&capsule->impl_dae_hess_{{ jj }}[i_fun]);
+        external_function_external_param_{{ model[jj].dyn_ext_fun_type }}_free(&capsule->impl_dae_hess_{{ jj }}[i_fun]);
     {%- endif %}
     }
     free(capsule->impl_dae_fun_{{ jj }});
@@ -2964,8 +2712,8 @@ int {{ name }}_acados_free({{ name }}_solver_capsule* capsule)
 {%- elif mocp_opts.integrator_type[jj] == "LIFTED_IRK" %}
     for (int i_fun = 0; i_fun < {{ end_idx[jj] - start_idx[jj] }}; i_fun++)
     {
-        external_function_param_{{ model[jj].dyn_ext_fun_type }}_free(&capsule->impl_dae_fun_{{ jj }}[i_fun]);
-        external_function_param_{{ model[jj].dyn_ext_fun_type }}_free(&capsule->impl_dae_fun_jac_x_xdot_u_{{ jj }}[i_fun]);
+        external_function_external_param_{{ model[jj].dyn_ext_fun_type }}_free(&capsule->impl_dae_fun_{{ jj }}[i_fun]);
+        external_function_external_param_{{ model[jj].dyn_ext_fun_type }}_free(&capsule->impl_dae_fun_jac_x_xdot_u_{{ jj }}[i_fun]);
     }
     free(capsule->impl_dae_fun_{{ jj }});
     free(capsule->impl_dae_fun_jac_x_xdot_u_{{ jj }});
@@ -2973,10 +2721,10 @@ int {{ name }}_acados_free({{ name }}_solver_capsule* capsule)
 {%- elif mocp_opts.integrator_type[jj] == "ERK" %}
     for (int i_fun = 0; i_fun < {{ end_idx[jj] - start_idx[jj] }}; i_fun++)
     {
-        external_function_param_casadi_free(&capsule->forw_vde_casadi_{{ jj }}[i_fun]);
-        external_function_param_casadi_free(&capsule->expl_ode_fun_{{ jj }}[i_fun]);
+        external_function_external_param_casadi_free(&capsule->forw_vde_casadi_{{ jj }}[i_fun]);
+        external_function_external_param_casadi_free(&capsule->expl_ode_fun_{{ jj }}[i_fun]);
     {%- if solver_options.hessian_approx == "EXACT" %}
-        external_function_param_casadi_free(&capsule->hess_vde_casadi_{{ jj }}[i_fun]);
+        external_function_external_param_casadi_free(&capsule->hess_vde_casadi_{{ jj }}[i_fun]);
     {%- endif %}
     }
     free(capsule->forw_vde_casadi_{{ jj }});
@@ -2989,14 +2737,14 @@ int {{ name }}_acados_free({{ name }}_solver_capsule* capsule)
     for (int i_fun = 0; i_fun < {{ end_idx[jj] - start_idx[jj] }}; i_fun++)
     {
         {% if model[jj].gnsf.purely_linear != 1 %}
-        external_function_param_casadi_free(&capsule->gnsf_phi_fun_{{ jj }}[i_fun]);
-        external_function_param_casadi_free(&capsule->gnsf_phi_fun_jac_y_{{ jj }}[i_fun]);
-        external_function_param_casadi_free(&capsule->gnsf_phi_jac_y_uhat_{{ jj }}[i_fun]);
+        external_function_external_param_casadi_free(&capsule->gnsf_phi_fun_{{ jj }}[i_fun]);
+        external_function_external_param_casadi_free(&capsule->gnsf_phi_fun_jac_y_{{ jj }}[i_fun]);
+        external_function_external_param_casadi_free(&capsule->gnsf_phi_jac_y_uhat_{{ jj }}[i_fun]);
         {% if model[jj].gnsf.nontrivial_f_LO == 1 %}
-        external_function_param_casadi_free(&capsule->gnsf_f_lo_jac_x1_x1dot_u_z_{{ jj }}[i_fun]);
+        external_function_external_param_casadi_free(&capsule->gnsf_f_lo_jac_x1_x1dot_u_z_{{ jj }}[i_fun]);
         {%- endif %}
         {%- endif %}
-        external_function_param_casadi_free(&capsule->gnsf_get_matrices_fun_{{ jj }}[i_fun]);
+        external_function_external_param_casadi_free(&capsule->gnsf_get_matrices_fun_{{ jj }}[i_fun]);
     }
   {% if model[jj].gnsf.purely_linear != 1 %}
     free(capsule->gnsf_phi_fun_{{ jj }});
@@ -3010,10 +2758,10 @@ int {{ name }}_acados_free({{ name }}_solver_capsule* capsule)
 {%- elif mocp_opts.integrator_type[jj] == "DISCRETE" %}
     for (int i_fun = 0; i_fun < {{ end_idx[jj] - start_idx[jj] }}; i_fun++)
     {
-        external_function_param_{{ model[jj].dyn_ext_fun_type }}_free(&capsule->discr_dyn_phi_fun_{{ jj }}[i_fun]);
-        external_function_param_{{ model[jj].dyn_ext_fun_type }}_free(&capsule->discr_dyn_phi_fun_jac_ut_xt_{{ jj }}[i_fun]);
+        external_function_external_param_{{ model[jj].dyn_ext_fun_type }}_free(&capsule->discr_dyn_phi_fun_{{ jj }}[i_fun]);
+        external_function_external_param_{{ model[jj].dyn_ext_fun_type }}_free(&capsule->discr_dyn_phi_fun_jac_ut_xt_{{ jj }}[i_fun]);
     {%- if solver_options.hessian_approx == "EXACT" %}
-        external_function_param_{{ model[jj].dyn_ext_fun_type }}_free(&capsule->discr_dyn_phi_fun_jac_ut_xt_hess_{{ jj }}[i_fun]);
+        external_function_external_param_{{ model[jj].dyn_ext_fun_type }}_free(&capsule->discr_dyn_phi_fun_jac_ut_xt_hess_{{ jj }}[i_fun]);
     {%- endif %}
     }
     free(capsule->discr_dyn_phi_fun_{{ jj }});
@@ -3027,9 +2775,9 @@ int {{ name }}_acados_free({{ name }}_solver_capsule* capsule)
 {%- if cost[jj].cost_type == "NONLINEAR_LS" %}
     for (int i_fun = 0; i_fun < {{ end_idx[jj] - cost_start_idx[jj] }}; i_fun++)
     {
-        external_function_param_casadi_free(&capsule->cost_y_fun_{{ jj }}[i_fun]);
-        external_function_param_casadi_free(&capsule->cost_y_fun_jac_ut_xt_{{ jj }}[i_fun]);
-        external_function_param_casadi_free(&capsule->cost_y_hess_{{ jj }}[i_fun]);
+        external_function_external_param_casadi_free(&capsule->cost_y_fun_{{ jj }}[i_fun]);
+        external_function_external_param_casadi_free(&capsule->cost_y_fun_jac_ut_xt_{{ jj }}[i_fun]);
+        external_function_external_param_casadi_free(&capsule->cost_y_hess_{{ jj }}[i_fun]);
     }
     free(capsule->cost_y_fun_{{ jj }});
     free(capsule->cost_y_fun_jac_ut_xt_{{ jj }});
@@ -3037,17 +2785,17 @@ int {{ name }}_acados_free({{ name }}_solver_capsule* capsule)
 {%- elif cost[jj].cost_type == "CONVEX_OVER_NONLINEAR" %}
     for (int i_fun = 0; i_fun < {{ end_idx[jj] - cost_start_idx[jj] }}; i_fun++)
     {
-        external_function_param_casadi_free(&capsule->conl_cost_fun_{{ jj }}[i_fun]);
-        external_function_param_casadi_free(&capsule->conl_cost_fun_jac_hess_{{ jj }}[i_fun]);
+        external_function_external_param_casadi_free(&capsule->conl_cost_fun_{{ jj }}[i_fun]);
+        external_function_external_param_casadi_free(&capsule->conl_cost_fun_jac_hess_{{ jj }}[i_fun]);
     }
     free(capsule->conl_cost_fun_{{ jj }});
     free(capsule->conl_cost_fun_jac_hess_{{ jj }});
 {%- elif cost[jj].cost_type == "EXTERNAL" %}
     for (int i_fun = 0; i_fun < {{ end_idx[jj] - cost_start_idx[jj] }}; i_fun++)
     {
-        external_function_param_{{ cost[jj].cost_ext_fun_type }}_free(&capsule->ext_cost_fun_{{ jj }}[i_fun]);
-        external_function_param_{{ cost[jj].cost_ext_fun_type }}_free(&capsule->ext_cost_fun_jac_{{ jj }}[i_fun]);
-        external_function_param_{{ cost[jj].cost_ext_fun_type }}_free(&capsule->ext_cost_fun_jac_hess_{{ jj }}[i_fun]);
+        external_function_external_param_{{ cost[jj].cost_ext_fun_type }}_free(&capsule->ext_cost_fun_{{ jj }}[i_fun]);
+        external_function_external_param_{{ cost[jj].cost_ext_fun_type }}_free(&capsule->ext_cost_fun_jac_{{ jj }}[i_fun]);
+        external_function_external_param_{{ cost[jj].cost_ext_fun_type }}_free(&capsule->ext_cost_fun_jac_hess_{{ jj }}[i_fun]);
     }
     free(capsule->ext_cost_fun_{{ jj }});
     free(capsule->ext_cost_fun_jac_{{ jj }});
@@ -3058,10 +2806,10 @@ int {{ name }}_acados_free({{ name }}_solver_capsule* capsule)
 {%- if constraints[jj].constr_type == "BGH" and phases_dims[jj].nh > 0 %}
     for (int i_fun = 0; i_fun < {{ end_idx[jj] - cost_start_idx[jj] }}; i_fun++)
     {
-        external_function_param_casadi_free(&capsule->nl_constr_h_fun_jac_{{ jj }}[i_fun]);
-        external_function_param_casadi_free(&capsule->nl_constr_h_fun_{{ jj }}[i_fun]);
+        external_function_external_param_casadi_free(&capsule->nl_constr_h_fun_jac_{{ jj }}[i_fun]);
+        external_function_external_param_casadi_free(&capsule->nl_constr_h_fun_{{ jj }}[i_fun]);
   {%- if solver_options.hessian_approx == "EXACT" %}
-        external_function_param_casadi_free(&capsule->nl_constr_h_fun_jac_hess_{{ jj }}[i_fun]);
+        external_function_external_param_casadi_free(&capsule->nl_constr_h_fun_jac_hess_{{ jj }}[i_fun]);
   {%- endif %}
     }
     free(capsule->nl_constr_h_fun_jac_{{ jj }});
@@ -3073,8 +2821,8 @@ int {{ name }}_acados_free({{ name }}_solver_capsule* capsule)
 {%- elif constraints[jj].constr_type == "BGP" and phases_dims[jj].nphi > 0 %}
     for (int i_fun = 0; i_fun < {{ end_idx[jj] - cost_start_idx[jj] }}; i_fun++)
     {
-        external_function_param_casadi_free(&capsule->phi_constraint_fun_{{ jj }}[i_fun]);
-        external_function_param_casadi_free(&capsule->phi_constraint_fun_jac_hess_{{ jj }}[i_fun]);
+        external_function_external_param_casadi_free(&capsule->phi_constraint_fun_{{ jj }}[i_fun]);
+        external_function_external_param_casadi_free(&capsule->phi_constraint_fun_jac_hess_{{ jj }}[i_fun]);
     }
     free(capsule->phi_constraint_fun_{{ jj }});
     free(capsule->phi_constraint_fun_jac_hess_{{ jj }});
@@ -3084,27 +2832,27 @@ int {{ name }}_acados_free({{ name }}_solver_capsule* capsule)
 
     /* Terminal node */
 {%- if constraints_e.constr_type_e == "BGH" and dims_e.nh_e > 0 %}
-    external_function_param_casadi_free(&capsule->nl_constr_h_e_fun_jac);
-    external_function_param_casadi_free(&capsule->nl_constr_h_e_fun);
+    external_function_external_param_casadi_free(&capsule->nl_constr_h_e_fun_jac);
+    external_function_external_param_casadi_free(&capsule->nl_constr_h_e_fun);
 {%- if solver_options.hessian_approx == "EXACT" %}
-    external_function_param_casadi_free(&capsule->nl_constr_h_e_fun_jac_hess);
+    external_function_external_param_casadi_free(&capsule->nl_constr_h_e_fun_jac_hess);
 {%- endif %}
 {%- elif constraints_e.constr_type_e == "BGP" and dims_e.nphi_e > 0 %}
-    external_function_param_casadi_free(&capsule->phi_e_constraint_fun);
-    external_function_param_casadi_free(&capsule->phi_e_constraint_fun_jac_hess);
+    external_function_external_param_casadi_free(&capsule->phi_e_constraint_fun);
+    external_function_external_param_casadi_free(&capsule->phi_e_constraint_fun_jac_hess);
 {%- endif %}
 
 {%- if cost_e.cost_type_e == "NONLINEAR_LS" %}
-    external_function_param_casadi_free(&capsule->cost_y_e_fun);
-    external_function_param_casadi_free(&capsule->cost_y_e_fun_jac_ut_xt);
-    external_function_param_casadi_free(&capsule->cost_y_e_hess);
+    external_function_external_param_casadi_free(&capsule->cost_y_e_fun);
+    external_function_external_param_casadi_free(&capsule->cost_y_e_fun_jac_ut_xt);
+    external_function_external_param_casadi_free(&capsule->cost_y_e_hess);
 {%- elif cost_e.cost_type_e == "CONVEX_OVER_NONLINEAR" %}
-    external_function_param_casadi_free(&capsule->conl_cost_e_fun);
-    external_function_param_casadi_free(&capsule->conl_cost_e_fun_jac_hess);
+    external_function_external_param_casadi_free(&capsule->conl_cost_e_fun);
+    external_function_external_param_casadi_free(&capsule->conl_cost_e_fun_jac_hess);
 {%- elif cost_e.cost_type_e == "EXTERNAL" %}
-    external_function_param_{{ cost_e.cost_ext_fun_type_e }}_free(&capsule->ext_cost_e_fun);
-    external_function_param_{{ cost_e.cost_ext_fun_type_e }}_free(&capsule->ext_cost_e_fun_jac);
-    external_function_param_{{ cost_e.cost_ext_fun_type_e }}_free(&capsule->ext_cost_e_fun_jac_hess);
+    external_function_external_param_{{ cost_e.cost_ext_fun_type_e }}_free(&capsule->ext_cost_e_fun);
+    external_function_external_param_{{ cost_e.cost_ext_fun_type_e }}_free(&capsule->ext_cost_e_fun_jac);
+    external_function_external_param_{{ cost_e.cost_ext_fun_type_e }}_free(&capsule->ext_cost_e_fun_jac_hess);
 {%- endif %}
 
     return 0;

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.h
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.h
@@ -76,120 +76,120 @@ typedef struct {{ name }}_solver_capsule
     /* external functions phase {{ jj }} */
     // dynamics
 {% if mocp_opts.integrator_type[jj] == "ERK" %}
-    external_function_param_casadi *forw_vde_casadi_{{ jj }};
-    external_function_param_casadi *expl_ode_fun_{{ jj }};
+    external_function_external_param_casadi *forw_vde_casadi_{{ jj }};
+    external_function_external_param_casadi *expl_ode_fun_{{ jj }};
 {% if solver_options.hessian_approx == "EXACT" %}
-    external_function_param_casadi *hess_vde_casadi_{{ jj }};
+    external_function_external_param_casadi *hess_vde_casadi_{{ jj }};
 {%- endif %}
 {% elif mocp_opts.integrator_type[jj] == "IRK" %}
-    external_function_param_{{ model[jj].dyn_ext_fun_type }} *impl_dae_fun_{{ jj }};
-    external_function_param_{{ model[jj].dyn_ext_fun_type }} *impl_dae_fun_jac_x_xdot_z_{{ jj }};
-    external_function_param_{{ model[jj].dyn_ext_fun_type }} *impl_dae_jac_x_xdot_u_z_{{ jj }};
+    external_function_external_param_{{ model[jj].dyn_ext_fun_type }} *impl_dae_fun_{{ jj }};
+    external_function_external_param_{{ model[jj].dyn_ext_fun_type }} *impl_dae_fun_jac_x_xdot_z_{{ jj }};
+    external_function_external_param_{{ model[jj].dyn_ext_fun_type }} *impl_dae_jac_x_xdot_u_z_{{ jj }};
 {% if solver_options.hessian_approx == "EXACT" %}
-    external_function_param_{{ model[jj].dyn_ext_fun_type }} *impl_dae_hess_{{ jj }};
+    external_function_external_param_{{ model[jj].dyn_ext_fun_type }} *impl_dae_hess_{{ jj }};
 {%- endif %}
 {% elif mocp_opts.integrator_type[jj] == "LIFTED_IRK" %}
-    external_function_param_{{ model[jj].dyn_ext_fun_type }} *impl_dae_fun_{{ jj }};
-    external_function_param_{{ model[jj].dyn_ext_fun_type }} *impl_dae_fun_jac_x_xdot_u_{{ jj }};
+    external_function_external_param_{{ model[jj].dyn_ext_fun_type }} *impl_dae_fun_{{ jj }};
+    external_function_external_param_{{ model[jj].dyn_ext_fun_type }} *impl_dae_fun_jac_x_xdot_u_{{ jj }};
 {% elif mocp_opts.integrator_type[jj] == "GNSF" %}
-    external_function_param_casadi *gnsf_phi_fun_{{ jj }};
-    external_function_param_casadi *gnsf_phi_fun_jac_y_{{ jj }};
-    external_function_param_casadi *gnsf_phi_jac_y_uhat_{{ jj }};
-    external_function_param_casadi *gnsf_f_lo_jac_x1_x1dot_u_z_{{ jj }};
-    external_function_param_casadi *gnsf_get_matrices_fun_{{ jj }};
+    external_function_external_param_casadi *gnsf_phi_fun_{{ jj }};
+    external_function_external_param_casadi *gnsf_phi_fun_jac_y_{{ jj }};
+    external_function_external_param_casadi *gnsf_phi_jac_y_uhat_{{ jj }};
+    external_function_external_param_casadi *gnsf_f_lo_jac_x1_x1dot_u_z_{{ jj }};
+    external_function_external_param_casadi *gnsf_get_matrices_fun_{{ jj }};
 {% elif mocp_opts.integrator_type[jj] == "DISCRETE" %}
-    external_function_param_{{ model[jj].dyn_ext_fun_type }} *discr_dyn_phi_fun_{{ jj }};
-    external_function_param_{{ model[jj].dyn_ext_fun_type }} *discr_dyn_phi_fun_jac_ut_xt_{{ jj }};
+    external_function_external_param_{{ model[jj].dyn_ext_fun_type }} *discr_dyn_phi_fun_{{ jj }};
+    external_function_external_param_{{ model[jj].dyn_ext_fun_type }} *discr_dyn_phi_fun_jac_ut_xt_{{ jj }};
 {%- if solver_options.hessian_approx == "EXACT" %}
-    external_function_param_{{ model[jj].dyn_ext_fun_type }} *discr_dyn_phi_fun_jac_ut_xt_hess_{{ jj }};
+    external_function_external_param_{{ model[jj].dyn_ext_fun_type }} *discr_dyn_phi_fun_jac_ut_xt_hess_{{ jj }};
 {%- endif %}
 {%- endif %}
 
     // constraints
 {%- if constraints[jj].constr_type == "BGP" %}
-    external_function_param_casadi *phi_constraint_fun_{{ jj }};
-    external_function_param_casadi *phi_constraint_fun_jac_hess_{{ jj }};
+    external_function_external_param_casadi *phi_constraint_fun_{{ jj }};
+    external_function_external_param_casadi *phi_constraint_fun_jac_hess_{{ jj }};
 {% elif constraints[jj].constr_type == "BGH" and phases_dims[jj].nh > 0 %}
-    external_function_param_casadi *nl_constr_h_fun_jac_{{ jj }};
-    external_function_param_casadi *nl_constr_h_fun_{{ jj }};
+    external_function_external_param_casadi *nl_constr_h_fun_jac_{{ jj }};
+    external_function_external_param_casadi *nl_constr_h_fun_{{ jj }};
 {%- if solver_options.hessian_approx == "EXACT" %}
-    external_function_param_casadi *nl_constr_h_fun_jac_hess_{{ jj }};
+    external_function_external_param_casadi *nl_constr_h_fun_jac_hess_{{ jj }};
 {%- endif %}
 {%- endif %}
 
 
     // cost
 {% if cost[jj].cost_type == "NONLINEAR_LS" %}
-    external_function_param_casadi *cost_y_fun_{{ jj }};
-    external_function_param_casadi *cost_y_fun_jac_ut_xt_{{ jj }};
-    external_function_param_casadi *cost_y_hess_{{ jj }};
+    external_function_external_param_casadi *cost_y_fun_{{ jj }};
+    external_function_external_param_casadi *cost_y_fun_jac_ut_xt_{{ jj }};
+    external_function_external_param_casadi *cost_y_hess_{{ jj }};
 {% elif cost[jj].cost_type == "CONVEX_OVER_NONLINEAR" %}
-    external_function_param_casadi *conl_cost_fun_{{ jj }};
-    external_function_param_casadi *conl_cost_fun_jac_hess_{{ jj }};
+    external_function_external_param_casadi *conl_cost_fun_{{ jj }};
+    external_function_external_param_casadi *conl_cost_fun_jac_hess_{{ jj }};
 {%- elif cost[jj].cost_type == "EXTERNAL" %}
-    external_function_param_{{ cost[jj].cost_ext_fun_type }} *ext_cost_fun_{{ jj }};
-    external_function_param_{{ cost[jj].cost_ext_fun_type }} *ext_cost_fun_jac_{{ jj }};
-    external_function_param_{{ cost[jj].cost_ext_fun_type }} *ext_cost_fun_jac_hess_{{ jj }};
+    external_function_external_param_{{ cost[jj].cost_ext_fun_type }} *ext_cost_fun_{{ jj }};
+    external_function_external_param_{{ cost[jj].cost_ext_fun_type }} *ext_cost_fun_jac_{{ jj }};
+    external_function_external_param_{{ cost[jj].cost_ext_fun_type }} *ext_cost_fun_jac_hess_{{ jj }};
     {% if solver_options.with_solution_sens_wrt_params %}
-    external_function_param_{{ cost[jj].cost_ext_fun_type }} *ext_cost_hess_xu_p_{{ jj }};
+    external_function_external_param_{{ cost[jj].cost_ext_fun_type }} *ext_cost_hess_xu_p_{{ jj }};
     {% endif %}
 {% endif %}
 	{%- endfor %}{# for jj in range(end=n_phases) #}
 
 
 {% if cost_0.cost_type_0 == "NONLINEAR_LS" %}
-    external_function_param_casadi cost_y_0_fun;
-    external_function_param_casadi cost_y_0_fun_jac_ut_xt;
-    external_function_param_casadi cost_y_0_hess;
+    external_function_external_param_casadi cost_y_0_fun;
+    external_function_external_param_casadi cost_y_0_fun_jac_ut_xt;
+    external_function_external_param_casadi cost_y_0_hess;
 {% elif cost_0.cost_type_0 == "CONVEX_OVER_NONLINEAR" %}
-    external_function_param_casadi conl_cost_0_fun;
-    external_function_param_casadi conl_cost_0_fun_jac_hess;
+    external_function_external_param_casadi conl_cost_0_fun;
+    external_function_external_param_casadi conl_cost_0_fun_jac_hess;
 {% elif cost_0.cost_type_0 == "EXTERNAL" %}
-    external_function_param_{{ cost_0.cost_ext_fun_type_0 }} ext_cost_0_fun;
-    external_function_param_{{ cost_0.cost_ext_fun_type_0 }} ext_cost_0_fun_jac;
-    external_function_param_{{ cost_0.cost_ext_fun_type_0 }} ext_cost_0_fun_jac_hess;
+    external_function_external_param_{{ cost_0.cost_ext_fun_type_0 }} ext_cost_0_fun;
+    external_function_external_param_{{ cost_0.cost_ext_fun_type_0 }} ext_cost_0_fun_jac;
+    external_function_external_param_{{ cost_0.cost_ext_fun_type_0 }} ext_cost_0_fun_jac_hess;
     {% if solver_options.with_solution_sens_wrt_params %}
-    external_function_param_{{ cost_0.cost_ext_fun_type_0 }} ext_cost_0_params_jac;
+    external_function_external_param_{{ cost_0.cost_ext_fun_type_0 }} ext_cost_0_params_jac;
     {% endif %}
 {%- endif %}
 
 
 {% if constraints[0].constr_type_0 == "BGP" %}
-    external_function_param_casadi phi_0_constraint_fun;
-    external_function_param_casadi phi_0_constraint_fun_jac_hess;
+    external_function_external_param_casadi phi_0_constraint_fun;
+    external_function_external_param_casadi phi_0_constraint_fun_jac_hess;
 {% elif constraints[0].constr_type_0 == "BGH" and dims_0.nh_0 > 0 %}
-    external_function_param_casadi nl_constr_h_0_fun_jac;
-    external_function_param_casadi nl_constr_h_0_fun;
+    external_function_external_param_casadi nl_constr_h_0_fun_jac;
+    external_function_external_param_casadi nl_constr_h_0_fun;
 {%- if solver_options.hessian_approx == "EXACT" %}
-    external_function_param_casadi nl_constr_h_0_fun_jac_hess;
+    external_function_external_param_casadi nl_constr_h_0_fun_jac_hess;
 {%- endif %}
 {%- endif %}
 
 {% if cost_e.cost_type_e == "NONLINEAR_LS" %}
-    external_function_param_casadi cost_y_e_fun;
-    external_function_param_casadi cost_y_e_fun_jac_ut_xt;
-    external_function_param_casadi cost_y_e_hess;
+    external_function_external_param_casadi cost_y_e_fun;
+    external_function_external_param_casadi cost_y_e_fun_jac_ut_xt;
+    external_function_external_param_casadi cost_y_e_hess;
 {% elif cost_e.cost_type_e == "CONVEX_OVER_NONLINEAR" %}
-    external_function_param_casadi conl_cost_e_fun;
-    external_function_param_casadi conl_cost_e_fun_jac_hess;
+    external_function_external_param_casadi conl_cost_e_fun;
+    external_function_external_param_casadi conl_cost_e_fun_jac_hess;
 {% elif cost_e.cost_type_e == "EXTERNAL" %}
-    external_function_param_{{ cost_e.cost_ext_fun_type_e }} ext_cost_e_fun;
-    external_function_param_{{ cost_e.cost_ext_fun_type_e }} ext_cost_e_fun_jac;
-    external_function_param_{{ cost_e.cost_ext_fun_type_e }} ext_cost_e_fun_jac_hess;
+    external_function_external_param_{{ cost_e.cost_ext_fun_type_e }} ext_cost_e_fun;
+    external_function_external_param_{{ cost_e.cost_ext_fun_type_e }} ext_cost_e_fun_jac;
+    external_function_external_param_{{ cost_e.cost_ext_fun_type_e }} ext_cost_e_fun_jac_hess;
     {% if solver_options.with_solution_sens_wrt_params %}
-    external_function_param_{{ cost_e.cost_ext_fun_type_e }} ext_cost_e_params_jac;
+    external_function_external_param_{{ cost_e.cost_ext_fun_type_e }} ext_cost_e_params_jac;
     {% endif %}
 {%- endif %}
 
 
 {% if constraints_e.constr_type_e == "BGP" %}
-    external_function_param_casadi phi_e_constraint_fun;
-    external_function_param_casadi phi_e_constraint_fun_jac_hess;
+    external_function_external_param_casadi phi_e_constraint_fun;
+    external_function_external_param_casadi phi_e_constraint_fun_jac_hess;
 {% elif constraints_e.constr_type_e == "BGH" and dims_e.nh_e > 0 %}
-    external_function_param_casadi nl_constr_h_e_fun_jac;
-    external_function_param_casadi nl_constr_h_e_fun;
+    external_function_external_param_casadi nl_constr_h_e_fun_jac;
+    external_function_external_param_casadi nl_constr_h_e_fun;
 {%- if solver_options.hessian_approx == "EXACT" %}
-    external_function_param_casadi nl_constr_h_e_fun_jac_hess;
+    external_function_external_param_casadi nl_constr_h_e_fun_jac_hess;
 {%- endif %}
 {%- endif %}
 

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -2346,7 +2346,7 @@ static void {{ model.name }}_acados_create_set_opts({{ model.name }}_solver_caps
 /**
  * Internal function for {{ model.name }}_acados_create: step 7
  */
-void {{ model.name }}_acados_setup_nlp_out({{ model.name }}_solver_capsule* capsule)
+void {{ model.name }}_acados_set_nlp_out({{ model.name }}_solver_capsule* capsule)
 {
     const int N = capsule->nlp_solver_plan->N;
     ocp_nlp_config* nlp_config = capsule->nlp_config;
@@ -2446,7 +2446,7 @@ int {{ model.name }}_acados_create_with_discretization({{ model.name }}_solver_c
     capsule->nlp_out = ocp_nlp_out_create(capsule->nlp_config, capsule->nlp_dims);
     // 7.2) sens_out
     capsule->sens_out = ocp_nlp_out_create(capsule->nlp_config, capsule->nlp_dims);
-    {{ model.name }}_acados_setup_nlp_out(capsule);
+    {{ model.name }}_acados_set_nlp_out(capsule);
 
     // 8) do precomputations
     int status = {{ model.name }}_acados_create_precompute(capsule);

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -405,7 +405,7 @@ void {{ model.name }}_acados_create_setup_functions({{ model.name }}_solver_caps
         capsule->__CAPSULE_FNC__.casadi_sparsity_in = & __MODEL_BASE_FNC__ ## _sparsity_in; \
         capsule->__CAPSULE_FNC__.casadi_sparsity_out = & __MODEL_BASE_FNC__ ## _sparsity_out; \
         capsule->__CAPSULE_FNC__.casadi_work = & __MODEL_BASE_FNC__ ## _work; \
-        external_function_external_param_casadi_create(&capsule->__CAPSULE_FNC__ , {{ dims.np }}); \
+        external_function_external_param_casadi_create(&capsule->__CAPSULE_FNC__ ); \
         ocp_nlp_in_get(config, dims, in, stage, "parameter_pointer", &parameter_ptr); \
         capsule->__CAPSULE_FNC__.set_param_pointer(&capsule->__CAPSULE_FNC__, parameter_ptr); \
     } while(false)
@@ -471,7 +471,7 @@ void {{ model.name }}_acados_create_setup_functions({{ model.name }}_solver_caps
     MAP_CASADI_FNC(ext_cost_0_fun, {{ model.name }}_cost_ext_cost_0_fun, 0);
     {%- else %}
     capsule->ext_cost_0_fun.fun = &{{ cost.cost_function_ext_cost_0 }};
-    external_function_external_param_{{ cost.cost_ext_fun_type_0 }}_create(&capsule->ext_cost_0_fun, {{ dims.np }});
+    external_function_external_param_{{ cost.cost_ext_fun_type_0 }}_create(&capsule->ext_cost_0_fun);
     capsule->ext_cost_0_fun.set_param_pointer(&capsule->ext_cost_0_fun, parameter_ptr);
     {%- endif %}
 
@@ -479,7 +479,7 @@ void {{ model.name }}_acados_create_setup_functions({{ model.name }}_solver_caps
     MAP_CASADI_FNC(ext_cost_0_fun_jac, {{ model.name }}_cost_ext_cost_0_fun_jac, 0);
     {%- else %}
     capsule->ext_cost_0_fun_jac.fun = &{{ cost.cost_function_ext_cost_0 }};
-    external_function_external_param_{{ cost.cost_ext_fun_type_0 }}_create(&capsule->ext_cost_0_fun_jac, {{ dims.np }});
+    external_function_external_param_{{ cost.cost_ext_fun_type_0 }}_create(&capsule->ext_cost_0_fun_jac);
     capsule->ext_cost_0_fun_jac.set_param_pointer(&capsule->ext_cost_0_fun_jac, parameter_ptr);
     {%- endif %}
 
@@ -487,7 +487,7 @@ void {{ model.name }}_acados_create_setup_functions({{ model.name }}_solver_caps
     MAP_CASADI_FNC(ext_cost_0_fun_jac_hess, {{ model.name }}_cost_ext_cost_0_fun_jac_hess, 0);
     {%- else %}
     capsule->ext_cost_0_fun_jac_hess.fun = &{{ cost.cost_function_ext_cost_0 }};
-    external_function_external_param_{{ cost.cost_ext_fun_type_0 }}_create(&capsule->ext_cost_0_fun_jac_hess, {{ dims.np }});
+    external_function_external_param_{{ cost.cost_ext_fun_type_0 }}_create(&capsule->ext_cost_0_fun_jac_hess);
     capsule->ext_cost_0_fun_jac_hess.set_param_pointer(&capsule->ext_cost_0_fun_jac_hess, parameter_ptr);
     {%- endif %}
 
@@ -529,7 +529,7 @@ void {{ model.name }}_acados_create_setup_functions({{ model.name }}_solver_caps
         MAP_CASADI_FNC(impl_dae_fun[i], {{ model.name }}_impl_dae_fun, i);
     {%- else %}
         capsule->impl_dae_fun[i].fun = &{{ model.dyn_impl_dae_fun }};
-        external_function_external_param_{{ model.dyn_ext_fun_type }}_create(&capsule->impl_dae_fun[i], {{ dims.np }});
+        external_function_external_param_{{ model.dyn_ext_fun_type }}_create(&capsule->impl_dae_fun[i]);
         ocp_nlp_in_get(config, dims, in, i+1, "parameter_pointer", &parameter_ptr);
         capsule->impl_dae_fun[i].set_param_pointer(&capsule->impl_dae_fun[i], parameter_ptr);
     {%- endif %}
@@ -541,7 +541,7 @@ void {{ model.name }}_acados_create_setup_functions({{ model.name }}_solver_caps
         MAP_CASADI_FNC(impl_dae_fun_jac_x_xdot_z[i], {{ model.name }}_impl_dae_fun_jac_x_xdot_z, i);
     {%- else %}
         capsule->impl_dae_fun_jac_x_xdot_z[i].fun = &{{ model.dyn_impl_dae_fun_jac }};
-        external_function_external_param_{{ model.dyn_ext_fun_type }}_create(&capsule->impl_dae_fun_jac_x_xdot_z[i], {{ dims.np }});
+        external_function_external_param_{{ model.dyn_ext_fun_type }}_create(&capsule->impl_dae_fun_jac_x_xdot_z[i]);
         ocp_nlp_in_get(config, dims, in, i+1, "parameter_pointer", &parameter_ptr);
         capsule->impl_dae_fun_jac_x_xdot_z[i].set_param_pointer(&capsule->impl_dae_fun_jac_x_xdot_z[i], parameter_ptr);
     {%- endif %}
@@ -553,7 +553,7 @@ void {{ model.name }}_acados_create_setup_functions({{ model.name }}_solver_caps
         MAP_CASADI_FNC(impl_dae_jac_x_xdot_u_z[i], {{ model.name }}_impl_dae_jac_x_xdot_u_z, i);
     {%- else %}
         capsule->impl_dae_jac_x_xdot_u_z[i].fun = &{{ model.dyn_impl_dae_jac }};
-        external_function_external_param_{{ model.dyn_ext_fun_type }}_create(&capsule->impl_dae_jac_x_xdot_u_z[i], {{ dims.np }});
+        external_function_external_param_{{ model.dyn_ext_fun_type }}_create(&capsule->impl_dae_jac_x_xdot_u_z[i]);
         ocp_nlp_in_get(config, dims, in, i+1, "parameter_pointer", &parameter_ptr);
         capsule->impl_dae_jac_x_xdot_u_z[i].set_param_pointer(&capsule->impl_dae_jac_x_xdot_u_z[i], parameter_ptr);
     {%- endif %}
@@ -614,7 +614,7 @@ void {{ model.name }}_acados_create_setup_functions({{ model.name }}_solver_caps
         MAP_CASADI_FNC(discr_dyn_phi_fun[i], {{ model.name }}_dyn_disc_phi_fun, i);
         {%- else %}
         capsule->discr_dyn_phi_fun[i].fun = &{{ model.dyn_disc_fun }};
-        external_function_external_param_{{ model.dyn_ext_fun_type }}_create(&capsule->discr_dyn_phi_fun[i], {{ dims.np }});
+        external_function_external_param_{{ model.dyn_ext_fun_type }}_create(&capsule->discr_dyn_phi_fun[i]);
         ocp_nlp_in_get(config, dims, in, i, "parameter_pointer", &parameter_ptr);
         capsule->discr_dyn_phi_fun[i].set_param_pointer(&capsule->discr_dyn_phi_fun[i], parameter_ptr);
         {%- endif %}
@@ -627,7 +627,7 @@ void {{ model.name }}_acados_create_setup_functions({{ model.name }}_solver_caps
         MAP_CASADI_FNC(discr_dyn_phi_fun_jac_ut_xt[i], {{ model.name }}_dyn_disc_phi_fun_jac, i);
         {%- else %}
         capsule->discr_dyn_phi_fun_jac_ut_xt[i].fun = &{{ model.dyn_disc_fun_jac }};
-        external_function_external_param_{{ model.dyn_ext_fun_type }}_create(&capsule->discr_dyn_phi_fun_jac_ut_xt[i], {{ dims.np }});
+        external_function_external_param_{{ model.dyn_ext_fun_type }}_create(&capsule->discr_dyn_phi_fun_jac_ut_xt[i]);
         ocp_nlp_in_get(config, dims, in, i, "parameter_pointer", &parameter_ptr);
         capsule->discr_dyn_phi_fun_jac_ut_xt[i].set_param_pointer(&capsule->discr_dyn_phi_fun_jac_ut_xt[i], parameter_ptr);
         {%- endif %}
@@ -641,7 +641,7 @@ void {{ model.name }}_acados_create_setup_functions({{ model.name }}_solver_caps
         MAP_CASADI_FNC(discr_dyn_phi_jac_p_hess_xu_p[i], {{ model.name }}_dyn_disc_phi_jac_p_hess_xu_p, i);
         {%- else %}
         capsule->discr_dyn_phi_jac_p_hess_xu_p[i].fun = &{{ model.dyn_disc_params_jac }};
-        external_function_external_param_{{ model.dyn_ext_fun_type }}_create(&capsule->discr_dyn_phi_jac_p_hess_xu_p[i], {{ dims.np }});
+        external_function_external_param_{{ model.dyn_ext_fun_type }}_create(&capsule->discr_dyn_phi_jac_p_hess_xu_p[i]);
         ocp_nlp_in_get(config, dims, in, i, "parameter_pointer", &parameter_ptr);
         capsule->discr_dyn_phi_jac_p_hess_xu_p[i].set_param_pointer(&capsule->discr_dyn_phi_jac_p_hess_xu_p[i], parameter_ptr);
         {%- endif %}
@@ -664,7 +664,7 @@ void {{ model.name }}_acados_create_setup_functions({{ model.name }}_solver_caps
         MAP_CASADI_FNC(discr_dyn_phi_fun_jac_ut_xt_hess[i], {{ model.name }}_dyn_disc_phi_fun_jac_hess, i);
         {%- else %}
         capsule->discr_dyn_phi_fun_jac_ut_xt_hess[i].fun = &{{ model.dyn_disc_fun_jac_hess }};
-        external_function_external_param_{{ model.dyn_ext_fun_type }}_create(&capsule->discr_dyn_phi_fun_jac_ut_xt_hess[i], {{ dims.np }});
+        external_function_external_param_{{ model.dyn_ext_fun_type }}_create(&capsule->discr_dyn_phi_fun_jac_ut_xt_hess[i]);
         ocp_nlp_in_get(config, dims, in, i, "parameter_pointer", &parameter_ptr);
         capsule->discr_dyn_phi_fun_jac_ut_xt_hess[i].set_param_pointer(&capsule->discr_dyn_phi_fun_jac_ut_xt_hess[i], parameter_ptr);
         {%- endif %}
@@ -716,7 +716,7 @@ void {{ model.name }}_acados_create_setup_functions({{ model.name }}_solver_caps
         MAP_CASADI_FNC(ext_cost_fun[i], {{ model.name }}_cost_ext_cost_fun, i+1);
         {%- else %}
         capsule->ext_cost_fun[i].fun = &{{ cost.cost_function_ext_cost }};
-        external_function_external_param_{{ cost.cost_ext_fun_type }}_create(&capsule->ext_cost_fun[i], {{ dims.np }});
+        external_function_external_param_{{ cost.cost_ext_fun_type }}_create(&capsule->ext_cost_fun[i]);
         ocp_nlp_in_get(config, dims, in, i+1, "parameter_pointer", &parameter_ptr);
         capsule->ext_cost_fun[i].set_param_pointer(&capsule->ext_cost_fun[i], parameter_ptr);
         {%- endif %}
@@ -729,7 +729,7 @@ void {{ model.name }}_acados_create_setup_functions({{ model.name }}_solver_caps
         MAP_CASADI_FNC(ext_cost_fun_jac[i], {{ model.name }}_cost_ext_cost_fun_jac, i+1);
         {%- else %}
         capsule->ext_cost_fun_jac[i].fun = &{{ cost.cost_function_ext_cost }};
-        external_function_external_param_{{ cost.cost_ext_fun_type }}_create(&capsule->ext_cost_fun_jac[i], {{ dims.np }});
+        external_function_external_param_{{ cost.cost_ext_fun_type }}_create(&capsule->ext_cost_fun_jac[i]);
         ocp_nlp_in_get(config, dims, in, i+1, "parameter_pointer", &parameter_ptr);
         capsule->ext_cost_fun_jac[i].set_param_pointer(&capsule->ext_cost_fun_jac[i], parameter_ptr);
         {%- endif %}
@@ -742,7 +742,7 @@ void {{ model.name }}_acados_create_setup_functions({{ model.name }}_solver_caps
         MAP_CASADI_FNC(ext_cost_fun_jac_hess[i], {{ model.name }}_cost_ext_cost_fun_jac_hess, i+1);
         {%- else %}
         capsule->ext_cost_fun_jac_hess[i].fun = &{{ cost.cost_function_ext_cost }};
-        external_function_external_param_{{ cost.cost_ext_fun_type }}_create(&capsule->ext_cost_fun_jac_hess[i], {{ dims.np }});
+        external_function_external_param_{{ cost.cost_ext_fun_type }}_create(&capsule->ext_cost_fun_jac_hess[i]);
         ocp_nlp_in_get(config, dims, in, i+1, "parameter_pointer", &parameter_ptr);
         capsule->ext_cost_fun_jac_hess[i].set_param_pointer(&capsule->ext_cost_fun_jac_hess[i], parameter_ptr);
         {%- endif %}
@@ -797,7 +797,7 @@ void {{ model.name }}_acados_create_setup_functions({{ model.name }}_solver_caps
     MAP_CASADI_FNC(ext_cost_e_fun, {{ model.name }}_cost_ext_cost_e_fun, N);
     {%- else %}
     capsule->ext_cost_e_fun.fun = &{{ cost.cost_function_ext_cost_e }};
-    external_function_external_param_{{ cost.cost_ext_fun_type_e }}_create(&capsule->ext_cost_e_fun, {{ dims.np }});
+    external_function_external_param_{{ cost.cost_ext_fun_type_e }}_create(&capsule->ext_cost_e_fun);
     ocp_nlp_in_get(config, dims, in, N, "parameter_pointer", &parameter_ptr);
     capsule->ext_cost_e_fun.set_param_pointer(&capsule->ext_cost_e_fun, parameter_ptr);
     {%- endif %}
@@ -807,7 +807,7 @@ void {{ model.name }}_acados_create_setup_functions({{ model.name }}_solver_caps
     MAP_CASADI_FNC(ext_cost_e_fun_jac, {{ model.name }}_cost_ext_cost_e_fun_jac, N);
     {%- else %}
     capsule->ext_cost_e_fun_jac.fun = &{{ cost.cost_function_ext_cost_e }};
-    external_function_external_param_{{ cost.cost_ext_fun_type_e }}_create(&capsule->ext_cost_e_fun_jac, {{ dims.np }});
+    external_function_external_param_{{ cost.cost_ext_fun_type_e }}_create(&capsule->ext_cost_e_fun_jac);
     ocp_nlp_in_get(config, dims, in, N, "parameter_pointer", &parameter_ptr);
     capsule->ext_cost_e_fun_jac.set_param_pointer(&capsule->ext_cost_e_fun_jac, parameter_ptr);
     {%- endif %}
@@ -817,7 +817,7 @@ void {{ model.name }}_acados_create_setup_functions({{ model.name }}_solver_caps
     MAP_CASADI_FNC(ext_cost_e_fun_jac_hess, {{ model.name }}_cost_ext_cost_e_fun_jac_hess, N);
     {%- else %}
     capsule->ext_cost_e_fun_jac_hess.fun = &{{ cost.cost_function_ext_cost_e }};
-    external_function_external_param_{{ cost.cost_ext_fun_type_e }}_create(&capsule->ext_cost_e_fun_jac_hess, {{ dims.np }});
+    external_function_external_param_{{ cost.cost_ext_fun_type_e }}_create(&capsule->ext_cost_e_fun_jac_hess);
     ocp_nlp_in_get(config, dims, in, N, "parameter_pointer", &parameter_ptr);
     capsule->ext_cost_e_fun_jac_hess.set_param_pointer(&capsule->ext_cost_e_fun_jac_hess, parameter_ptr);
     {%- endif %}

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -2037,10 +2037,7 @@ void {{ model.name }}_acados_create_5_set_nlp_in({{ model.name }}_solver_capsule
 }
 
 
-/**
- * Internal function for {{ model.name }}_acados_create: step 6
- */
-void {{ model.name }}_acados_create_6_set_opts({{ model.name }}_solver_capsule* capsule)
+static void {{ model.name }}_acados_create_3_set_opts({{ model.name }}_solver_capsule* capsule)
 {
     const int N = capsule->nlp_solver_plan->N;
     ocp_nlp_config* nlp_config = capsule->nlp_config;
@@ -2460,20 +2457,23 @@ int {{ model.name }}_acados_create_with_discretization({{ model.name }}_solver_c
     {{ model.name }}_acados_create_1_set_plan(capsule->nlp_solver_plan, N);
     capsule->nlp_config = ocp_nlp_config_create(*capsule->nlp_solver_plan);
 
-    // 3) create and set dimensions
+    // 2) create and set dimensions
     capsule->nlp_dims = {{ model.name }}_acados_create_2_create_and_set_dimensions(capsule);
-    {{ model.name }}_acados_create_3_create_and_set_functions(capsule);
 
-    // 4) set default parameters in functions
+    // 3) create and set nlp_opts
+    capsule->nlp_opts = ocp_nlp_solver_opts_create(capsule->nlp_config, capsule->nlp_dims);
+    {{ model.name }}_acados_create_3_set_opts(capsule);
+
+    // 4) create solver
+    capsule->nlp_solver = ocp_nlp_solver_create(capsule->nlp_config, capsule->nlp_dims, capsule->nlp_opts);
+
+    // 5) set default parameters in functions
+    {{ model.name }}_acados_create_3_create_and_set_functions(capsule);
     {{ model.name }}_acados_create_4_set_default_parameters(capsule);
 
     // 5) create and set nlp_in
     capsule->nlp_in = ocp_nlp_in_create(capsule->nlp_config, capsule->nlp_dims);
     {{ model.name }}_acados_create_5_set_nlp_in(capsule, N, new_time_steps);
-
-    // 6) create and set nlp_opts
-    capsule->nlp_opts = ocp_nlp_solver_opts_create(capsule->nlp_config, capsule->nlp_dims);
-    {{ model.name }}_acados_create_6_set_opts(capsule);
 
     // 7) create and set nlp_out
     // 7.1) nlp_out
@@ -2481,10 +2481,6 @@ int {{ model.name }}_acados_create_with_discretization({{ model.name }}_solver_c
     // 7.2) sens_out
     capsule->sens_out = ocp_nlp_out_create(capsule->nlp_config, capsule->nlp_dims);
     {{ model.name }}_acados_create_7_set_nlp_out(capsule);
-
-    // 8) create solver
-    capsule->nlp_solver = ocp_nlp_solver_create(capsule->nlp_config, capsule->nlp_dims, capsule->nlp_opts);
-    //{{ model.name }}_acados_create_8_create_solver(capsule);
 
     // 9) do precomputations
     int status = {{ model.name }}_acados_create_9_precompute(capsule);

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.h
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.h
@@ -101,133 +101,133 @@ typedef struct {{ model.name }}_solver_capsule
     /* external functions */
     // dynamics
 {% if solver_options.integrator_type == "ERK" %}
-    external_function_param_casadi *forw_vde_casadi;
-    external_function_param_casadi *expl_ode_fun;
+    external_function_external_param_casadi *forw_vde_casadi;
+    external_function_external_param_casadi *expl_ode_fun;
 {% if solver_options.hessian_approx == "EXACT" %}
-    external_function_param_casadi *hess_vde_casadi;
+    external_function_external_param_casadi *hess_vde_casadi;
 {%- endif %}
 {% elif solver_options.integrator_type == "IRK" %}
-    external_function_param_{{ model.dyn_ext_fun_type }} *impl_dae_fun;
-    external_function_param_{{ model.dyn_ext_fun_type }} *impl_dae_fun_jac_x_xdot_z;
-    external_function_param_{{ model.dyn_ext_fun_type }} *impl_dae_jac_x_xdot_u_z;
+    external_function_external_param_{{ model.dyn_ext_fun_type }} *impl_dae_fun;
+    external_function_external_param_{{ model.dyn_ext_fun_type }} *impl_dae_fun_jac_x_xdot_z;
+    external_function_external_param_{{ model.dyn_ext_fun_type }} *impl_dae_jac_x_xdot_u_z;
 {% if solver_options.hessian_approx == "EXACT" %}
-    external_function_param_{{ model.dyn_ext_fun_type }} *impl_dae_hess;
+    external_function_external_param_{{ model.dyn_ext_fun_type }} *impl_dae_hess;
 {%- endif %}
 {% elif solver_options.integrator_type == "LIFTED_IRK" %}
-    external_function_param_{{ model.dyn_ext_fun_type }} *impl_dae_fun;
-    external_function_param_{{ model.dyn_ext_fun_type }} *impl_dae_fun_jac_x_xdot_u;
+    external_function_external_param_{{ model.dyn_ext_fun_type }} *impl_dae_fun;
+    external_function_external_param_{{ model.dyn_ext_fun_type }} *impl_dae_fun_jac_x_xdot_u;
 {% elif solver_options.integrator_type == "GNSF" %}
-    external_function_param_casadi *gnsf_phi_fun;
-    external_function_param_casadi *gnsf_phi_fun_jac_y;
-    external_function_param_casadi *gnsf_phi_jac_y_uhat;
-    external_function_param_casadi *gnsf_f_lo_jac_x1_x1dot_u_z;
-    external_function_param_casadi *gnsf_get_matrices_fun;
+    external_function_external_param_casadi *gnsf_phi_fun;
+    external_function_external_param_casadi *gnsf_phi_fun_jac_y;
+    external_function_external_param_casadi *gnsf_phi_jac_y_uhat;
+    external_function_external_param_casadi *gnsf_f_lo_jac_x1_x1dot_u_z;
+    external_function_external_param_casadi *gnsf_get_matrices_fun;
 {% elif solver_options.integrator_type == "DISCRETE" %}
-    external_function_param_{{ model.dyn_ext_fun_type }} *discr_dyn_phi_fun;
-    external_function_param_{{ model.dyn_ext_fun_type }} *discr_dyn_phi_fun_jac_ut_xt;
+    external_function_external_param_{{ model.dyn_ext_fun_type }} *discr_dyn_phi_fun;
+    external_function_external_param_{{ model.dyn_ext_fun_type }} *discr_dyn_phi_fun_jac_ut_xt;
 {% if solver_options.with_solution_sens_wrt_params %}
-    external_function_param_{{ model.dyn_ext_fun_type }} *discr_dyn_phi_jac_p_hess_xu_p;
+    external_function_external_param_{{ model.dyn_ext_fun_type }} *discr_dyn_phi_jac_p_hess_xu_p;
 {%- endif %}
 {% if solver_options.with_value_sens_wrt_params %}
-    external_function_param_{{ model.dyn_ext_fun_type }} *discr_dyn_phi_adj_p;
+    external_function_external_param_{{ model.dyn_ext_fun_type }} *discr_dyn_phi_adj_p;
 {%- endif %}
 {%- if solver_options.hessian_approx == "EXACT" %}
-    external_function_param_{{ model.dyn_ext_fun_type }} *discr_dyn_phi_fun_jac_ut_xt_hess;
+    external_function_external_param_{{ model.dyn_ext_fun_type }} *discr_dyn_phi_fun_jac_ut_xt_hess;
 {%- endif %}
 {%- endif %}
 
 
     // cost
 {% if cost.cost_type == "NONLINEAR_LS" %}
-    external_function_param_casadi *cost_y_fun;
-    external_function_param_casadi *cost_y_fun_jac_ut_xt;
-    external_function_param_casadi *cost_y_hess;
+    external_function_external_param_casadi *cost_y_fun;
+    external_function_external_param_casadi *cost_y_fun_jac_ut_xt;
+    external_function_external_param_casadi *cost_y_hess;
 {% elif cost.cost_type == "CONVEX_OVER_NONLINEAR" %}
-    external_function_param_casadi *conl_cost_fun;
-    external_function_param_casadi *conl_cost_fun_jac_hess;
+    external_function_external_param_casadi *conl_cost_fun;
+    external_function_external_param_casadi *conl_cost_fun_jac_hess;
 {%- elif cost.cost_type == "EXTERNAL" %}
-    external_function_param_{{ cost.cost_ext_fun_type }} *ext_cost_fun;
-    external_function_param_{{ cost.cost_ext_fun_type }} *ext_cost_fun_jac;
-    external_function_param_{{ cost.cost_ext_fun_type }} *ext_cost_fun_jac_hess;
+    external_function_external_param_{{ cost.cost_ext_fun_type }} *ext_cost_fun;
+    external_function_external_param_{{ cost.cost_ext_fun_type }} *ext_cost_fun_jac;
+    external_function_external_param_{{ cost.cost_ext_fun_type }} *ext_cost_fun_jac_hess;
 {% if solver_options.with_solution_sens_wrt_params %}
-    external_function_param_{{ cost.cost_ext_fun_type }} *ext_cost_hess_xu_p;
+    external_function_external_param_{{ cost.cost_ext_fun_type }} *ext_cost_hess_xu_p;
 {%- endif %}
 {% if solver_options.with_value_sens_wrt_params %}
-    external_function_param_{{ cost.cost_ext_fun_type }} *ext_cost_grad_p;
+    external_function_external_param_{{ cost.cost_ext_fun_type }} *ext_cost_grad_p;
 {%- endif %}
 {% endif %}
 
 {% if cost.cost_type_0 == "NONLINEAR_LS" %}
-    external_function_param_casadi cost_y_0_fun;
-    external_function_param_casadi cost_y_0_fun_jac_ut_xt;
-    external_function_param_casadi cost_y_0_hess;
+    external_function_external_param_casadi cost_y_0_fun;
+    external_function_external_param_casadi cost_y_0_fun_jac_ut_xt;
+    external_function_external_param_casadi cost_y_0_hess;
 {% elif cost.cost_type_0 == "CONVEX_OVER_NONLINEAR" %}
-    external_function_param_casadi conl_cost_0_fun;
-    external_function_param_casadi conl_cost_0_fun_jac_hess;
+    external_function_external_param_casadi conl_cost_0_fun;
+    external_function_external_param_casadi conl_cost_0_fun_jac_hess;
 {% elif cost.cost_type_0 == "EXTERNAL" %}
-    external_function_param_{{ cost.cost_ext_fun_type_0 }} ext_cost_0_fun;
-    external_function_param_{{ cost.cost_ext_fun_type_0 }} ext_cost_0_fun_jac;
-    external_function_param_{{ cost.cost_ext_fun_type_0 }} ext_cost_0_fun_jac_hess;
+    external_function_external_param_{{ cost.cost_ext_fun_type_0 }} ext_cost_0_fun;
+    external_function_external_param_{{ cost.cost_ext_fun_type_0 }} ext_cost_0_fun_jac;
+    external_function_external_param_{{ cost.cost_ext_fun_type_0 }} ext_cost_0_fun_jac_hess;
 {% if solver_options.with_solution_sens_wrt_params %}
-    external_function_param_{{ cost.cost_ext_fun_type_0 }} ext_cost_0_hess_xu_p;
+    external_function_external_param_{{ cost.cost_ext_fun_type_0 }} ext_cost_0_hess_xu_p;
 {%- endif %}
 {% if solver_options.with_value_sens_wrt_params %}
-    external_function_param_{{ cost.cost_ext_fun_type_0 }} ext_cost_0_grad_p;
+    external_function_external_param_{{ cost.cost_ext_fun_type_0 }} ext_cost_0_grad_p;
 {%- endif %}
 {%- endif %}
 
 {% if cost.cost_type_e == "NONLINEAR_LS" %}
-    external_function_param_casadi cost_y_e_fun;
-    external_function_param_casadi cost_y_e_fun_jac_ut_xt;
-    external_function_param_casadi cost_y_e_hess;
+    external_function_external_param_casadi cost_y_e_fun;
+    external_function_external_param_casadi cost_y_e_fun_jac_ut_xt;
+    external_function_external_param_casadi cost_y_e_hess;
 {% elif cost.cost_type_e == "CONVEX_OVER_NONLINEAR" %}
-    external_function_param_casadi conl_cost_e_fun;
-    external_function_param_casadi conl_cost_e_fun_jac_hess;
+    external_function_external_param_casadi conl_cost_e_fun;
+    external_function_external_param_casadi conl_cost_e_fun_jac_hess;
 {% elif cost.cost_type_e == "EXTERNAL" %}
-    external_function_param_{{ cost.cost_ext_fun_type_e }} ext_cost_e_fun;
-    external_function_param_{{ cost.cost_ext_fun_type_e }} ext_cost_e_fun_jac;
-    external_function_param_{{ cost.cost_ext_fun_type_e }} ext_cost_e_fun_jac_hess;
+    external_function_external_param_{{ cost.cost_ext_fun_type_e }} ext_cost_e_fun;
+    external_function_external_param_{{ cost.cost_ext_fun_type_e }} ext_cost_e_fun_jac;
+    external_function_external_param_{{ cost.cost_ext_fun_type_e }} ext_cost_e_fun_jac_hess;
 {% if solver_options.with_solution_sens_wrt_params %}
-    external_function_param_{{ cost.cost_ext_fun_type_e }} ext_cost_e_hess_xu_p;
+    external_function_external_param_{{ cost.cost_ext_fun_type_e }} ext_cost_e_hess_xu_p;
 {%- endif %}
 {% if solver_options.with_value_sens_wrt_params %}
-    external_function_param_{{ cost.cost_ext_fun_type_e }} ext_cost_e_grad_p;
+    external_function_external_param_{{ cost.cost_ext_fun_type_e }} ext_cost_e_grad_p;
 {%- endif %}
 {%- endif %}
 
     // constraints
 {%- if constraints.constr_type == "BGP" %}
-    external_function_param_casadi *phi_constraint_fun_jac_hess;
-    external_function_param_casadi *phi_constraint_fun;
+    external_function_external_param_casadi *phi_constraint_fun_jac_hess;
+    external_function_external_param_casadi *phi_constraint_fun;
 {% elif constraints.constr_type == "BGH" and dims.nh > 0 %}
-    external_function_param_casadi *nl_constr_h_fun_jac;
-    external_function_param_casadi *nl_constr_h_fun;
+    external_function_external_param_casadi *nl_constr_h_fun_jac;
+    external_function_external_param_casadi *nl_constr_h_fun;
 {%- if solver_options.hessian_approx == "EXACT" %}
-    external_function_param_casadi *nl_constr_h_fun_jac_hess;
+    external_function_external_param_casadi *nl_constr_h_fun_jac_hess;
 {%- endif %}
 {%- endif %}
 
 
 {% if constraints.constr_type_0 == "BGP" %}
-    external_function_param_casadi phi_0_constraint_fun_jac_hess;
-    external_function_param_casadi phi_0_constraint_fun;
+    external_function_external_param_casadi phi_0_constraint_fun_jac_hess;
+    external_function_external_param_casadi phi_0_constraint_fun;
 {% elif constraints.constr_type_0 == "BGH" and dims.nh_0 > 0 %}
-    external_function_param_casadi nl_constr_h_0_fun_jac;
-    external_function_param_casadi nl_constr_h_0_fun;
+    external_function_external_param_casadi nl_constr_h_0_fun_jac;
+    external_function_external_param_casadi nl_constr_h_0_fun;
 {%- if solver_options.hessian_approx == "EXACT" %}
-    external_function_param_casadi nl_constr_h_0_fun_jac_hess;
+    external_function_external_param_casadi nl_constr_h_0_fun_jac_hess;
 {%- endif %}
 {%- endif %}
 
 
 {% if constraints.constr_type_e == "BGP" %}
-    external_function_param_casadi phi_e_constraint_fun_jac_hess;
-    external_function_param_casadi phi_e_constraint_fun;
+    external_function_external_param_casadi phi_e_constraint_fun_jac_hess;
+    external_function_external_param_casadi phi_e_constraint_fun;
 {% elif constraints.constr_type_e == "BGH" and dims.nh_e > 0 %}
-    external_function_param_casadi nl_constr_h_e_fun_jac;
-    external_function_param_casadi nl_constr_h_e_fun;
+    external_function_external_param_casadi nl_constr_h_e_fun_jac;
+    external_function_external_param_casadi nl_constr_h_e_fun;
 {%- if solver_options.hessian_approx == "EXACT" %}
-    external_function_param_casadi nl_constr_h_e_fun_jac_hess;
+    external_function_external_param_casadi nl_constr_h_e_fun_jac_hess;
 {%- endif %}
 {%- endif %}
 


### PR DESCRIPTION
Previously parameter values could be set function wise and stage wise.

- add external function classes: `external_function_external_param_casadi`, `external_function_external_param_generic`. These classes contain a pointer to the parameter values instead of a memory.
- Adjust OCP solver templates (single- and multi-phase) to use the new classes.
- Parameter vectors are now only stored once per stage in `ocp_nlp_in`

This allows to update parameters faster and lowers memory footprint. Moreover, it will be possible to get parameter values which allows to perform tests on parameters and more.

- Integrator not changes (yet). Benefit is that `external_function_param_casadi` is still tested.