### PR TITLE
Detect Nan and Inf in merit function based line search

### DIFF
--- a/acados/ocp_nlp/ocp_nlp_common.c
+++ b/acados/ocp_nlp/ocp_nlp_common.c
@@ -2772,9 +2772,9 @@ double ocp_nlp_evaluate_merit_fun(ocp_nlp_config *config, ocp_nlp_dims *dims,
 
 
 
-double ocp_nlp_line_search(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in,
+int ocp_nlp_line_search(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in,
             ocp_nlp_out *out, ocp_nlp_opts *opts, ocp_nlp_memory *mem, ocp_nlp_workspace *work,
-            int check_early_termination, int sqp_iter)
+            int check_early_termination, int sqp_iter, double *alpha_reference)
 {
     int i, j;
 
@@ -2895,11 +2895,13 @@ double ocp_nlp_line_search(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_i
                 {
                     // full step if merit and constraint violation improves
                     // TODO: check armijo in this case?
-                    return alpha;
+                    *alpha_reference = alpha;
+                    return;
                 }
                 else // this implies SOC will be done
                 {
-                    return reduction_factor * reduction_factor;
+                    *alpha_reference = reduction_factor * reduction_factor;
+                    return;
                 }
             }
 
@@ -2965,7 +2967,8 @@ double ocp_nlp_line_search(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_i
     // if (opts->globalization != FIXED_STEP)
     //     printf("alpha %f\n", alpha);
 
-    return alpha;
+    *alpha_reference = alpha;
+    return;
 }
 
 /*

--- a/acados/ocp_nlp/ocp_nlp_common.c
+++ b/acados/ocp_nlp/ocp_nlp_common.c
@@ -2886,6 +2886,11 @@ double ocp_nlp_line_search(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_i
                     printf("\npreliminary line_search: merit0 %e, merit1 %e; viol_current %e, viol_step %e\n", merit_fun0, merit_fun1, violation_current, violation_step);
                 }
 
+                // TODO: do nothing and continue with normal line search, i.e. step reduction
+                // if (isnan(merit_fun1) || isinf(merit_fun1))
+                // {
+                //     ;
+                // }
                 if (merit_fun1 < merit_fun0 && violation_step < violation_current)
                 {
                     // full step if merit and constraint violation improves
@@ -2937,7 +2942,7 @@ double ocp_nlp_line_search(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_i
                 merit_fun1 = ocp_nlp_evaluate_merit_fun(config, dims, in, out, opts, mem, work);
                 if (opts->print_level > 1)
                 {
-                    printf("backtracking %d, merit_fun1 = %e, merit_fun0 %e\n", j, merit_fun1, merit_fun0);
+                    printf("backtracking %d alpha = %f, merit_fun1 = %e, merit_fun0 %e\n", j, alpha, merit_fun1, merit_fun0);
                 }
 
                 // if (merit_fun1 < merit_fun0 && merit_fun1 > max_next_merit_fun_val)
@@ -2946,7 +2951,7 @@ double ocp_nlp_line_search(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_i
                 // }
 
                 max_next_merit_fun_val = merit_fun0 + eps_sufficient_descent * dmerit_dy * alpha;
-                if (merit_fun1 < max_next_merit_fun_val)
+                if ((merit_fun1 < max_next_merit_fun_val) && !isnan(merit_fun1) && !isinf(merit_fun1))
                 {
                     break;
                 }

--- a/acados/ocp_nlp/ocp_nlp_common.c
+++ b/acados/ocp_nlp/ocp_nlp_common.c
@@ -2895,7 +2895,7 @@ int ocp_nlp_line_search(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *
                 }
                 else
                 {
-                    // alpha < 0 implies SOC will be done
+                    // alpha < 1.0 implies SOC will be done
                     *alpha_reference = reduction_factor * reduction_factor;
                     return ACADOS_SUCCESS;
                 }

--- a/acados/ocp_nlp/ocp_nlp_common.c
+++ b/acados/ocp_nlp/ocp_nlp_common.c
@@ -2796,14 +2796,10 @@ int ocp_nlp_line_search(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *
         // copy out (current iterate) to work->tmp_nlp_out
         for (i = 0; i <= N; i++)
             blasfeo_dveccp(nv[i], out->ux+i, 0, work->tmp_nlp_out->ux+i, 0);
+        // NOTE: copying duals not needed, as they dont enter the merit function
 
-        // for (i = 0; i < N; i++)
-        //     blasfeo_dveccp(nx[i+1], out->pi+i, 0, work->tmp_nlp_out->pi+i, 0);
-
-        // for (i = 0; i <= N; i++)
-        //     blasfeo_dveccp(2*ni[i], out->lam+i, 0, work->tmp_nlp_out->lam+i, 0);
-
-            // linear update of algebraic variables using state and input sensitivity
+        // TODO: think about z here!
+        // linear update of algebraic variables using state and input sensitivity
     //        if (i < N)
     //        {
     //            blasfeo_dgemv_t(nu[i]+nx[i], nz[i], alpha, mem->dzduxt+i, 0, 0, mem->qp_out->ux+i, 0, 1.0, mem->z_alg+i, 0, out->z+i, 0);
@@ -2830,7 +2826,6 @@ int ocp_nlp_line_search(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *
         else
         {
             // update weights
-            // printf("merit fun: update weights, sqp_iter = %d\n", sqp_iter);
             for (i = 0; i < N; i++)
             {
                 for(j=0; j<nx[i+1]; j++)

--- a/acados/ocp_nlp/ocp_nlp_common.h
+++ b/acados/ocp_nlp/ocp_nlp_common.h
@@ -456,9 +456,9 @@ void ocp_nlp_update_variables_sqp(ocp_nlp_config *config, ocp_nlp_dims *dims, oc
 int ocp_nlp_precompute_common(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in,
             ocp_nlp_out *out, ocp_nlp_opts *opts, ocp_nlp_memory *mem, ocp_nlp_workspace *work);
 //
-double ocp_nlp_line_search(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in,
+int ocp_nlp_line_search(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in,
             ocp_nlp_out *out, ocp_nlp_opts *opts, ocp_nlp_memory *mem, ocp_nlp_workspace *work,
-            int check_early_termination, int sqp_iter);
+            int check_early_termination, int sqp_iter, double *alpha_ref);
 //
 double ocp_nlp_evaluate_merit_fun(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in,
           ocp_nlp_out *out, ocp_nlp_opts *opts, ocp_nlp_memory *mem, ocp_nlp_workspace *work);

--- a/acados/ocp_nlp/ocp_nlp_sqp.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp.c
@@ -559,7 +559,7 @@ static bool ocp_nlp_soc_line_search(ocp_nlp_config *config, ocp_nlp_dims *dims, 
     // NOTE: the "and" is interpreted as an "or" in the current implementation
 
     // preliminary line search
-    mem->alpha = ocp_nlp_line_search(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work, 1, sqp_iter);
+    ocp_nlp_line_search(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work, 1, sqp_iter, &mem->alpha);
     if (mem->alpha >= 1.0)
     {
         return false; // do_line_search;
@@ -1533,7 +1533,7 @@ int ocp_nlp_sqp(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
 
             if (do_line_search)
             {
-                mem->alpha = ocp_nlp_line_search(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work, 0, sqp_iter);
+                ocp_nlp_line_search(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work, 0, sqp_iter, &mem->alpha);
             }
             mem->time_glob += acados_toc(&timer1);
             mem->stat[mem->stat_n*(sqp_iter+1)+6] = mem->alpha;

--- a/acados/ocp_nlp/ocp_nlp_sqp_rti.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp_rti.c
@@ -555,7 +555,7 @@ static void ocp_nlp_sqp_rti_feedback_step(ocp_nlp_config *config, ocp_nlp_dims *
     ocp_qp_xcond_solver_config *qp_solver = config->qp_solver;
 
     int qp_iter = 0;
-    int qp_status = 0;
+    int qp_status, line_search_status;
     double tmp_time;
 
     // update QP rhs for SQP (step prim var, abs dual var)
@@ -665,12 +665,17 @@ static void ocp_nlp_sqp_rti_feedback_step(ocp_nlp_config *config, ocp_nlp_dims *
         return;
     }
 
+    double alpha;
     // globalization
     acados_tic(&timer1);
     // TODO: not clear if line search should be called with sqp_iter==0 in RTI;
-    double alpha;
-    ocp_nlp_line_search(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work, 0, 1, &alpha);
+    line_search_status = ocp_nlp_line_search(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work, 0, 1, &alpha);
     mem->time_glob += acados_toc(&timer1);
+    if (line_search_status == ACADOS_NAN_DETECTED)
+    {
+        mem->status = line_search_status;
+        return;
+    }
 
     // update variables
     ocp_nlp_update_variables_sqp(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work, nlp_out, alpha);
@@ -843,7 +848,7 @@ static void ocp_nlp_sqp_rti_preparation_advanced_step(ocp_nlp_config *config, oc
 
     // printf("AS_RTI preparation\n");
     qp_info *qp_info_;
-    int qp_iter, qp_status;
+    int qp_iter, qp_status, line_search_status;
     double alpha, tmp_time;
 
     // prepare submodules
@@ -925,8 +930,13 @@ static void ocp_nlp_sqp_rti_preparation_advanced_step(ocp_nlp_config *config, oc
         // globalization
         acados_tic(&timer1);
         // TODO: not clear if line search should be called with sqp_iter==0 in RTI;
-        ocp_nlp_line_search(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work, 0, 1, &alpha);
+        line_search_status = ocp_nlp_line_search(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work, 0, 1, &alpha);
         mem->time_glob += acados_toc(&timer1);
+        if (line_search_status == ACADOS_NAN_DETECTED)
+        {
+            mem->status = line_search_status;
+            return;
+        }
 
         // update variables
         ocp_nlp_update_variables_sqp(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work, nlp_out, alpha);
@@ -1000,8 +1010,13 @@ static void ocp_nlp_sqp_rti_preparation_advanced_step(ocp_nlp_config *config, oc
             // globalization
             acados_tic(&timer1);
             // TODO: not clear if line search should be called with sqp_iter==0 in RTI;
-            ocp_nlp_line_search(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work, 0, 1, &alpha);
+            line_search_status = ocp_nlp_line_search(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work, 0, 1, &alpha);
             mem->time_glob += acados_toc(&timer1);
+            if (line_search_status == ACADOS_NAN_DETECTED)
+            {
+                mem->status = line_search_status;
+                return;
+            }
 
             // update variables
             ocp_nlp_update_variables_sqp(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work, nlp_out, alpha);
@@ -1078,8 +1093,13 @@ static void ocp_nlp_sqp_rti_preparation_advanced_step(ocp_nlp_config *config, oc
             // globalization
             acados_tic(&timer1);
             // TODO: not clear if line search should be called with sqp_iter==0 in RTI;
-            ocp_nlp_line_search(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work, 0, 1, &alpha);
+            line_search_status = ocp_nlp_line_search(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work, 0, 1, &alpha);
             mem->time_glob += acados_toc(&timer1);
+            if (line_search_status == ACADOS_NAN_DETECTED)
+            {
+                mem->status = line_search_status;
+                return;
+            }
 
             // update variables
             ocp_nlp_update_variables_sqp(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work, nlp_out, alpha);
@@ -1157,8 +1177,13 @@ static void ocp_nlp_sqp_rti_preparation_advanced_step(ocp_nlp_config *config, oc
             // globalization
             acados_tic(&timer1);
             // TODO: not clear if line search should be called with sqp_iter==0 in RTI;
-            ocp_nlp_line_search(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work, 0, 1, &alpha);
+            line_search_status = ocp_nlp_line_search(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work, 0, 1, &alpha);
             mem->time_glob += acados_toc(&timer1);
+            if (line_search_status == ACADOS_NAN_DETECTED)
+            {
+                mem->status = line_search_status;
+                return;
+            }
 
             // update variables
             ocp_nlp_update_variables_sqp(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work, nlp_out, alpha);

--- a/acados/ocp_nlp/ocp_nlp_sqp_rti.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp_rti.c
@@ -668,7 +668,8 @@ static void ocp_nlp_sqp_rti_feedback_step(ocp_nlp_config *config, ocp_nlp_dims *
     // globalization
     acados_tic(&timer1);
     // TODO: not clear if line search should be called with sqp_iter==0 in RTI;
-    double alpha = ocp_nlp_line_search(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work, 0, 1);
+    double alpha;
+    ocp_nlp_line_search(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work, 0, 1, &alpha);
     mem->time_glob += acados_toc(&timer1);
 
     // update variables
@@ -924,7 +925,7 @@ static void ocp_nlp_sqp_rti_preparation_advanced_step(ocp_nlp_config *config, oc
         // globalization
         acados_tic(&timer1);
         // TODO: not clear if line search should be called with sqp_iter==0 in RTI;
-        alpha = ocp_nlp_line_search(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work, 0, 1);
+        ocp_nlp_line_search(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work, 0, 1, &alpha);
         mem->time_glob += acados_toc(&timer1);
 
         // update variables
@@ -999,7 +1000,7 @@ static void ocp_nlp_sqp_rti_preparation_advanced_step(ocp_nlp_config *config, oc
             // globalization
             acados_tic(&timer1);
             // TODO: not clear if line search should be called with sqp_iter==0 in RTI;
-            alpha = ocp_nlp_line_search(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work, 0, 1);
+            ocp_nlp_line_search(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work, 0, 1, &alpha);
             mem->time_glob += acados_toc(&timer1);
 
             // update variables
@@ -1077,7 +1078,7 @@ static void ocp_nlp_sqp_rti_preparation_advanced_step(ocp_nlp_config *config, oc
             // globalization
             acados_tic(&timer1);
             // TODO: not clear if line search should be called with sqp_iter==0 in RTI;
-            alpha = ocp_nlp_line_search(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work, 0, 1);
+            ocp_nlp_line_search(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work, 0, 1, &alpha);
             mem->time_glob += acados_toc(&timer1);
 
             // update variables
@@ -1156,7 +1157,7 @@ static void ocp_nlp_sqp_rti_preparation_advanced_step(ocp_nlp_config *config, oc
             // globalization
             acados_tic(&timer1);
             // TODO: not clear if line search should be called with sqp_iter==0 in RTI;
-            alpha = ocp_nlp_line_search(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work, 0, 1);
+            ocp_nlp_line_search(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work, 0, 1, &alpha);
             mem->time_glob += acados_toc(&timer1);
 
             // update variables

--- a/examples/acados_python/tests/test_nan_globalization.py
+++ b/examples/acados_python/tests/test_nan_globalization.py
@@ -1,0 +1,125 @@
+#
+# Copyright (c) The acados authors.
+#
+# This file is part of acados.
+#
+# The 2-Clause BSD License
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.;
+#
+
+import sys
+sys.path.insert(0, '../pendulum_on_cart/common')
+
+from acados_template import AcadosOcp, AcadosOcpSolver
+from pendulum_model import export_pendulum_ode_model
+from utils import plot_pendulum
+import numpy as np
+import casadi as ca
+import scipy.linalg
+
+def main():
+    ocp = AcadosOcp()
+
+    # set model
+    model = export_pendulum_ode_model()
+    ocp.model = model
+
+    Tf = 1.0
+    nx = model.x.rows()
+    nu = model.u.rows()
+
+    N = 20
+
+    # set dimensions
+    ocp.dims.N = N
+
+    # set cost
+    Q_mat = 2*np.diag([1e3, 1e3, 1e-2, 1e-2])
+    R_mat = 2*np.diag([1e-2])
+
+    ocp.cost.cost_type = 'EXTERNAL'
+    ocp.cost.cost_type_e = 'EXTERNAL'
+
+    cost_W = scipy.linalg.block_diag(Q_mat, R_mat)
+
+    x = model.x
+    u = model.u
+    ocp.model.cost_expr_ext_cost = .5*ca.vertcat(x, u).T @ cost_W @ ca.vertcat(x, u)
+    ocp.model.cost_expr_ext_cost_e = .5*x.T @ Q_mat @ x
+
+    # add log barrier term
+    p_max = 1.0
+    ocp.model.cost_expr_ext_cost += -ca.log(ca.fmax(p_max - x[0], 0))
+
+    # set constraints
+    Fmax = 80
+    ocp.constraints.lbu = np.array([-Fmax])
+    ocp.constraints.ubu = np.array([+Fmax])
+    ocp.constraints.idxbu = np.array([0])
+
+    ocp.constraints.x0 = np.array([0.0, np.pi, 0.0, 0.0])
+
+    # set options
+    ocp.solver_options.qp_solver = 'PARTIAL_CONDENSING_HPIPM'
+    ocp.solver_options.globalization = 'MERIT_BACKTRACKING'
+    ocp.solver_options.alpha_min = 1e-5
+    ocp.solver_options.globalization_use_SOC = 0
+    ocp.solver_options.print_level = 2
+
+    ocp.solver_options.hessian_approx = 'GAUSS_NEWTON'
+    ocp.solver_options.integrator_type = 'ERK'
+    ocp.solver_options.nlp_solver_type = 'SQP'
+    ocp.solver_options.nlp_solver_max_iter = 1000
+    ocp.solver_options.full_step_dual = 0
+    ocp.solver_options.qp_solver_iter_max = 2000
+    ocp.solver_options.tol = 1e-4
+    ocp.solver_options.qp_tol = 1e-6
+
+
+    ocp.solver_options.tf = Tf
+
+    # create solver
+    ocp_solver = AcadosOcpSolver(ocp)
+
+    simX = np.zeros((N+1, nx))
+    simU = np.zeros((N, nu))
+
+    status = ocp_solver.solve()
+
+    ocp_solver.print_statistics()
+    if status != 0:
+        raise Exception(f'acados returned status {status}.')
+
+    # get solution
+    for i in range(N):
+        simX[i,:] = ocp_solver.get(i, "x")
+        simU[i,:] = ocp_solver.get(i, "u")
+    simX[N,:] = ocp_solver.get(N, "x")
+
+    print("cost function value", ocp_solver.get_cost())
+
+    plot_pendulum(np.linspace(0, Tf, N+1), Fmax, simU, simX, latexify=False)
+
+if __name__ == "__main__":
+    main()

--- a/examples/acados_python/tests/test_osqp.py
+++ b/examples/acados_python/tests/test_osqp.py
@@ -35,99 +35,91 @@ from acados_template import AcadosOcp, AcadosOcpSolver
 from pendulum_model import export_pendulum_ode_model
 import numpy as np
 import scipy.linalg
-# from utils import plot_pendulum
-
-# create ocp object to formulate the OCP
-ocp = AcadosOcp()
-
-# set model
-model = export_pendulum_ode_model()
-ocp.model = model
-
-Tf = 1.0
-nx = model.x.rows()
-nu = model.u.rows()
-ny = nx + nu
-ny_e = nx
-N = 20
-
-# set dimensions
-ocp.dims.N = N
-
-# set cost
-Q = 2*np.diag([1e3, 1e3, 1e-2, 1e-2])
-R = 2*np.diag([1e-2])
-
-ocp.cost.W_e = Q
-ocp.cost.W = scipy.linalg.block_diag(Q, R)
-
-ocp.cost.cost_type = 'LINEAR_LS'
-ocp.cost.cost_type_e = 'LINEAR_LS'
-
-ocp.cost.Vx = np.zeros((ny, nx))
-ocp.cost.Vx[:nx,:nx] = np.eye(nx)
-
-Vu = np.zeros((ny, nu))
-Vu[4,0] = 1.0
-ocp.cost.Vu = Vu
-
-ocp.cost.Vx_e = np.eye(nx)
-
-ocp.cost.yref  = np.zeros((ny, ))
-ocp.cost.yref_e = np.zeros((ny_e, ))
-
-# set constraints
-Fmax = 80
-ocp.constraints.lbu = np.array([-Fmax])
-ocp.constraints.ubu = np.array([+Fmax])
-ocp.constraints.idxbu = np.array([0])
-
-ocp.constraints.x0 = np.array([0.0, np.pi, 0.0, 0.0])
-
-# set options
-ocp.solver_options.qp_solver = 'PARTIAL_CONDENSING_OSQP' # FULL_CONDENSING_QPOASES
-# ('PARTIAL_CONDENSING_HPIPM', \
-# 'FULL_CONDENSING_QPOASES', 'FULL_CONDENSING_HPIPM', \
-# 'PARTIAL_CONDENSING_QPDUNES', 'PARTIAL_CONDENSING_OSQP')
-
-ocp.solver_options.hessian_approx = 'GAUSS_NEWTON'
-ocp.solver_options.integrator_type = 'ERK'
-# ocp.solver_options.print_level = 1
-ocp.solver_options.nlp_solver_type = 'SQP' # SQP_RTI, SQP
-ocp.solver_options.nlp_solver_max_iter = 20 # SQP_RTI, SQP
-ocp.solver_options.qp_solver_iter_max = 2000
-# ocp.solver_options.qp_solver_warm_start = 1
 
 
-# set prediction horizon
-ocp.solver_options.tf = Tf
+def main():
+    ocp = AcadosOcp()
 
-ocp_solver = AcadosOcpSolver(ocp, json_file = 'acados_ocp.json')
+    # set model
+    model = export_pendulum_ode_model()
+    ocp.model = model
 
-# ocp_solver.options_set("qp_solver_warm_start", 1)
+    Tf = 1.0
+    nx = model.x.rows()
+    nu = model.u.rows()
+    ny = nx + nu
+    ny_e = nx
+    N = 20
 
-simX = np.zeros((N+1, nx))
-simU = np.zeros((N, nu))
+    # set dimensions
+    ocp.dims.N = N
 
-# test setter
-ocp_solver.set(0, "u", 0.0)
-ocp_solver.set(0, "u", 0)
-ocp_solver.set(0, "u", np.array([0]))
+    # set cost
+    Q = 2*np.diag([1e3, 1e3, 1e-2, 1e-2])
+    R = 2*np.diag([1e-2])
 
-status = ocp_solver.solve()
+    ocp.cost.W_e = Q
+    ocp.cost.W = scipy.linalg.block_diag(Q, R)
 
-if status != 0:
-    ocp_solver.print_statistics() # encapsulates: stat = ocp_solver.get_stats("statistics")
-    raise Exception(f'acados returned status {status}.')
+    ocp.cost.cost_type = 'LINEAR_LS'
+    ocp.cost.cost_type_e = 'LINEAR_LS'
 
-# get solution
-for i in range(N):
-    simX[i,:] = ocp_solver.get(i, "x")
-    simU[i,:] = ocp_solver.get(i, "u")
-simX[N,:] = ocp_solver.get(N, "x")
+    ocp.cost.Vx = np.zeros((ny, nx))
+    ocp.cost.Vx[:nx,:nx] = np.eye(nx)
 
-ocp_solver.print_statistics() # encapsulates: stat = ocp_solver.get_stats("statistics")
+    Vu = np.zeros((ny, nu))
+    Vu[4,0] = 1.0
+    ocp.cost.Vu = Vu
 
-print("cost function value", ocp_solver.get_cost())
+    ocp.cost.Vx_e = np.eye(nx)
 
-# plot_pendulum(np.linspace(0, Tf, N+1), Fmax, simU, simX, latexify=False)
+    ocp.cost.yref  = np.zeros((ny, ))
+    ocp.cost.yref_e = np.zeros((ny_e, ))
+
+    # set constraints
+    Fmax = 80
+    ocp.constraints.lbu = np.array([-Fmax])
+    ocp.constraints.ubu = np.array([+Fmax])
+    ocp.constraints.idxbu = np.array([0])
+
+    ocp.constraints.x0 = np.array([0.0, np.pi, 0.0, 0.0])
+
+    # set options
+    ocp.solver_options.qp_solver = 'PARTIAL_CONDENSING_OSQP'
+
+    ocp.solver_options.hessian_approx = 'GAUSS_NEWTON'
+    ocp.solver_options.integrator_type = 'ERK'
+    ocp.solver_options.nlp_solver_type = 'SQP'
+    ocp.solver_options.nlp_solver_max_iter = 20
+    ocp.solver_options.qp_solver_iter_max = 2000
+    ocp.solver_options.tf = Tf
+
+    # create solver
+    ocp_solver = AcadosOcpSolver(ocp)
+
+    simX = np.zeros((N+1, nx))
+    simU = np.zeros((N, nu))
+
+    # test setter
+    ocp_solver.set(0, "u", 0.0)
+    ocp_solver.set(0, "u", 0)
+    ocp_solver.set(0, "u", np.array([0]))
+
+    status = ocp_solver.solve()
+
+    ocp_solver.print_statistics()
+    if status != 0:
+        raise Exception(f'acados returned status {status}.')
+
+    # get solution
+    for i in range(N):
+        simX[i,:] = ocp_solver.get(i, "x")
+        simU[i,:] = ocp_solver.get(i, "u")
+    simX[N,:] = ocp_solver.get(N, "x")
+
+    print("cost function value", ocp_solver.get_cost())
+
+    # plot_pendulum(np.linspace(0, Tf, N+1), Fmax, simU, simX, latexify=False)
+
+if __name__ == "__main__":
+    main()

--- a/interfaces/CMakeLists.txt
+++ b/interfaces/CMakeLists.txt
@@ -235,7 +235,7 @@ add_test(NAME python_pendulum_ocp_example_cmake
     add_test(NAME python_max_iter_termination_test
         COMMAND "${CMAKE_COMMAND}" -E chdir ${PROJECT_SOURCE_DIR}/examples/acados_python/max_iter_test
         python max_iter_test.py)
-        
+
     # Simple OCP with Maratos effect
     add_test(NAME python_OCP_maratos_test_problem_globalization
         COMMAND "${CMAKE_COMMAND}" -E chdir ${PROJECT_SOURCE_DIR}/examples/acados_python/linear_mass_model
@@ -245,6 +245,11 @@ add_test(NAME python_pendulum_ocp_example_cmake
     add_test(NAME python_armijo_test
         COMMAND "${CMAKE_COMMAND}" -E chdir ${PROJECT_SOURCE_DIR}/examples/acados_python/tests
         python armijo_test.py)
+
+    # Test NaN in globalization
+    add_test(NAME python_test_nan_globalization
+        COMMAND "${CMAKE_COMMAND}" -E chdir ${PROJECT_SOURCE_DIR}/examples/acados_python/tests
+        python test_nan_globalization.py)
 
     # Multiphase nonlinear constraint test problem
     add_test(NAME python_multiphase_nonlinear_constraints
@@ -375,7 +380,8 @@ add_test(NAME python_pendulum_ocp_example_cmake
     set_tests_properties(python_test_cost_integration_value PROPERTIES DEPENDS python_armijo_test)
     set_tests_properties(python_armijo_test PROPERTIES DEPENDS python_pendulum_soft_constraints_example)
     set_tests_properties(python_pendulum_soft_constraints_example PROPERTIES DEPENDS python_pendulum_parametric_nonlinear_constraint_h_test)
-    set_tests_properties(python_pendulum_parametric_nonlinear_constraint_h_test PROPERTIES DEPENDS python_test_sim_dae)
+    set_tests_properties(python_pendulum_parametric_nonlinear_constraint_h_test PROPERTIES DEPENDS python_test_nan_globalization)
+    set_tests_properties(python_test_nan_globalization PROPERTIES DEPENDS python_test_sim_dae)
     set_tests_properties(python_test_sim_dae PROPERTIES DEPENDS python_sparse_param_test)
 
     if(ACADOS_WITH_OSQP)


### PR DESCRIPTION
This PR adds Nan and Inf detection in merit function based line search. If Nan/inf is encountered during the evaluation of the merit function, the step size is decreased. If Nan/inf is encountered during the early termination check, no second-order corrections are performed.

Follow-up: backtrack if new linearization results in NaN or infeasible QP.