### PR TITLE
Merit backtracking cleanup

### DIFF
--- a/acados/ocp_nlp/ocp_nlp_common.h
+++ b/acados/ocp_nlp/ocp_nlp_common.h
@@ -396,7 +396,7 @@ typedef struct ocp_nlp_workspace
     void **cost;         // cost_workspace
     void **constraints;  // constraints_workspace
 
-    // temp QP in & out (to be used as workspace in param sens)
+    // temp QP in & out (to be used as workspace in param sens) and merit line search
     ocp_qp_in *tmp_qp_in;
     ocp_qp_out *tmp_qp_out;
 

--- a/acados/ocp_nlp/ocp_nlp_common.h
+++ b/acados/ocp_nlp/ocp_nlp_common.h
@@ -458,10 +458,14 @@ int ocp_nlp_precompute_common(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nl
 //
 int ocp_nlp_line_search(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in,
             ocp_nlp_out *out, ocp_nlp_opts *opts, ocp_nlp_memory *mem, ocp_nlp_workspace *work,
-            int check_early_termination, int sqp_iter, double *alpha_ref);
+            int sqp_iter, double *alpha_ref);
 //
 double ocp_nlp_evaluate_merit_fun(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in,
           ocp_nlp_out *out, ocp_nlp_opts *opts, ocp_nlp_memory *mem, ocp_nlp_workspace *work);
+//
+void merit_backtracking_initialize_weights(ocp_nlp_dims *dims, ocp_nlp_out *weight_merit_fun, ocp_qp_out *qp_out);
+//
+void merit_backtracking_update_weights(ocp_nlp_dims *dims, ocp_nlp_out *weight_merit_fun, ocp_qp_out *qp_out);
 //
 void ocp_nlp_res_compute(ocp_nlp_dims *dims, ocp_nlp_in *in, ocp_nlp_out *out,
                          ocp_nlp_res *res, ocp_nlp_memory *mem);

--- a/acados/ocp_nlp/ocp_nlp_sqp.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp.c
@@ -537,6 +537,105 @@ static void ocp_nlp_sqp_dump_qp_out_to_file(ocp_qp_out *qp_out, int sqp_iter, in
 #endif
 
 
+static double ocp_nlp_get_violation_inf_norm(ocp_nlp_config *config, ocp_nlp_dims *dims,
+                                  ocp_nlp_in *in, ocp_nlp_out *out, ocp_nlp_opts *opts,
+                                  ocp_nlp_memory *mem, ocp_nlp_workspace *work)
+{
+    // computes constraint violation infinity norm
+    // assumes constraint functions are evaluated before, e.g. done in ocp_nlp_evaluate_merit_fun
+    int i, j;
+    int N = dims->N;
+    int *nx = dims->nx;
+    int *ni = dims->ni;
+    struct blasfeo_dvec *tmp_fun_vec;
+    double violation = 0.0;
+    double tmp;
+    for (i=0; i<N; i++)
+    {
+        tmp_fun_vec = config->dynamics[i]->memory_get_fun_ptr(mem->dynamics[i]);
+        for (j=0; j<nx[i+1]; j++)
+        {
+            tmp = fabs(BLASFEO_DVECEL(tmp_fun_vec, j));
+            violation = tmp > violation ? tmp : violation;
+        }
+    }
+
+    for (i=0; i<=N; i++)
+    {
+        tmp_fun_vec = config->constraints[i]->memory_get_fun_ptr(mem->constraints[i]);
+        for (j=0; j<2*ni[i]; j++)
+        {
+            // Note constraint violation corresponds to > 0
+            tmp = BLASFEO_DVECEL(tmp_fun_vec, j);
+            violation = tmp > violation ? tmp : violation;
+        }
+    }
+
+    return violation;
+}
+
+
+static int ocp_nlp_line_search_merit_check_full_step(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in,
+            ocp_nlp_out *out, ocp_nlp_opts *opts, ocp_nlp_memory *mem, ocp_nlp_workspace *work, int sqp_iter)
+{
+    int N = dims->N;
+    int *nv = dims->nv;
+
+    ocp_qp_out *qp_out = mem->qp_out;
+
+    double merit_fun1;
+
+    // copy out (current iterate) to work->tmp_nlp_out
+    for (int i = 0; i <= N; i++)
+        blasfeo_dveccp(nv[i], out->ux+i, 0, work->tmp_nlp_out->ux+i, 0);
+    // NOTE: copying duals not needed, as they dont enter the merit function, see ocp_nlp_line_search
+
+
+    /* modify/initialize merit function weights (Leineweber1999 M5.1, p.89) */
+    if (sqp_iter==0)
+    {
+        merit_backtracking_initialize_weights(dims, work->weight_merit_fun, qp_out);
+    }
+    else
+    {
+        merit_backtracking_update_weights(dims, work->weight_merit_fun, qp_out);
+    }
+
+    double merit_fun0 = ocp_nlp_evaluate_merit_fun(config, dims, in, out, opts, mem, work);
+    double alpha = 1.0;
+
+    // TODO(oj): should the merit weight update be undone in case of early termination?
+    double violation_current = ocp_nlp_get_violation_inf_norm(config, dims, in, out, opts, mem, work);
+
+    // tmp_nlp_out = out + alpha * qp_out
+    for (int i = 0; i <= N; i++)
+        blasfeo_daxpy(nv[i], alpha, qp_out->ux+i, 0, out->ux+i, 0, work->tmp_nlp_out->ux+i, 0);
+    merit_fun1 = ocp_nlp_evaluate_merit_fun(config, dims, in, out, opts, mem, work);
+
+    double violation_step = ocp_nlp_get_violation_inf_norm(config, dims, in, out, opts, mem, work);
+    if (opts->print_level > 0)
+    {
+        printf("\npreliminary line_search: merit0 %e, merit1 %e; viol_current %e, viol_step %e\n", merit_fun0, merit_fun1, violation_current, violation_step);
+    }
+
+    if (isnan(merit_fun1) || isinf(merit_fun1))
+    {
+        // do nothing and continue with normal line search, i.e. step reduction
+        return ACADOS_NAN_DETECTED;
+    }
+    if (merit_fun1 < merit_fun0 && violation_step < violation_current)
+    {
+        // full step if merit and constraint violation improves
+        // TODO: check armijo in this case?
+        return ACADOS_SUCCESS;
+    }
+    else
+    {
+        return ACADOS_MINSTEP;
+    }
+}
+
+
 static bool ocp_nlp_soc_line_search(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *nlp_in,
             ocp_nlp_out *nlp_out, ocp_nlp_sqp_opts *opts, ocp_nlp_sqp_memory *mem, ocp_nlp_sqp_workspace *work, int sqp_iter)
 {
@@ -559,7 +658,7 @@ static bool ocp_nlp_soc_line_search(ocp_nlp_config *config, ocp_nlp_dims *dims, 
     // NOTE: the "and" is interpreted as an "or" in the current implementation
 
     // preliminary line search
-    int line_search_status = ocp_nlp_line_search(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work, 1, sqp_iter, &mem->alpha);
+    int line_search_status = ocp_nlp_line_search_merit_check_full_step(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work, mem->sqp_iter);
 
     // return bool do_line_search;
     if (line_search_status == ACADOS_NAN_DETECTED)
@@ -567,17 +666,19 @@ static bool ocp_nlp_soc_line_search(ocp_nlp_config *config, ocp_nlp_dims *dims, 
         // do line search but no SOC.
         return true;
     }
-    if (mem->alpha >= 1.0)
+    else if (line_search_status == ACADOS_SUCCESS)
     {
+        mem->alpha = 1.0;
         return false;
     }
+    // else perform SOC (below)
 
     // Second Order Correction (SOC): following Nocedal2006: p.557, eq. (18.51) -- (18.56)
     // Paragraph: APPROACH III: S l1 QP (SEQUENTIAL l1 QUADRATIC PROGRAMMING),
     // Section 18.8 TRUST-REGION SQP METHODS
     //   - just no trust region radius here.
     if (nlp_opts->print_level > 0)
-        printf("ocp_nlp_sqp: performing SOC, since alpha %e in prelim. line search\n\n", mem->alpha);
+        printf("ocp_nlp_sqp: performing SOC, since prelim. line search returned %d\n\n", line_search_status);
     int *nb = qp_in->dim->nb;
     int *ng = qp_in->dim->ng;
     int *nx = dims->nx;
@@ -1541,7 +1642,7 @@ int ocp_nlp_sqp(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
             if (do_line_search)
             {
                 int line_search_status;
-                line_search_status = ocp_nlp_line_search(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work, 0, sqp_iter, &mem->alpha);
+                line_search_status = ocp_nlp_line_search(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work, sqp_iter, &mem->alpha);
                 if (line_search_status == ACADOS_NAN_DETECTED)
                 {
                     mem->status = ACADOS_NAN_DETECTED;

--- a/acados/ocp_nlp/ocp_nlp_sqp.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp.c
@@ -658,6 +658,11 @@ static int ocp_nlp_line_search_merit_check_full_step(ocp_nlp_config *config, ocp
     if (isnan(merit_fun1) || isinf(merit_fun1))
     {
         // do nothing and continue with normal line search, i.e. step reduction
+        if (sqp_iter != 0)
+        {
+            // reset merit function weights;
+            copy_multipliers_qp_to_nlp(dims, work->tmp_qp_out, work->weight_merit_fun);
+        }
         return ACADOS_NAN_DETECTED;
     }
     if (merit_fun1 < merit_fun0 && violation_step < violation_current)

--- a/acados/ocp_nlp/ocp_nlp_sqp_rti.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp_rti.c
@@ -669,7 +669,7 @@ static void ocp_nlp_sqp_rti_feedback_step(ocp_nlp_config *config, ocp_nlp_dims *
     // globalization
     acados_tic(&timer1);
     // TODO: not clear if line search should be called with sqp_iter==0 in RTI;
-    line_search_status = ocp_nlp_line_search(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work, 0, 1, &alpha);
+    line_search_status = ocp_nlp_line_search(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work, 1, &alpha);
     mem->time_glob += acados_toc(&timer1);
     if (line_search_status == ACADOS_NAN_DETECTED)
     {
@@ -930,7 +930,7 @@ static void ocp_nlp_sqp_rti_preparation_advanced_step(ocp_nlp_config *config, oc
         // globalization
         acados_tic(&timer1);
         // TODO: not clear if line search should be called with sqp_iter==0 in RTI;
-        line_search_status = ocp_nlp_line_search(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work, 0, 1, &alpha);
+        line_search_status = ocp_nlp_line_search(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work, 1, &alpha);
         mem->time_glob += acados_toc(&timer1);
         if (line_search_status == ACADOS_NAN_DETECTED)
         {
@@ -1010,7 +1010,7 @@ static void ocp_nlp_sqp_rti_preparation_advanced_step(ocp_nlp_config *config, oc
             // globalization
             acados_tic(&timer1);
             // TODO: not clear if line search should be called with sqp_iter==0 in RTI;
-            line_search_status = ocp_nlp_line_search(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work, 0, 1, &alpha);
+            line_search_status = ocp_nlp_line_search(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work, 1, &alpha);
             mem->time_glob += acados_toc(&timer1);
             if (line_search_status == ACADOS_NAN_DETECTED)
             {
@@ -1093,7 +1093,7 @@ static void ocp_nlp_sqp_rti_preparation_advanced_step(ocp_nlp_config *config, oc
             // globalization
             acados_tic(&timer1);
             // TODO: not clear if line search should be called with sqp_iter==0 in RTI;
-            line_search_status = ocp_nlp_line_search(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work, 0, 1, &alpha);
+            line_search_status = ocp_nlp_line_search(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work, 1, &alpha);
             mem->time_glob += acados_toc(&timer1);
             if (line_search_status == ACADOS_NAN_DETECTED)
             {
@@ -1177,7 +1177,7 @@ static void ocp_nlp_sqp_rti_preparation_advanced_step(ocp_nlp_config *config, oc
             // globalization
             acados_tic(&timer1);
             // TODO: not clear if line search should be called with sqp_iter==0 in RTI;
-            line_search_status = ocp_nlp_line_search(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work, 0, 1, &alpha);
+            line_search_status = ocp_nlp_line_search(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work, 1, &alpha);
             mem->time_glob += acados_toc(&timer1);
             if (line_search_status == ACADOS_NAN_DETECTED)
             {

--- a/examples/acados_python/non_ocp_nlp/maratos_test_problem.py
+++ b/examples/acados_python/non_ocp_nlp/maratos_test_problem.py
@@ -203,7 +203,6 @@ def solve_maratos_problem_with_setting(setting):
 
     try:
         if globalization == 'FIXED_STEP':
-            # import pdb; pdb.set_trace()
             if max_infeasibility < 5.0:
                 raise Exception(f"Expected max_infeasibility > 5.0 when using full step SQP on Maratos problem")
             if iter != 10:
@@ -225,8 +224,8 @@ def solve_maratos_problem_with_setting(setting):
                     # Jonathan Laptop: merit_grad = -1.737950e-01, merit_grad_cost = -1.737950e-01, merit_grad_dyn = 0.000000e+00, merit_grad_ineq = 0.000000e+00
                     raise Exception(f"Expected SQP iterations in range(29, 37) when using globalized SQP with SOC on Maratos problem, got {iter}")
             else:
-                if iter != 12:
-                    raise Exception(f"Expected 12 SQP iterations when using globalized SQP with SOC on Maratos problem, got {iter}")
+                if iter != 16:
+                    raise Exception(f"Expected 16 SQP iterations when using globalized SQP with SOC on Maratos problem, got {iter}")
         elif globalization == 'FUNNEL_L1PEN_LINESEARCH':
             if iter > 12:
                     raise Exception(f"Expected not more than 12 SQP iterations when using Funnel Method SQP, got {iter}")


### PR DESCRIPTION
- split into functions
- separate function for preliminary line search before SOC
- reset merit function weights when doing SOC. This is the only change affecting the behavior of the algorithm in this PR.
- adjusted test to account for point above.