### PR TITLE
MATLAB: Code generation of CasADi functions based on `AcadosOcp`/`AcadosSim`

### DIFF
--- a/examples/acados_matlab_octave/test/test_all_examples.m
+++ b/examples/acados_matlab_octave/test/test_all_examples.m
@@ -113,7 +113,10 @@ for idx = 1:length(targets)
     if contains(targets{idx},'simulink'); bdclose('all'); end
     delete(strcat(testpath, "/test_workspace.mat"));
     % delete generated code to avoid failure in examples using similar names
-    rmdir(strcat(testpath, "/", dir, "/c_generated_code"), 's')
+    code_gen_dir = strcat(testpath, "/", dir, "/c_generated_code");
+    if exist(code_gen_dir, 'dir')
+        rmdir(code_gen_dir, 's')
+    end
     close all; clc;
 end
 

--- a/examples/acados_matlab_octave/test/test_ocp_wtnx6.m
+++ b/examples/acados_matlab_octave/test/test_ocp_wtnx6.m
@@ -366,7 +366,6 @@ x_traj_init = repmat(x0_ref, 1, ocp_N+1);
 u_traj_init = repmat(u0_ref, 1, ocp_N);
 pi_traj_init = zeros(nx, ocp_N);
 
-
 for ii=1:n_sim
 
 %    fprintf('\nsimulation step %d\n', ii);

--- a/examples/acados_matlab_octave/test/test_ocp_wtnx6.m
+++ b/examples/acados_matlab_octave/test/test_ocp_wtnx6.m
@@ -135,7 +135,7 @@ W(2, 2) =  0.0180;
 W(3, 3) =  0.01;
 W(4, 4) =  0.001;
 % weight matrix in mayer term
-W_e = zeros(ny_e, ny_e); 
+W_e = zeros(ny_e, ny_e);
 W_e(1, 1) =  1.5114;
 W_e(2, 1) = -0.0649;
 W_e(1, 2) = -0.0649;

--- a/interfaces/acados_matlab_octave/acados_ocp.m
+++ b/interfaces/acados_matlab_octave/acados_ocp.m
@@ -58,7 +58,7 @@ classdef acados_ocp < handle
             addpath(obj.opts_struct.output_dir);
 
             % check model consistency
-            obj.model_struct = create_consistent_empty_fields(obj.model_struct, obj.opts_struct);
+            obj.model_struct = create_consistent_empty_fields(obj.model_struct);
 
             % detect GNSF structure
             if (strcmp(obj.opts_struct.sim_method, 'irk_gnsf'))

--- a/interfaces/acados_matlab_octave/acados_ocp.m
+++ b/interfaces/acados_matlab_octave/acados_ocp.m
@@ -200,7 +200,7 @@ classdef acados_ocp < handle
                 simulink_opts = get_acados_simulink_opts();
             end
             obj.ocp = setup_ocp(obj, simulink_opts);
-            ocp_generate_c_code(obj);
+            ocp_generate_c_code(obj.ocp);
 
             % templated MEX
             return_dir = pwd();

--- a/interfaces/acados_matlab_octave/acados_ocp.m
+++ b/interfaces/acados_matlab_octave/acados_ocp.m
@@ -221,7 +221,7 @@ classdef acados_ocp < handle
             obj.t_ocp.solve();
         end
 
-
+        % TODO: remove this? does not seem to do anything
         function generate_c_code(obj, simulink_opts)
             if nargin < 2
                 warning("Code is generated with the default simulink options via the constructor of acados_ocp.")

--- a/interfaces/acados_matlab_octave/acados_sim.m
+++ b/interfaces/acados_matlab_octave/acados_sim.m
@@ -54,7 +54,7 @@ classdef acados_sim < handle
             addpath(obj.opts_struct.output_dir);
 
             % check model consistency
-            obj.model_struct = create_consistent_empty_fields(obj.model_struct, obj.opts_struct);
+            obj.model_struct = create_consistent_empty_fields(obj.model_struct);
             % detect GNSF structure
             if (strcmp(obj.opts_struct.method, 'irk_gnsf'))
                 if (strcmp(obj.opts_struct.gnsf_detect_struct, 'true'))

--- a/interfaces/acados_matlab_octave/acados_sim.m
+++ b/interfaces/acados_matlab_octave/acados_sim.m
@@ -96,7 +96,6 @@ classdef acados_sim < handle
             % detect dimensions & sanity checks
             obj.model_struct = detect_dims_sim(obj.model_struct,obj.opts_struct);
 
-
             % create template sim
             obj.sim = setup_sim(obj);
             sim_generate_c_code(obj);

--- a/interfaces/acados_matlab_octave/acados_sim.m
+++ b/interfaces/acados_matlab_octave/acados_sim.m
@@ -98,7 +98,7 @@ classdef acados_sim < handle
 
             % create template sim
             obj.sim = setup_sim(obj);
-            sim_generate_c_code(obj);
+            sim_generate_c_code(obj.sim);
 
             % templated MEX
             return_dir = pwd();

--- a/interfaces/acados_matlab_octave/acados_template_mex/+acados_template_mex/set_up_t_renderer.m
+++ b/interfaces/acados_matlab_octave/acados_template_mex/+acados_template_mex/set_up_t_renderer.m
@@ -51,9 +51,7 @@ function set_up_t_renderer(t_renderer_location,varargin)
         end
     end
 
-    if ~exist(destination, 'dir')
-        [~,~] = mkdir(destination);
-    end
+    check_dir_and_create(destination);
 
     movefile(tmp_file, t_renderer_location);
 

--- a/interfaces/acados_matlab_octave/check_dir_and_create.m
+++ b/interfaces/acados_matlab_octave/check_dir_and_create.m
@@ -1,0 +1,35 @@
+%
+% Copyright (c) The acados authors.
+%
+% This file is part of acados.
+%
+% The 2-Clause BSD License
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%
+% 1. Redistributions of source code must retain the above copyright notice,
+% this list of conditions and the following disclaimer.
+%
+% 2. Redistributions in binary form must reproduce the above copyright notice,
+% this list of conditions and the following disclaimer in the documentation
+% and/or other materials provided with the distribution.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.;
+
+
+function check_dir_and_create(dir)
+    if ~exist(dir, 'dir')
+        mkdir(dir);
+    end
+end

--- a/interfaces/acados_matlab_octave/create_consistent_empty_fields.m
+++ b/interfaces/acados_matlab_octave/create_consistent_empty_fields.m
@@ -29,31 +29,29 @@
 
 %
 
-function model = create_consistent_empty_fields(model, opts)
+function model = create_consistent_empty_fields(model)
 
-    if (strcmp(opts.codgen_model, 'true'))
-        % xdot, u, p, z might not exist in model
-        % this function empty fields of consistent types
-        import casadi.*
-        x = model.sym_x;
-        if isa(x(1), 'casadi.SX')
-            empty_var = SX.sym('empty_var', 0, 0);
-        else
-            empty_var = MX.sym('empty_var', 0, 0);
-        end
+    % xdot, u, p, z might not exist in model
+    % this function empty fields of consistent types
+    import casadi.*
+    x = model.sym_x;
+    if isa(x(1), 'casadi.SX')
+        empty_var = SX.sym('empty_var', 0, 0);
+    else
+        empty_var = MX.sym('empty_var', 0, 0);
+    end
 
-        if ~isfield(model, 'sym_p')
-            model.sym_p = empty_var;
-        end
-        if ~isfield(model, 'sym_xdot')
-            model.sym_xdot = empty_var;
-        end
-        if ~isfield(model, 'sym_z')
-            model.sym_z = empty_var;
-        end
-        if ~isfield(model, 'sym_u')
-            model.sym_u = empty_var;
-        end
+    if ~isfield(model, 'sym_p')
+        model.sym_p = empty_var;
+    end
+    if ~isfield(model, 'sym_xdot')
+        model.sym_xdot = empty_var;
+    end
+    if ~isfield(model, 'sym_z')
+        model.sym_z = empty_var;
+    end
+    if ~isfield(model, 'sym_u')
+        model.sym_u = empty_var;
     end
 
 end

--- a/interfaces/acados_matlab_octave/generate_c_code_disc_dyn.m
+++ b/interfaces/acados_matlab_octave/generate_c_code_disc_dyn.m
@@ -42,8 +42,7 @@ x = model.x;
 u = model.u;
 p = model.p;
 nx = length(x);
-nu = length(u);
-np = length(p);
+
 
 % check type
 if isa(x(1), 'casadi.SX')
@@ -84,7 +83,7 @@ phi_fun_jac_ut_xt_hess = Function([model_name,'_dyn_disc_phi_fun_jac_hess'], {x,
 phi_fun.generate([model_name,'_dyn_disc_phi_fun'], casadi_opts);
 phi_fun_jac_ut_xt.generate([model_name,'_dyn_disc_phi_fun_jac'], casadi_opts);
 
-if code_gen_opts.generate_hess
+if opts.generate_hess
     phi_fun_jac_ut_xt_hess.generate([model_name,'_dyn_disc_phi_fun_jac_hess'], casadi_opts);
 end
 

--- a/interfaces/acados_matlab_octave/generate_c_code_disc_dyn.m
+++ b/interfaces/acados_matlab_octave/generate_c_code_disc_dyn.m
@@ -43,7 +43,6 @@ u = model.u;
 p = model.p;
 nx = length(x);
 
-
 % check type
 if isa(x(1), 'casadi.SX')
     isSX = true;

--- a/interfaces/acados_matlab_octave/generate_c_code_explicit_ode.m
+++ b/interfaces/acados_matlab_octave/generate_c_code_explicit_ode.m
@@ -45,7 +45,6 @@ u = model.u;
 p = model.p;
 nx = length(x);
 nu = length(u);
-np = length(p);
 
 % check type
 if isa(x(1), 'casadi.SX')

--- a/interfaces/acados_matlab_octave/generate_c_code_explicit_ode.m
+++ b/interfaces/acados_matlab_octave/generate_c_code_explicit_ode.m
@@ -37,9 +37,7 @@ import casadi.*
 casadi_opts = struct('mex', false, 'casadi_int', 'int', 'casadi_real', 'double');
 check_casadi_version();
 
-
 %% load model
-
 x = model.x;
 u = model.u;
 p = model.p;

--- a/interfaces/acados_matlab_octave/generate_c_code_ext_cost.m
+++ b/interfaces/acados_matlab_octave/generate_c_code_ext_cost.m
@@ -54,15 +54,17 @@ else
     isSX = false;
 end
 
-if isfield(model, 'p')
-    p = model.p;
-else
-    if isSX
-        p = SX.sym('p',0, 0);
-    else
-        p = MX.sym('p',0, 0);
-    end
-end
+p = model.p;
+
+% if ~isempty(model.p)
+%     p = model.p;
+% else
+%     if isSX
+%         p = SX.sym('p',0, 0);
+%     else
+%         p = MX.sym('p',0, 0);
+%     end
+% end
 
 model_name = model.name;
 
@@ -83,6 +85,7 @@ if strcmp(stage_type, "initial")
     else
         ext_cost_0_fun_jac_hess = Function([model_name,'_cost_ext_cost_0_fun_jac_hess'], {x, u, z, p}, {ext_cost_0, grad, full_hess});
     end
+
     % generate C code
     ext_cost_0_fun.generate([model_name,'_cost_ext_cost_0_fun'], casadi_opts);
     ext_cost_0_fun_jac.generate([model_name,'_cost_ext_cost_0_fun_jac'], casadi_opts);

--- a/interfaces/acados_matlab_octave/generate_c_code_ext_cost.m
+++ b/interfaces/acados_matlab_octave/generate_c_code_ext_cost.m
@@ -29,9 +29,8 @@
 
 
 
-function generate_c_code_ext_cost( model, opts, target_dir, stage_type )
+function generate_c_code_ext_cost( model, target_dir, stage_type )
 
-%% import casadi
 import casadi.*
 
 casadi_opts = struct('mex', false, 'casadi_int', 'int', 'casadi_real', 'double');
@@ -40,28 +39,23 @@ check_casadi_version();
 % cd to target folder
 if nargin > 2
     original_dir = pwd;
-    if ~exist(target_dir, 'dir')
-        mkdir(target_dir);
-    end
     chdir(target_dir)
 end
 
 %% load model
-% x
-x = model.sym_x;
+x = model.x;
+u = model.u;
+z = model.z;
+
 % check type
 if isa(x(1), 'casadi.SX')
     isSX = true;
 else
     isSX = false;
 end
-% u
-u = model.sym_u;
-% z
-z = model.sym_z;
-% p
-if isfield(model, 'sym_p')
-    p = model.sym_p;
+
+if isfield(model, 'p')
+    p = model.p;
 else
     if isSX
         p = SX.sym('p',0, 0);
@@ -71,8 +65,9 @@ else
 end
 
 model_name = model.name;
+
 if strcmp(stage_type, "initial")
-    if ~isfield(model, 'cost_expr_ext_cost_0')
+    if isempty(model.cost_expr_ext_cost_0)
         error('Field `cost_expr_ext_cost_0` is required for cost_type_0 == EXTERNAL.')
     end
 
@@ -94,7 +89,7 @@ if strcmp(stage_type, "initial")
     ext_cost_0_fun_jac_hess.generate([model_name,'_cost_ext_cost_0_fun_jac_hess'], casadi_opts);
 
 elseif strcmp(stage_type, "path")
-    if ~isfield(model, 'cost_expr_ext_cost')
+    if isempty(model.cost_expr_ext_cost)
         error('Field `cost_expr_ext_cost` is required for cost_type == EXTERNAL.')
     end
     ext_cost = model.cost_expr_ext_cost;
@@ -116,7 +111,7 @@ elseif strcmp(stage_type, "path")
     ext_cost_fun_jac.generate([model_name,'_cost_ext_cost_fun_jac'], casadi_opts);
 
 elseif strcmp(stage_type, "terminal")
-    if ~isfield(model, 'cost_expr_ext_cost_e')
+    if isempty(model.cost_expr_ext_cost_e)
         error('Field `cost_expr_ext_cost_e` is required for cost_type_e == EXTERNAL.')
     end
     ext_cost_e = model.cost_expr_ext_cost_e;

--- a/interfaces/acados_matlab_octave/generate_c_code_ext_cost.m
+++ b/interfaces/acados_matlab_octave/generate_c_code_ext_cost.m
@@ -37,34 +37,14 @@ casadi_opts = struct('mex', false, 'casadi_int', 'int', 'casadi_real', 'double')
 check_casadi_version();
 
 % cd to target folder
-if nargin > 2
-    original_dir = pwd;
-    chdir(target_dir)
-end
+original_dir = pwd;
+chdir(target_dir)
 
 %% load model
 x = model.x;
 u = model.u;
 z = model.z;
-
-% check type
-if isa(x(1), 'casadi.SX')
-    isSX = true;
-else
-    isSX = false;
-end
-
 p = model.p;
-
-% if ~isempty(model.p)
-%     p = model.p;
-% else
-%     if isSX
-%         p = SX.sym('p',0, 0);
-%     else
-%         p = MX.sym('p',0, 0);
-%     end
-% end
 
 model_name = model.name;
 

--- a/interfaces/acados_matlab_octave/generate_c_code_ext_cost.m
+++ b/interfaces/acados_matlab_octave/generate_c_code_ext_cost.m
@@ -38,6 +38,9 @@ check_casadi_version();
 
 % cd to target folder
 original_dir = pwd;
+if ~exist(target_dir, 'dir')
+    mkdir(target_dir);
+end
 chdir(target_dir)
 
 %% load model
@@ -119,9 +122,8 @@ else
     error("Unknown stage type.")
 end
 
-if nargin > 2
-    chdir(original_dir)
-end
+chdir(original_dir)
+
 
 end
 

--- a/interfaces/acados_matlab_octave/generate_c_code_ext_cost.m
+++ b/interfaces/acados_matlab_octave/generate_c_code_ext_cost.m
@@ -38,9 +38,7 @@ check_casadi_version();
 
 % cd to target folder
 original_dir = pwd;
-if ~exist(target_dir, 'dir')
-    mkdir(target_dir);
-end
+check_dir_and_create(target_dir);
 chdir(target_dir)
 
 %% load model

--- a/interfaces/acados_matlab_octave/generate_c_code_gnsf.m
+++ b/interfaces/acados_matlab_octave/generate_c_code_gnsf.m
@@ -30,118 +30,58 @@
 %
 
 
-function generate_c_code_gnsf(model, opts)
+function generate_c_code_gnsf(model, opts, model_dir)
 
-%% import casadi
 import casadi.*
 
 casadi_opts = struct('mex', false, 'casadi_int', 'int', 'casadi_real', 'double');
 check_casadi_version();
 
-is_template = false;
-if isa(model, 'acados_template_mex.AcadosModel')
-    is_template = true;
-end
+A = model.gnsf.A;
+B = model.gnsf.B;
+C = model.gnsf.C;
+E = model.gnsf.E;
+c = model.gnsf.c;
 
-if is_template
-    % model matrices
-    A = model.gnsf.A;
-    B = model.gnsf.B;
-    C = model.gnsf.C;
-    E = model.gnsf.E;
-    c = model.gnsf.c;
+L_x    = model.gnsf.L_x;
+L_z    = model.gnsf.L_z;
+L_xdot = model.gnsf.L_xdot;
+L_u    = model.gnsf.L_u;
 
-    L_x    = model.gnsf.L_x;
-    L_z    = model.gnsf.L_z;
-    L_xdot = model.gnsf.L_xdot;
-    L_u    = model.gnsf.L_u;
+A_LO = model.gnsf.A_LO;
+E_LO = model.gnsf.E_LO;
+B_LO = model.gnsf.B_LO;
+c_LO = model.gnsf.c_LO;
 
-    A_LO = model.gnsf.A_LO;
-    E_LO = model.gnsf.E_LO;
-    B_LO = model.gnsf.B_LO;
-    c_LO = model.gnsf.c_LO;
+% state permutation vector: x_gnsf = dvecpe(x, ipiv)
+ipiv_x = model.gnsf.ipiv_x;
+idx_perm_x = model.gnsf.idx_perm_x;
+ipiv_z = model.gnsf.ipiv_z;
+idx_perm_z = model.gnsf.idx_perm_z;
+ipiv_f = model.gnsf.ipiv_f;
+idx_perm_f = model.gnsf.idx_perm_f;
 
-    % state permutation vector: x_gnsf = dvecpe(x, ipiv)
-    ipiv_x = model.gnsf.ipiv_x;
-    idx_perm_x = model.gnsf.idx_perm_x;
-    ipiv_z = model.gnsf.ipiv_z;
-    idx_perm_z = model.gnsf.idx_perm_z;
-    ipiv_f = model.gnsf.ipiv_f;
-    idx_perm_f = model.gnsf.idx_perm_f;
+% expressions
+phi = model.gnsf.expr_phi;
+f_lo = model.gnsf.expr_f_lo;
 
+% binaries
+nontrivial_f_LO = model.gnsf.nontrivial_f_LO;
+purely_linear = model.gnsf.purely_linear;
 
-    % expressions
-    phi = model.gnsf.expr_phi;
-    f_lo = model.gnsf.expr_f_lo;
+% symbolics
+% y
+y = model.gnsf.y;
+% uhat
+uhat = model.gnsf.uhat;
+% general
+x = model.x;
+xdot = model.xdot;
+u = model.u;
+z = model.z;
+p = model.p;
 
-    % binaries
-    nontrivial_f_LO = model.gnsf.nontrivial_f_LO;
-    purely_linear = model.gnsf.purely_linear;
-
-    % symbolics
-    % y
-    y = model.gnsf.y;
-    % uhat
-    uhat = model.gnsf.uhat;
-    % general
-    x = model.x;
-    xdot = model.xdot;
-    u = model.u;
-    z = model.z;
-    p = model.p;
-
-    model_name = model.name;
-
-else
-    % model matrices
-    A = model.dyn_gnsf_A;
-    B = model.dyn_gnsf_B;
-    C = model.dyn_gnsf_C;
-    E = model.dyn_gnsf_E;
-    c = model.dyn_gnsf_c;
-
-    L_x    = model.dyn_gnsf_L_x;
-    L_z    = model.dyn_gnsf_L_z;
-    L_xdot = model.dyn_gnsf_L_xdot;
-    L_u    = model.dyn_gnsf_L_u;
-
-    A_LO = model.dyn_gnsf_A_LO;
-    E_LO = model.dyn_gnsf_E_LO;
-    B_LO = model.dyn_gnsf_B_LO;
-    c_LO = model.dyn_gnsf_c_LO;
-
-    % state permutation vector: x_gnsf = dvecpe(x, ipiv)
-    ipiv_x = model.dyn_gnsf_ipiv_x;
-    idx_perm_x = model.dyn_gnsf_idx_perm_x;
-    ipiv_z = model.dyn_gnsf_ipiv_z;
-    idx_perm_z = model.dyn_gnsf_idx_perm_z;
-    ipiv_f = model.dyn_gnsf_ipiv_f;
-    idx_perm_f = model.dyn_gnsf_idx_perm_f;
-
-    % expressions
-    phi = model.dyn_gnsf_expr_phi;
-    f_lo = model.dyn_gnsf_expr_f_lo;
-
-    % binaries
-    nontrivial_f_LO = model.dyn_gnsf_nontrivial_f_LO;
-    purely_linear = model.dyn_gnsf_purely_linear;
-
-    % symbolics
-    % y
-    y = model.sym_gnsf_y;
-    % uhat
-    uhat = model.sym_gnsf_uhat;
-    % general
-    x = model.sym_x;
-    xdot = model.sym_xdot;
-    u = model.sym_u;
-    z = model.sym_z;
-    p = model.sym_p;
-
-    % name
-    model_name = model.name;
-    model_name = [model_name, '_dyn'];
-end
+model_name = model.name;
 
 nx1 = size(L_x, 2);
 nz1 = size(L_z, 2);
@@ -151,17 +91,8 @@ x1 = x(idx_perm_x(1:nx1));
 x1dot = xdot(idx_perm_x(1:nx1));
 z1 = z(idx_perm_z(1:nz1));
 
-if is_template
-    if ~exist(fullfile(pwd,'c_generated_code'), 'dir')
-        mkdir('c_generated_code');
-    end
-    cd 'c_generated_code'
-    model_dir = [model_name, '_model'];
-    if ~exist(fullfile(pwd, model_dir), 'dir')
-        mkdir(model_dir);
-    end
-    cd(model_dir)
-end
+return_dir = pwd;
+cd(model_dir)
 
 %% generate functions
 if ~purely_linear
@@ -175,7 +106,7 @@ if ~purely_linear
     phi_fun.generate([model_name,'_gnsf_phi_fun'], casadi_opts);
     phi_fun_jac_y.generate([model_name,'_gnsf_phi_fun_jac_y'], casadi_opts);
     phi_jac_y_uhat.generate([model_name,'_gnsf_phi_jac_y_uhat'], casadi_opts);
-    
+
     if nontrivial_f_LO
         f_lo_fun_jac_x1k1uz = Function([model_name,'_gnsf_f_lo_fun_jac_x1k1uz'], {x1, x1dot, z1, u, p}, ...
             {f_lo, [jacobian(f_lo,x1), jacobian(f_lo,x1dot), jacobian(f_lo,u), jacobian(f_lo,z1)]});
@@ -190,8 +121,6 @@ get_matrices_fun = Function([model_name,'_gnsf_get_matrices_fun'], {dummy},...
       nontrivial_f_LO, purely_linear, ipiv_x, ipiv_z, c_LO});
 get_matrices_fun.generate([model_name,'_gnsf_get_matrices_fun'], casadi_opts);
 
-if is_template
-    cd '../..'
-end
+cd(return_dir)
 
 end

--- a/interfaces/acados_matlab_octave/generate_c_code_implicit_ode.m
+++ b/interfaces/acados_matlab_octave/generate_c_code_implicit_ode.m
@@ -45,9 +45,7 @@ xdot = model.xdot;
 z = model.z;
 
 nx = length(x);
-nu = length(u);
 nz = length(z);
-np = length(p);
 
 % check type
 if isa(x(1), 'casadi.SX')

--- a/interfaces/acados_matlab_octave/generate_c_code_nonlinear_constr.m
+++ b/interfaces/acados_matlab_octave/generate_c_code_nonlinear_constr.m
@@ -40,6 +40,8 @@ check_casadi_version();
 %% load model
 x = model.sym_x;
 u = model.sym_u;
+p = model.sym_p;
+z = model.sym_z;
 
 if isa(x(1), 'casadi.SX')
     isSX = true;
@@ -47,36 +49,11 @@ else
     isSX = false;
 end
 
-z = model.sym_z;
-
-% if ~isempty(model, 'sym_z')
-%     z = model.sym_z;
-% else
-%     if isSX
-%         z = SX.sym('z',0, 0);
-%     else
-%         z = MX.sym('z',0, 0);
-%     end
-% end
-
-p = model.sym_p;
-
-% if ~isempty(model, 'sym_p')
-%     p = model.sym_p;
-% else
-%     if isSX
-%         p = SX.sym('p',0, 0);
-%     else
-%         p = MX.sym('p',0, 0);
-%     end
-% end
-
 model_name = model.name;
 
 % cd to target folder
 return_dir = pwd;
 chdir(target_dir)
-
 
 if isfield(model, 'constr_expr_h')
     h = model.constr_expr_h;

--- a/interfaces/acados_matlab_octave/generate_c_code_nonlinear_constr.m
+++ b/interfaces/acados_matlab_octave/generate_c_code_nonlinear_constr.m
@@ -39,41 +39,32 @@ casadi_opts = struct('mex', false, 'casadi_int', 'int', 'casadi_real', 'double')
 check_casadi_version();
 
 %% load model
-% x
 x = model.sym_x;
-nx = length(x);
 % check type
 if isa(x(1), 'casadi.SX')
     isSX = true;
 else
     isSX = false;
 end
-% u
 u = model.sym_u;
-nu = length(u);
-% z
 if isfield(model, 'sym_z')
     z = model.sym_z;
-    nz = length(z);
 else
     if isSX
         z = SX.sym('z',0, 0);
     else
         z = MX.sym('z',0, 0);
     end
-    nz = 0;
 end
 % p
 if isfield(model, 'sym_p')
     p = model.sym_p;
-    np = length(p);
 else
     if isSX
         p = SX.sym('p',0, 0);
     else
         p = MX.sym('p',0, 0);
     end
-    np = 0;
 end
 
 model_name = model.name;

--- a/interfaces/acados_matlab_octave/generate_c_code_nonlinear_constr.m
+++ b/interfaces/acados_matlab_octave/generate_c_code_nonlinear_constr.m
@@ -32,7 +32,6 @@
 
 function generate_c_code_nonlinear_constr( model, opts, target_dir )
 
-%% import casadi
 import casadi.*
 
 casadi_opts = struct('mex', false, 'casadi_int', 'int', 'casadi_real', 'double');
@@ -40,43 +39,44 @@ check_casadi_version();
 
 %% load model
 x = model.sym_x;
-% check type
+u = model.sym_u;
+
 if isa(x(1), 'casadi.SX')
     isSX = true;
 else
     isSX = false;
 end
-u = model.sym_u;
-if isfield(model, 'sym_z')
-    z = model.sym_z;
-else
-    if isSX
-        z = SX.sym('z',0, 0);
-    else
-        z = MX.sym('z',0, 0);
-    end
-end
-% p
-if isfield(model, 'sym_p')
-    p = model.sym_p;
-else
-    if isSX
-        p = SX.sym('p',0, 0);
-    else
-        p = MX.sym('p',0, 0);
-    end
-end
+
+z = model.sym_z;
+
+% if ~isempty(model, 'sym_z')
+%     z = model.sym_z;
+% else
+%     if isSX
+%         z = SX.sym('z',0, 0);
+%     else
+%         z = MX.sym('z',0, 0);
+%     end
+% end
+
+p = model.sym_p;
+
+% if ~isempty(model, 'sym_p')
+%     p = model.sym_p;
+% else
+%     if isSX
+%         p = SX.sym('p',0, 0);
+%     else
+%         p = MX.sym('p',0, 0);
+%     end
+% end
 
 model_name = model.name;
 
 % cd to target folder
-if nargin > 2
-    original_dir = pwd;
-    if ~exist(target_dir, 'dir')
-        mkdir(target_dir);
-    end
-    chdir(target_dir)
-end
+return_dir = pwd;
+chdir(target_dir)
+
 
 if isfield(model, 'constr_expr_h')
     h = model.constr_expr_h;
@@ -166,9 +166,6 @@ if isfield(model, 'constr_expr_h_e')
     h_e_fun_jac_uxt_zt_hess.generate([model_name,'_constr_h_e_fun_jac_uxt_zt_hess'], casadi_opts);
 end
 
-if nargin > 2
-    chdir(original_dir)
-end
-
+chdir(return_dir)
 
 end

--- a/interfaces/acados_matlab_octave/generate_c_code_nonlinear_constr.m
+++ b/interfaces/acados_matlab_octave/generate_c_code_nonlinear_constr.m
@@ -53,9 +53,7 @@ model_name = model.name;
 
 % cd to target folder
 return_dir = pwd;
-if ~exist(target_dir, 'dir')
-    mkdir(target_dir);
-end
+check_dir_and_create(target_dir);
 chdir(target_dir)
 disp(pwd);
 

--- a/interfaces/acados_matlab_octave/generate_c_code_nonlinear_least_squares.m
+++ b/interfaces/acados_matlab_octave/generate_c_code_nonlinear_least_squares.m
@@ -52,10 +52,12 @@ end
 model_name = model.name;
 
 % cd to target folder
-if nargin > 2
-    original_dir = pwd;
-    chdir(target_dir)
+original_dir = pwd;
+if ~exist(target_dir, 'dir')
+    mkdir(target_dir);
 end
+chdir(target_dir)
+
 
 if strcmp(stage_type, 'initial')
 
@@ -151,9 +153,7 @@ elseif strcmp(stage_type, 'terminal')
     y_e_hess.generate([model_name,'_cost_y_e_hess'], casadi_opts);
 end
 
-if nargin > 2
-    chdir(original_dir)
-end
+chdir(original_dir)
 
 end
 

--- a/interfaces/acados_matlab_octave/generate_c_code_nonlinear_least_squares.m
+++ b/interfaces/acados_matlab_octave/generate_c_code_nonlinear_least_squares.m
@@ -30,7 +30,7 @@
 %
 
 
-function generate_c_code_nonlinear_least_squares( model, opts, target_dir )
+function generate_c_code_nonlinear_least_squares( model, opts, target_dir, stage_type )
 
 %% import casadi
 import casadi.*
@@ -76,7 +76,7 @@ if nargin > 2
     chdir(target_dir)
 end
 
-if isfield(model, 'cost_expr_y_0')
+if strcmp(stage_type, 'initial')
     fun = model.cost_expr_y_0;
     if all(size(fun) == 0)
         error('empty cost_expr_y_0 is not allowed.\nPlease use SX.zeros(1) or %s',...
@@ -104,9 +104,8 @@ if isfield(model, 'cost_expr_y_0')
     y_0_fun.generate([model_name,'_cost_y_0_fun'], casadi_opts);
     y_0_fun_jac_ut_xt.generate([model_name,'_cost_y_0_fun_jac_ut_xt'], casadi_opts);
     y_0_hess.generate([model_name,'_cost_y_0_hess'], casadi_opts);
-end
 
-if isfield(model, 'cost_expr_y')
+elseif strcmp(stage_type, 'path')
     fun = model.cost_expr_y;
     if all(size(fun) == 0)
         error('empty cost_expr_y is not allowed.\nPlease use SX.zeros(1) or %s',...
@@ -135,9 +134,7 @@ if isfield(model, 'cost_expr_y')
     y_fun.generate([model_name,'_cost_y_fun'], casadi_opts);
     y_fun_jac_ut_xt.generate([model_name,'_cost_y_fun_jac_ut_xt'], casadi_opts);
     y_hess.generate([model_name,'_cost_y_hess'], casadi_opts);
-end
-
-if isfield(model, 'cost_expr_y_e')
+elseif strcmp(stage_type, 'terminal')
     fun = model.cost_expr_y_e;
     if all(size(fun) == 0)
         error('empty cost_expr_y_e is not allowed.\nPlease use SX.zeros(1) or %s',...

--- a/interfaces/acados_matlab_octave/generate_c_code_nonlinear_least_squares.m
+++ b/interfaces/acados_matlab_octave/generate_c_code_nonlinear_least_squares.m
@@ -30,57 +30,53 @@
 %
 
 
-function generate_c_code_nonlinear_least_squares( model, opts, target_dir, stage_type )
+function generate_c_code_nonlinear_least_squares( model, target_dir, stage_type )
 
-%% import casadi
 import casadi.*
 
 casadi_opts = struct('mex', false, 'casadi_int', 'int', 'casadi_real', 'double');
 check_casadi_version();
 
 %% load model
-% x
-x = model.sym_x;
-nx = length(x);
+x = model.x;
+u = model.u;
+z = model.z;
+
 % check type
 if isa(x(1), 'casadi.SX')
     isSX = true;
 else
     isSX = false;
 end
-% u
-u = model.sym_u;
-nu = length(u);
-% p
-if isfield(model, 'sym_p')
-    p = model.sym_p;
-    np = length(p);
+
+if isfield(model, 'p')
+    p = model.p;
 else
     if isSX
         p = SX.sym('p',0, 0);
     else
         p = MX.sym('p',0, 0);
     end
-    np = 0;
 end
-z = model.sym_z;
 
 model_name = model.name;
 
 % cd to target folder
 if nargin > 2
     original_dir = pwd;
-    if ~exist(target_dir, 'dir')
-        mkdir(target_dir);
-    end
     chdir(target_dir)
 end
 
 if strcmp(stage_type, 'initial')
-    fun = model.cost_expr_y_0;
-    if all(size(fun) == 0)
-        error('empty cost_expr_y_0 is not allowed.\nPlease use SX.zeros(1) or %s',...
-              'linear least squares formulation for a zero cost term.');
+
+    if ~isempty(model.cost_y_expr_0)
+        fun = model.cost_y_expr_0;
+    elseif isempty(model.cost_y_expr_0) && ~isempty(model.cost_y_expr)
+        disp('path used')
+        fun = model.cost_y_expr;
+    else
+        error('empty cost_y_expr is not allowed.\nPlease use SX.zeros(1) or %s',...
+        'linear least squares formulation for a zero cost term.');
     end
     % generate jacobians
     jac_x = jacobian(fun, x);
@@ -106,9 +102,9 @@ if strcmp(stage_type, 'initial')
     y_0_hess.generate([model_name,'_cost_y_0_hess'], casadi_opts);
 
 elseif strcmp(stage_type, 'path')
-    fun = model.cost_expr_y;
-    if all(size(fun) == 0)
-        error('empty cost_expr_y is not allowed.\nPlease use SX.zeros(1) or %s',...
+    fun = model.cost_y_expr;
+    if isempty(fun)
+        error('empty cost_y_expr is not allowed.\nPlease use SX.zeros(1) or %s',...
               'linear least squares formulation for a zero cost term.');
     end
     % generate jacobians
@@ -135,9 +131,9 @@ elseif strcmp(stage_type, 'path')
     y_fun_jac_ut_xt.generate([model_name,'_cost_y_fun_jac_ut_xt'], casadi_opts);
     y_hess.generate([model_name,'_cost_y_hess'], casadi_opts);
 elseif strcmp(stage_type, 'terminal')
-    fun = model.cost_expr_y_e;
-    if all(size(fun) == 0)
-        error('empty cost_expr_y_e is not allowed.\nPlease use SX.zeros(1) or %s',...
+    fun = model.cost_y_expr_e;
+    if isempty(fun)
+        error('empty cost_y_expr_e is not allowed.\nPlease use SX.zeros(1) or %s',...
               'linear least squares formulation for a zero cost term.');
     end
     % generate jacobians

--- a/interfaces/acados_matlab_octave/generate_c_code_nonlinear_least_squares.m
+++ b/interfaces/acados_matlab_octave/generate_c_code_nonlinear_least_squares.m
@@ -49,16 +49,6 @@ else
     isSX = false;
 end
 
-if isfield(model, 'p')
-    p = model.p;
-else
-    if isSX
-        p = SX.sym('p',0, 0);
-    else
-        p = MX.sym('p',0, 0);
-    end
-end
-
 model_name = model.name;
 
 % cd to target folder

--- a/interfaces/acados_matlab_octave/generate_c_code_nonlinear_least_squares.m
+++ b/interfaces/acados_matlab_octave/generate_c_code_nonlinear_least_squares.m
@@ -41,6 +41,7 @@ check_casadi_version();
 x = model.x;
 u = model.u;
 z = model.z;
+p = model.p;
 
 % check type
 if isa(x(1), 'casadi.SX')

--- a/interfaces/acados_matlab_octave/generate_c_code_nonlinear_least_squares.m
+++ b/interfaces/acados_matlab_octave/generate_c_code_nonlinear_least_squares.m
@@ -54,11 +54,8 @@ model_name = model.name;
 
 % cd to target folder
 original_dir = pwd;
-if ~exist(target_dir, 'dir')
-    mkdir(target_dir);
-end
+check_dir_and_create(target_dir);
 chdir(target_dir)
-
 
 if strcmp(stage_type, 'initial')
 

--- a/interfaces/acados_matlab_octave/ocp_generate_c_code.m
+++ b/interfaces/acados_matlab_octave/ocp_generate_c_code.m
@@ -315,6 +315,9 @@ function setup_generic_cost(cost, target_dir, stage_type)
         error('Unknown stage_type.')
     end
 
+    if ~exist(target_dir, 'dir')
+        mkdir(target_dir);
+    end
     copyfile(fullfile(pwd, cost_source_ext_cost), target_dir);
 end
 

--- a/interfaces/acados_matlab_octave/ocp_generate_c_code.m
+++ b/interfaces/acados_matlab_octave/ocp_generate_c_code.m
@@ -58,7 +58,7 @@ function ocp_generate_c_code(obj)
         generate_c_code_explicit_ode(obj.ocp.model, code_gen_opts, model_dir);
     elseif (strcmp(solver_opts.integrator_type, 'IRK')) && strcmp(obj.ocp.model.dyn_ext_fun_type, 'casadi')
         generate_c_code_implicit_ode(obj.ocp.model, code_gen_opts, model_dir);
-    elseif (strcmp(solver_opts.integrator_type, 'IRK_GNSF'))
+    elseif (strcmp(solver_opts.integrator_type, 'GNSF'))
         generate_c_code_gnsf(obj.ocp.model, code_gen_opts, model_dir);
     elseif (strcmp(solver_opts.integrator_type, 'DISCRETE')) && strcmp(obj.ocp.model.dyn_ext_fun_type, 'casadi')
         generate_c_code_disc_dyn(obj.ocp.model, code_gen_opts, model_dir);

--- a/interfaces/acados_matlab_octave/ocp_generate_c_code.m
+++ b/interfaces/acados_matlab_octave/ocp_generate_c_code.m
@@ -31,9 +31,8 @@
 
 function ocp_generate_c_code(ocp)
     %% create folder
-    if ~exist(fullfile(pwd,'c_generated_code'), 'dir')
-        mkdir(fullfile(pwd, 'c_generated_code'))
-    end
+
+    check_dir_and_create(fullfile(pwd,'c_generated_code'));
 
     %% generate C code for CasADi functions / copy external functions
     cost = ocp.cost;
@@ -48,11 +47,9 @@ function ocp_generate_c_code(ocp)
     code_gen_opts.with_value_sens_wrt_params = solver_opts.with_value_sens_wrt_params;
 
     % dynamics
-    model_dir = fullfile(pwd, 'c_generated_code', [ocp.name '_model']);
     % model dir is always need, other dirs are  only created if necessary
-    if ~exist(model_dir, 'dir')
-        mkdir(model_dir);
-    end
+    model_dir = fullfile(pwd, 'c_generated_code', [ocp.name '_model']);
+    check_dir_and_create(model_dir);
 
     if (strcmp(solver_opts.integrator_type, 'ERK'))
         generate_c_code_explicit_ode(ocp.model, code_gen_opts, model_dir);
@@ -309,9 +306,7 @@ function setup_generic_cost(cost, target_dir, stage_type)
         error('Unknown stage_type.')
     end
 
-    if ~exist(target_dir, 'dir')
-        mkdir(target_dir);
-    end
+    check_dir_and_create(target_dir);
     copyfile(fullfile(pwd, cost_source_ext_cost), target_dir);
 end
 

--- a/interfaces/acados_matlab_octave/setup_ocp.m
+++ b/interfaces/acados_matlab_octave/setup_ocp.m
@@ -221,21 +221,6 @@ function ocp = setup_ocp(obj, simulink_opts)
     end
 
     ocp.cost.cost_ext_fun_type = model.cost_ext_fun_type;
-    if strcmp(model.cost_ext_fun_type, 'generic')
-        ocp.cost.cost_source_ext_cost = model.cost_source_ext_cost;
-        ocp.cost.cost_function_ext_cost = model.cost_function_ext_cost;
-    end
-    ocp.cost.cost_ext_fun_type_0 = model.cost_ext_fun_type_0;
-    if strcmp(model.cost_ext_fun_type_0, 'generic')
-        ocp.cost.cost_source_ext_cost_0 = model.cost_source_ext_cost_0;
-        ocp.cost.cost_function_ext_cost_0 = model.cost_function_ext_cost_0;
-    end
-    ocp.cost.cost_ext_fun_type_e = model.cost_ext_fun_type_e;
-    if strcmp(model.cost_ext_fun_type_e, 'generic')
-        ocp.cost.cost_source_ext_cost_e = model.cost_source_ext_cost_e;
-        ocp.cost.cost_function_ext_cost_e = model.cost_function_ext_cost_e;
-    end
-
     ocp.constraints.constr_type = upper(model.constr_type);
     ocp.constraints.constr_type_0 = upper(model.constr_type_0);
     ocp.constraints.constr_type_e = upper(model.constr_type_e);
@@ -437,12 +422,48 @@ function ocp = setup_ocp(obj, simulink_opts)
 
 
     %% Cost
+    if strcmp(model.cost_type, 'ext_cost') && strcmp(model.cost_ext_fun_type, 'casadi')
+        ocp.model.cost_expr_ext_cost = model.cost_expr_ext_cost
+    end
+    if strcmp(model.cost_type_0, 'ext_cost') && strcmp(model.cost_ext_fun_type_0, 'casadi')
+        ocp.model.cost_expr_ext_cost_0 = model.cost_expr_ext_cost_0
+    end
+    if strcmp(model.cost_type_e, 'ext_cost') && strcmp(model.cost_ext_fun_type_e, 'casadi')
+        ocp.model.cost_expr_ext_cost_e = model.cost_expr_ext_cost_e
+    end
+
+    if strcmp(model.cost_ext_fun_type, 'generic')
+        ocp.cost.cost_source_ext_cost = model.cost_source_ext_cost;
+        ocp.cost.cost_function_ext_cost = model.cost_function_ext_cost;
+    end
+    ocp.cost.cost_ext_fun_type_0 = model.cost_ext_fun_type_0;
+    if strcmp(model.cost_ext_fun_type_0, 'generic')
+        ocp.cost.cost_source_ext_cost_0 = model.cost_source_ext_cost_0;
+        ocp.cost.cost_function_ext_cost_0 = model.cost_function_ext_cost_0;
+    end
+    ocp.cost.cost_ext_fun_type_e = model.cost_ext_fun_type_e;
+    if strcmp(model.cost_ext_fun_type_e, 'generic')
+        ocp.cost.cost_source_ext_cost_e = model.cost_source_ext_cost_e;
+        ocp.cost.cost_function_ext_cost_e = model.cost_function_ext_cost_e;
+    end
     if strcmp(model.cost_type, 'linear_ls')
         ocp.cost.Vu = model.cost_Vu;
         ocp.cost.Vx = model.cost_Vx;
         if isfield(model, 'cost_Vz')
             ocp.cost.Vz = model.cost_Vz;
         end
+    end
+    if strcmp(model.cost_type_0, 'linear_ls')
+        ocp.cost.Vu_0 = model.cost_Vu_0;
+        ocp.cost.Vx_0 = model.cost_Vx_0;
+        if isfield(model, 'cost_Vz_0')
+            ocp.cost.Vz_0 = model.cost_Vz_0;
+        end
+    end
+
+    % terminal cost might be empty
+    if isfield(model, 'cost_Vx_e')
+        ocp.cost.Vx_e = model.cost_Vx_e;
     end
 
     if strcmp(model.cost_type, 'nonlinear_ls') || strcmp(model.cost_type, 'linear_ls')
@@ -455,13 +476,6 @@ function ocp = setup_ocp(obj, simulink_opts)
         end
     end
 
-    if strcmp(model.cost_type_0, 'linear_ls')
-        ocp.cost.Vu_0 = model.cost_Vu_0;
-        ocp.cost.Vx_0 = model.cost_Vx_0;
-        if isfield(model, 'cost_Vz_0')
-            ocp.cost.Vz_0 = model.cost_Vz_0;
-        end
-    end
     if strcmp(model.cost_type_0, 'nonlinear_ls') || strcmp(model.cost_type_0, 'linear_ls')
         ocp.cost.W_0 = model.cost_W_0;
 
@@ -473,20 +487,31 @@ function ocp = setup_ocp(obj, simulink_opts)
         end
     end
 
-    if isfield(model, 'cost_Vx_e')
-        ocp.cost.Vx_e = model.cost_Vx_e;
-    end
-
     if strcmp(model.cost_type_e, 'nonlinear_ls') || strcmp(model.cost_type_e, 'linear_ls')
         if isfield(model, 'cost_W_e')
             ocp.cost.W_e = model.cost_W_e;
-
         end
         if isfield(model, 'cost_y_ref_e')
             ocp.cost.yref_e = model.cost_y_ref_e;
         else
 			warning(['cost_y_ref_e not defined for ocp json.' 10 'Using zeros(ny_e,1) by default.']);
             ocp.cost.yref_e = zeros(model.dim_ny_e,1);
+        end
+    end
+
+    if strcmp(model.cost_type, 'nonlinear_ls')
+        if isfield(model, 'cost_expr_y')
+            ocp.model.cost_y_expr = model.cost_expr_y
+        end
+    end
+    if strcmp(model.cost_type_0, 'nonlinear_ls')
+        if isfield(model, 'cost_expr_y_0')
+            ocp.model.cost_y_expr_0 = model.cost_expr_y_0
+        end
+    end
+    if strcmp(model.cost_type_e, 'nonlinear_ls')
+        if isfield(model, 'cost_expr_y_e')
+            ocp.model.cost_y_expr_e = model.cost_expr_y_e
         end
     end
 

--- a/interfaces/acados_matlab_octave/setup_ocp.m
+++ b/interfaces/acados_matlab_octave/setup_ocp.m
@@ -256,7 +256,15 @@ function ocp = setup_ocp(obj, simulink_opts)
     end
     ocp.constraints.idxbxe_0 = model.constr_idxbxe_0;
 
-
+    if isfield(model, 'constr_expr_h_0') && ocp.dims.nh_0 > 0
+        ocp.model.con_h_expr_0 = model.constr_expr_h_0
+    end
+    if isfield(model, 'constr_expr_h') && ocp.dims.nh > 0
+        ocp.model.con_h_expr = model.constr_expr_h
+    end
+    if isfield(model, 'constr_expr_h_e') && ocp.dims.nh_e > 0
+        ocp.model.con_h_expr_e = model.constr_expr_h_e
+    end
     % path
     if ocp.dims.nbx > 0
         ocp.constraints.idxbx = J_to_idx( model.constr_Jbx );

--- a/interfaces/acados_matlab_octave/setup_ocp.m
+++ b/interfaces/acados_matlab_octave/setup_ocp.m
@@ -618,7 +618,6 @@ function ocp = setup_ocp(obj, simulink_opts)
     ocp.model.z = model.sym_z;
     ocp.model.xdot = model.sym_xdot;
     ocp.model.p = model.sym_p;
-
 end
 
 

--- a/interfaces/acados_matlab_octave/setup_ocp.m
+++ b/interfaces/acados_matlab_octave/setup_ocp.m
@@ -257,13 +257,13 @@ function ocp = setup_ocp(obj, simulink_opts)
     ocp.constraints.idxbxe_0 = model.constr_idxbxe_0;
 
     if isfield(model, 'constr_expr_h_0') && ocp.dims.nh_0 > 0
-        ocp.model.con_h_expr_0 = model.constr_expr_h_0
+        ocp.model.con_h_expr_0 = model.constr_expr_h_0;
     end
     if isfield(model, 'constr_expr_h') && ocp.dims.nh > 0
-        ocp.model.con_h_expr = model.constr_expr_h
+        ocp.model.con_h_expr = model.constr_expr_h;
     end
     if isfield(model, 'constr_expr_h_e') && ocp.dims.nh_e > 0
-        ocp.model.con_h_expr_e = model.constr_expr_h_e
+        ocp.model.con_h_expr_e = model.constr_expr_h_e;
     end
     % path
     if ocp.dims.nbx > 0
@@ -431,13 +431,13 @@ function ocp = setup_ocp(obj, simulink_opts)
 
     %% Cost
     if strcmp(model.cost_type, 'ext_cost') && strcmp(model.cost_ext_fun_type, 'casadi')
-        ocp.model.cost_expr_ext_cost = model.cost_expr_ext_cost
+        ocp.model.cost_expr_ext_cost = model.cost_expr_ext_cost;
     end
     if strcmp(model.cost_type_0, 'ext_cost') && strcmp(model.cost_ext_fun_type_0, 'casadi')
-        ocp.model.cost_expr_ext_cost_0 = model.cost_expr_ext_cost_0
+        ocp.model.cost_expr_ext_cost_0 = model.cost_expr_ext_cost_0;
     end
     if strcmp(model.cost_type_e, 'ext_cost') && strcmp(model.cost_ext_fun_type_e, 'casadi')
-        ocp.model.cost_expr_ext_cost_e = model.cost_expr_ext_cost_e
+        ocp.model.cost_expr_ext_cost_e = model.cost_expr_ext_cost_e;
     end
 
     if strcmp(model.cost_ext_fun_type, 'generic')
@@ -509,17 +509,17 @@ function ocp = setup_ocp(obj, simulink_opts)
 
     if strcmp(model.cost_type, 'nonlinear_ls')
         if isfield(model, 'cost_expr_y')
-            ocp.model.cost_y_expr = model.cost_expr_y
+            ocp.model.cost_y_expr = model.cost_expr_y;
         end
     end
     if strcmp(model.cost_type_0, 'nonlinear_ls')
         if isfield(model, 'cost_expr_y_0')
-            ocp.model.cost_y_expr_0 = model.cost_expr_y_0
+            ocp.model.cost_y_expr_0 = model.cost_expr_y_0;
         end
     end
     if strcmp(model.cost_type_e, 'nonlinear_ls')
         if isfield(model, 'cost_expr_y_e')
-            ocp.model.cost_y_expr_e = model.cost_expr_y_e
+            ocp.model.cost_y_expr_e = model.cost_expr_y_e;
         end
     end
 

--- a/interfaces/acados_matlab_octave/sim_generate_c_code.m
+++ b/interfaces/acados_matlab_octave/sim_generate_c_code.m
@@ -35,7 +35,7 @@ function sim_generate_c_code(obj)
         mkdir(fullfile(pwd, 'c_generated_code'))
     end
 
-    model_dir = fullfile(pwd, 'c_generated_code', [obj.ocp.name '_model']);
+    model_dir = fullfile(pwd, 'c_generated_code', [obj.sim.model.name '_model']);
     if ~exist(model_dir, 'dir')
         mkdir(model_dir);
     end

--- a/interfaces/acados_matlab_octave/sim_generate_c_code.m
+++ b/interfaces/acados_matlab_octave/sim_generate_c_code.m
@@ -30,12 +30,15 @@
 %
 
 function sim_generate_c_code(obj)
-    %% create folder
+    %% create folders
     if ~exist(fullfile(pwd,'c_generated_code'), 'dir')
         mkdir(fullfile(pwd, 'c_generated_code'))
     end
 
-    model_dir = setup_target_dir(obj.model_struct.name, '_model');
+    model_dir = fullfile(pwd, 'c_generated_code', [obj.ocp.name '_model']);
+    if ~exist(model_dir, 'dir')
+        mkdir(model_dir);
+    end
 
     code_gen_opts = struct('generate_hess', strcmp(obj.opts_struct.sens_hess, 'true'));
     %% generate C code for CasADi functions / copy external functions
@@ -143,9 +146,3 @@ function sim_generate_c_code(obj)
     acados_template_mex.compile_sim_shared_lib(obj.sim.code_export_directory)
 end
 
-function target_dir = setup_target_dir(name, postfix)
-    target_dir = fullfile(pwd, 'c_generated_code', [name postfix]);
-    if ~exist(target_dir, 'dir')
-        mkdir(target_dir);
-    end
-end

--- a/interfaces/acados_matlab_octave/sim_generate_c_code.m
+++ b/interfaces/acados_matlab_octave/sim_generate_c_code.m
@@ -37,8 +37,7 @@ function sim_generate_c_code(obj)
 
     model_dir = setup_target_dir(obj.model_struct.name, '_model');
 
-    % TODO: where do we get this option from?
-    code_gen_opts = struct('generate_hess', false);
+    code_gen_opts = struct('generate_hess', strcmp(obj.opts_struct.sens_hess, 'true'));
     %% generate C code for CasADi functions / copy external functions
     % dynamics
     if (strcmp(obj.model_struct.dyn_type, 'explicit'))

--- a/interfaces/acados_matlab_octave/sim_generate_c_code.m
+++ b/interfaces/acados_matlab_octave/sim_generate_c_code.m
@@ -31,14 +31,10 @@
 
 function sim_generate_c_code(sim)
     %% create folders
-    if ~exist(fullfile(pwd,'c_generated_code'), 'dir')
-        mkdir(fullfile(pwd, 'c_generated_code'))
-    end
+    check_dir_and_create(fullfile(pwd,'c_generated_code'));
 
     model_dir = fullfile(pwd, 'c_generated_code', [sim.model.name '_model']);
-    if ~exist(model_dir, 'dir')
-        mkdir(model_dir);
-    end
+    check_dir_and_create(model_dir);
 
     code_gen_opts = struct('generate_hess', sim.sim_options.sens_hess);
     %% generate C code for CasADi functions / copy external functions
@@ -83,7 +79,6 @@ function sim_generate_c_code(sim)
     % end
 
     %% reshape opts
-    opts = sim.sim_options;
     opts_layout = acados_sim_layout.solver_options;
     fields = fieldnames(opts_layout);
     for i = 1:numel(fields)
@@ -95,19 +90,18 @@ function sim_generate_c_code(sim)
                 this_dims = [dims.(property_dim_names{1}), dims.(property_dim_names{2})];
             end
             try
-                opts.(fields{i}) = reshape(opts.(fields{i}), this_dims);
+                sim.sim_options.(fields{i}) = reshape(sim.sim_options.(fields{i}), this_dims);
             catch e
-                error(['error while reshaping opts.' fields{i} ...
+                error(['error while reshaping sim_options' fields{i} ...
                     ' to dimension ' num2str(this_dims), ', got ',...
-                    num2str( size(opts.(fields{i}) )) , 10,...
+                    num2str( size(sim.sim_options.(fields{i}) )) , 10,...
                     e.message ]);
             end
             if this_dims(1) == 1 && length(property_dim_names) ~= 1 % matrix with 1 row
-                opts.(fields{i}) = {opts.(fields{i})};
+                sim.sim_options.(fields{i}) = {sim.sim_options.(fields{i})};
             end
         end
     end
-    sim.sim_options = opts;
 
     % parameter values
     sim.parameter_values = reshape(num2cell(sim.parameter_values), [ 1, dims.np]);

--- a/interfaces/acados_matlab_octave/sim_generate_c_code.m
+++ b/interfaces/acados_matlab_octave/sim_generate_c_code.m
@@ -29,48 +29,46 @@
 
 %
 
-function sim_generate_c_code(obj)
+function sim_generate_c_code(sim)
     %% create folders
     if ~exist(fullfile(pwd,'c_generated_code'), 'dir')
         mkdir(fullfile(pwd, 'c_generated_code'))
     end
 
-    model_dir = fullfile(pwd, 'c_generated_code', [obj.sim.model.name '_model']);
+    model_dir = fullfile(pwd, 'c_generated_code', [sim.model.name '_model']);
     if ~exist(model_dir, 'dir')
         mkdir(model_dir);
     end
 
-    code_gen_opts = struct('generate_hess', strcmp(obj.opts_struct.sens_hess, 'true'));
+    code_gen_opts = struct('generate_hess', sim.sim_options.sens_hess);
     %% generate C code for CasADi functions / copy external functions
     % dynamics
-    if (strcmp(obj.model_struct.dyn_type, 'explicit'))
-        generate_c_code_explicit_ode(obj.sim.model, code_gen_opts, model_dir);
-    elseif (strcmp(obj.model_struct.dyn_type, 'implicit'))
-        if (strcmp(obj.opts_struct.method, 'irk'))
-            generate_c_code_implicit_ode(obj.sim.model, code_gen_opts, model_dir);
-        elseif (strcmp(obj.opts_struct.method, 'irk_gnsf'))
-            generate_c_code_gnsf(obj.sim.model, code_gen_opts, model_dir);
-        end
-    elseif (strcmp(obj.model_struct.dyn_type, 'discrete'))
-        generate_c_code_disc_dyn(obj.sim.model, code_gen_opts, model_dir);
+    if (strcmp(sim.sim_options.integrator_type, 'ERK'))
+        generate_c_code_explicit_ode(sim.model, code_gen_opts, model_dir);
+    elseif (strcmp(sim.sim_options.integrator_type, 'IRK'))
+        generate_c_code_implicit_ode(sim.model, code_gen_opts, model_dir);
+    elseif (strcmp(sim.sim_options.integrator_type, 'GNSF'))
+        generate_c_code_gnsf(sim.model, code_gen_opts, model_dir);
+    elseif (strcmp(sim.sim_options.integrator_type, 'DISCRETE'))
+        generate_c_code_disc_dyn(sim.model, code_gen_opts, model_dir);
     end
-    if strcmp(obj.sim.model.dyn_ext_fun_type, 'generic')
-        copyfile( fullfile(pwd, obj.sim.model.dyn_generic_source), model_dir);
+    if strcmp(sim.model.dyn_ext_fun_type, 'generic')
+        copyfile(fullfile(pwd, sim.model.dyn_generic_source), model_dir);
     end
 
 
     %% remove CasADi objects from model
-    model.name = obj.sim.model.name;
-    model.dyn_ext_fun_type = obj.sim.model.dyn_ext_fun_type;
-    model.dyn_generic_source = obj.sim.model.dyn_generic_source;
-    model.dyn_disc_fun_jac_hess = obj.sim.model.dyn_disc_fun_jac_hess;
-    model.dyn_disc_fun_jac = obj.sim.model.dyn_disc_fun_jac;
-    model.dyn_disc_fun = obj.sim.model.dyn_disc_fun;
-    model.gnsf.nontrivial_f_LO = obj.sim.model.gnsf.nontrivial_f_LO;
-    model.gnsf.purely_linear = obj.sim.model.gnsf.purely_linear;
-    obj.sim.model = model;
+    model.name = sim.model.name;
+    model.dyn_ext_fun_type = sim.model.dyn_ext_fun_type;
+    model.dyn_generic_source = sim.model.dyn_generic_source;
+    model.dyn_disc_fun_jac_hess = sim.model.dyn_disc_fun_jac_hess;
+    model.dyn_disc_fun_jac = sim.model.dyn_disc_fun_jac;
+    model.dyn_disc_fun = sim.model.dyn_disc_fun;
+    model.gnsf.nontrivial_f_LO = sim.model.gnsf.nontrivial_f_LO;
+    model.gnsf.purely_linear = sim.model.gnsf.purely_linear;
+    sim.model = model;
     %% post process numerical data (mostly cast scalars to 1-dimensional cells)
-    dims = obj.sim.dims;
+    dims = sim.dims;
 
     %% load JSON layout
     acados_folder = getenv('ACADOS_INSTALL_DIR');
@@ -85,7 +83,7 @@ function sim_generate_c_code(obj)
     % end
 
     %% reshape opts
-    opts = obj.sim.sim_options;
+    opts = sim.sim_options;
     opts_layout = acados_sim_layout.solver_options;
     fields = fieldnames(opts_layout);
     for i = 1:numel(fields)
@@ -109,18 +107,18 @@ function sim_generate_c_code(obj)
             end
         end
     end
-    obj.sim.sim_options = opts;
+    sim.sim_options = opts;
 
     % parameter values
-    obj.sim.parameter_values = reshape(num2cell(obj.sim.parameter_values), [ 1, dims.np]);
+    sim.parameter_values = reshape(num2cell(sim.parameter_values), [ 1, dims.np]);
 
     %% dump JSON file
     % if is_octave()
         % savejson does not work for classes!
         % -> consider making the sim properties structs directly.
-        sim_json_struct = obj.sim.struct();
-        sim_json_struct.dims = obj.sim.dims.struct();
-        sim_json_struct.solver_options = obj.sim.sim_options;
+        sim_json_struct = sim.struct();
+        sim_json_struct.dims = sim.dims.struct();
+        sim_json_struct.solver_options = sim.sim_options;
 
         % add compilation information to json
         libs = loadjson(fileread(fullfile(acados_folder, 'lib', 'link_libs.json')));
@@ -135,14 +133,14 @@ function sim_generate_c_code(obj)
 
         json_string = savejson('', sim_json_struct, 'ForceRootName', 0);
     % else % Matlab
-    %     json_string = jsonencode(obj.sim);
+    %     json_string = jsonencode(sim);
     % end
-    fid = fopen(obj.sim.json_file, 'w');
+    fid = fopen(sim.json_file, 'w');
     if fid == -1, error('Cannot create JSON file'); end
     fwrite(fid, json_string, 'char');
     fclose(fid);
     %% render templated code
-    acados_template_mex.render_acados_sim_templates(obj.sim.json_file)
-    acados_template_mex.compile_sim_shared_lib(obj.sim.code_export_directory)
+    acados_template_mex.render_acados_sim_templates(sim.json_file)
+    acados_template_mex.compile_sim_shared_lib(sim.code_export_directory)
 end
 

--- a/interfaces/acados_matlab_octave/sim_generate_casadi_ext_fun.m
+++ b/interfaces/acados_matlab_octave/sim_generate_casadi_ext_fun.m
@@ -33,11 +33,13 @@ function sim_generate_casadi_ext_fun(model_struct, opts_struct)
 
 model_name = model_struct.name;
 
+model_dir = setup_target_dir(model_name, '_model');
+
 c_files = {};
 if (strcmp(opts_struct.method, 'erk'))
     % generate c for function and derivatives using casadi
     if (strcmp(opts_struct.codgen_model, 'true'))
-        generate_c_code_explicit_ode(model_struct, opts_struct);
+        generate_c_code_explicit_ode(model_struct, opts_struct, model_dir);
     end
     % compile the code in a shared library
     c_files{end+1} = [model_name, '_dyn_expl_ode_fun.c'];
@@ -47,7 +49,7 @@ if (strcmp(opts_struct.method, 'erk'))
 elseif (strcmp(opts_struct.method, 'irk'))
     % generate c for function and derivatives using casadi
     if (strcmp(opts_struct.codgen_model, 'true'))
-        generate_c_code_implicit_ode(model_struct, opts_struct);
+        generate_c_code_implicit_ode(model_struct, opts_struct, model_dir);
     end
     % compile the code in a shared library
     c_files{end+1} = [model_name, '_dyn_impl_dae_fun.c'];
@@ -60,7 +62,7 @@ elseif (strcmp(opts_struct.method, 'irk'))
 elseif (strcmp(opts_struct.method, 'irk_gnsf'))
     % generate c for function and derivatives using casadi
     if (strcmp(opts_struct.codgen_model, 'true'))
-        generate_c_code_gnsf(model_struct); %, opts_struct);
+        generate_c_code_gnsf(model_struct, opts_struct, model_dir);
     end
     % compile the code in a shared library
     c_files{end+1} = [model_name, '_dyn_gnsf_get_matrices_fun.c'];
@@ -146,3 +148,11 @@ end
 
 end
 
+
+
+function target_dir = setup_target_dir(name, postfix)
+    target_dir = fullfile(pwd, 'c_generated_code', [name postfix]);
+    if ~exist(target_dir, 'dir')
+        mkdir(target_dir);
+    end
+end

--- a/interfaces/acados_matlab_octave/sim_generate_casadi_ext_fun.m
+++ b/interfaces/acados_matlab_octave/sim_generate_casadi_ext_fun.m
@@ -152,7 +152,5 @@ end
 
 function target_dir = setup_target_dir(name, postfix)
     target_dir = fullfile(pwd, 'c_generated_code', [name postfix]);
-    if ~exist(target_dir, 'dir')
-        mkdir(target_dir);
-    end
+    check_dir_and_create(target_dir);
 end

--- a/interfaces/acados_template/acados_template/acados_ocp.py
+++ b/interfaces/acados_template/acados_template/acados_ocp.py
@@ -1010,7 +1010,7 @@ class AcadosOcp:
                 generate_c_code_conl_cost(model, stage_type, code_gen_opts)
             elif getattr(self.cost, attr) == 'EXTERNAL':
                 generate_c_code_external_cost(model, stage_type, code_gen_opts)
-
+            # TODO: generic
 
     def remove_x0_elimination(self) -> None:
         self.constraints.idxbxe_0 = np.zeros((0,))


### PR DESCRIPTION
This PR changes the code generation of CasADi functions in MATLAB such that it is solely based on the OCP description used of the template interface, i.e. `AcadosOcp`. Similar for integrators where only `AcadosSim` is used for code generation.