### PR TITLE
One sided constraint support for HPIPM solvers

### DIFF
--- a/acados/ocp_nlp/ocp_nlp_common.c
+++ b/acados/ocp_nlp/ocp_nlp_common.c
@@ -2114,6 +2114,7 @@ void ocp_nlp_alias_memory_to_submodules(ocp_nlp_config *config, ocp_nlp_dims *di
         config->constraints[i]->memory_set_idxb_ptr(nlp_mem->qp_in->idxb[i], nlp_mem->constraints[i]);
         config->constraints[i]->memory_set_idxs_rev_ptr(nlp_mem->qp_in->idxs_rev[i], nlp_mem->constraints[i]);
         config->constraints[i]->memory_set_idxe_ptr(nlp_mem->qp_in->idxe[i], nlp_mem->constraints[i]);
+        config->constraints[i]->memory_set_dmask_ptr(nlp_mem->qp_in->d_mask+i, nlp_mem->constraints[i]);
     }
 
     // alias to regularize memory

--- a/acados/ocp_nlp/ocp_nlp_constraints_bgh.c
+++ b/acados/ocp_nlp/ocp_nlp_constraints_bgh.c
@@ -1650,6 +1650,24 @@ void ocp_nlp_constraints_bgh_update_qp_vectors(void *config_, void *dims_, void 
     // fun[2*ni : 2*(ni+ns)] = - slack + slack_bounds
     blasfeo_daxpy(2*ns, -1.0, memory->ux, nu+nx, &model->d, 2*nb+2*ng+2*nh, &memory->fun, 2*nb+2*ng+2*nh);
 
+    // Set dmask for QP: 0 means unconstrained.
+    for (int i = 0; i < nb+ng+nh; i++)
+    {
+        if (BLASFEO_DVECEL(&model->d, i) == -ACADOS_INFTY)
+        {
+            // printf("found upper infinity bound\n");
+            BLASFEO_DVECEL(memory->dmask, i) = 0;
+        }
+    }
+    for (int i = nb+ng+nh; i < 2*nb+ng+nh; i++)
+    {
+        if (BLASFEO_DVECEL(&model->d, i) == ACADOS_INFTY)
+        {
+            // printf("found upper infinity bound\n");
+            BLASFEO_DVECEL(memory->dmask, i) = 0;
+        }
+    }
+
     return;
 }
 

--- a/acados/ocp_nlp/ocp_nlp_constraints_bgh.c
+++ b/acados/ocp_nlp/ocp_nlp_constraints_bgh.c
@@ -1612,6 +1612,9 @@ void ocp_nlp_constraints_bgh_compute_fun(void *config_, void *dims_, void *model
     // fun[2*ni : 2*(ni+ns)] = - slack + slack_bounds
     blasfeo_daxpy(2*ns, -1.0, ux, nu+nx, &model->d, 2*nb+2*ng+2*nh, &memory->fun, 2*nb+2*ng+2*nh);
 
+    // fun = fun * mask
+    blasfeo_dvecmul(2*(nb+ng+nh), memory->dmask, 0, &memory->fun, 0, &memory->fun, 0);
+
     return;
 }
 
@@ -1667,6 +1670,9 @@ void ocp_nlp_constraints_bgh_update_qp_vectors(void *config_, void *dims_, void 
             BLASFEO_DVECEL(memory->dmask, i) = 0;
         }
     }
+
+    // fun = fun * mask
+    blasfeo_dvecmul(2*(nb+ng+nh), memory->dmask, 0, &memory->fun, 0, &memory->fun, 0);
 
     return;
 }

--- a/acados/ocp_nlp/ocp_nlp_constraints_bgh.c
+++ b/acados/ocp_nlp/ocp_nlp_constraints_bgh.c
@@ -1123,6 +1123,12 @@ void ocp_nlp_constraints_bgh_memory_set_z_alg_ptr(struct blasfeo_dvec *z_alg, vo
     memory->z_alg = z_alg;
 }
 
+void ocp_nlp_constraints_bgh_memory_set_dmask_ptr(struct blasfeo_dvec *dmask, void *memory_)
+{
+    ocp_nlp_constraints_bgh_memory *memory = memory_;
+
+    memory->dmask = dmask;
+}
 
 
 void ocp_nlp_constraints_bgh_memory_set_dzduxt_ptr(struct blasfeo_dmat *dzduxt, void *memory_)
@@ -1674,6 +1680,7 @@ void ocp_nlp_constraints_bgh_config_initialize_default(void *config_)
     config->memory_set_DCt_ptr = &ocp_nlp_constraints_bgh_memory_set_DCt_ptr;
     config->memory_set_RSQrq_ptr = &ocp_nlp_constraints_bgh_memory_set_RSQrq_ptr;
     config->memory_set_z_alg_ptr = &ocp_nlp_constraints_bgh_memory_set_z_alg_ptr;
+    config->memory_set_dmask_ptr = &ocp_nlp_constraints_bgh_memory_set_dmask_ptr;
     config->memory_set_dzdux_tran_ptr = &ocp_nlp_constraints_bgh_memory_set_dzduxt_ptr;
     config->memory_set_idxb_ptr = &ocp_nlp_constraints_bgh_memory_set_idxb_ptr;
     config->memory_set_idxs_rev_ptr = &ocp_nlp_constraints_bgh_memory_set_idxs_rev_ptr;

--- a/acados/ocp_nlp/ocp_nlp_constraints_bgh.c
+++ b/acados/ocp_nlp/ocp_nlp_constraints_bgh.c
@@ -1613,7 +1613,7 @@ void ocp_nlp_constraints_bgh_compute_fun(void *config_, void *dims_, void *model
     blasfeo_daxpy(2*ns, -1.0, ux, nu+nx, &model->d, 2*nb+2*ng+2*nh, &memory->fun, 2*nb+2*ng+2*nh);
 
     // fun = fun * mask
-    blasfeo_dvecmul(2*(nb+ng+nh), memory->dmask, 0, &memory->fun, 0, &memory->fun, 0);
+    blasfeo_dvecmul(2*(nb+ng+nh+ns), memory->dmask, 0, &memory->fun, 0, &memory->fun, 0);
 
     return;
 }
@@ -1670,9 +1670,17 @@ void ocp_nlp_constraints_bgh_update_qp_vectors(void *config_, void *dims_, void 
             BLASFEO_DVECEL(memory->dmask, i) = 0;
         }
     }
+    for (int i = 2*(nb+ng+nh); i < 2*(nb+ng+nh+ns); i++)
+    {
+        if (BLASFEO_DVECEL(&model->d, i) <= -ACADOS_INFTY)
+        {
+            // printf("found lower infinity bound on slacks\n");
+            BLASFEO_DVECEL(memory->dmask, i) = 0;
+        }
+    }
 
     // fun = fun * mask
-    blasfeo_dvecmul(2*(nb+ng+nh), memory->dmask, 0, &memory->fun, 0, &memory->fun, 0);
+    blasfeo_dvecmul(2*(nb+ng+nh+ns), memory->dmask, 0, &memory->fun, 0, &memory->fun, 0);
 
     return;
 }

--- a/acados/ocp_nlp/ocp_nlp_constraints_bgh.c
+++ b/acados/ocp_nlp/ocp_nlp_constraints_bgh.c
@@ -1653,7 +1653,7 @@ void ocp_nlp_constraints_bgh_update_qp_vectors(void *config_, void *dims_, void 
     // Set dmask for QP: 0 means unconstrained.
     for (int i = 0; i < nb+ng+nh; i++)
     {
-        if (BLASFEO_DVECEL(&model->d, i) == -ACADOS_INFTY)
+        if (BLASFEO_DVECEL(&model->d, i) <= -ACADOS_INFTY)
         {
             // printf("found upper infinity bound\n");
             BLASFEO_DVECEL(memory->dmask, i) = 0;
@@ -1661,7 +1661,7 @@ void ocp_nlp_constraints_bgh_update_qp_vectors(void *config_, void *dims_, void 
     }
     for (int i = nb+ng+nh; i < 2*nb+ng+nh; i++)
     {
-        if (BLASFEO_DVECEL(&model->d, i) == ACADOS_INFTY)
+        if (BLASFEO_DVECEL(&model->d, i) >= ACADOS_INFTY)
         {
             // printf("found upper infinity bound\n");
             BLASFEO_DVECEL(memory->dmask, i) = 0;

--- a/acados/ocp_nlp/ocp_nlp_constraints_bgh.c
+++ b/acados/ocp_nlp/ocp_nlp_constraints_bgh.c
@@ -1662,7 +1662,7 @@ void ocp_nlp_constraints_bgh_update_qp_vectors(void *config_, void *dims_, void 
             BLASFEO_DVECEL(memory->dmask, i) = 0;
         }
     }
-    for (int i = nb+ng+nh; i < 2*nb+ng+nh; i++)
+    for (int i = nb+ng+nh; i < 2*(nb+ng+nh); i++)
     {
         if (BLASFEO_DVECEL(&model->d, i) >= ACADOS_INFTY)
         {

--- a/acados/ocp_nlp/ocp_nlp_constraints_bgh.h
+++ b/acados/ocp_nlp/ocp_nlp_constraints_bgh.h
@@ -150,6 +150,7 @@ typedef struct
     struct blasfeo_dvec *ux;     // pointer to ux in nlp_out
     struct blasfeo_dvec *lam;    // pointer to lam in nlp_out
     struct blasfeo_dvec *z_alg;  // pointer to z_alg in ocp_nlp memory
+    struct blasfeo_dvec *dmask;  // pointer to dmask in ocp_nlp memory
     struct blasfeo_dmat *DCt;    // pointer to DCt in qp_in
     struct blasfeo_dmat *RSQrq;  // pointer to RSQrq in qp_in
     struct blasfeo_dmat *dzduxt; // pointer to dzduxt in ocp_nlp memory

--- a/acados/ocp_nlp/ocp_nlp_constraints_bgp.c
+++ b/acados/ocp_nlp/ocp_nlp_constraints_bgp.c
@@ -1527,8 +1527,17 @@ void ocp_nlp_constraints_bgp_update_qp_vectors(void *config_, void *dims_, void 
             BLASFEO_DVECEL(memory->dmask, i) = 0;
         }
     }
+    for (int i = 2*(nb+ng+nphi); i < 2*(nb+ng+nphi+ns); i++)
+    {
+        if (BLASFEO_DVECEL(&model->d, i) <= -ACADOS_INFTY)
+        {
+            // printf("found lower infinity bound on slacks\n");
+            BLASFEO_DVECEL(memory->dmask, i) = 0;
+        }
+    }
+
     // fun = fun * mask
-    blasfeo_dvecmul(2*(nb+ng+nphi), memory->dmask, 0, &memory->fun, 0, &memory->fun, 0);
+    blasfeo_dvecmul(2*(nb+ng+nphi+ns), memory->dmask, 0, &memory->fun, 0, &memory->fun, 0);
 
     // printf("BGH mask\n");
     // blasfeo_print_tran_dvec(2*(nb+ng+nphi), memory->dmask, 0);

--- a/acados/ocp_nlp/ocp_nlp_constraints_bgp.c
+++ b/acados/ocp_nlp/ocp_nlp_constraints_bgp.c
@@ -1031,6 +1031,12 @@ void ocp_nlp_constraints_bgp_memory_set_DCt_ptr(struct blasfeo_dmat *DCt, void *
 }
 
 
+void ocp_nlp_constraints_bgp_memory_set_dmask_ptr(struct blasfeo_dvec *dmask, void *memory_)
+{
+    ocp_nlp_constraints_bgp_memory *memory = memory_;
+    memory->dmask = dmask;
+}
+
 
 void ocp_nlp_constraints_bgp_memory_set_RSQrq_ptr(struct blasfeo_dmat *RSQrq, void *memory_)
 {
@@ -1532,6 +1538,7 @@ void ocp_nlp_constraints_bgp_config_initialize_default(void *config_)
     config->memory_set_DCt_ptr = &ocp_nlp_constraints_bgp_memory_set_DCt_ptr;
     config->memory_set_RSQrq_ptr = &ocp_nlp_constraints_bgp_memory_set_RSQrq_ptr;
     config->memory_set_z_alg_ptr = &ocp_nlp_constraints_bgp_memory_set_z_alg_ptr;
+    config->memory_set_dmask_ptr = &ocp_nlp_constraints_bgp_memory_set_dmask_ptr;
     config->memory_set_dzdux_tran_ptr = &ocp_nlp_constraints_bgp_memory_set_dzduxt_ptr;
     config->memory_set_idxb_ptr = &ocp_nlp_constraints_bgp_memory_set_idxb_ptr;
     config->memory_set_idxs_rev_ptr = &ocp_nlp_constraints_bgp_memory_set_idxs_rev_ptr;

--- a/acados/ocp_nlp/ocp_nlp_constraints_bgp.c
+++ b/acados/ocp_nlp/ocp_nlp_constraints_bgp.c
@@ -1507,6 +1507,27 @@ void ocp_nlp_constraints_bgp_update_qp_vectors(void *config_, void *dims_, void 
     // fun[2*ni : 2*(ni+ns)] = - slack + slack_bounds
     blasfeo_daxpy(2*ns, -1.0, memory->ux, nu+nx, &model->d, 2*nb+2*ng+2*nphi, &memory->fun, 2*nb+2*ng+2*nphi);
 
+    // Set dmask for QP: 0 means unconstrained.
+    for (int i = 0; i < nb+ng+nphi; i++)
+    {
+        if (BLASFEO_DVECEL(&model->d, i) == -ACADOS_INFTY)
+        {
+            // printf("found upper infinity bound\n");
+            BLASFEO_DVECEL(memory->dmask, i) = 0;
+        }
+    }
+    for (int i = nb+ng+nphi; i < 2*nb+ng+nphi; i++)
+    {
+        if (BLASFEO_DVECEL(&model->d, i) == ACADOS_INFTY)
+        {
+            // printf("found upper infinity bound\n");
+            BLASFEO_DVECEL(memory->dmask, i) = 0;
+        }
+    }
+    // printf("BGH mask\n");
+    // blasfeo_print_tran_dvec(2*(nb+ng+nphi), memory->dmask, 0);
+    // blasfeo_print_exp_tran_dvec(2*(nb+ng+nphi), &model->d, 0);
+
     return;
 }
 

--- a/acados/ocp_nlp/ocp_nlp_constraints_bgp.c
+++ b/acados/ocp_nlp/ocp_nlp_constraints_bgp.c
@@ -1466,6 +1466,9 @@ void ocp_nlp_constraints_bgp_compute_fun(void *config_, void *dims_, void *model
     // fun[2*ni : 2*(ni+ns)] = - slack + slack_bounds
     blasfeo_daxpy(2*ns, -1.0, ux, nu+nx, &model->d, 2*nb+2*ng+2*nphi, &memory->fun, 2*nb+2*ng+2*nphi);
 
+    // fun = fun * mask
+    blasfeo_dvecmul(2*(nb+ng+nphi), memory->dmask, 0, &memory->fun, 0, &memory->fun, 0);
+
     return;
 
 }
@@ -1524,6 +1527,9 @@ void ocp_nlp_constraints_bgp_update_qp_vectors(void *config_, void *dims_, void 
             BLASFEO_DVECEL(memory->dmask, i) = 0;
         }
     }
+    // fun = fun * mask
+    blasfeo_dvecmul(2*(nb+ng+nphi), memory->dmask, 0, &memory->fun, 0, &memory->fun, 0);
+
     // printf("BGH mask\n");
     // blasfeo_print_tran_dvec(2*(nb+ng+nphi), memory->dmask, 0);
     // blasfeo_print_exp_tran_dvec(2*(nb+ng+nphi), &model->d, 0);

--- a/acados/ocp_nlp/ocp_nlp_constraints_bgp.c
+++ b/acados/ocp_nlp/ocp_nlp_constraints_bgp.c
@@ -1519,7 +1519,7 @@ void ocp_nlp_constraints_bgp_update_qp_vectors(void *config_, void *dims_, void 
             BLASFEO_DVECEL(memory->dmask, i) = 0;
         }
     }
-    for (int i = nb+ng+nphi; i < 2*nb+ng+nphi; i++)
+    for (int i = nb+ng+nphi; i < 2*(nb+ng+nphi); i++)
     {
         if (BLASFEO_DVECEL(&model->d, i) >= ACADOS_INFTY)
         {

--- a/acados/ocp_nlp/ocp_nlp_constraints_bgp.c
+++ b/acados/ocp_nlp/ocp_nlp_constraints_bgp.c
@@ -1510,7 +1510,7 @@ void ocp_nlp_constraints_bgp_update_qp_vectors(void *config_, void *dims_, void 
     // Set dmask for QP: 0 means unconstrained.
     for (int i = 0; i < nb+ng+nphi; i++)
     {
-        if (BLASFEO_DVECEL(&model->d, i) == -ACADOS_INFTY)
+        if (BLASFEO_DVECEL(&model->d, i) <= -ACADOS_INFTY)
         {
             // printf("found upper infinity bound\n");
             BLASFEO_DVECEL(memory->dmask, i) = 0;
@@ -1518,7 +1518,7 @@ void ocp_nlp_constraints_bgp_update_qp_vectors(void *config_, void *dims_, void 
     }
     for (int i = nb+ng+nphi; i < 2*nb+ng+nphi; i++)
     {
-        if (BLASFEO_DVECEL(&model->d, i) == ACADOS_INFTY)
+        if (BLASFEO_DVECEL(&model->d, i) >= ACADOS_INFTY)
         {
             // printf("found upper infinity bound\n");
             BLASFEO_DVECEL(memory->dmask, i) = 0;

--- a/acados/ocp_nlp/ocp_nlp_constraints_bgp.c
+++ b/acados/ocp_nlp/ocp_nlp_constraints_bgp.c
@@ -629,11 +629,11 @@ int ocp_nlp_constraints_bgp_model_set(void *config_, void *dims_,
     int nge = dims->nge;
     int nphie = dims->nphie;
 
-    if (!strcmp(field, "lb")) // TODO(fuck_lint) remove !!!
+    if (!strcmp(field, "lb"))
     {
         blasfeo_pack_dvec(nb, value, 1, &model->d, 0);
     }
-    else if (!strcmp(field, "ub")) // TODO(fuck_lint) remove !!!
+    else if (!strcmp(field, "ub"))
     {
         blasfeo_pack_dvec(nb, value, 1, &model->d, nb+ng+nphi);
     }
@@ -689,7 +689,7 @@ int ocp_nlp_constraints_bgp_model_set(void *config_, void *dims_,
     {
         model->nl_constr_phi_o_r_fun = value;
     }
-    else if (!strcmp(field, "lphi")) // TODO(fuck_lint) remove
+    else if (!strcmp(field, "lphi"))
     {
         blasfeo_pack_dvec(nphi, value, 1, &model->d, nb+ng);
     }

--- a/acados/ocp_nlp/ocp_nlp_constraints_bgp.h
+++ b/acados/ocp_nlp/ocp_nlp_constraints_bgp.h
@@ -136,6 +136,7 @@ typedef struct
     struct blasfeo_dvec *ux;     // pointer to ux in nlp_out
     struct blasfeo_dvec *lam;    // pointer to lam in nlp_out
     struct blasfeo_dvec *z_alg;  // pointer to z_alg in ocp_nlp memory
+    struct blasfeo_dvec *dmask;  // pointer to dmask in qp_in
     struct blasfeo_dmat *DCt;    // pointer to DCt in qp_in
     struct blasfeo_dmat *RSQrq;  // pointer to RSQrq in qp_in
     struct blasfeo_dmat *dzduxt; // pointer to dzduxt in ocp_nlp memory
@@ -161,6 +162,8 @@ void ocp_nlp_constraints_bgp_memory_set_lam_ptr(struct blasfeo_dvec *lam, void *
 void ocp_nlp_constraints_bgp_memory_set_DCt_ptr(struct blasfeo_dmat *DCt, void *memory);
 //
 void ocp_nlp_constraints_bgp_memory_set_z_alg_ptr(struct blasfeo_dvec *z_alg, void *memory_);
+//
+void ocp_nlp_constraints_bgp_memory_set_dmask_ptr(struct blasfeo_dvec *dmask, void *memory_);
 //
 void ocp_nlp_constraints_bgp_memory_set_dzduxt_ptr(struct blasfeo_dmat *dzduxt, void *memory_);
 //

--- a/acados/ocp_nlp/ocp_nlp_constraints_common.h
+++ b/acados/ocp_nlp/ocp_nlp_constraints_common.h
@@ -74,6 +74,7 @@ typedef struct
     void (*memory_set_DCt_ptr)(struct blasfeo_dmat *DCt, void *memory);
     void (*memory_set_RSQrq_ptr)(struct blasfeo_dmat *RSQrq, void *memory);
     void (*memory_set_z_alg_ptr)(struct blasfeo_dvec *z_alg, void *memory);
+    void (*memory_set_dmask_ptr)(struct blasfeo_dvec *dmask, void *memory);
     void (*memory_set_dzdux_tran_ptr)(struct blasfeo_dmat *dzduxt, void *memory);
     void (*memory_set_idxb_ptr)(int *idxb, void *memory);
     void (*memory_set_idxs_rev_ptr)(int *idxs_rev, void *memory);

--- a/acados/utils/types.h
+++ b/acados/utils/types.h
@@ -56,8 +56,7 @@ extern "C" {
 
 #define MAX_STR_LEN 256
 #define ACADOS_EPS 1e-12
-#define ACADOS_NEG_INFTY -1.0e9
-#define ACADOS_POS_INFTY +1.0e9
+#define ACADOS_INFTY 1e10
 #define UNUSED(x) ((void)(x))
 
 

--- a/examples/acados_python/tests/one_sided_constraints_test.py
+++ b/examples/acados_python/tests/one_sided_constraints_test.py
@@ -132,6 +132,16 @@ def main(constraint_variant='one_sided'):
         simU0[i, :] = ocp_solver.get(i, "u")
     simX0[N_horizon, :] = ocp_solver.get(N_horizon, "x")
 
+    lambdas = [ocp_solver.get(i, "lam") for i in range(1, N_horizon)]
+    for lam in lambdas:
+        assert np.all(lam >= 0)
+
+    # if unbounded constraint is defined properly, lambda should be zero
+    i_infty = 1
+    if constraint_variant == 'one_sided':
+        assert lam[i_infty] == 0
+    elif constraint_variant == 'one_sided_wrong_infty':
+        assert lam[i_infty] != 0
 
     if PLOT:
         plot_pendulum(np.linspace(0, Tf, N_horizon + 1), Fmax, simU0, simX0, latexify=False, plt_show=True, X_true_label=f'N={N_horizon}, Tf={Tf}')

--- a/examples/acados_python/tests/one_sided_constraints_test.py
+++ b/examples/acados_python/tests/one_sided_constraints_test.py
@@ -96,7 +96,7 @@ def main(constraint_variant='one_sided'):
         ocp.constraints.idxbx = np.array([0])
         expected_status = 0
     elif constraint_variant == 'one_sided_wrong_infty':
-        ocp.constraints.lbx = np.array([-2*ACADOS_INFTY])
+        ocp.constraints.lbx = np.array([-0.5*ACADOS_INFTY])
         ocp.constraints.ubx = np.array([+5.0])
         ocp.constraints.idxbx = np.array([0])
         # complementarity residual does not converge to tolerance if infty is too large
@@ -107,6 +107,7 @@ def main(constraint_variant='one_sided'):
     ocp.solver_options.hessian_approx = 'GAUSS_NEWTON'
     ocp.solver_options.integrator_type = 'ERK'
     ocp.solver_options.nlp_solver_type = 'SQP'
+    ocp.solver_options.tol = 1e-7
 
     # set prediction horizon
     ocp.solver_options.tf = Tf

--- a/examples/acados_python/tests/one_sided_constraints_test.py
+++ b/examples/acados_python/tests/one_sided_constraints_test.py
@@ -1,0 +1,143 @@
+# This test is an extension of the 'minimal_example_ocp_reuse_code.py' example.
+#
+# Copyright (c) The acados authors.
+#
+# This file is part of acados.
+#
+# The 2-Clause BSD License
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.;
+#
+import sys
+
+sys.path.insert(0, '../pendulum_on_cart/common')
+
+from acados_template import AcadosOcp, AcadosOcpSolver, ACADOS_INFTY
+from pendulum_model import export_pendulum_ode_model
+import numpy as np
+import scipy.linalg
+from utils import plot_pendulum
+
+PLOT = False
+
+def main(constraint_variant='one_sided'):
+
+    # create ocp object to formulate the OCP
+    ocp = AcadosOcp()
+
+    # set model
+    model = export_pendulum_ode_model()
+    ocp.model = model
+
+    nx = model.x.rows()
+    nu = model.u.rows()
+    ny = nx + nu
+    ny_e = nx
+
+    N_horizon = 20  # number of shooting nodes
+    Tf = 1.0
+
+    # set dimensions
+    ocp.dims.N = N_horizon
+
+    # set cost
+    Q = 2 * np.diag([1e3, 1e3, 1e-2, 1e-2])
+    R = 2 * np.diag([1e-2])
+
+    ocp.cost.W_e = Q
+    ocp.cost.W = scipy.linalg.block_diag(Q, R)
+
+    ocp.cost.cost_type = 'LINEAR_LS'
+    ocp.cost.cost_type_e = 'LINEAR_LS'
+
+    ocp.cost.Vx = np.zeros((ny, nx))
+    ocp.cost.Vx[:nx, :nx] = np.eye(nx)
+
+    Vu = np.zeros((ny, nu))
+    Vu[4, 0] = 1.0
+    ocp.cost.Vu = Vu
+
+    ocp.cost.Vx_e = np.eye(nx)
+
+    ocp.cost.yref = np.zeros((ny,))
+    ocp.cost.yref_e = np.zeros((ny_e,))
+
+    # set constraints
+    Fmax = 80
+    ocp.constraints.lbu = np.array([-Fmax])
+    ocp.constraints.ubu = np.array([+Fmax])
+    ocp.constraints.idxbu = np.array([0])
+
+    ocp.constraints.x0 = np.array([0.0, np.pi, 0.0, 0.0])
+
+    if constraint_variant == 'one_sided':
+        ocp.constraints.lbx = np.array([-ACADOS_INFTY])
+        ocp.constraints.ubx = np.array([+5.0])
+        ocp.constraints.idxbx = np.array([0])
+        expected_status = 0
+    elif constraint_variant == 'one_sided_wrong_infty':
+        ocp.constraints.lbx = np.array([-2*ACADOS_INFTY])
+        ocp.constraints.ubx = np.array([+5.0])
+        ocp.constraints.idxbx = np.array([0])
+        # complementarity residual does not converge to tolerance if infty is too large
+        expected_status = 2
+
+    # set options
+    ocp.solver_options.qp_solver = 'PARTIAL_CONDENSING_HPIPM'
+    ocp.solver_options.hessian_approx = 'GAUSS_NEWTON'
+    ocp.solver_options.integrator_type = 'ERK'
+    ocp.solver_options.nlp_solver_type = 'SQP'
+
+    # set prediction horizon
+    ocp.solver_options.tf = Tf
+
+    # create solver
+    ocp_solver = AcadosOcpSolver(ocp)
+
+    # solve the problem defined here (original from code export), analog to 'minimal_example_ocp.py'
+    simX0 = np.zeros((N_horizon + 1, nx))
+    simU0 = np.zeros((N_horizon, nu))
+
+    print(80*'-')
+    print(f'solve original code with N = {N_horizon} and Tf = {Tf} s:')
+    status = ocp_solver.solve()
+    ocp_solver.print_statistics()
+
+    if status != expected_status:
+        raise Exception(f"expected status {expected_status}, got {status} for constraint_variant {constraint_variant}.")
+
+    # get solution
+    for i in range(N_horizon):
+        simX0[i, :] = ocp_solver.get(i, "x")
+        simU0[i, :] = ocp_solver.get(i, "u")
+    simX0[N_horizon, :] = ocp_solver.get(N_horizon, "x")
+
+
+    if PLOT:
+        plot_pendulum(np.linspace(0, Tf, N_horizon + 1), Fmax, simU0, simX0, latexify=False, plt_show=True, X_true_label=f'N={N_horizon}, Tf={Tf}')
+
+    ocp_solver = None
+
+if __name__ == "__main__":
+    main(constraint_variant='one_sided')
+    main(constraint_variant='one_sided_wrong_infty')

--- a/examples/acados_python/tests/test_cython_ctypes.py
+++ b/examples/acados_python/tests/test_cython_ctypes.py
@@ -54,15 +54,11 @@ def main(interface_type='ctypes'):
     ny = nx + nu
     ny_e = nx
 
-    # define the different options for the use-case demonstration
-    N0 = 20  # original number of shooting nodes
-    N12 = 15  # change the number of shooting nodes for use-cases 1 and 2
-    condN12 = max(1, round(N12/1)) # change the number of cond_N for use-cases 1 and 2 (for PARTIAL_* solvers only)
-    Tf_01 = 1.0  # original final time and for use-case 1
-    Tf_2 = Tf_01 * 0.7  # change final time for use-case 2 (but keep N identical)
+    N_horizon = 20  # number of shooting nodes
+    Tf = 1.0
 
     # set dimensions
-    ocp.dims.N = N0
+    ocp.dims.N = N_horizon
 
     # set cost
     Q = 2 * np.diag([1e3, 1e3, 1e-2, 1e-2])
@@ -95,16 +91,13 @@ def main(interface_type='ctypes'):
     ocp.constraints.x0 = np.array([0.0, np.pi, 0.0, 0.0])
 
     # set options
-    ocp.solver_options.qp_solver = 'PARTIAL_CONDENSING_HPIPM'  # FULL_CONDENSING_QPOASES
-    # PARTIAL_CONDENSING_HPIPM, FULL_CONDENSING_QPOASES, FULL_CONDENSING_HPIPM,
-    # PARTIAL_CONDENSING_QPDUNES, PARTIAL_CONDENSING_OSQP
+    ocp.solver_options.qp_solver = 'PARTIAL_CONDENSING_HPIPM'
     ocp.solver_options.hessian_approx = 'GAUSS_NEWTON'
     ocp.solver_options.integrator_type = 'ERK'
-    # ocp.solver_options.print_level = 1
-    ocp.solver_options.nlp_solver_type = 'SQP'  # SQP_RTI, SQP
+    ocp.solver_options.nlp_solver_type = 'SQP'
 
     # set prediction horizon
-    ocp.solver_options.tf = Tf_01
+    ocp.solver_options.tf = Tf
 
     print(80*'-')
     print('generate code and compile...')
@@ -125,108 +118,29 @@ def main(interface_type='ctypes'):
     ocp_solver.options_set('qp_tau_min', 1e-10)
     ocp_solver.options_set('qp_mu0', 1e0)
 
-    # --------------------------------------------------------------------------------
-    # 0) solve the problem defined here (original from code export), analog to 'minimal_example_ocp.py'
+    # solve the problem defined here (original from code export), analog to 'minimal_example_ocp.py'
     nvariant = 0
-    simX0 = np.zeros((N0 + 1, nx))
-    simU0 = np.zeros((N0, nu))
+    simX0 = np.zeros((N_horizon + 1, nx))
+    simU0 = np.zeros((N_horizon, nu))
 
     print(80*'-')
-    print(f'solve original code with N = {N0} and Tf = {Tf_01} s:')
+    print(f'solve original code with N = {N_horizon} and Tf = {Tf} s:')
     status = ocp_solver.solve()
+    ocp_solver.print_statistics()
 
     if status != 0:
-        ocp_solver.print_statistics()  # encapsulates: stat = ocp_solver.get_stats("statistics")
         raise Exception(f'acados returned status {status}.')
 
     # get solution
-    for i in range(N0):
+    for i in range(N_horizon):
         simX0[i, :] = ocp_solver.get(i, "x")
         simU0[i, :] = ocp_solver.get(i, "u")
-    simX0[N0, :] = ocp_solver.get(N0, "x")
+    simX0[N_horizon, :] = ocp_solver.get(N_horizon, "x")
 
-    ocp_solver.print_statistics()  # encapsulates: stat = ocp_solver.get_stats("statistics")
     ocp_solver.store_iterate(filename=f'final_iterate_{interface_type}_variant{nvariant}.json', overwrite=True)
 
     if PLOT:# plot but don't halt
-        plot_pendulum(np.linspace(0, Tf_01, N0 + 1), Fmax, simU0, simX0, latexify=False, plt_show=False, X_true_label=f'original: N={N0}, Tf={Tf_01}')
-
-    # # --------------------------------------------------------------------------------
-    # # 1) now reuse the code but set a new time-steps vector, with a new number of elements
-    # nvariant = 1
-    # dt1 = Tf_01 / N12
-
-    # new_time_steps1 = np.tile(dt1, (N12,))  # Matlab's equivalent to repmat
-    # time1 = np.hstack([0, np.cumsum(new_time_steps1)])
-
-    # simX1 = np.zeros((N12 + 1, nx))
-    # simU1 = np.zeros((N12, nu))
-
-    # ocp_solver.set_new_time_steps(new_time_steps1)
-    # print(80*'-')
-    # if ocp.solver_options.qp_solver.startswith('PARTIAL'):
-    #     ocp_solver.update_qp_solver_cond_N(condN12)
-    #     print(f'solve use-case 2 with N = {N12}, cond_N = {condN12} and Tf = {Tf_01} s (instead of {Tf_01} s):')
-    #     X_true_label = f'use-case 1: N={N12}, N_cond = {condN12}'
-    # else:
-    #     print(f'solve use-case 2 with N = {N12} and Tf = {Tf_01} s (instead of {Tf_01} s):')
-    #     X_true_label = f'use-case 1: N={N12}'
-
-    # status = ocp_solver.solve()
-
-    # if status != 0:
-    #     ocp_solver.print_statistics()  # encapsulates: stat = ocp_solver.get_stats("statistics")
-    #     raise Exception(f'acados returned status {status}.')
-
-    # # get solution
-    # for i in range(N12):
-    #     simX1[i, :] = ocp_solver.get(i, "x")
-    #     simU1[i, :] = ocp_solver.get(i, "u")
-    # simX1[N12, :] = ocp_solver.get(N12, "x")
-
-    # ocp_solver.print_statistics()  # encapsulates: stat = ocp_solver.get_stats("statistics")
-    # ocp_solver.store_iterate(filename=f'final_iterate_{interface_type}_variant{nvariant}.json', overwrite=True)
-
-
-    # if PLOT:
-    #     plot_pendulum(time1, Fmax, simU1, simX1, latexify=False, plt_show=False, X_true_label=X_true_label)
-
-    # # --------------------------------------------------------------------------------
-    # # 2) reuse the code again, set a new time-steps vector, only with a different final time
-    # nvariant = 2
-    # dt2 = Tf_2 / N12
-
-    # new_time_steps2 = np.tile(dt2, (N12,))  # Matlab's equivalent to repmat
-    # time2 = np.hstack([0, np.cumsum(new_time_steps2)])
-
-    # simX2 = np.zeros((N12 + 1, nx))
-    # simU2 = np.zeros((N12, nu))
-
-    # ocp_solver.set_new_time_steps(new_time_steps2)
-    # print(80*'-')
-    # if ocp.solver_options.qp_solver.startswith('PARTIAL'):
-    #     ocp_solver.update_qp_solver_cond_N(condN12)
-    #     print(f'solve use-case 2 with N = {N12}, cond_N = {condN12} and Tf = {Tf_2} s (instead of {Tf_01} s):')
-    # else:
-    #     print(f'solve use-case 2 with N = {N12} and Tf = {Tf_2} s (instead of {Tf_01} s):')
-    # status = ocp_solver.solve()
-
-    # if status != 0:
-    #     ocp_solver.print_statistics()  # encapsulates: stat = ocp_solver.get_stats("statistics")
-    #     raise Exception(f'acados returned status {status}.')
-
-    # # get solution
-    # for i in range(N12):
-    #     simX2[i, :] = ocp_solver.get(i, "x")
-    #     simU2[i, :] = ocp_solver.get(i, "u")
-    # simX2[N12, :] = ocp_solver.get(N12, "x")
-
-    # ocp_solver.print_statistics()  # encapsulates: stat = ocp_solver.get_stats("statistics")
-
-    # if PLOT:
-    #     plot_pendulum(time2, Fmax, simU2, simX2, latexify=False, plt_show=True, X_true_label=f'use-case 2: Tf={Tf_2} s')
-    # ocp_solver.store_iterate(filename=f'final_iterate_{interface_type}_variant{nvariant}.json', overwrite=True)
-    # print(f"timing of last solver call {ocp_solver.get_stats('time_tot')}")
+        plot_pendulum(np.linspace(0, Tf, N_horizon + 1), Fmax, simU0, simX0, latexify=False, plt_show=False, X_true_label=f'original: N={N_horizon}, Tf={Tf}')
 
 
 if __name__ == "__main__":

--- a/interfaces/CMakeLists.txt
+++ b/interfaces/CMakeLists.txt
@@ -354,6 +354,10 @@ add_test(NAME python_pendulum_ocp_example_cmake
     add_test(NAME python_regularization_test
         COMMAND "${CMAKE_COMMAND}" -E chdir ${PROJECT_SOURCE_DIR}/examples/acados_python/tests
         python regularization_test.py)
+    add_test(NAME python_one_sided_constraints_test
+        COMMAND "${CMAKE_COMMAND}" -E chdir ${PROJECT_SOURCE_DIR}/examples/acados_python/tests
+        python one_sided_constraints_test.py)
+
 
     add_test(NAME python_pmsm_example
         COMMAND "${CMAKE_COMMAND}" -E chdir ${PROJECT_SOURCE_DIR}/examples/acados_python/pmsm_example
@@ -381,7 +385,8 @@ add_test(NAME python_pendulum_ocp_example_cmake
     set_tests_properties(python_test_cython_vs_ctypes PROPERTIES DEPENDS python_test_reset)
     set_tests_properties(python_test_reset PROPERTIES DEPENDS python_test_ocp)
     set_tests_properties(python_test_ocp PROPERTIES DEPENDS python_test_cost_integration_euler)
-    set_tests_properties(python_test_cost_integration_euler PROPERTIES DEPENDS python_test_cost_integration_value)
+    set_tests_properties(python_test_cost_integration_euler PROPERTIES DEPENDS python_one_sided_constraints_test)
+    set_tests_properties(python_one_sided_constraints_test PROPERTIES DEPENDS python_test_cost_integration_value)
     set_tests_properties(python_test_cost_integration_value PROPERTIES DEPENDS python_armijo_test)
     set_tests_properties(python_armijo_test PROPERTIES DEPENDS python_pendulum_soft_constraints_example)
     set_tests_properties(python_pendulum_soft_constraints_example PROPERTIES DEPENDS python_pendulum_parametric_nonlinear_constraint_h_test)

--- a/interfaces/CMakeLists.txt
+++ b/interfaces/CMakeLists.txt
@@ -391,7 +391,8 @@ add_test(NAME python_pendulum_ocp_example_cmake
     set_tests_properties(python_armijo_test PROPERTIES DEPENDS python_pendulum_soft_constraints_example)
     set_tests_properties(python_pendulum_soft_constraints_example PROPERTIES DEPENDS python_pendulum_parametric_nonlinear_constraint_h_test)
     set_tests_properties(python_pendulum_parametric_nonlinear_constraint_h_test PROPERTIES DEPENDS python_test_nan_globalization)
-    set_tests_properties(python_test_nan_globalization PROPERTIES DEPENDS python_test_sim_dae)
+    set_tests_properties(python_test_nan_globalization PROPERTIES DEPENDS python_regularization_test)
+    set_tests_properties(python_regularization_test PROPERTIES DEPENDS python_test_sim_dae)
     set_tests_properties(python_test_sim_dae PROPERTIES DEPENDS python_sparse_param_test)
 
     if(ACADOS_WITH_OSQP)

--- a/interfaces/acados_matlab_octave/get_acados_infty.m
+++ b/interfaces/acados_matlab_octave/get_acados_infty.m
@@ -1,0 +1,34 @@
+%
+% Copyright (c) The acados authors.
+%
+% This file is part of acados.
+%
+% The 2-Clause BSD License
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%
+% 1. Redistributions of source code must retain the above copyright notice,
+% this list of conditions and the following disclaimer.
+%
+% 2. Redistributions in binary form must reproduce the above copyright notice,
+% this list of conditions and the following disclaimer in the documentation
+% and/or other materials provided with the distribution.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.;
+
+%
+
+function infty = get_acados_infty()
+    infty = 1e10;
+end

--- a/interfaces/acados_template/acados_template/__init__.py
+++ b/interfaces/acados_template/acados_template/__init__.py
@@ -47,7 +47,7 @@ from .acados_sim_batch_solver import AcadosSimBatchSolver
 from .utils import print_casadi_expression, get_acados_path, get_python_interface_path, \
     get_tera_exec_path, get_tera, check_casadi_version, acados_dae_model_json_dump, \
     casadi_length, make_object_json_dumpable, J_to_idx, get_default_simulink_opts, \
-    is_empty, get_simulink_default_opts
+    is_empty, get_simulink_default_opts, ACADOS_INFTY
 
 from .builders import ocp_get_default_cmake_builder, sim_get_default_cmake_builder
 

--- a/interfaces/acados_template/acados_template/utils.py
+++ b/interfaces/acados_template/acados_template/utils.py
@@ -68,6 +68,7 @@ PLATFORM2TERA = {
     "win32": "windows"
 }
 
+ACADOS_INFTY = 1e10
 
 def check_if_square(mat: np.ndarray, name: str):
     if mat.shape[0] != mat.shape[1]:


### PR DESCRIPTION
- add `ACADOS_INFTY` in Python and C, `get_acados_infty` in Matlab.
- If any constraints have bounds `ACADOS_INFTY`, the constraint is marked as not relevant in the QP representation object `ocp_qp`, by setting the corresponding `d_mask` values to `0`.
- The underlying QP solver interface should make use of this mask.
- The HPIPM solvers do make use of this natively.
- For now the value is `ACADOS_INFTY=1e10` which might can be changed later after some more extensive testing.
- Support for that in QP solvers other than HPIPM is not included in this PR and tracked in https://github.com/acados/acados/issues/650