### PR TITLE
Use `d_mask` in DAQP interface to handle one-sided constraints

### DIFF
--- a/acados/dense_qp/dense_qp_daqp.c
+++ b/acados/dense_qp/dense_qp_daqp.c
@@ -515,7 +515,7 @@ static void dense_qp_daqp_update_memory(dense_qp_in *qp_in, const dense_qp_daqp_
     // blasfeo_print_tran_dvec(2*(nb+ng), qp_in->d_mask, 0);
     for (int ii = 0; ii < nb; ii++)
     {
-        // TODO: @Daniel: what about SET_MUTABLE? if constraint is one sided? Can we just set one of the bounds to be immutable, such that this one can never be moved to the working set in DAQP?
+        // NOTE: DAQP always works with double sided constraints, so currently one can not only ignore the upper bound or the lower bound.
 
         // "ignore" bounds that are marked as unconstrained in qp_in via dmask
         if (BLASFEO_DVECEL(qp_in->d_mask, ii) == 0.0)


### PR DESCRIPTION
See https://github.com/acados/acados/pull/1174 and https://github.com/acados/acados/issues/650