### PR TITLE
Sparse parameter update in Matlab and parameter getters

### DIFF
--- a/.github/workflows/full_build.yml
+++ b/.github/workflows/full_build.yml
@@ -149,7 +149,7 @@ jobs:
         cd ${{runner.workspace}}/acados/examples/acados_matlab_octave/test
         source env.sh
 
-    - name: Matlab test native MEX
+    - name: Run Matlab tests
       uses: matlab-actions/run-command@v2
       if: always()
       with:
@@ -202,7 +202,7 @@ jobs:
         cd ${{runner.workspace}}/acados/examples/acados_matlab_octave/test
         source env.sh
 
-    - name: Matlab test native MEX
+    - name: Run Matlab examples
       uses: matlab-actions/run-command@v2
       if: always()
       with:

--- a/examples/acados_matlab_octave/test/create_ocp_qp_solver_formulation.m
+++ b/examples/acados_matlab_octave/test/create_ocp_qp_solver_formulation.m
@@ -4,6 +4,9 @@ import casadi.*
 %% solver settings
 T = 1; % [s] prediction horizon length
 nlp_solver = 'sqp'; % sqp, sqp_rti
+% integrator type
+sim_method = 'erk'; % erk, irk, irk_gnsf
+
 nx = 3; % state size
 nu = 3; % input size
 ny = nx+nu;
@@ -48,8 +51,10 @@ ocp_model.set('cost_y_ref', y_ref);
 ocp_model.set('cost_y_ref_e', y_ref_e);
 
 % dynamics
-ocp_model.set('dyn_type', 'discrete');
-ocp_model.set('dyn_expr_f', sym_x);
+if (strcmp(sim_method, 'erk'))
+    ocp_model.set('dyn_type', 'explicit');
+    ocp_model.set('dyn_expr_f', sym_u);
+end
 
 % constraints
 ocp_model.set('constr_x0', x0);  % set the initial state

--- a/examples/acados_matlab_octave/test/create_ocp_qp_solver_formulation.m
+++ b/examples/acados_matlab_octave/test/create_ocp_qp_solver_formulation.m
@@ -4,9 +4,6 @@ import casadi.*
 %% solver settings
 T = 1; % [s] prediction horizon length
 nlp_solver = 'sqp'; % sqp, sqp_rti
-% integrator type
-sim_method = 'erk'; % erk, irk, irk_gnsf
-
 nx = 3; % state size
 nu = 3; % input size
 ny = nx+nu;
@@ -51,10 +48,8 @@ ocp_model.set('cost_y_ref', y_ref);
 ocp_model.set('cost_y_ref_e', y_ref_e);
 
 % dynamics
-if (strcmp(sim_method, 'erk'))
-    ocp_model.set('dyn_type', 'explicit');
-    ocp_model.set('dyn_expr_f', sym_u);
-end
+ocp_model.set('dyn_type', 'discrete');
+ocp_model.set('dyn_expr_f', sym_x);
 
 % constraints
 ocp_model.set('constr_x0', x0);  % set the initial state

--- a/examples/acados_matlab_octave/test/create_parametric_ocp_qp.m
+++ b/examples/acados_matlab_octave/test/create_parametric_ocp_qp.m
@@ -1,0 +1,97 @@
+function [ocp_model, ocp_opts, simulink_opts, x0] = create_parametric_ocp_qp(N, np)
+import casadi.*
+
+%% solver settings
+T = 1; % [s] prediction horizon length
+nlp_solver = 'sqp'; % sqp, sqp_rti
+% integrator type
+nx = 3; % state size
+nu = 3; % input size
+ny = nx+nu;
+ny_e = nx;
+
+x0 = ones(nx, 1); % initial state
+
+%% acados ocp model
+ocp_model = acados_ocp_model();
+
+sym_x = SX.sym('x', nx);
+sym_u = SX.sym('u', nu);
+sym_p = SX.sym('p', np);
+
+
+ocp_model.set('name', 'trivial');
+ocp_model.set('T', T);  % prediction horizon
+
+% symbolics
+ocp_model.set('sym_x', sym_x);
+ocp_model.set('sym_u', sym_u);
+ocp_model.set('sym_p', sym_p);
+
+% cost
+cost_type = 'linear_ls';
+cost_type_e = 'linear_ls';
+Vx = zeros(ny,nx); Vx(1:nx,:) = eye(nx);        % state-to-output matrix in lagrange term
+Vu = zeros(ny,nu); Vu(nx+1:ny,:) = eye(nu);     % input-to-output matrix in lagrange term
+Vx_e = zeros(ny_e,nx); Vx_e(1:nx,:) = eye(nx);  % state-to-output matrix in mayer term
+W = eye(ny);
+W_e = 5 * W(1:ny_e,1:ny_e);                         % cost weights in mayer term
+y_ref = zeros(ny,1);                            % set intial references
+y_ref_e = zeros(ny_e,1);
+
+% cost
+ocp_model.set('cost_type', cost_type);
+ocp_model.set('cost_type_e', cost_type_e);
+ocp_model.set('cost_Vx', Vx);
+ocp_model.set('cost_Vu', Vu);
+ocp_model.set('cost_Vx_e', Vx_e);
+ocp_model.set('cost_W', W);
+ocp_model.set('cost_W_e', W_e);
+ocp_model.set('cost_y_ref', y_ref);
+ocp_model.set('cost_y_ref_e', y_ref_e);
+
+% dynamics
+ocp_model.set('dyn_type', 'discrete');
+ocp_model.set('dyn_expr_phi', sym_x + sym_p(1));
+
+
+% constraints
+ocp_model.set('constr_x0', x0);  % set the initial state
+
+%% acados ocp options
+ocp_opts = acados_ocp_opts();
+ocp_opts.set('param_scheme_N', N);
+ocp_opts.set('nlp_solver', nlp_solver);
+ocp_opts.set('sim_method', 'discrete');
+
+
+%% Simulink opts
+simulink_opts = get_acados_simulink_opts;
+
+% inputs
+simulink_opts.inputs.y_ref = 0;
+simulink_opts.inputs.y_ref_0 = 0;
+simulink_opts.inputs.y_ref_e = 0;
+
+simulink_opts.inputs.cost_W = 0;
+simulink_opts.inputs.cost_W_0 = 0;
+simulink_opts.inputs.cost_W_e = 0;
+
+simulink_opts.inputs.x_init = 1;
+simulink_opts.inputs.u_init = 1;
+simulink_opts.inputs.pi_init = 1;
+
+simulink_opts.inputs.reset_solver = 1;
+simulink_opts.inputs.ignore_inits = 1;
+
+% outputs
+simulink_opts.outputs.u0 = 0;
+simulink_opts.outputs.utraj = 1;
+simulink_opts.outputs.xtraj = 1;
+simulink_opts.outputs.pi_all = 1;
+
+simulink_opts.outputs.solver_status = 1;
+simulink_opts.outputs.CPU_time = 0;
+simulink_opts.outputs.sqp_iter = 1;
+simulink_opts.outputs.x1 = 0;
+end

--- a/examples/acados_matlab_octave/test/param_test.m
+++ b/examples/acados_matlab_octave/test/param_test.m
@@ -1,0 +1,104 @@
+%
+% Copyright (c) The acados authors.
+%
+% This file is part of acados.
+%
+% The 2-Clause BSD License
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%
+% 1. Redistributions of source code must retain the above copyright notice,
+% this list of conditions and the following disclaimer.
+%
+% 2. Redistributions in binary form must reproduce the above copyright notice,
+% this list of conditions and the following disclaimer in the documentation
+% and/or other materials provided with the distribution.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.;
+
+%
+
+clear all;
+check_acados_requirements()
+
+import casadi.*
+
+%%
+N = 20; % number of discretization steps
+nx = 3;
+nu = 3;
+np = 100;
+[ocp_model, ocp_opts, simulink_opts, x0] = create_parametric_ocp_qp(N, np);
+% NOTE: here we don't perform iterations and just test initialization
+% functionality
+ocp_opts.set('nlp_solver_max_iter', 0);
+
+%% create ocp solver
+ocp_solver = acados_ocp(ocp_model, ocp_opts, simulink_opts);
+
+%% test parameter setters and getters;
+ocp_solver.set('p', zeros(np, 1));
+
+p_values = {ones(np, 1), (1:np)'};
+
+for i_p = 1: length(p_values);
+    p_val = p_values{i_p};
+    ocp_solver.set('p', p_val, 0);
+    p = ocp_solver.get('p', 0);
+
+    if any(p~=p_val)
+        disp('simple parameter setter doesnt work properly');
+        exit(1);
+    end
+end
+
+for stage = 1:N
+    p = ocp_solver.get('p', stage);
+    if any(p)
+        disp('simple parameter setter doesnt work properly, parameter values should not change after setting at another stage');
+        exit(1);
+    end
+end
+disp('simple parameter setter works properly');
+
+
+%% test sparse parameter update
+for stage = [0, 8]
+    ocp_solver.set('p', 0 * p_val, stage);
+
+    idx_values = [0, 5, np-1];
+    new_p_values = [9, 42, 12];
+
+    ocp_solver.set_params_sparse(idx_values, new_p_values, stage);
+    p = ocp_solver.get('p', stage);
+
+    p_val = zeros(np, 1);
+    idx_values_matlab = idx_values + 1;
+    p_val(idx_values_matlab) = new_p_values;
+
+    if any(p~=p_val)
+        disp('sparse parameter update doesnt work properly.');
+        exit(1)
+    end
+end
+disp('sparse parameter setter works properly');
+
+
+%
+% %% simulink test
+% cd c_generated_code
+% make_sfun; % ocp solver
+% cd ..;
+%
+% n_sim = 3;

--- a/examples/acados_matlab_octave/test/run_matlab_tests.m
+++ b/examples/acados_matlab_octave/test/run_matlab_tests.m
@@ -22,7 +22,7 @@ disp(pwd)
 
 disp('running tests')
 
-%% run all Octave tests
+%% run all tests
 test_names = ["run_test_dim_check",
 "run_test_ocp_mass_spring",
 % "run_test_ocp_pendulum",
@@ -33,7 +33,8 @@ test_names = ["run_test_dim_check",
 "run_test_sim_dae",
 % "run_test_sim_forw",
 "run_test_sim_hess",
-"run_test_mhe_lorentz"
+"run_test_mhe_lorentz",
+"param_test",
 ];
 
 for k = 1:length(test_names)

--- a/examples/acados_python/tests/test_parametric_nonlinear_constraint_h.py
+++ b/examples/acados_python/tests/test_parametric_nonlinear_constraint_h.py
@@ -129,6 +129,8 @@ def main():
             # set subset of parameters
             ocp_solver.set_params_sparse(i, np.array(range(n_param)), np.zeros(n_param))
             ocp_solver.set_params_sparse(i, np.ascontiguousarray([0, 1]), np.array([1.0, 1.0]))
+            p_out = ocp_solver.get(i, "p")
+            assert np.allclose(p_out, p_0)
 
     solX = np.zeros((N+1, nx))
     solU = np.zeros((N, nu))

--- a/interfaces/CMakeLists.txt
+++ b/interfaces/CMakeLists.txt
@@ -386,7 +386,8 @@ add_test(NAME python_pendulum_ocp_example_cmake
     set_tests_properties(python_armijo_test PROPERTIES DEPENDS python_pendulum_soft_constraints_example)
     set_tests_properties(python_pendulum_soft_constraints_example PROPERTIES DEPENDS python_pendulum_parametric_nonlinear_constraint_h_test)
     set_tests_properties(python_pendulum_parametric_nonlinear_constraint_h_test PROPERTIES DEPENDS python_test_nan_globalization)
-    set_tests_properties(python_test_nan_globalization PROPERTIES DEPENDS python_test_sim_dae)
+    set_tests_properties(python_test_nan_globalization PROPERTIES DEPENDS python_regularization_test)
+    set_tests_properties(python_regularization_test PROPERTIES DEPENDS python_test_sim_dae)
     set_tests_properties(python_test_sim_dae PROPERTIES DEPENDS python_sparse_param_test)
 
     if(ACADOS_WITH_OSQP)

--- a/interfaces/acados_c/ocp_nlp_interface.c
+++ b/interfaces/acados_c/ocp_nlp_interface.c
@@ -437,6 +437,14 @@ void ocp_nlp_in_get(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in, 
         double **ptr = value;
         ptr[0] = in->parameter_values[stage];
     }
+    else if (!strcmp(field, "p"))
+    {
+        double *out = (double *) value;
+        for (int ii = 0; ii < dims->np[stage]; ii++)
+        {
+            out[ii] = in->parameter_values[stage][ii];
+        }
+    }
     else
     {
         printf("\nerror: ocp_nlp_in_get: field %s not available\n", field);

--- a/interfaces/acados_matlab_octave/acados_ocp.m
+++ b/interfaces/acados_matlab_octave/acados_ocp.m
@@ -370,6 +370,7 @@ classdef acados_ocp < handle
         function set_params_sparse(obj, varargin)
             % usage:
             % ocp.set_params_sparse(idx_values, param_values, Optional[stage])
+            % updates the parameters with indices idx_values (0 based) at stage with the new values new_p_values.
             % if stage is not provided, sparse parameter update is performed for all stages.
             obj.t_ocp.set_params_sparse(varargin{:});
         end

--- a/interfaces/acados_matlab_octave/acados_ocp.m
+++ b/interfaces/acados_matlab_octave/acados_ocp.m
@@ -367,6 +367,12 @@ classdef acados_ocp < handle
             fclose(fid);
         end
 
+        function set_params_sparse(obj, varargin)
+            % usage:
+            % ocp.set_params_sparse(idx_values, param_values, Optional[stage])
+            % if stage is not provided, sparse parameter update is performed for all stages.
+            obj.t_ocp.set_params_sparse(varargin{:});
+        end
         % function delete(obj)
         %     Use default implementation.
         %     MATLAB destroys the property values after the destruction of the object.

--- a/interfaces/acados_matlab_octave/ocp_get.c
+++ b/interfaces/acados_matlab_octave/ocp_get.c
@@ -96,9 +96,9 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
             sprintf(buffer, "\nocp_get: invalid stage index, got %d\n", stage);
             mexErrMsgTxt(buffer);
         }
-        else if (stage == N && strcmp(field, "x") && strcmp(field, "lam") && strcmp(field, "sens_x") && strcmp(field, "sl") && strcmp(field, "su") && strcmp(field, "qp_Q") && strcmp(field, "qp_R") && strcmp(field, "qp_S") && strcmp(field, "qp_q") )
+        else if (stage == N && strcmp(field, "x") && strcmp(field, "lam") && strcmp(field, "p") && strcmp(field, "sens_x") && strcmp(field, "sl") && strcmp(field, "su") && strcmp(field, "qp_Q") && strcmp(field, "qp_R") && strcmp(field, "qp_S") && strcmp(field, "qp_q") )
         {
-            sprintf(buffer, "\nocp_get: invalid stage index, got stage = %d = N, field = %s, only x, lam, t, slacks available at this stage\n", stage, field);
+            sprintf(buffer, "\nocp_get: invalid stage index, got stage = %d = N, field = %s, only x, lam, p, slacks available at this stage\n", stage, field);
             mexErrMsgTxt(buffer);
         }
     }
@@ -215,7 +215,27 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
             mexErrMsgTxt(buffer);
         }
     }
-        else if (!strcmp(field, "lam"))
+    else if (!strcmp(field, "p"))
+    {
+        if (nrhs==2)
+        {
+            sprintf(buffer, "\nocp_get: field p: only supported for a single shooting node.\n");
+            mexErrMsgTxt(buffer);
+        }
+        else if (nrhs==3)
+        {
+            int np = ocp_nlp_dims_get_from_attr(config, dims, out, stage, field);
+            plhs[0] = mxCreateNumericMatrix(np, 1, mxDOUBLE_CLASS, mxREAL);
+            double *p = mxGetPr( plhs[0] );
+            ocp_nlp_in_get(config, dims, in, stage, "p", p);
+        }
+        else
+        {
+            sprintf(buffer, "\nocp_get: wrong nrhs: %d\n", nrhs);
+            mexErrMsgTxt(buffer);
+        }
+    }
+    else if (!strcmp(field, "lam"))
     {
         if (nrhs==2)
         {

--- a/interfaces/acados_template/acados_template/acados_ocp.py
+++ b/interfaces/acados_template/acados_template/acados_ocp.py
@@ -821,31 +821,31 @@ class AcadosOcp:
                 raise Exception('DDP only supports initial state constraints, got terminal constraints.')
 
         # Set default parameters for globalization
-        if opts.alpha_min == None:
+        if opts.alpha_min is None:
             if opts.globalization == 'FUNNEL_L1PEN_LINESEARCH':
                 opts.alpha_min = 1e-17
             else:
                 opts.alpha_min = 0.05
 
-        if opts.alpha_reduction == None:
+        if opts.alpha_reduction is None:
             if opts.globalization == 'FUNNEL_L1PEN_LINESEARCH':
                 opts.alpha_reduction = 0.5
             else:
                 opts.alpha_reduction = 0.7
 
-        if opts.eps_sufficient_descent == None:
+        if opts.eps_sufficient_descent is None:
             if opts.globalization == 'FUNNEL_L1PEN_LINESEARCH':
                 opts.eps_sufficient_descent = 1e-6
             else:
                 opts.eps_sufficient_descent = 1e-4
 
-        if opts.eval_residual_at_max_iter == None:
+        if opts.eval_residual_at_max_iter is None:
             if opts.globalization == 'FUNNEL_L1PEN_LINESEARCH':
                 opts.eval_residual_at_max_iter = True
             else:
                 opts.eval_residual_at_max_iter = False
 
-        if opts.full_step_dual == None:
+        if opts.full_step_dual is None:
             if opts.globalization == 'FUNNEL_L1PEN_LINESEARCH':
                 opts.full_step_dual = 1
             else:

--- a/interfaces/acados_template/acados_template/acados_ocp_solver_pyx.pyx
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver_pyx.pyx
@@ -449,8 +449,9 @@ cdef class AcadosOcpSolverCython:
         """
 
         out_fields = ['x', 'u', 'z', 'pi', 'lam', 'sl', 'su']
+        in_fields = ['p']
         sens_fields = ['sens_u', 'sens_x']
-        all_fields = out_fields + sens_fields
+        all_fields = out_fields + in_fields + sens_fields
 
         if field_ not in all_fields:
             raise Exception(f'AcadosOcpSolver.get(stage={stage}, field={field_}): \'{field_}\' is an invalid argument.\
@@ -478,6 +479,9 @@ cdef class AcadosOcpSolverCython:
         elif field_ in sens_fields:
             acados_solver_common.ocp_nlp_out_get(self.nlp_config, \
                 self.nlp_dims, self.sens_out, stage, field, <void *> out.data)
+        elif field_ in in_fields:
+            acados_solver_common.ocp_nlp_in_get(self.nlp_config, \
+                self.nlp_dims, self.nlp_in, stage, field, <void *> out.data)
 
         return out
 

--- a/interfaces/acados_template/acados_template/acados_solver_common.pxd
+++ b/interfaces/acados_template/acados_template/acados_solver_common.pxd
@@ -87,6 +87,12 @@ cdef extern from "acados_c/ocp_nlp_interface.h":
     void ocp_nlp_qp_dims_get_from_attr(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_out *out,
         int stage, const char *field, int *dims_out)
 
+    # in
+    void ocp_nlp_in_set(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *nlp_in,
+        int stage, const char *field, void *value)
+    void ocp_nlp_in_get(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *nlp_in,
+        int stage, const char *field, void *value)
+
     # opts
     void ocp_nlp_solver_opts_set(ocp_nlp_config *config, void *opts_, const char *field, void* value)
 

--- a/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_mex_set.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_mex_set.in.c
@@ -551,6 +551,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     }
     else if (!strcmp(field, "p"))
     {
+        MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, {{ dims.np }})
         if (nrhs==min_nrhs) // all stages
         {
             for (int ii=0; ii<=N; ii++)

--- a/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_mex_set.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_mex_set.in.c
@@ -564,6 +564,28 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
             {{ model.name }}_acados_update_params(capsule, stage, value, matlab_size);
         }
     }
+    else if (!strcmp(field, "params_sparse"))
+    {
+        MEX_DIM_CHECK_MAT(fun_name, field, nrow, ncol, nrow, 2);
+
+        // create int index vector
+        int idx_tmp[{{ dims.np }}];
+        for (int ip = 0; ip<nrow; ip++)
+            idx_tmp[ip] = (int) value[ip];
+
+        if (nrhs==min_nrhs) // all stages
+        {
+            for (int ii=0; ii<=N; ii++)
+            {
+                {{ model.name }}_acados_update_params_sparse(capsule, ii, idx_tmp, value+nrow, nrow);
+            }
+        }
+        else if (nrhs==min_nrhs+1) // one stage
+        {
+            int stage = mxGetScalar( prhs[5] );
+                {{ model.name }}_acados_update_params_sparse(capsule, stage, idx_tmp, value+nrow, nrow);
+        }
+    }
     else if (!strcmp(field, "nlp_solver_max_iter"))
     {
         acados_size = 1;

--- a/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_solver_sfun.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_solver_sfun.in.c
@@ -525,7 +525,7 @@ static void mdlOutputs(SimStruct *S, int_T tid)
     // local buffer
     {%- set buffer_size = buffer_sizes | sort | last %}
     real_t buffer[{{ buffer_size }}];
-    double tmp_cpu_time;
+    double tmp_double;
 
     /* go through inputs */
     {%- set i_input = -1 %}
@@ -854,7 +854,7 @@ static void mdlOutputs(SimStruct *S, int_T tid)
     int acados_status = {{ model.name }}_acados_solve(capsule);
     // get time
     ocp_nlp_get(nlp_config, capsule->nlp_solver, "time_tot", (void *) buffer);
-    tmp_cpu_time = buffer[0];
+    tmp_double = buffer[0];
 
   {%- elif simulink_opts.inputs.rti_phase %}{# SPLIT RTI PHASE#}
     {% if solver_options.nlp_solver_type != "SQP_RTI" %}
@@ -866,7 +866,7 @@ static void mdlOutputs(SimStruct *S, int_T tid)
     int acados_status = {{ model.name }}_acados_solve(capsule);
     // get time
     ocp_nlp_get(nlp_config, capsule->nlp_solver, "time_tot", (void *) buffer);
-    tmp_cpu_time = buffer[0];
+    tmp_double = buffer[0];
     {%- endif %}
   {%- elif solver_options.nlp_solver_type == "SQP_RTI" %}{# if custom_update_filename != "" #}
     // preparation
@@ -876,7 +876,7 @@ static void mdlOutputs(SimStruct *S, int_T tid)
 
     // preparation time
     ocp_nlp_get(nlp_config, capsule->nlp_solver, "time_tot", (void *) buffer);
-    tmp_cpu_time = buffer[0];
+    tmp_double = buffer[0];
 
     // call custom update function
     int data_len = 0;
@@ -889,7 +889,7 @@ static void mdlOutputs(SimStruct *S, int_T tid)
     acados_status = {{ model.name }}_acados_solve(capsule);
     // feedback time
     ocp_nlp_get(nlp_config, capsule->nlp_solver, "time_tot", (void *) buffer);
-    tmp_cpu_time += buffer[0];
+    tmp_double += buffer[0];
   {%- else -%}
     Simulink block with custom solver template only works with SQP_RTI!
   {%- endif %}
@@ -983,7 +983,7 @@ static void mdlOutputs(SimStruct *S, int_T tid)
   {%- if simulink_opts.outputs.CPU_time == 1 %}
     {%- set i_output = i_output + 1 %}
     out_cpu_time = ssGetOutputPortRealSignal(S, {{ i_output }});
-    out_cpu_time[0] = tmp_cpu_time;
+    out_cpu_time[0] = tmp_double;
   {%- endif -%}
 
   {%- if simulink_opts.outputs.CPU_time_sim == 1 %}

--- a/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/mex_solver.in.m
+++ b/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/mex_solver.in.m
@@ -69,12 +69,10 @@ classdef {{ model.name }}_mex_solver < handle
             disp("done.");
         end
 
-        % solve
         function solve(obj)
             acados_mex_solve_{{ model.name }}(obj.C_ocp);
         end
 
-        % set
         function set(varargin)
             obj = varargin{1};
             field = varargin{2};
@@ -86,6 +84,27 @@ classdef {{ model.name }}_mex_solver < handle
                 acados_mex_set_{{ model.name }}(obj.cost_ext_fun_type, obj.cost_ext_fun_type_e, obj.C_ocp, field, value);
             elseif nargin==4
                 stage = varargin{4};
+                acados_mex_set_{{ model.name }}(obj.cost_ext_fun_type, obj.cost_ext_fun_type_e, obj.C_ocp, field, value, stage);
+            else
+                disp('acados_ocp.set: wrong number of input arguments (2 or 3 allowed)');
+            end
+        end
+
+
+        function set_params_sparse(varargin)
+            obj = varargin{1};
+            idx_values = varargin{2};
+            param_values = varargin{2};
+            value = [idx_values(:)', param_values(:)'];
+            field = 'params_sparse';
+
+            if ~isa(field, 'char')
+                error('field must be a char vector, use '' ''');
+            end
+            if nargin==2
+                acados_mex_set_{{ model.name }}(obj.cost_ext_fun_type, obj.cost_ext_fun_type_e, obj.C_ocp, field, value);
+            elseif nargin==3
+                stage = varargin{3};
                 acados_mex_set_{{ model.name }}(obj.cost_ext_fun_type, obj.cost_ext_fun_type_e, obj.C_ocp, field, value, stage);
             else
                 disp('acados_ocp.set: wrong number of input arguments (2 or 3 allowed)');

--- a/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/mex_solver.in.m
+++ b/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/mex_solver.in.m
@@ -94,20 +94,20 @@ classdef {{ model.name }}_mex_solver < handle
         function set_params_sparse(varargin)
             obj = varargin{1};
             idx_values = varargin{2};
-            param_values = varargin{2};
-            value = [idx_values(:)', param_values(:)'];
+            param_values = varargin{3};
+            value = [idx_values(:), param_values(:)];
             field = 'params_sparse';
 
             if ~isa(field, 'char')
                 error('field must be a char vector, use '' ''');
             end
-            if nargin==2
+            if nargin==3
                 acados_mex_set_{{ model.name }}(obj.cost_ext_fun_type, obj.cost_ext_fun_type_e, obj.C_ocp, field, value);
-            elseif nargin==3
-                stage = varargin{3};
+            elseif nargin==4
+                stage = varargin{4};
                 acados_mex_set_{{ model.name }}(obj.cost_ext_fun_type, obj.cost_ext_fun_type_e, obj.C_ocp, field, value, stage);
             else
-                disp('acados_ocp.set: wrong number of input arguments (2 or 3 allowed)');
+                disp('acados_ocp.set_params_sparse: wrong number of input arguments (3 or 4 allowed)');
             end
         end
 

--- a/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/mex_solver.in.m
+++ b/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/mex_solver.in.m
@@ -92,6 +92,10 @@ classdef {{ model.name }}_mex_solver < handle
 
 
         function set_params_sparse(varargin)
+            % usage:
+            % ocp.set_params_sparse(idx_values, param_values, Optional[stage])
+            % updates the parameters with indices idx_values (0 based) at stage with the new values new_p_values.
+            % if stage is not provided, sparse parameter update is performed for all stages.
             obj = varargin{1};
             idx_values = varargin{2};
             param_values = varargin{3};


### PR DESCRIPTION
- added functionality in Matlab interface: `ocp_solver.set_params_sparse(idx_values, new_p_values, stage);`. This updates the parameters with indices `idx_values` (0 based) at `stage` with the new values `new_p_values`.
- Added getters for parameter values `p` in Matlab and Python.
- Tests for parameter setters are added, both in Matlab and Python.