### PR TITLE
Hotfix sparse parameter setter Matlab for empty parameter and MSVC compiler

### DIFF
--- a/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_mex_set.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_mex_set.in.c
@@ -567,8 +567,8 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     }
     else if (!strcmp(field, "params_sparse"))
     {
+{% if dims.np > 0 %}
         MEX_DIM_CHECK_MAT(fun_name, field, nrow, ncol, nrow, 2);
-
         // create int index vector
         int idx_tmp[{{ dims.np }}];
         for (int ip = 0; ip<nrow; ip++)
@@ -586,6 +586,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
             int stage = mxGetScalar( prhs[5] );
                 {{ model.name }}_acados_update_params_sparse(capsule, stage, idx_tmp, value+nrow, nrow);
         }
+{% endif %}
     }
     else if (!strcmp(field, "nlp_solver_max_iter"))
     {


### PR DESCRIPTION
- empty array does not work with some compilers
- nothing has to be set if parameter vector is empty, thus added if in template
- reported in  https://discourse.acados.org/t/minimal-example-ocp-m-error/1702
- introduced in #1176