### PR TITLE
Fix links to OSQP to point to its new GitHub organization

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,7 +25,7 @@
 	url = https://github.com/acados/qpOASES.git
 [submodule "external/osqp"]
 	path = external/osqp
-	url = https://github.com/oxfordcontrol/osqp.git
+	url = https://github.com/osqp/osqp.git
 	branch = develop
 [submodule "interfaces/acados_template/tera_renderer"]
 	path = interfaces/acados_template/tera_renderer

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ Problems can be conveniently formulated using the [`CasADi`](https://web.casadi.
 `acados` provides a collection of computationally efficient building blocks tailored to optimal control structured problems, most prominently optimal control problems (OCP) and moving horizon estimation (MHE) problems.
 Among others, `acados` implements:
 - modules for the integration of ordinary differential equations (ODE) and differential-algebraic equations (DAE),
-- interfaces to state-of-the-art QP solvers like [`HPIPM`](https://github.com/giaf/hpipm), `qpOASES`, [`DAQP`](https://github.com/darnstrom/daqp) and [`OSQP`](https://github.com/oxfordcontrol/osqp)
+- interfaces to state-of-the-art QP solvers like [`HPIPM`](https://github.com/giaf/hpipm), `qpOASES`, [`DAQP`](https://github.com/darnstrom/daqp) and [`OSQP`](https://github.com/osqp/osqp)
 - (partial) condensing routines, provided by `HPIPM`
 - nonlinear programming solvers for optimal control structured problems
 - real-time algorithms, such as the real-time iteration (RTI) and advanced-step real-time iteration (AS-RTI) algorithms


### PR DESCRIPTION
OSQP moved to a dedicated organization a while ago, so this updates all the docs references and the submodule to point to the new organization.