### PR TITLE
Fix `external_function_external_param_casadi`

### DIFF
--- a/acados/utils/external_function_generic.c
+++ b/acados/utils/external_function_generic.c
@@ -1493,8 +1493,7 @@ void external_function_external_param_casadi_assign(external_function_external_p
 
     fun->param_mem_is_set = false;
 
-    assert((char *) raw_memory + external_function_external_param_casadi_calculate_size(fun, fun->np) >=
-           c_ptr);
+    assert((char *) raw_memory + external_function_external_param_casadi_calculate_size(fun) >= c_ptr);
 
     return;
 }


### PR DESCRIPTION
fixes call to `external_function_external_param_casadi_calculate_size`

- reported in https://github.com/acados/acados/issues/1186
- introduced in https://github.com/acados/acados/pull/1163