### PR TITLE
Compile acados with `BUILD_TYPE = DEBUG` on Github actions

### DIFF
--- a/.github/workflows/full_build.yml
+++ b/.github/workflows/full_build.yml
@@ -10,7 +10,7 @@ on:
       - '*'
 
 env:
-  BUILD_TYPE: Release
+  BUILD_TYPE: Debug
   ACADOS_PYTHON: ON
   ACADOS_OCTAVE: ON
   ACADOS_WITH_OSQP: ON


### PR DESCRIPTION
- in order to check asserts on CI to avoid issues like https://github.com/acados/acados/issues/1186