### PR TITLE
migrate `dims.N` to `solver_options.N_horizon`

### DIFF
--- a/examples/acados_matlab_octave/getting_started/new_minimal_example_ocp.m
+++ b/examples/acados_matlab_octave/getting_started/new_minimal_example_ocp.m
@@ -84,7 +84,7 @@ ocp.constraints.uh_0 = U_max;
 ocp.constraints.x0 = x0;
 
 % define solver options
-ocp.dims.N = N;
+ocp.solver_options.N_horizon = N;
 ocp.solver_options.tf = 1.0;
 ocp.solver_options.nlp_solver_type = 'SQP';
 ocp.solver_options.integrator_type = 'ERK';

--- a/examples/acados_python/chain_mass/main.py
+++ b/examples/acados_python/chain_mass/main.py
@@ -100,7 +100,7 @@ def run_nominal_control(chain_params):
     xrest = compute_steady_state(n_mass, m, D, L, xPosFirstMass, xEndRef)
 
     # set dimensions
-    ocp.dims.N = N
+    ocp.solver_options.N_horizon = N
 
     # set cost module
     ocp.cost.cost_type = 'LINEAR_LS'

--- a/examples/acados_python/chain_mass/solution_sensitivity_example.py
+++ b/examples/acados_python/chain_mass/solution_sensitivity_example.py
@@ -245,7 +245,7 @@ def export_parametric_ocp(
 ) -> Tuple[AcadosOcp, DMStruct]:
     # create ocp object to formulate the OCP
     ocp = AcadosOcp()
-    ocp.dims.N = chain_params_["N"]
+    ocp.solver_options.N_horizon = chain_params_["N"]
 
     # export model
     ocp.model, p = export_chain_mass_model(n_mass=chain_params_["n_mass"], Ts=chain_params_["Ts"], disturbance=True)
@@ -340,15 +340,15 @@ def export_parametric_ocp(
         ocp.solver_options.qp_solver_iter_max = 200
         ocp.solver_options.tol = 1e-10
         ocp.solver_options.qp_solver_ric_alg = qp_solver_ric_alg
-        ocp.solver_options.qp_solver_cond_N = ocp.dims.N
+        ocp.solver_options.qp_solver_cond_N = ocp.solver_options.N_horizon
         ocp.solver_options.with_solution_sens_wrt_params = True
     else:
         ocp.solver_options.nlp_solver_max_iter = nlp_iter
-        ocp.solver_options.qp_solver_cond_N = ocp.dims.N
+        ocp.solver_options.qp_solver_cond_N = ocp.solver_options.N_horizon
         ocp.solver_options.qp_tol = nlp_tol
         ocp.solver_options.tol = nlp_tol
 
-    ocp.solver_options.tf = ocp.dims.N * chain_params_["Ts"]
+    ocp.solver_options.tf = ocp.solver_options.N_horizon * chain_params_["Ts"]
 
     return ocp, p
 
@@ -412,7 +412,7 @@ def main_parametric(qp_solver_ric_alg: int = 0, chain_params_: dict = get_chain_
         parameter_values.cat[p_idx] = p_var[i]
 
         p_val = parameter_values.cat.full().flatten()
-        for stage in range(ocp.dims.N + 1):
+        for stage in range(ocp.solver_options.N_horizon + 1):
             ocp_solver.set(stage, "p", p_val)
             sensitivity_solver.set(stage, "p", p_val)
 

--- a/examples/acados_python/convex_problem_globalization_needed/convex_problem_globalization_necessary.py
+++ b/examples/acados_python/convex_problem_globalization_needed/convex_problem_globalization_necessary.py
@@ -43,7 +43,7 @@ def solve_problem_with_setting(setting):
     # discretization
     Tf = 1
     N = 1
-    ocp.dims.N = N
+    ocp.solver_options.N_horizon = N
     ocp.solver_options.tf = Tf
 
     # cost

--- a/examples/acados_python/crane/time_optimal_example.py
+++ b/examples/acados_python/crane/time_optimal_example.py
@@ -91,7 +91,7 @@ def setup_solver_and_integrator(x0: np.ndarray, xf: np.ndarray, N: int, use_cyth
 
     ocp = AcadosOcp()
     ocp.model = model
-    ocp.dims.N = N
+    ocp.solver_options.N_horizon = N
     ocp.solver_options.tf = N
 
     ocp.cost.cost_type = 'EXTERNAL'

--- a/examples/acados_python/cstr/main.py
+++ b/examples/acados_python/cstr/main.py
@@ -78,9 +78,9 @@ def simulate(
                     controller.set_params_sparse(stage, np.array([1]), np.array([t]))
             else:
                 yref = np.concatenate((X_ref[i, :], U_ref[i, :]))
-                for stage in range(controller.acados_ocp.dims.N):
+                for stage in range(controller.acados_ocp.solver_options.N_horizon):
                     controller.set(stage, "yref", yref)
-                controller.set(controller.acados_ocp.dims.N, "yref", X_ref[i, :])
+                controller.set(controller.acados_ocp.solver_options.N_horizon, "yref", X_ref[i, :])
 
             # solve ocp
             U[i, :] = controller.solve_for_x0(xcurrent)

--- a/examples/acados_python/cstr/setup_acados_ocp_solver.py
+++ b/examples/acados_python/cstr/setup_acados_ocp_solver.py
@@ -73,7 +73,7 @@ def setup_acados_ocp_solver(
     nu = u.shape[0]
 
     # number of shooting intervals
-    ocp.dims.N = mpc_params.N
+    ocp.solver_options.N_horizon = mpc_params.N
 
     # set prediction horizon
     ocp.solver_options.tf = mpc_params.Tf

--- a/examples/acados_python/external_model/minimal_example_external_ode.py
+++ b/examples/acados_python/external_model/minimal_example_external_ode.py
@@ -64,7 +64,7 @@ x0 = np.array([0, 0])
 xT = np.array([1/2, 1])
 
 # set dimensions
-ocp.dims.N = N
+ocp.solver_options.N_horizon = N
 
 # set cost module
 ocp.cost.cost_type = 'LINEAR_LS'

--- a/examples/acados_python/furuta_pendulum/main_closed_loop.py
+++ b/examples/acados_python/furuta_pendulum/main_closed_loop.py
@@ -48,7 +48,7 @@ def setup(x0, umax, dt_0, N_horizon, Tf, RTI=False):
     ny = nx + nu
     ny_e = nx
 
-    ocp.dims.N = N_horizon
+    ocp.solver_options.N_horizon = N_horizon
 
     # set cost module
     ocp.cost.cost_type = 'NONLINEAR_LS'

--- a/examples/acados_python/generic_dyn_disc/main.py
+++ b/examples/acados_python/generic_dyn_disc/main.py
@@ -197,7 +197,7 @@ def main():
     ocp.constraints.uh_e = uh_e
 
     # acados ocp opts
-    ocp.dims.N = N
+    ocp.solver_options.N_horizon = N
     ocp.solver_options.shooting_nodes = shooting_nodes
     ocp.solver_options.hessian_approx = 'EXACT'
     ocp.solver_options.regularize_method = regularize_method

--- a/examples/acados_python/generic_impl_dyn/minimal_example_ocp_generic_impl_dyn.py
+++ b/examples/acados_python/generic_impl_dyn/minimal_example_ocp_generic_impl_dyn.py
@@ -60,7 +60,7 @@ ocp.model.dyn_impl_dae_fun_jac = 'generic_impl_dyn_fun_jac'
 ocp.model.dyn_impl_dae_jac = 'generic_impl_dyn_jac'
 
 # set dimensions
-ocp.dims.N = N
+ocp.solver_options.N_horizon = N
 
 # set cost
 Q = 2*np.diag([1e3, 1e3, 1e-2, 1e-2])

--- a/examples/acados_python/getting_started/minimal_example_closed_loop.py
+++ b/examples/acados_python/getting_started/minimal_example_closed_loop.py
@@ -49,7 +49,6 @@ def setup(x0, Fmax, N_horizon, Tf, RTI=False):
     ny = nx + nu
     ny_e = nx
 
-    ocp.dims.N = N_horizon
 
     # set cost module
     ocp.cost.cost_type = 'NONLINEAR_LS'
@@ -73,6 +72,10 @@ def setup(x0, Fmax, N_horizon, Tf, RTI=False):
     ocp.constraints.x0 = x0
     ocp.constraints.idxbu = np.array([0])
 
+    # set prediction horizon
+    ocp.solver_options.N_horizon = N_horizon
+    ocp.solver_options.tf = Tf
+
     ocp.solver_options.qp_solver = 'PARTIAL_CONDENSING_HPIPM' # FULL_CONDENSING_QPOASES
     ocp.solver_options.hessian_approx = 'GAUSS_NEWTON'
     ocp.solver_options.integrator_type = 'IRK'
@@ -87,8 +90,6 @@ def setup(x0, Fmax, N_horizon, Tf, RTI=False):
 
     ocp.solver_options.qp_solver_cond_N = N_horizon
 
-    # set prediction horizon
-    ocp.solver_options.tf = Tf
 
     solver_json = 'acados_ocp_' + model.name + '.json'
     acados_ocp_solver = AcadosOcpSolver(ocp, json_file = solver_json)

--- a/examples/acados_python/getting_started/minimal_example_ocp.py
+++ b/examples/acados_python/getting_started/minimal_example_ocp.py
@@ -47,10 +47,8 @@ def main():
     nu = model.u.rows()
     N = 20
 
-    # set number of shooting intervals
-    ocp.dims.N = N
-
     # set prediction horizon
+    ocp.solver_options.N_horizon = N
     ocp.solver_options.tf = Tf
 
     # cost matrices

--- a/examples/acados_python/linear_mass_model/linear_mass_test_problem.py
+++ b/examples/acados_python/linear_mass_model/linear_mass_test_problem.py
@@ -86,7 +86,7 @@ def solve_maratos_ocp(setting):
     Tf = 2
     N = 20
     shooting_nodes = np.linspace(0, Tf, N+1)
-    ocp.dims.N = N
+    ocp.solver_options.N_horizon = N
 
     # set cost
     Q = 2*np.diag([])

--- a/examples/acados_python/max_iter_test/max_iter_test.py
+++ b/examples/acados_python/max_iter_test/max_iter_test.py
@@ -59,7 +59,7 @@ def create_acados_solver_and_solve_problem(globalization='FIXED_STEP', solver_ty
     ocp.model = model
 
     # set dimensions
-    ocp.dims.N = N
+    ocp.solver_options.N_horizon = N
 
     # set cost
     ocp.cost.cost_type = "LINEAR_LS"

--- a/examples/acados_python/mocp_transition_example/main.py
+++ b/examples/acados_python/mocp_transition_example/main.py
@@ -124,7 +124,7 @@ def formulate_double_integrator_ocp() -> AcadosOcp:
 
     ocp.model = get_double_integrator_model()
 
-    ocp.dims.N = N_HORIZON
+    ocp.solver_options.N_horizon = N_HORIZON
 
     ocp.cost.cost_type = 'NONLINEAR_LS'
     ocp.cost.cost_type_e = 'NONLINEAR_LS'
@@ -151,7 +151,7 @@ def formulate_single_integrator_ocp() -> AcadosOcp:
 
     ocp.model = get_single_integrator_model()
 
-    ocp.dims.N = N_HORIZON
+    ocp.solver_options.N_horizon = N_HORIZON
 
     ocp.cost.cost_type = 'NONLINEAR_LS'
     ocp.cost.cost_type_e = 'NONLINEAR_LS'
@@ -277,8 +277,8 @@ def main_standard_ocp():
     status = acados_ocp_solver.solve_for_x0(X0)
     acados_ocp_solver.print_statistics()
 
-    x_traj = [acados_ocp_solver.get(i, 'x') for i in range(ocp.dims.N+1)]
-    u_traj = [acados_ocp_solver.get(i, 'u') for i in range(ocp.dims.N)]
+    x_traj = [acados_ocp_solver.get(i, 'x') for i in range(ocp.solver_options.N_horizon+1)]
+    u_traj = [acados_ocp_solver.get(i, 'u') for i in range(ocp.solver_options.N_horizon)]
 
     t_grid = ocp.solver_options.shooting_nodes
 

--- a/examples/acados_python/multiphase_nonlinear_constraints/main.py
+++ b/examples/acados_python/multiphase_nonlinear_constraints/main.py
@@ -62,7 +62,7 @@ def main():
 
     ocp = AcadosOcp()
     ocp.model = acados_model
-    ocp.dims.N = N_list[phase_idx]
+    ocp.solver_options.N_horizon = N_list[phase_idx]
 
     ocp.cost.cost_type = 'EXTERNAL'
     ocp.cost.cost_type_e = 'EXTERNAL'
@@ -98,7 +98,7 @@ def main():
 
     ocp = AcadosOcp()
     ocp.model = acados_model
-    ocp.dims.N = N_list[phase_idx]
+    ocp.solver_options.N_horizon = N_list[phase_idx]
 
     ocp.cost.cost_type = 'EXTERNAL'
     ocp.cost.cost_type_e = 'EXTERNAL'

--- a/examples/acados_python/non_ocp_nlp/maratos_test_problem.py
+++ b/examples/acados_python/non_ocp_nlp/maratos_test_problem.py
@@ -91,7 +91,7 @@ def solve_maratos_problem_with_setting(setting):
     # discretization
     Tf = 1
     N = 1
-    ocp.dims.N = N
+    ocp.solver_options.N_horizon = N
     ocp.solver_options.tf = Tf
 
     # cost

--- a/examples/acados_python/pendulum_on_cart/as_rti/as_rti_closed_loop_example.py
+++ b/examples/acados_python/pendulum_on_cart/as_rti/as_rti_closed_loop_example.py
@@ -57,7 +57,7 @@ def setup(x0, Fmax, N_horizon, Tf, algorithm, as_rti_iter=1):
     ny = nx + nu
     ny_e = nx
 
-    ocp.dims.N = N_horizon
+    ocp.solver_options.N_horizon = N_horizon
 
     # set cost module
     ocp.cost.cost_type = 'NONLINEAR_LS'

--- a/examples/acados_python/pendulum_on_cart/custom_update/example_custom_rti_loop.py
+++ b/examples/acados_python/pendulum_on_cart/custom_update/example_custom_rti_loop.py
@@ -53,7 +53,7 @@ def main(use_cython=False):
     N = 20
 
     # set dimensions
-    ocp.dims.N = N
+    ocp.solver_options.N_horizon = N
 
     # set cost
     Q = 2*np.diag([1e3, 1e3, 1e-2, 1e-2])

--- a/examples/acados_python/pendulum_on_cart/cython_example_closed_loop.py
+++ b/examples/acados_python/pendulum_on_cart/cython_example_closed_loop.py
@@ -55,7 +55,7 @@ def main():
     N_horizon = 20
 
     # set dimensions
-    ocp.dims.N = N_horizon
+    ocp.solver_options.N_horizon = N_horizon
     # NOTE: all dimensions but N are now detected automatically in the Python
     #  interface, all other dimensions will be overwritten by the detection.
 

--- a/examples/acados_python/pendulum_on_cart/example_solution_sens_closed_loop.py
+++ b/examples/acados_python/pendulum_on_cart/example_solution_sens_closed_loop.py
@@ -58,7 +58,7 @@ def create_ocp_solver():
     ny_e = nx
 
     # set dimensions
-    ocp.dims.N = N
+    ocp.solver_options.N_horizon = N
     # NOTE: all dimensions but N are now detected automatically in the Python
     #  interface, all other dimensions will be overwritten by the detection.
 

--- a/examples/acados_python/pendulum_on_cart/mhe/export_ocp_solver.py
+++ b/examples/acados_python/pendulum_on_cart/mhe/export_ocp_solver.py
@@ -46,7 +46,7 @@ def export_ocp_solver(model, N, h, Q, R, Fmax=80, use_cython=False):
     ny = nx + nu
     ny_e = nx
 
-    ocp.dims.N = N
+    ocp.solver_options.N_horizon = N
 
     # set cost
     ocp.cost.cost_type = 'NONLINEAR_LS'

--- a/examples/acados_python/pendulum_on_cart/ocp/example_custom_hessian.py
+++ b/examples/acados_python/pendulum_on_cart/ocp/example_custom_hessian.py
@@ -53,7 +53,7 @@ ny_e = nx
 N = 40
 
 # set dimensions
-ocp.dims.N = N
+ocp.solver_options.N_horizon = N
 
 # set cost
 ocp.cost.cost_type = 'EXTERNAL'

--- a/examples/acados_python/pendulum_on_cart/ocp/example_ocp_dynamics_formulations.py
+++ b/examples/acados_python/pendulum_on_cart/ocp/example_ocp_dynamics_formulations.py
@@ -86,7 +86,7 @@ if __name__ == "__main__":
     ny_e = nx
 
     # set dimensions
-    ocp.dims.N = N
+    ocp.solver_options.N_horizon = N
 
     # set cost
     Q = 2*np.diag([1e3, 1e3, 1e-2, 1e-2])

--- a/examples/acados_python/pendulum_on_cart/ocp/example_optimal_value_derivative.py
+++ b/examples/acados_python/pendulum_on_cart/ocp/example_optimal_value_derivative.py
@@ -46,7 +46,7 @@ def setup_solver(N: int, dt: float, u_max: float = 60):
     ocp.model = model
 
     Tf = N*dt
-    ocp.dims.N = N
+    ocp.solver_options.N_horizon = N
 
     nx = model.x.rows()
     nu = model.u.rows()

--- a/examples/acados_python/pendulum_on_cart/ocp/example_sqp_qpDUNES.py
+++ b/examples/acados_python/pendulum_on_cart/ocp/example_sqp_qpDUNES.py
@@ -52,7 +52,7 @@ ny_e = nx
 N = 20
 
 # set dimensions
-ocp.dims.N = N
+ocp.solver_options.N_horizon = N
 
 # set cost
 # NOTE: qpDUNES requires very similar values on diag of hessian.

--- a/examples/acados_python/pendulum_on_cart/ocp/example_sqp_rti_loop.py
+++ b/examples/acados_python/pendulum_on_cart/ocp/example_sqp_rti_loop.py
@@ -53,7 +53,7 @@ def main():
     N = 20
 
     # set dimensions
-    ocp.dims.N = N
+    ocp.solver_options.N_horizon = N
 
     # set cost
     Q = 2*np.diag([1e3, 1e3, 1e-2, 1e-2])

--- a/examples/acados_python/pendulum_on_cart/ocp/minimal_example_batch_ocp_solver.py
+++ b/examples/acados_python/pendulum_on_cart/ocp/minimal_example_batch_ocp_solver.py
@@ -57,7 +57,7 @@ def setup_ocp(num_threads_in_batch_solve=1, tol=1e-7):
     N = 20
 
     # set dimensions
-    ocp.dims.N = N
+    ocp.solver_options.N_horizon = N
 
     Q_mat = 2*np.diag([1e3, 1e3, 1e-2, 1e-2])
     R_mat = 2*np.diag([1e-2])
@@ -130,7 +130,7 @@ def main_batch(Xinit, simU, tol, num_threads_in_batch_solve=1):
         batch_solver.ocp_solvers[n].constraints_set(0, "ubx", Xinit[n])
 
         # set initial guess
-        for i in range(ocp.dims.N):
+        for i in range(ocp.solver_options.N_horizon):
             batch_solver.ocp_solvers[n].set(i, "x", Xinit[n])
 
     t0 = time.time()

--- a/examples/acados_python/pendulum_on_cart/ocp/minimal_example_ocp_cmake.py
+++ b/examples/acados_python/pendulum_on_cart/ocp/minimal_example_ocp_cmake.py
@@ -53,7 +53,7 @@ ny_e = nx
 N = 20
 
 # set dimensions
-ocp.dims.N = N
+ocp.solver_options.N_horizon = N
 
 # set cost
 Q = 2*np.diag([1e3, 1e3, 1e-2, 1e-2])

--- a/examples/acados_python/pendulum_on_cart/ocp/minimal_example_ocp_reuse_code.py
+++ b/examples/acados_python/pendulum_on_cart/ocp/minimal_example_ocp_reuse_code.py
@@ -71,7 +71,7 @@ Tf_01 = 1.0  # original final time and for use-case 1
 Tf_2 = Tf_01 * 0.7  # change final time for use-case 2 (but keep N identical)
 
 # set dimensions
-ocp.dims.N = N0
+ocp.solver_options.N_horizon = N0
 
 # set cost
 Q = 2 * np.diag([1e3, 1e3, 1e-2, 1e-2])

--- a/examples/acados_python/pendulum_on_cart/ocp/nonuniform_discretization_example.py
+++ b/examples/acados_python/pendulum_on_cart/ocp/nonuniform_discretization_example.py
@@ -71,7 +71,7 @@ def main(discretization='shooting_nodes'):
     N = 15
 
     # discretization
-    ocp.dims.N = N
+    ocp.solver_options.N_horizon = N
     # shooting_nodes = np.linspace(0, Tf, N+1)
 
     time_steps = np.linspace(0, 1, N+1)[1:]

--- a/examples/acados_python/pendulum_on_cart/ocp/ocp_example_cost_formulations.py
+++ b/examples/acados_python/pendulum_on_cart/ocp/ocp_example_cost_formulations.py
@@ -66,7 +66,7 @@ def formulate_ocp(cost_version: str) -> AcadosOcp:
     ny = NX + NU
     ny_e = NX
 
-    ocp.dims.N = N
+    ocp.solver_options.N_horizon = N
 
     # set cost
     Q_mat = 2*np.diag([1e3, 1e3, 1e-2, 1e-2])

--- a/examples/acados_python/pendulum_on_cart/ocp/ocp_example_h_init_contraints.py
+++ b/examples/acados_python/pendulum_on_cart/ocp/ocp_example_h_init_contraints.py
@@ -64,7 +64,7 @@ def test_initial_h_constraints(constraint_version: str):
     ny_e = nx
     N = 20
 
-    ocp.dims.N = N
+    ocp.solver_options.N_horizon = N
 
     # set cost
     Q = 2*np.diag([1e3, 1e3, 1e-2, 1e-2])

--- a/examples/acados_python/pendulum_on_cart/ocp/simulink_example.py
+++ b/examples/acados_python/pendulum_on_cart/ocp/simulink_example.py
@@ -50,7 +50,7 @@ def main():
     N = 20
 
     # set dimensions
-    ocp.dims.N = N
+    ocp.solver_options.N_horizon = N
 
     # set cost
     Q_mat = 2*np.diag([1e3, 1e3, 1e-2, 1e-2])

--- a/examples/acados_python/pendulum_on_cart/solution_sensitivities/sensitivity_utils.py
+++ b/examples/acados_python/pendulum_on_cart/solution_sensitivities/sensitivity_utils.py
@@ -81,7 +81,7 @@ def export_parametric_ocp(
     dt = T_horizon/N_horizon
     ocp.model = export_pendulum_ode_model_with_mass_as_param(dt=dt)
 
-    ocp.dims.N = N_horizon
+    ocp.solver_options.N_horizon = N_horizon
 
     Q_mat = 2 * np.diag([1e3, 1e3, 1e-2, 1e-2])
     R_mat = 2 * np.diag([1e-1])

--- a/examples/acados_python/pendulum_on_cart/solution_sensitivities/state_augementation_policy_gradient.py
+++ b/examples/acados_python/pendulum_on_cart/solution_sensitivities/state_augementation_policy_gradient.py
@@ -123,7 +123,7 @@ def export_parameter_augmented_ocp(
     ocp.model, nx_original = export_parameter_augmented_pendulum_ode_model(param_M_as_state=param_M_as_state)
 
     # set dimensions
-    ocp.dims.N = N_horizon
+    ocp.solver_options.N_horizon = N_horizon
     nu = ocp.model.u.rows()
     nx = ocp.model.x.rows()
 

--- a/examples/acados_python/pendulum_on_cart/solution_sensitivities/test_solution_sens_and_exact_hess.py
+++ b/examples/acados_python/pendulum_on_cart/solution_sensitivities/test_solution_sens_and_exact_hess.py
@@ -71,7 +71,7 @@ def create_ocp_description(hessian_approx, linearized_dynamics=False, discrete=F
     nu = model.u.rows()
     ny = nx + nu
     ny_e = nx
-    ocp.dims.N = N
+    ocp.solver_options.N_horizon = N
 
     # set cost module
     Q = 2*np.diag([1e3, 1e3, 1e-2, 1e-2])

--- a/examples/acados_python/pmsm_example/main.py
+++ b/examples/acados_python/pmsm_example/main.py
@@ -256,7 +256,7 @@ def run_simulation(qp_solver="FULL_CONDENSING_HPIPM", show_plots=False, verbose=
     Tf = N * Ts
 
     # set ocp_nlp_dimensions
-    ocp.dims.N = N
+    ocp.solver_options.N_horizon = N
     # NOTE: all dimensions but N are now detected by the interface.
 
     # set weighting matrices

--- a/examples/acados_python/quadrotor_nav/acados_settings.py
+++ b/examples/acados_python/quadrotor_nav/acados_settings.py
@@ -75,7 +75,7 @@ class AcadosCustomOcp:
         ocp.model = model_ac
 
         # set dimensions
-        ocp.dims.N = N
+        ocp.solver_options.N_horizon = N
         self.nx = model_ac.x.size()[0]
         self.nu = model_ac.u.size()[0]
         ny = self.nx + self.nu

--- a/examples/acados_python/race_cars/acados_settings.py
+++ b/examples/acados_python/race_cars/acados_settings.py
@@ -64,7 +64,7 @@ def acados_settings(Tf, N, track_file):
     ny = nx + nu
     ny_e = nx
 
-    ocp.dims.N = N
+    ocp.solver_options.N_horizon = N
     ns = 2
     nsh = 2
 

--- a/examples/acados_python/race_cars/acados_settings_dev.py
+++ b/examples/acados_python/race_cars/acados_settings_dev.py
@@ -70,7 +70,7 @@ def acados_settings(Tf, N, track_file):
     ns = nsh + nsbx
 
     # discretization
-    ocp.dims.N = N
+    ocp.solver_options.N_horizon = N
 
     # set cost
     Q = np.diag([ 1e-1, 1e-8, 1e-8, 1e-8, 1e-3, 5e-3 ])

--- a/examples/acados_python/rsm_example/main.py
+++ b/examples/acados_python/rsm_example/main.py
@@ -179,7 +179,7 @@ def create_ocp_solver(tol = 1e-3):
     Tf = N*Ts
 
     # set number of shooting intervals
-    ocp.dims.N = N
+    ocp.solver_options.N_horizon = N
 
     # set cost
     Q = np.diag([5e2, 5e2])
@@ -299,7 +299,7 @@ def main():
     ocp = acados_solver.acados_ocp
     nx = ocp.dims.nx
     nu = ocp.dims.nu
-    N = ocp.dims.N
+    N = ocp.solver_options.N_horizon
     Nsim = 100
 
     if USE_PLANT:

--- a/examples/acados_python/tests/armijo_test.py
+++ b/examples/acados_python/tests/armijo_test.py
@@ -83,7 +83,7 @@ def solve_armijo_problem_with_setting(setting):
     # discretization
     Tf = 1
     N = 1
-    ocp.dims.N = N
+    ocp.solver_options.N_horizon = N
     ocp.solver_options.tf = Tf
 
     # cost

--- a/examples/acados_python/tests/one_sided_constraints_test.py
+++ b/examples/acados_python/tests/one_sided_constraints_test.py
@@ -59,7 +59,7 @@ def main(constraint_variant='one_sided',
     Tf = 1.0
 
     # set dimensions
-    ocp.dims.N = N_horizon
+    ocp.solver_options.N_horizon = N_horizon
 
     # set cost
     Q = 2 * np.diag([1e3, 1e3, 1e-2, 1e-2])

--- a/examples/acados_python/tests/regularization_test.py
+++ b/examples/acados_python/tests/regularization_test.py
@@ -62,7 +62,7 @@ def main(regularize_method: str):
     N = 1
 
     # set dimensions
-    ocp.dims.N = N
+    ocp.solver_options.N_horizon = N
 
     # set cost
     Q_mat = np.array([[8.332636379960917, -0.2025707437550449, 65.20466910278751, 0],

--- a/examples/acados_python/tests/reset_test.py
+++ b/examples/acados_python/tests/reset_test.py
@@ -64,7 +64,7 @@ def main(cost_type='NONLINEAR_LS', hessian_approximation='EXACT', ext_cost_use_n
     ny_e = nx
     N = 20
 
-    ocp.dims.N = N
+    ocp.solver_options.N_horizon = N
 
     # set cost
     Q = 2*np.diag([1e3, 1e3, 1e-2, 1e-2])

--- a/examples/acados_python/tests/soft_constraint_test.py
+++ b/examples/acados_python/tests/soft_constraint_test.py
@@ -69,7 +69,7 @@ def run_closed_loop_experiment(soft_constr_type='bx', verbose=False, qp_solver='
 
     # set dimensions
     # NOTE: all dimensions but N ar detected
-    ocp.dims.N = N
+    ocp.solver_options.N_horizon = N
 
     # set cost module
     ocp.cost.cost_type = 'LINEAR_LS'

--- a/examples/acados_python/tests/test_cost_integration_euler.py
+++ b/examples/acados_python/tests/test_cost_integration_euler.py
@@ -61,7 +61,7 @@ def solve_ocp(cost_discretization, cost_variant):
     N = 20
 
     # set dimensions
-    ocp.dims.N = N
+    ocp.solver_options.N_horizon = N
 
     # set cost
     Q = 2 * np.diag([1e3, 1e3, 1e-2, 1e-2])

--- a/examples/acados_python/tests/test_cost_integration_value.py
+++ b/examples/acados_python/tests/test_cost_integration_value.py
@@ -60,7 +60,7 @@ def solve_ocp(cost_variant, num_stages):
 
     Tf = 1.0
     N = 20
-    ocp.dims.N = N
+    ocp.solver_options.N_horizon = N
 
     # set cost
     Q = 2 * np.diag([1e3, 1e3, 1e-2, 1e-2])

--- a/examples/acados_python/tests/test_cython_ctypes.py
+++ b/examples/acados_python/tests/test_cython_ctypes.py
@@ -58,7 +58,7 @@ def main(interface_type='ctypes'):
     Tf = 1.0
 
     # set dimensions
-    ocp.dims.N = N_horizon
+    ocp.solver_options.N_horizon = N_horizon
 
     # set cost
     Q = 2 * np.diag([1e3, 1e3, 1e-2, 1e-2])
@@ -110,7 +110,7 @@ def main(interface_type='ctypes'):
         ocp_solver = AcadosOcpSolver(ocp, json_file='acados_ocp.json')
     elif interface_type == 'cython_prebuilt':
         from c_generated_code.acados_ocp_solver_pyx import AcadosOcpSolverCython
-        ocp_solver = AcadosOcpSolverCython(ocp.model.name, ocp.solver_options.nlp_solver_type, ocp.dims.N)
+        ocp_solver = AcadosOcpSolverCython(ocp.model.name, ocp.solver_options.nlp_solver_type, ocp.solver_options.N_horizon)
 
 
     # test setting HPIPM options

--- a/examples/acados_python/tests/test_ggn_cost_integration.py
+++ b/examples/acados_python/tests/test_ggn_cost_integration.py
@@ -59,7 +59,7 @@ def solve_ocp(cost_discretization, cost_type, num_stages, collocation_type):
 
     Tf = 1.0
     N = 20
-    ocp.dims.N = N
+    ocp.solver_options.N_horizon = N
 
     Q = 2 * np.diag([1e3, 1e3, 1e-2, 1e-2, 0.1, 1e-3])
     R = 2 * np.diag([1e-2])

--- a/examples/acados_python/tests/test_nan_globalization.py
+++ b/examples/acados_python/tests/test_nan_globalization.py
@@ -60,7 +60,7 @@ def main(globalization_options: GlobalizationOptions):
     N = 20
 
     # set dimensions
-    ocp.dims.N = N
+    ocp.solver_options.N_horizon = N
 
     # set cost
     Q_mat = 2*np.diag([1e3, 1e3, 1e-2, 1e-2])

--- a/examples/acados_python/tests/test_ocp_setting.py
+++ b/examples/acados_python/tests/test_ocp_setting.py
@@ -158,7 +158,7 @@ ny_e = nx
 N = 20
 
 # set dimensions
-ocp.dims.N = N
+ocp.solver_options.N_horizon = N
 
 # set cost
 Q = 2*np.diag([1e3, 1e3, 1e-2, 1e-2])

--- a/examples/acados_python/tests/test_osqp.py
+++ b/examples/acados_python/tests/test_osqp.py
@@ -52,7 +52,7 @@ def main():
     N = 20
 
     # set dimensions
-    ocp.dims.N = N
+    ocp.solver_options.N_horizon = N
 
     # set cost
     Q = 2*np.diag([1e3, 1e3, 1e-2, 1e-2])

--- a/examples/acados_python/tests/test_parametric_nonlinear_constraint_h.py
+++ b/examples/acados_python/tests/test_parametric_nonlinear_constraint_h.py
@@ -55,7 +55,7 @@ def main():
     N = 20
 
     # set dimensions
-    ocp.dims.N = N
+    ocp.solver_options.N_horizon = N
 
     # set cost
     Q = 2*np.diag([1e3, 1e3, 1e-2, 1e-2])

--- a/examples/acados_python/time_varying/piecewiese_polynomial_control_example.py
+++ b/examples/acados_python/time_varying/piecewiese_polynomial_control_example.py
@@ -111,7 +111,7 @@ def create_ocp_solver(cost_type, N_horizon, degree_u_polynom,
     ocp: AcadosOcp
     ocp, evaluate_polynomial_u_fun = create_ocp_formulation_without_opts(cost_type, degree_u_polynom, explicit_symmetric_penalties=explicit_symmetric_penalties, penalty_type=penalty_type)
 
-    ocp.dims.N = N_horizon
+    ocp.solver_options.N_horizon = N_horizon
 
     # set options
     ocp.solver_options.qp_solver = 'PARTIAL_CONDENSING_HPIPM' # FULL_CONDENSING_QPOASES

--- a/examples/acados_python/timing_example/reset_timing.py
+++ b/examples/acados_python/timing_example/reset_timing.py
@@ -56,7 +56,7 @@ def main(cost_type='NONLINEAR_LS', hessian_approximation='EXACT', ext_cost_use_n
     ny_e = nx
     N = 20
 
-    ocp.dims.N = N
+    ocp.solver_options.N_horizon = N
 
     # set cost
     Q = 2*np.diag([1e3, 1e3, 1e-2, 1e-2])
@@ -140,7 +140,7 @@ def main(cost_type='NONLINEAR_LS', hessian_approximation='EXACT', ext_cost_use_n
         t0 = time.time()
         # ocp_solver = AcadosOcpSolver(ocp, json_file = 'acados_ocp.json', build=False, generate=False)
         from c_generated_code.acados_ocp_solver_pyx import AcadosOcpSolverCython
-        ocp_solver = AcadosOcpSolverCython(ocp.model.name, ocp.solver_options.nlp_solver_type, ocp.dims.N)
+        ocp_solver = AcadosOcpSolverCython(ocp.model.name, ocp.solver_options.nlp_solver_type, ocp.solver_options.N_horizon)
         create_time.append( time.time() - t0)
     print(f"create_time: min {np.min(create_time)*1e3:.4f} ms mean {np.mean(create_time)*1e3:.4f} ms max {np.max(create_time)*1e3:.4f} ms over {Ncreate} executions")
     # create_time: min 0.2189 ms mean 0.2586 ms max 0.6881 ms over 10000 executions

--- a/examples/acados_python/unconstrained_ocps/chen_allgoewer_unconstrained_ocp/chen_allgoewer_ocp.py
+++ b/examples/acados_python/unconstrained_ocps/chen_allgoewer_unconstrained_ocp/chen_allgoewer_ocp.py
@@ -53,7 +53,7 @@ def main(plot_solution = False):
     M = 10 # Needed for integrator
 
     # set dimensions
-    ocp.dims.N = N
+    ocp.solver_options.N_horizon = N
 
     # set cost
     Q_mat = np.array([[0.5, 0], [0, 0.5]])

--- a/examples/acados_python/unconstrained_ocps/hour_glass_p2p_motion/hour_glass_time_optimal_p2p_motion.py
+++ b/examples/acados_python/unconstrained_ocps/hour_glass_p2p_motion/hour_glass_time_optimal_p2p_motion.py
@@ -97,9 +97,6 @@ def solve_acados_ocp(solve_feasibility_problem: bool, acados_opts: AcadosOcpOpti
     N = 20
     M = 2 # Needed for integrator
 
-    # set dimensions
-    ocp.dims.N = N
-
     x0 = 0.0
     y0 = 0.0
     theta0 = np.pi/2
@@ -153,6 +150,7 @@ def solve_acados_ocp(solve_feasibility_problem: bool, acados_opts: AcadosOcpOpti
     # set solver options
     ###########################################################################
     ocp.solver_options = acados_opts
+    ocp.solver_options.N_horizon = N
 
     if SOLVE_FEASIBILITY_PROBLEM:
         ocp.translate_to_feasibility_problem()

--- a/examples/acados_python/unconstrained_ocps/linear_dynamics_qp_ocp/acados_unconstrained_QP.py
+++ b/examples/acados_python/unconstrained_ocps/linear_dynamics_qp_ocp/acados_unconstrained_QP.py
@@ -59,7 +59,7 @@ def create_acados_solver_and_solve_problem(method="SQP"):
     ocp.model = model
 
     # set dimensions
-    ocp.dims.N = N
+    ocp.solver_options.N_horizon = N
 
     # set cost
     ocp.cost.cost_type = "LINEAR_LS"

--- a/examples/acados_python/unconstrained_ocps/pendulum_point_to_point.py
+++ b/examples/acados_python/unconstrained_ocps/pendulum_point_to_point.py
@@ -50,7 +50,7 @@ def main():
     N = 20
 
     # set dimensions
-    ocp.dims.N = N
+    ocp.solver_options.N_horizon = N
 
     # set constraints
     Fmax = 80

--- a/examples/acados_python/unconstrained_ocps/rockit_hello_world/rockit_hello_world_ocp.py
+++ b/examples/acados_python/unconstrained_ocps/rockit_hello_world/rockit_hello_world_ocp.py
@@ -52,7 +52,7 @@ def main():
     N = 2
 
     # set dimensions
-    ocp.dims.N = N
+    ocp.solver_options.N_horizon = N
 
     if not SOLVE_FEASIBILITY_PROBLEM:
         # set cost

--- a/examples/acados_python/unicycle/main.py
+++ b/examples/acados_python/unicycle/main.py
@@ -21,7 +21,7 @@ def create_ocp_solver_description() -> AcadosOcp:
     nu = model.u.rows()
 
     # set dimensions
-    ocp.dims.N = N_horizon
+    ocp.solver_options.N_horizon = N_horizon
 
     # set cost
     Q_mat = 2 * np.diag([1e3, 1e3, 1e-4, 1e-3, 1e-3])  # [x,y,x_d,y_d,th,th_d]

--- a/examples/acados_python/zoRO_example/cstr/zoro_ocp_solver.py
+++ b/examples/acados_python/zoRO_example/cstr/zoro_ocp_solver.py
@@ -90,7 +90,7 @@ def setup_acados_ocp_solver(
     nu = u.shape[0]
 
     # number of shooting intervals
-    ocp.dims.N = mpc_params.N
+    ocp.solver_options.N_horizon = mpc_params.N
 
     # set prediction horizon
     ocp.solver_options.tf = mpc_params.Tf

--- a/examples/acados_python/zoRO_example/diff_drive/diff_drive_zoro_mpc.py
+++ b/examples/acados_python/zoRO_example/diff_drive/diff_drive_zoro_mpc.py
@@ -46,7 +46,7 @@ class ZoroMPCSolver:
         self.ocp.model = self.model
 
         # set prediction horizon
-        self.ocp.dims.N = cfg.n_hrzn
+        self.ocp.solver_options.N_horizon = cfg.n_hrzn
         self.ocp.solver_options.tf = cfg.n_hrzn * cfg.delta_t
 
         # set stage cost = ||u(k)-u_r(k)||_R^2 + ||x(k)-x_r(k)||_Q^2

--- a/examples/acados_python/zoRO_example/pendulum_on_cart/minimal_example_zoro.py
+++ b/examples/acados_python/zoRO_example/pendulum_on_cart/minimal_example_zoro.py
@@ -57,7 +57,7 @@ def main():
     N = 20
 
     # set dimensions
-    ocp.dims.N = N
+    ocp.solver_options.N_horizon = N
 
     # set cost
     Q = 2 * np.diag([1e3, 1e3, 1e-2, 1e-2])

--- a/interfaces/acados_matlab_octave/AcadosOcpOptions.m
+++ b/interfaces/acados_matlab_octave/AcadosOcpOptions.m
@@ -34,6 +34,8 @@ classdef AcadosOcpOptions < handle
         hessian_approx         %  hessian approximation
         integrator_type        %  integrator type
         tf                     %  prediction horizon
+        N_horizon
+
         nlp_solver_type        %  NLP solver
         nlp_solver_step_length
         nlp_solver_tol_stat
@@ -112,6 +114,7 @@ classdef AcadosOcpOptions < handle
             obj.hessian_approx = 'GAUSS_NEWTON';
             obj.integrator_type = 'ERK';
             obj.tf = [];
+            obj.N_horizon = [];
             obj.nlp_solver_type = 'SQP_RTI';
             obj.nlp_solver_step_length = 1.0;
             obj.nlp_solver_tol_stat = 1e-6;

--- a/interfaces/acados_matlab_octave/AcadosOcpSolver.m
+++ b/interfaces/acados_matlab_octave/AcadosOcpSolver.m
@@ -114,8 +114,8 @@ classdef AcadosOcpSolver < handle
                     value = [R, S; S', Q];
                     return;
                 else
-                    value = cell(obj.ocp.dims.N, 1);
-                    for n=0:obj.ocp.dims.N
+                    value = cell(obj.ocp.solver_options.N_horizon, 1);
+                    for n=0:obj.ocp.solver_options.N_horizon
                         Q = obj.get('qp_Q', n);
                         R = obj.get('qp_R', n);
                         S = obj.get('qp_S', n);
@@ -172,12 +172,12 @@ classdef AcadosOcpSolver < handle
             % condition_number: condition number for each Hessian block.
 
             result = struct();
-            result.min_ev = zeros(obj.ocp.dims.N+1, 1);
-            result.max_ev = zeros(obj.ocp.dims.N+1, 1);
-            result.condition_number = zeros(obj.ocp.dims.N+1, 1);
+            result.min_ev = zeros(obj.ocp.solver_options.N_horizon+1, 1);
+            result.max_ev = zeros(obj.ocp.solver_options.N_horizon+1, 1);
+            result.condition_number = zeros(obj.ocp.solver_options.N_horizon+1, 1);
 
-            for n=0:obj.ocp.dims.N
-                if n < obj.ocp.dims.N
+            for n=0:obj.ocp.solver_options.N_horizon
+                if n < obj.ocp.solver_options.N_horizon
                     Q = obj.get('qp_Q', n);
                     R = obj.get('qp_R', n);
                     S = obj.get('qp_S', n);
@@ -197,12 +197,12 @@ classdef AcadosOcpSolver < handle
         function dump_last_qp_to_json(obj, filename)
             qp_data = struct();
 
-            lN = length(num2str(obj.ocp.dims.N+1));
+            lN = length(num2str(obj.ocp.solver_options.N_horizon+1));
             n_fields = length(obj.qp_gettable_fields);
             for n=1:n_fields
 
                 field = obj.qp_gettable_fields{n};
-                for i=0:obj.ocp.dims.N-1
+                for i=0:obj.ocp.solver_options.N_horizon-1
                     s_indx = sprintf(strcat('%0', num2str(lN), 'd'), i);
                     key = strcat(field, '_', s_indx);
                     val = obj.get(field, i);
@@ -210,9 +210,9 @@ classdef AcadosOcpSolver < handle
                 end
 
                 if strcmp(field, 'qp_Q') || strcmp(field, 'qp_q')
-                    s_indx = sprintf(strcat('%0', num2str(lN), 'd'), obj.ocp.dims.N);
+                    s_indx = sprintf(strcat('%0', num2str(lN), 'd'), obj.ocp.solver_options.N_horizon);
                     key = strcat(field, '_', s_indx);
-                    val = obj.get(field, obj.ocp.dims.N);
+                    val = obj.get(field, obj.ocp.solver_options.N_horizon);
                     qp_data = setfield(qp_data, key, val);
                 end
             end

--- a/interfaces/acados_matlab_octave/setup_AcadosOcp_from_legacy_ocp_description.m
+++ b/interfaces/acados_matlab_octave/setup_AcadosOcp_from_legacy_ocp_description.m
@@ -43,7 +43,7 @@ function ocp = setup_AcadosOcp_from_legacy_ocp_description(model_old, opts_old, 
     ocp.simulink_opts = simulink_opts;
 
     % general
-    ocp.dims.N = opts_struct.param_scheme_N;
+    ocp.solver_options.N_horizon = opts_struct.param_scheme_N;
     ocp.solver_options.tf = model.T;
 
     ocp.model.name = model.name;

--- a/interfaces/acados_template/acados_template/acados_dims.py
+++ b/interfaces/acados_template/acados_template/acados_dims.py
@@ -366,7 +366,10 @@ class AcadosOcpDims:
 
     @property
     def N(self):
-        """:math:`N` - prediction horizon.
+        """
+        :math:`N` - Number of shooting intervals.
+        DEPRECATED: use ocp.solver_options.N instead.
+
         Type: int; default: None"""
         return self.__N
 

--- a/interfaces/acados_template/acados_template/acados_multiphase_ocp.py
+++ b/interfaces/acados_template/acados_template/acados_multiphase_ocp.py
@@ -228,6 +228,7 @@ class AcadosMultiphaseOcp:
     def make_consistent(self) -> None:
 
         self.N_horizon = sum(self.N_list)
+        self.solver_options.N_horizon = self.N_horizon # NOTE: to not change options when making ocp consistent
 
         # check options
         self.mocp_opts.make_consistent(self.solver_options, n_phases=self.n_phases)
@@ -262,7 +263,6 @@ class AcadosMultiphaseOcp:
         for i in range(self.n_phases):
             ocp = AcadosOcp()
             ocp.dims = self.phases_dims[i]
-            ocp.dims.N = self.N_horizon # NOTE: to not change options when making ocp consistent
             ocp.model = self.model[i]
             ocp.constraints = self.constraints[i]
             ocp.cost = self.cost[i]

--- a/interfaces/acados_template/acados_template/acados_ocp_options.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_options.py
@@ -45,6 +45,7 @@ class AcadosOcpOptions:
         self.__hessian_approx = 'GAUSS_NEWTON'
         self.__integrator_type = 'ERK'
         self.__tf = None
+        self.__N_horizon = None
         self.__nlp_solver_type = 'SQP_RTI'
         self.__nlp_solver_step_length = 1.0
         self.__nlp_solver_tol_stat = 1e-6
@@ -792,6 +793,15 @@ class AcadosOcpOptions:
         return self.__tf
 
     @property
+    def N_horizon(self):
+        """
+        Number of shooting nodes
+        Type: int > 0
+        Default: :code:`None`
+        """
+        return self.__N_horizon
+
+    @property
     def Tsim(self):
         """
         Time horizon for one integrator step. Automatically calculated as :py:attr:`tf`/:py:attr:`N`.
@@ -1016,6 +1026,13 @@ class AcadosOcpOptions:
     @tf.setter
     def tf(self, tf):
         self.__tf = tf
+
+    @N_horizon.setter
+    def N_horizon(self, N_horizon):
+        if isinstance(N_horizon, int) and N_horizon > 0:
+            self.__N_horizon = N_horizon
+        else:
+            raise Exception('Invalid N_horizon value, expected positive integer.')
 
     @time_steps.setter
     def time_steps(self, time_steps):

--- a/interfaces/acados_template/acados_template/acados_ocp_options.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_options.py
@@ -795,7 +795,7 @@ class AcadosOcpOptions:
     @property
     def N_horizon(self):
         """
-        Number of shooting nodes
+        Number of shooting intervals.
         Type: int > 0
         Default: :code:`None`
         """
@@ -804,7 +804,7 @@ class AcadosOcpOptions:
     @property
     def Tsim(self):
         """
-        Time horizon for one integrator step. Automatically calculated as :py:attr:`tf`/:py:attr:`N`.
+        Time horizon for one integrator step. Automatically calculated as first time step if not provided.
         Default: :code:`None`
         """
         return self.__Tsim

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -594,7 +594,7 @@ class AcadosOcpSolver:
         sens_x = []
         sens_u = []
 
-        N = self.acados_ocp.dims.N
+        N = self.acados_ocp.solver_options.N_horizon
 
         for s in stages_:
             if not isinstance(s, int) or s < 0 or s > N:
@@ -1407,7 +1407,7 @@ class AcadosOcpSolver:
         if field_ not in self.__qp_dynamics_fields + self.__qp_cost_fields + self.__qp_constraint_fields + self.__qp_pc_hpipm_fields + self.__qp_pc_fields:
             raise Exception(f"field {field_} not supported.")
         if field_ in self.__qp_pc_hpipm_fields:
-            if self.acados_ocp.solver_options.qp_solver != "PARTIAL_CONDENSING_HPIPM" or self.acados_ocp.solver_options.qp_solver_cond_N != self.acados_ocp.dims.N:
+            if self.acados_ocp.solver_options.qp_solver != "PARTIAL_CONDENSING_HPIPM" or self.acados_ocp.solver_options.qp_solver_cond_N != self.acados_ocp.solver_options.N_horizon:
                 raise Exception(f"field {field_} only works for PARTIAL_CONDENSING_HPIPM QP solver with qp_solver_cond_N == N.")
             if field_ in ["P", "K", "p"] and stage_ == 0 and self.acados_ocp.dims.nbxe_0 > 0:
                 raise Exception(f"getting field {field_} at stage 0 only works without x0 elimination (see nbxe_0).")

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_sim_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_sim_solver.in.c
@@ -86,7 +86,6 @@ int {{ model.name }}_acados_sim_create({{ model.name }}_sim_solver_capsule * cap
     const int np = {{ model.name | upper }}_NP;
     bool tmp_bool;
 
-    {#// double Tsim = {{ solver_options.tf / dims.N }};#}
     double Tsim = {{ solver_options.Tsim }};
 
     {% if solver_options.integrator_type == "IRK" %}

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -844,7 +844,7 @@ void {{ model.name }}_acados_setup_nlp_in({{ model.name }}_solver_capsule* capsu
     // set up time_steps
     {%- set all_equal = true -%}
     {%- set val = solver_options.time_steps[0] %}
-    {%- for j in range(start=1, end=dims.N) %}
+    {%- for j in range(start=1, end=solver_options.N_horizon) %}
         {%- if val != solver_options.time_steps[j] %}
             {%- set_global all_equal = false %}
             {%- break %}
@@ -866,7 +866,7 @@ void {{ model.name }}_acados_setup_nlp_in({{ model.name }}_solver_capsule* capsu
         }
     {%- else -%}{# time_steps are varying #}
         double* time_steps = malloc(N*sizeof(double));
-        {%- for j in range(end=dims.N) %}
+        {%- for j in range(end=solver_options.N_horizon) %}
         time_steps[{{ j }}] = {{ solver_options.time_steps[j] }};
         {%- endfor %}
         {{ model.name }}_acados_update_time_steps(capsule, N, time_steps);
@@ -2102,7 +2102,7 @@ static void {{ model.name }}_acados_create_set_opts({{ model.name }}_solver_caps
     // set up sim_method_num_steps
     {%- set all_equal = true %}
     {%- set val = solver_options.sim_method_num_steps[0] %}
-    {%- for j in range(start=1, end=dims.N) %}
+    {%- for j in range(start=1, end=solver_options.N_horizon) %}
         {%- if val != solver_options.sim_method_num_steps[j] %}
             {%- set_global all_equal = false %}
             {%- break %}
@@ -2117,7 +2117,7 @@ static void {{ model.name }}_acados_create_set_opts({{ model.name }}_solver_caps
     {%- else %}
     // sim_method_num_steps are different
     int* sim_method_num_steps = malloc(N*sizeof(int));
-    {%- for j in range(end=dims.N) %}
+    {%- for j in range(end=solver_options.N_horizon) %}
     sim_method_num_steps[{{ j }}] = {{ solver_options.sim_method_num_steps[j] }};
     {%- endfor %}
 
@@ -2129,7 +2129,7 @@ static void {{ model.name }}_acados_create_set_opts({{ model.name }}_solver_caps
     // set up sim_method_num_stages
     {%- set all_equal = true %}
     {%- set val = solver_options.sim_method_num_stages[0] %}
-    {%- for j in range(start=1, end=dims.N) %}
+    {%- for j in range(start=1, end=solver_options.N_horizon) %}
         {%- if val != solver_options.sim_method_num_stages[j] %}
             {%- set_global all_equal = false %}
             {%- break %}
@@ -2143,7 +2143,7 @@ static void {{ model.name }}_acados_create_set_opts({{ model.name }}_solver_caps
         ocp_nlp_solver_opts_set_at_stage(nlp_config, nlp_opts, i, "dynamics_num_stages", &sim_method_num_stages);
   {%- else %}
     int* sim_method_num_stages = malloc(N*sizeof(int));
-    {%- for j in range(end=dims.N) %}
+    {%- for j in range(end=solver_options.N_horizon) %}
     sim_method_num_stages[{{ j }}] = {{ solver_options.sim_method_num_stages[j] }};
     {%- endfor %}
 
@@ -2159,7 +2159,7 @@ static void {{ model.name }}_acados_create_set_opts({{ model.name }}_solver_caps
     // set up sim_method_jac_reuse
     {%- set all_equal = true %}
     {%- set val = solver_options.sim_method_jac_reuse[0] %}
-    {%- for j in range(start=1, end=dims.N) %}
+    {%- for j in range(start=1, end=solver_options.N_horizon) %}
         {%- if val != solver_options.sim_method_jac_reuse[j] %}
             {%- set_global all_equal = false %}
             {%- break %}
@@ -2171,7 +2171,7 @@ static void {{ model.name }}_acados_create_set_opts({{ model.name }}_solver_caps
         ocp_nlp_solver_opts_set_at_stage(nlp_config, nlp_opts, i, "dynamics_jac_reuse", &tmp_bool);
   {%- else %}
     bool* sim_method_jac_reuse = malloc(N*sizeof(bool));
-    {%- for j in range(end=dims.N) %}
+    {%- for j in range(end=solver_options.N_horizon) %}
     sim_method_jac_reuse[{{ j }}] = (bool){{ solver_options.sim_method_jac_reuse[j] }};
     {%- endfor %}
 

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.h
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.h
@@ -63,7 +63,7 @@
 #define {{ model.name | upper }}_NY0    {{ dims.ny_0 }}
 #define {{ model.name | upper }}_NY     {{ dims.ny }}
 #define {{ model.name | upper }}_NYN    {{ dims.ny_e }}
-#define {{ model.name | upper }}_N      {{ dims.N }}
+#define {{ model.name | upper }}_N      {{ solver_options.N_horizon }}
 #define {{ model.name | upper }}_NH     {{ dims.nh }}
 #define {{ model.name | upper }}_NHN    {{ dims.nh_e }}
 #define {{ model.name | upper }}_NH0    {{ dims.nh_0 }}

--- a/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_solver_sfun.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_solver_sfun.in.c
@@ -96,28 +96,28 @@ static void mdlInitializeSizes (SimStruct *S)
   {%- if dims.ny_0 > 0 and simulink_opts.inputs.y_ref_0 -%}  {#- y_ref_0 -#}
     {%- set n_inputs = n_inputs + 1 -%}
   {%- endif -%}
-  {%- if dims.ny > 0 and dims.N > 1 and simulink_opts.inputs.y_ref -%}  {#- y_ref -#}
+  {%- if dims.ny > 0 and solver_options.N_horizon > 1 and simulink_opts.inputs.y_ref -%}  {#- y_ref -#}
     {%- set n_inputs = n_inputs + 1 -%}
   {%- endif -%}
-  {%- if dims.ny_e > 0 and dims.N > 0 and simulink_opts.inputs.y_ref_e -%}  {#- y_ref_e #}
+  {%- if dims.ny_e > 0 and solver_options.N_horizon > 0 and simulink_opts.inputs.y_ref_e -%}  {#- y_ref_e #}
     {%- set n_inputs = n_inputs + 1 -%}
   {%- endif -%}
-  {%- if dims.nbx > 0 and dims.N > 1 and simulink_opts.inputs.lbx -%}  {#- lbx #}
+  {%- if dims.nbx > 0 and solver_options.N_horizon > 1 and simulink_opts.inputs.lbx -%}  {#- lbx #}
     {%- set n_inputs = n_inputs + 1 -%}
   {%- endif -%}
-  {%- if dims.nbx > 0 and dims.N > 1 and simulink_opts.inputs.ubx -%}  {#- ubx #}
+  {%- if dims.nbx > 0 and solver_options.N_horizon > 1 and simulink_opts.inputs.ubx -%}  {#- ubx #}
     {%- set n_inputs = n_inputs + 1 -%}
   {%- endif -%}
-  {%- if dims.nbx_e > 0 and dims.N > 0 and simulink_opts.inputs.lbx_e -%}  {#- lbx_e #}
+  {%- if dims.nbx_e > 0 and solver_options.N_horizon > 0 and simulink_opts.inputs.lbx_e -%}  {#- lbx_e #}
     {%- set n_inputs = n_inputs + 1 -%}
   {%- endif -%}
-  {%- if dims.nbx_e > 0 and dims.N > 0 and simulink_opts.inputs.ubx_e -%}  {#- ubx_e #}
+  {%- if dims.nbx_e > 0 and solver_options.N_horizon > 0 and simulink_opts.inputs.ubx_e -%}  {#- ubx_e #}
     {%- set n_inputs = n_inputs + 1 -%}
   {%- endif -%}
-  {%- if dims.nbu > 0 and dims.N > 0 and simulink_opts.inputs.lbu -%}  {#- lbu #}
+  {%- if dims.nbu > 0 and solver_options.N_horizon > 0 and simulink_opts.inputs.lbu -%}  {#- lbu #}
     {%- set n_inputs = n_inputs + 1 -%}
   {%- endif -%}
-  {%- if dims.nbu > 0 and dims.N > 0 and simulink_opts.inputs.ubu -%}  {#- ubu #}
+  {%- if dims.nbu > 0 and solver_options.N_horizon > 0 and simulink_opts.inputs.ubu -%}  {#- ubu #}
     {%- set n_inputs = n_inputs + 1 -%}
   {%- endif -%}
   {%- if dims.ng > 0 and simulink_opts.inputs.lg -%}  {#- lg #}
@@ -230,72 +230,72 @@ static void mdlInitializeSizes (SimStruct *S)
     ssSetInputPortVectorDimension(S, {{ i_input }}, {{ dims.ny_0 }});
   {%- endif %}
 
-  {%- if dims.ny > 0 and dims.N > 1 and simulink_opts.inputs.y_ref %}
+  {%- if dims.ny > 0 and solver_options.N_horizon > 1 and simulink_opts.inputs.y_ref %}
     {%- set i_input = i_input + 1 %}
     // y_ref
-    ssSetInputPortVectorDimension(S, {{ i_input }}, {{ (dims.N-1) * dims.ny }});
+    ssSetInputPortVectorDimension(S, {{ i_input }}, {{ (solver_options.N_horizon-1) * dims.ny }});
   {%- endif %}
 
-  {%- if dims.ny_e > 0 and dims.N > 0 and simulink_opts.inputs.y_ref_e %}
+  {%- if dims.ny_e > 0 and solver_options.N_horizon > 0 and simulink_opts.inputs.y_ref_e %}
     {%- set i_input = i_input + 1 %}
     // y_ref_e
     ssSetInputPortVectorDimension(S, {{ i_input }}, {{ dims.ny_e }});
   {%- endif %}
 
-  {%- if dims.nbx > 0 and dims.N > 1 and simulink_opts.inputs.lbx -%}  {#- lbx #}
+  {%- if dims.nbx > 0 and solver_options.N_horizon > 1 and simulink_opts.inputs.lbx -%}  {#- lbx #}
     {%- set i_input = i_input + 1 %}
     // lbx
-    ssSetInputPortVectorDimension(S, {{ i_input }}, {{ (dims.N-1) * dims.nbx }});
+    ssSetInputPortVectorDimension(S, {{ i_input }}, {{ (solver_options.N_horizon-1) * dims.nbx }});
   {%- endif %}
-  {%- if dims.nbx > 0 and dims.N > 1 and simulink_opts.inputs.ubx -%}  {#- ubx #}
+  {%- if dims.nbx > 0 and solver_options.N_horizon > 1 and simulink_opts.inputs.ubx -%}  {#- ubx #}
     {%- set i_input = i_input + 1 %}
     // ubx
-    ssSetInputPortVectorDimension(S, {{ i_input }}, {{ (dims.N-1) * dims.nbx }});
+    ssSetInputPortVectorDimension(S, {{ i_input }}, {{ (solver_options.N_horizon-1) * dims.nbx }});
   {%- endif %}
 
-  {%- if dims.nbx_e > 0 and dims.N > 0 and simulink_opts.inputs.lbx_e -%}  {#- lbx_e #}
+  {%- if dims.nbx_e > 0 and solver_options.N_horizon > 0 and simulink_opts.inputs.lbx_e -%}  {#- lbx_e #}
     {%- set i_input = i_input + 1 %}
     // lbx_e
     ssSetInputPortVectorDimension(S, {{ i_input }}, {{ dims.nbx_e }});
   {%- endif %}
-  {%- if dims.nbx_e > 0 and dims.N > 0 and simulink_opts.inputs.ubx_e -%}  {#- ubx_e #}
+  {%- if dims.nbx_e > 0 and solver_options.N_horizon > 0 and simulink_opts.inputs.ubx_e -%}  {#- ubx_e #}
     {%- set i_input = i_input + 1 %}
     // ubx_e
     ssSetInputPortVectorDimension(S, {{ i_input }}, {{ dims.nbx_e }});
   {%- endif %}
 
-  {%- if dims.nbu > 0 and dims.N > 0 and simulink_opts.inputs.lbu -%}  {#- lbu #}
+  {%- if dims.nbu > 0 and solver_options.N_horizon > 0 and simulink_opts.inputs.lbu -%}  {#- lbu #}
     {%- set i_input = i_input + 1 %}
     // lbu
-    ssSetInputPortVectorDimension(S, {{ i_input }}, {{ dims.N*dims.nbu }});
+    ssSetInputPortVectorDimension(S, {{ i_input }}, {{ solver_options.N_horizon*dims.nbu }});
   {%- endif -%}
-  {%- if dims.nbu > 0 and dims.N > 0 and simulink_opts.inputs.ubu -%}  {#- ubu #}
+  {%- if dims.nbu > 0 and solver_options.N_horizon > 0 and simulink_opts.inputs.ubu -%}  {#- ubu #}
     {%- set i_input = i_input + 1 %}
     // ubu
-    ssSetInputPortVectorDimension(S, {{ i_input }}, {{ dims.N*dims.nbu }});
+    ssSetInputPortVectorDimension(S, {{ i_input }}, {{ solver_options.N_horizon*dims.nbu }});
   {%- endif -%}
 
 
   {%- if dims.ng > 0 and simulink_opts.inputs.lg -%}  {#- lg #}
     {%- set i_input = i_input + 1 %}
     // lg
-    ssSetInputPortVectorDimension(S, {{ i_input }}, {{ dims.N*dims.ng }});
+    ssSetInputPortVectorDimension(S, {{ i_input }}, {{ solver_options.N_horizon*dims.ng }});
   {%- endif -%}
   {%- if dims.ng > 0 and simulink_opts.inputs.ug -%}  {#- ug #}
     {%- set i_input = i_input + 1 %}
     // ug
-    ssSetInputPortVectorDimension(S, {{ i_input }}, {{ dims.N*dims.ng }});
+    ssSetInputPortVectorDimension(S, {{ i_input }}, {{ solver_options.N_horizon*dims.ng }});
   {%- endif -%}
 
   {%- if dims.nh > 0 and simulink_opts.inputs.lh -%}  {#- lh #}
     {%- set i_input = i_input + 1 %}
     // lh
-    ssSetInputPortVectorDimension(S, {{ i_input }}, {{ dims.N*dims.nh }});
+    ssSetInputPortVectorDimension(S, {{ i_input }}, {{ solver_options.N_horizon*dims.nh }});
   {%- endif -%}
   {%- if dims.nh > 0 and simulink_opts.inputs.uh -%}  {#- uh #}
     {%- set i_input = i_input + 1 %}
     // uh
-    ssSetInputPortVectorDimension(S, {{ i_input }}, {{ dims.N*dims.nh }});
+    ssSetInputPortVectorDimension(S, {{ i_input }}, {{ solver_options.N_horizon*dims.nh }});
   {%- endif -%}
 
 {%- if dims.nh_0 > 0 and simulink_opts.inputs.lh_0 -%}  {#- lh_0 #}
@@ -353,19 +353,19 @@ static void mdlInitializeSizes (SimStruct *S)
   {%- if simulink_opts.inputs.x_init -%}  {#- x_init #}
     {%- set i_input = i_input + 1 %}
     // x_init
-    ssSetInputPortVectorDimension(S, {{ i_input }}, {{ dims.nx * (dims.N+1) }});
+    ssSetInputPortVectorDimension(S, {{ i_input }}, {{ dims.nx * (solver_options.N_horizon+1) }});
   {%- endif -%}
 
   {%- if simulink_opts.inputs.u_init -%}  {#- u_init #}
     {%- set i_input = i_input + 1 %}
     // u_init
-    ssSetInputPortVectorDimension(S, {{ i_input }}, {{ dims.nu * (dims.N) }});
+    ssSetInputPortVectorDimension(S, {{ i_input }}, {{ dims.nu * (solver_options.N_horizon) }});
   {%- endif -%}
 
   {%- if simulink_opts.inputs.pi_init -%}  {#- pi_init #}
     {%- set i_input = i_input + 1 %}
     // pi_init
-    ssSetInputPortVectorDimension(S, {{ i_input }}, {{ dims.nx * (dims.N) }});
+    ssSetInputPortVectorDimension(S, {{ i_input }}, {{ dims.nx * (solver_options.N_horizon) }});
   {%- endif -%}
 
   {%- if simulink_opts.inputs.rti_phase -%}  {#- rti_phase #}
@@ -402,22 +402,22 @@ static void mdlInitializeSizes (SimStruct *S)
 
   {%- if simulink_opts.outputs.utraj == 1 %}
     {%- set i_output = i_output + 1 %}
-    ssSetOutputPortVectorDimension(S, {{ i_output }}, {{ dims.nu * dims.N }} );
+    ssSetOutputPortVectorDimension(S, {{ i_output }}, {{ dims.nu * solver_options.N_horizon }} );
   {%- endif %}
 
   {%- if simulink_opts.outputs.xtraj == 1 %}
     {%- set i_output = i_output + 1 %}
-    ssSetOutputPortVectorDimension(S, {{ i_output }}, {{ dims.nx * (dims.N+1) }} );
+    ssSetOutputPortVectorDimension(S, {{ i_output }}, {{ dims.nx * (solver_options.N_horizon+1) }} );
   {%- endif %}
 
   {%- if simulink_opts.outputs.ztraj == 1 %}
     {%- set i_output = i_output + 1 %}
-    ssSetOutputPortVectorDimension(S, {{ i_output }}, {{ dims.nz * dims.N }} );
+    ssSetOutputPortVectorDimension(S, {{ i_output }}, {{ dims.nz * solver_options.N_horizon }} );
   {%- endif %}
 
   {%- if simulink_opts.outputs.pi_all == 1 %}
     {%- set i_output = i_output + 1 %}
-    ssSetOutputPortVectorDimension(S, {{ i_output }}, {{ dims.nx * dims.N }} );
+    ssSetOutputPortVectorDimension(S, {{ i_output }}, {{ dims.nx * solver_options.N_horizon }} );
   {%- endif %}
 
   {%- if simulink_opts.outputs.solver_status == 1 %}
@@ -440,7 +440,7 @@ static void mdlInitializeSizes (SimStruct *S)
     ssSetOutputPortVectorDimension(S, {{ i_output }}, 4 );
   {%- endif %}
 
-  {%- if dims.N > 0 and simulink_opts.outputs.x1 == 1 %}
+  {%- if solver_options.N_horizon > 0 and simulink_opts.outputs.x1 == 1 %}
     {%- set i_output = i_output + 1 %}
     ssSetOutputPortVectorDimension(S, {{ i_output }}, {{ dims.nx }} ); // state at shooting node 1
   {%- endif %}
@@ -471,7 +471,7 @@ static void mdlInitializeSizes (SimStruct *S)
   {%- endif %}
   {%- if simulink_opts.outputs.parameter_traj -%}  {#- parameter_traj #}
     {%- set i_output = i_output + 1 %}
-    ssSetOutputPortVectorDimension(S, {{ i_output }}, {{ dims.np * (dims.N + 1) }});
+    ssSetOutputPortVectorDimension(S, {{ i_output }}, {{ dims.np * (solver_options.N_horizon + 1) }});
   {%- endif -%}
 
     // specify the direct feedthrough status
@@ -538,10 +538,10 @@ static void mdlOutputs(SimStruct *S, int_T tid)
   {%- if dims.ny_0 > 0 and simulink_opts.inputs.y_ref_0 %}  {# y_ref_0 #}
     {%- set buffer_sizes = buffer_sizes | concat(with=(dims.ny_0)) %}
   {%- endif %}
-  {%- if dims.ny > 0 and dims.N > 1 and simulink_opts.inputs.y_ref %}  {# y_ref #}
+  {%- if dims.ny > 0 and solver_options.N_horizon > 1 and simulink_opts.inputs.y_ref %}  {# y_ref #}
     {%- set buffer_sizes = buffer_sizes | concat(with=(dims.ny)) %}
   {%- endif %}
-  {%- if dims.ny_e > 0 and dims.N > 0 and simulink_opts.inputs.y_ref_e %}  {# y_ref_e #}
+  {%- if dims.ny_e > 0 and solver_options.N_horizon > 0 and simulink_opts.inputs.y_ref_e %}  {# y_ref_e #}
     {%- set buffer_sizes = buffer_sizes | concat(with=(dims.ny_e)) %}
   {%- endif %}
 
@@ -607,7 +607,7 @@ static void mdlOutputs(SimStruct *S, int_T tid)
     ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, 0, "yref", (void *) buffer);
   {%- endif %}
 
-  {% if dims.ny > 0 and dims.N > 1 and simulink_opts.inputs.y_ref %}
+  {% if dims.ny > 0 and solver_options.N_horizon > 1 and simulink_opts.inputs.y_ref %}
     // y_ref - for stages 1 to N-1
     {%- set i_input = i_input + 1 %}
     in_sign = ssGetInputPortRealSignalPtrs(S, {{ i_input }});
@@ -620,7 +620,7 @@ static void mdlOutputs(SimStruct *S, int_T tid)
     }
   {%- endif %}
 
-  {% if dims.ny_e > 0 and dims.N > 0 and simulink_opts.inputs.y_ref_e %}
+  {% if dims.ny_e > 0 and solver_options.N_horizon > 0 and simulink_opts.inputs.y_ref_e %}
     // y_ref_e
     {%- set i_input = i_input + 1 %}
     in_sign = ssGetInputPortRealSignalPtrs(S, {{ i_input }});
@@ -631,7 +631,7 @@ static void mdlOutputs(SimStruct *S, int_T tid)
     ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, N, "yref", (void *) buffer);
   {%- endif %}
 
-  {%- if dims.nbx > 0 and dims.N > 1 and simulink_opts.inputs.lbx -%}  {#- lbx #}
+  {%- if dims.nbx > 0 and solver_options.N_horizon > 1 and simulink_opts.inputs.lbx -%}  {#- lbx #}
     // lbx
     {%- set i_input = i_input + 1 %}
     in_sign = ssGetInputPortRealSignalPtrs(S, {{ i_input }});
@@ -642,7 +642,7 @@ static void mdlOutputs(SimStruct *S, int_T tid)
         ocp_nlp_constraints_model_set(nlp_config, nlp_dims, nlp_in, ii, "lbx", (void *) buffer);
     }
   {%- endif %}
-  {%- if dims.nbx > 0 and dims.N > 1 and simulink_opts.inputs.ubx -%}  {#- ubx #}
+  {%- if dims.nbx > 0 and solver_options.N_horizon > 1 and simulink_opts.inputs.ubx -%}  {#- ubx #}
     // ubx
     {%- set i_input = i_input + 1 %}
     in_sign = ssGetInputPortRealSignalPtrs(S, {{ i_input }});
@@ -655,7 +655,7 @@ static void mdlOutputs(SimStruct *S, int_T tid)
   {%- endif %}
 
 
-  {%- if dims.nbx_e > 0 and dims.N > 0 and simulink_opts.inputs.lbx_e -%}  {#- lbx_e #}
+  {%- if dims.nbx_e > 0 and solver_options.N_horizon > 0 and simulink_opts.inputs.lbx_e -%}  {#- lbx_e #}
     // lbx_e
     {%- set i_input = i_input + 1 %}
     in_sign = ssGetInputPortRealSignalPtrs(S, {{ i_input }});
@@ -664,7 +664,7 @@ static void mdlOutputs(SimStruct *S, int_T tid)
         buffer[i] = (double)(*in_sign[i]);
     ocp_nlp_constraints_model_set(nlp_config, nlp_dims, nlp_in, N, "lbx", buffer);
   {%- endif %}
-  {%- if dims.nbx_e > 0 and dims.N > 0 and simulink_opts.inputs.ubx_e -%}  {#- ubx_e #}
+  {%- if dims.nbx_e > 0 and solver_options.N_horizon > 0 and simulink_opts.inputs.ubx_e -%}  {#- ubx_e #}
     // ubx_e
     {%- set i_input = i_input + 1 %}
     in_sign = ssGetInputPortRealSignalPtrs(S, {{ i_input }});
@@ -675,7 +675,7 @@ static void mdlOutputs(SimStruct *S, int_T tid)
   {%- endif %}
 
 
-  {%- if dims.nbu > 0 and dims.N > 0 and simulink_opts.inputs.lbu -%}  {#- lbu #}
+  {%- if dims.nbu > 0 and solver_options.N_horizon > 0 and simulink_opts.inputs.lbu -%}  {#- lbu #}
     // lbu
     {%- set i_input = i_input + 1 %}
     in_sign = ssGetInputPortRealSignalPtrs(S, {{ i_input }});
@@ -686,7 +686,7 @@ static void mdlOutputs(SimStruct *S, int_T tid)
         ocp_nlp_constraints_model_set(nlp_config, nlp_dims, nlp_in, ii, "lbu", (void *) buffer);
     }
   {%- endif -%}
-  {%- if dims.nbu > 0 and dims.N > 0 and simulink_opts.inputs.ubu -%}  {#- ubu #}
+  {%- if dims.nbu > 0 and solver_options.N_horizon > 0 and simulink_opts.inputs.ubu -%}  {#- ubu #}
     // ubu
     {%- set i_input = i_input + 1 %}
     in_sign = ssGetInputPortRealSignalPtrs(S, {{ i_input }});
@@ -839,7 +839,7 @@ static void mdlOutputs(SimStruct *S, int_T tid)
         // x_init
         {%- set i_input = i_input + 1 %}
         in_sign = ssGetInputPortRealSignalPtrs(S, {{ i_input }});
-        for (int ii = 0; ii < {{ dims.N + 1 }}; ii++)
+        for (int ii = 0; ii < {{ solver_options.N_horizon + 1 }}; ii++)
         {
             for (int jj = 0; jj < {{ dims.nx }}; jj++)
                 buffer[jj] = (double)(*in_sign[(ii)*{{ dims.nx }}+jj]);
@@ -991,7 +991,7 @@ static void mdlOutputs(SimStruct *S, int_T tid)
     {%- set i_output = i_output + 1 %}
 
     out_xtraj = ssGetOutputPortRealSignal(S, {{ i_output }});
-    for (int ii = 0; ii < {{ dims.N + 1 }}; ii++)
+    for (int ii = 0; ii < {{ solver_options.N_horizon + 1 }}; ii++)
         ocp_nlp_out_get(nlp_config, nlp_dims, nlp_out, ii,
                         "x", (void *) (out_xtraj + ii * {{ dims.nx }}));
   {%- endif %}
@@ -1047,7 +1047,7 @@ static void mdlOutputs(SimStruct *S, int_T tid)
     ocp_nlp_get(nlp_config, capsule->nlp_solver, "res_comp", (void *) &out_KKT_residuals[3]);
   {%- endif %}
 
-  {%- if dims.N > 0 and simulink_opts.outputs.x1 == 1 %}
+  {%- if solver_options.N_horizon > 0 and simulink_opts.outputs.x1 == 1 %}
     {%- set i_output = i_output + 1 %}
     out_x1 = ssGetOutputPortRealSignal(S, {{ i_output }});
     ocp_nlp_out_get(nlp_config, nlp_dims, nlp_out, 1, "x", (void *) out_x1);

--- a/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/make_sfun.in.m
+++ b/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/make_sfun.in.m
@@ -217,8 +217,8 @@ i_in = i_in + 1;
 
 {%- if dims.np > 0 and simulink_opts.inputs.parameter_traj -%}  {#- parameter_traj #}
 input_note = strcat(input_note, num2str(i_in), ') parameters - concatenated for all shooting nodes 0 to N,',...
-                    ' size [{{ (dims.N+1)*dims.np }}]\n ');
-sfun_input_names = [sfun_input_names; 'parameter_traj [{{ (dims.N+1)*dims.np }}]'];
+                    ' size [{{ (solver_options.N_horizon+1)*dims.np }}]\n ');
+sfun_input_names = [sfun_input_names; 'parameter_traj [{{ (solver_options.N_horizon+1)*dims.np }}]'];
 i_in = i_in + 1;
 {%- endif %}
 
@@ -228,72 +228,72 @@ sfun_input_names = [sfun_input_names; 'y_ref_0 [{{ dims.ny_0 }}]'];
 i_in = i_in + 1;
 {%- endif %}
 
-{%- if dims.ny > 0 and dims.N > 1 and simulink_opts.inputs.y_ref %}
+{%- if dims.ny > 0 and solver_options.N_horizon > 1 and simulink_opts.inputs.y_ref %}
 input_note = strcat(input_note, num2str(i_in), ') y_ref - concatenated for shooting nodes 1 to N-1,',...
-                    ' size [{{ (dims.N-1) * dims.ny }}]\n ');
-sfun_input_names = [sfun_input_names; 'y_ref [{{ (dims.N-1) * dims.ny }}]'];
+                    ' size [{{ (solver_options.N_horizon-1) * dims.ny }}]\n ');
+sfun_input_names = [sfun_input_names; 'y_ref [{{ (solver_options.N_horizon-1) * dims.ny }}]'];
 i_in = i_in + 1;
 {%- endif %}
 
-{%- if dims.ny_e > 0 and dims.N > 0 and simulink_opts.inputs.y_ref_e %}
+{%- if dims.ny_e > 0 and solver_options.N_horizon > 0 and simulink_opts.inputs.y_ref_e %}
 input_note = strcat(input_note, num2str(i_in), ') y_ref_e - size [{{ dims.ny_e }}]\n ');
 sfun_input_names = [sfun_input_names; 'y_ref_e [{{ dims.ny_e }}]'];
 i_in = i_in + 1;
 {%- endif %}
 
-{%- if dims.nbx > 0 and dims.N > 1 and simulink_opts.inputs.lbx -%}  {#- lbx #}
-input_note = strcat(input_note, num2str(i_in), ') lbx for shooting nodes 1 to N-1, size [{{ (dims.N-1) * dims.nbx }}]\n ');
-sfun_input_names = [sfun_input_names; 'lbx [{{ (dims.N-1) * dims.nbx }}]'];
+{%- if dims.nbx > 0 and solver_options.N_horizon > 1 and simulink_opts.inputs.lbx -%}  {#- lbx #}
+input_note = strcat(input_note, num2str(i_in), ') lbx for shooting nodes 1 to N-1, size [{{ (solver_options.N_horizon-1) * dims.nbx }}]\n ');
+sfun_input_names = [sfun_input_names; 'lbx [{{ (solver_options.N_horizon-1) * dims.nbx }}]'];
 i_in = i_in + 1;
 {%- endif %}
-{%- if dims.nbx > 0 and dims.N > 1 and simulink_opts.inputs.ubx -%}  {#- ubx #}
-input_note = strcat(input_note, num2str(i_in), ') ubx for shooting nodes 1 to N-1, size [{{ (dims.N-1) * dims.nbx }}]\n ');
-sfun_input_names = [sfun_input_names; 'ubx [{{ (dims.N-1) * dims.nbx }}]'];
+{%- if dims.nbx > 0 and solver_options.N_horizon > 1 and simulink_opts.inputs.ubx -%}  {#- ubx #}
+input_note = strcat(input_note, num2str(i_in), ') ubx for shooting nodes 1 to N-1, size [{{ (solver_options.N_horizon-1) * dims.nbx }}]\n ');
+sfun_input_names = [sfun_input_names; 'ubx [{{ (solver_options.N_horizon-1) * dims.nbx }}]'];
 i_in = i_in + 1;
 {%- endif %}
 
 
-{%- if dims.nbx_e > 0 and dims.N > 0 and simulink_opts.inputs.lbx_e -%}  {#- lbx_e #}
+{%- if dims.nbx_e > 0 and solver_options.N_horizon > 0 and simulink_opts.inputs.lbx_e -%}  {#- lbx_e #}
 input_note = strcat(input_note, num2str(i_in), ') lbx_e (lbx at shooting node N), size [{{ dims.nbx_e }}]\n ');
 sfun_input_names = [sfun_input_names; 'lbx_e [{{ dims.nbx_e }}]'];
 i_in = i_in + 1;
 {%- endif %}
-{%- if dims.nbx_e > 0 and dims.N > 0 and simulink_opts.inputs.ubx_e -%}  {#- ubx_e #}
+{%- if dims.nbx_e > 0 and solver_options.N_horizon > 0 and simulink_opts.inputs.ubx_e -%}  {#- ubx_e #}
 input_note = strcat(input_note, num2str(i_in), ') ubx_e (ubx at shooting node N), size [{{ dims.nbx_e }}]\n ');
 sfun_input_names = [sfun_input_names; 'ubx_e [{{ dims.nbx_e }}]'];
 i_in = i_in + 1;
 {%- endif %}
 
-{%- if dims.nbu > 0 and dims.N > 0 and simulink_opts.inputs.lbu -%}  {#- lbu #}
-input_note = strcat(input_note, num2str(i_in), ') lbu for shooting nodes 0 to N-1, size [{{ dims.N*dims.nbu }}]\n ');
-sfun_input_names = [sfun_input_names; 'lbu [{{ dims.N*dims.nbu }}]'];
+{%- if dims.nbu > 0 and solver_options.N_horizon > 0 and simulink_opts.inputs.lbu -%}  {#- lbu #}
+input_note = strcat(input_note, num2str(i_in), ') lbu for shooting nodes 0 to N-1, size [{{ solver_options.N_horizon*dims.nbu }}]\n ');
+sfun_input_names = [sfun_input_names; 'lbu [{{ solver_options.N_horizon*dims.nbu }}]'];
 i_in = i_in + 1;
 {%- endif -%}
-{%- if dims.nbu > 0 and dims.N > 0 and simulink_opts.inputs.ubu -%}  {#- ubu #}
-input_note = strcat(input_note, num2str(i_in), ') ubu for shooting nodes 0 to N-1, size [{{ dims.N*dims.nbu }}]\n ');
-sfun_input_names = [sfun_input_names; 'ubu [{{ dims.N*dims.nbu }}]'];
+{%- if dims.nbu > 0 and solver_options.N_horizon > 0 and simulink_opts.inputs.ubu -%}  {#- ubu #}
+input_note = strcat(input_note, num2str(i_in), ') ubu for shooting nodes 0 to N-1, size [{{ solver_options.N_horizon*dims.nbu }}]\n ');
+sfun_input_names = [sfun_input_names; 'ubu [{{ solver_options.N_horizon*dims.nbu }}]'];
 i_in = i_in + 1;
 {%- endif -%}
 
 {%- if dims.ng > 0 and simulink_opts.inputs.lg -%}  {#- lg #}
-input_note = strcat(input_note, num2str(i_in), ') lg for shooting nodes 0 to N-1, size [{{ dims.N*dims.ng }}]\n ');
-sfun_input_names = [sfun_input_names; 'lg [{{ dims.N*dims.ng }}]'];
+input_note = strcat(input_note, num2str(i_in), ') lg for shooting nodes 0 to N-1, size [{{ solver_options.N_horizon*dims.ng }}]\n ');
+sfun_input_names = [sfun_input_names; 'lg [{{ solver_options.N_horizon*dims.ng }}]'];
 i_in = i_in + 1;
 {%- endif %}
 {%- if dims.ng > 0 and simulink_opts.inputs.ug -%}  {#- ug #}
-input_note = strcat(input_note, num2str(i_in), ') ug for shooting nodes 0 to N-1, size [{{ dims.N*dims.ng }}]\n ');
-sfun_input_names = [sfun_input_names; 'ug [{{ dims.N*dims.ng }}]'];
+input_note = strcat(input_note, num2str(i_in), ') ug for shooting nodes 0 to N-1, size [{{ solver_options.N_horizon*dims.ng }}]\n ');
+sfun_input_names = [sfun_input_names; 'ug [{{ solver_options.N_horizon*dims.ng }}]'];
 i_in = i_in + 1;
 {%- endif %}
 
 {%- if dims.nh > 0 and simulink_opts.inputs.lh -%}  {#- lh #}
-input_note = strcat(input_note, num2str(i_in), ') lh for shooting nodes 0 to N-1, size [{{ dims.N*dims.nh }}]\n ');
-sfun_input_names = [sfun_input_names; 'lh [{{ dims.N*dims.nh }}]'];
+input_note = strcat(input_note, num2str(i_in), ') lh for shooting nodes 0 to N-1, size [{{ solver_options.N_horizon*dims.nh }}]\n ');
+sfun_input_names = [sfun_input_names; 'lh [{{ solver_options.N_horizon*dims.nh }}]'];
 i_in = i_in + 1;
 {%- endif %}
 {%- if dims.nh > 0 and simulink_opts.inputs.uh -%}  {#- uh #}
-input_note = strcat(input_note, num2str(i_in), ') uh for shooting nodes 0 to N-1, size [{{ dims.N*dims.nh }}]\n ');
-sfun_input_names = [sfun_input_names; 'uh [{{ dims.N*dims.nh }}]'];
+input_note = strcat(input_note, num2str(i_in), ') uh for shooting nodes 0 to N-1, size [{{ solver_options.N_horizon*dims.nh }}]\n ');
+sfun_input_names = [sfun_input_names; 'uh [{{ solver_options.N_horizon*dims.nh }}]'];
 i_in = i_in + 1;
 {%- endif %}
 
@@ -350,20 +350,20 @@ i_in = i_in + 1;
 {%- endif %}
 
 {%- if simulink_opts.inputs.x_init %}  {#- x_init #}
-input_note = strcat(input_note, num2str(i_in), ') x_init - initialization of x for all shooting nodes, size [{{ dims.nx * (dims.N+1) }}]\n ');
-sfun_input_names = [sfun_input_names; 'x_init [{{ dims.nx * (dims.N+1) }}]'];
+input_note = strcat(input_note, num2str(i_in), ') x_init - initialization of x for all shooting nodes, size [{{ dims.nx * (solver_options.N_horizon+1) }}]\n ');
+sfun_input_names = [sfun_input_names; 'x_init [{{ dims.nx * (solver_options.N_horizon+1) }}]'];
 i_in = i_in + 1;
 {%- endif %}
 
 {%- if simulink_opts.inputs.u_init %}  {#- u_init #}
-input_note = strcat(input_note, num2str(i_in), ') u_init - initialization of u for shooting nodes 0 to N-1, size [{{ dims.nu * (dims.N) }}]\n ');
-sfun_input_names = [sfun_input_names; 'u_init [{{ dims.nu * (dims.N) }}]'];
+input_note = strcat(input_note, num2str(i_in), ') u_init - initialization of u for shooting nodes 0 to N-1, size [{{ dims.nu * (solver_options.N_horizon) }}]\n ');
+sfun_input_names = [sfun_input_names; 'u_init [{{ dims.nu * (solver_options.N_horizon) }}]'];
 i_in = i_in + 1;
 {%- endif %}
 
 {%- if simulink_opts.inputs.pi_init %}  {#- pi_init #}
-input_note = strcat(input_note, num2str(i_in), ') pi_init - initialization of pi for shooting nodes 0 to N-1, size [{{ dims.nx * (dims.N) }}]\n ');
-sfun_input_names = [sfun_input_names; 'pi_init [{{ dims.nx * (dims.N) }}]'];
+input_note = strcat(input_note, num2str(i_in), ') pi_init - initialization of pi for shooting nodes 0 to N-1, size [{{ dims.nx * (solver_options.N_horizon) }}]\n ');
+sfun_input_names = [sfun_input_names; 'pi_init [{{ dims.nx * (solver_options.N_horizon) }}]'];
 i_in = i_in + 1;
 {%- endif %}
 
@@ -409,26 +409,26 @@ sfun_output_names = [sfun_output_names; 'u0 [{{ dims.nu }}]'];
 
 {%- if simulink_opts.outputs.utraj == 1 %}
 i_out = i_out + 1;
-output_note = strcat(output_note, num2str(i_out), ') utraj, control input concatenated for nodes 0 to N-1, size [{{ dims.nu * dims.N }}]\n ');
-sfun_output_names = [sfun_output_names; 'utraj [{{ dims.nu * dims.N }}]'];
+output_note = strcat(output_note, num2str(i_out), ') utraj, control input concatenated for nodes 0 to N-1, size [{{ dims.nu * solver_options.N_horizon }}]\n ');
+sfun_output_names = [sfun_output_names; 'utraj [{{ dims.nu * solver_options.N_horizon }}]'];
 {%- endif %}
 
 {%- if simulink_opts.outputs.xtraj == 1 %}
 i_out = i_out + 1;
-output_note = strcat(output_note, num2str(i_out), ') xtraj, state concatenated for nodes 0 to N, size [{{ dims.nx * (dims.N + 1) }}]\n ');
-sfun_output_names = [sfun_output_names; 'xtraj [{{ dims.nx * (dims.N + 1) }}]'];
+output_note = strcat(output_note, num2str(i_out), ') xtraj, state concatenated for nodes 0 to N, size [{{ dims.nx * (solver_options.N_horizon + 1) }}]\n ');
+sfun_output_names = [sfun_output_names; 'xtraj [{{ dims.nx * (solver_options.N_horizon + 1) }}]'];
 {%- endif %}
 
 {%- if simulink_opts.outputs.ztraj == 1 %}
 i_out = i_out + 1;
-output_note = strcat(output_note, num2str(i_out), ') ztraj, algebraic states concatenated for nodes 0 to N-1, size [{{ dims.nz * dims.N }}]\n ');
-sfun_output_names = [sfun_output_names; 'ztraj [{{ dims.nz * dims.N }}]'];
+output_note = strcat(output_note, num2str(i_out), ') ztraj, algebraic states concatenated for nodes 0 to N-1, size [{{ dims.nz * solver_options.N_horizon }}]\n ');
+sfun_output_names = [sfun_output_names; 'ztraj [{{ dims.nz * solver_options.N_horizon }}]'];
 {%- endif %}
 
 {%- if simulink_opts.outputs.pi_all == 1 %}
 i_out = i_out + 1;
-output_note = strcat(output_note, num2str(i_out), ') pi_all, equality Lagrange multipliers concatenated for nodes 0 to N-1, size [{{ dims.nx * dims.N }}]\n ');
-sfun_output_names = [sfun_output_names; 'pi_all [{{ dims.nx * dims.N }}]'];
+output_note = strcat(output_note, num2str(i_out), ') pi_all, equality Lagrange multipliers concatenated for nodes 0 to N-1, size [{{ dims.nx * solver_options.N_horizon }}]\n ');
+sfun_output_names = [sfun_output_names; 'pi_all [{{ dims.nx * solver_options.N_horizon }}]'];
 {%- endif %}
 
 {%- if simulink_opts.outputs.solver_status == 1 %}
@@ -456,7 +456,7 @@ output_note = strcat(output_note, num2str(i_out), ') KKT residuals, size [4] (st
 sfun_output_names = [sfun_output_names; 'KKT_residuals [4]'];
 {%- endif %}
 
-{%- if dims.N > 0 and simulink_opts.outputs.x1 == 1 %}
+{%- if solver_options.N_horizon > 0 and simulink_opts.outputs.x1 == 1 %}
 i_out = i_out + 1;
 output_note = strcat(output_note, num2str(i_out), ') x1, state at node 1\n ');
 sfun_output_names = [sfun_output_names; 'x1'];
@@ -496,7 +496,7 @@ sfun_output_names = [sfun_output_names; 'sqp_iter'];
 {%- if simulink_opts.outputs.parameter_traj == 1 %}
 i_out = i_out + 1;
 output_note = strcat(output_note, num2str(i_out), ') parameter trajectory\n ');
-sfun_output_names = [sfun_output_names; 'parameter_traj [{{ (dims.N + 1) * dims.np}}]'];
+sfun_output_names = [sfun_output_names; 'parameter_traj [{{ (solver_options.N_horizon + 1) * dims.np}}]'];
 {%- endif %}
 
 

--- a/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/mex_solver.in.m
+++ b/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/mex_solver.in.m
@@ -48,7 +48,7 @@ classdef {{ name }}_mex_solver < handle
             obj.C_ocp = acados_mex_create_{{ name }}();
             % to have path to destructor when changing directory
             addpath('.')
-            obj.N = {{ dims.N }};
+            obj.N = {{ solver_options.N_horizon }};
             obj.name = '{{ name }}';
             obj.code_gen_dir = pwd();
         end


### PR DESCRIPTION
Implemented in a backwards compatible way, but added a warning.
Motivation: all dimensions are detected and none needs to be set, `dims.N` was the only exception to this paradigm.
Simplifies work on multi-phase support for Matlab, as `AcadosOcp` and `AcadosMultiphaseOcp` have the field `solver_options` of class `AcadosOcpOptions`.