### PR TITLE
New MATLAB frontend: change defaults to match Python

### DIFF
--- a/interfaces/acados_matlab_octave/AcadosOcp.m
+++ b/interfaces/acados_matlab_octave/AcadosOcp.m
@@ -730,6 +730,54 @@ classdef AcadosOcp < handle
                     opts.nlp_solver_tol_min_step_norm = 0.0;
                 end
             end
+
+            % Set default parameters for globalization
+            if isempty(opts.alpha_min)
+                if strcmp(opts.globalization, 'FUNNEL_L1PEN_LINESEARCH')
+                    opts.alpha_min = 1e-17;
+                else
+                    opts.alpha_min = 0.05;
+                end
+            end
+
+            if isempty(opts.alpha_reduction)
+                if strcmp(opts.globalization, 'FUNNEL_L1PEN_LINESEARCH')
+                    opts.alpha_reduction = 0.5;
+                else
+                    opts.alpha_reduction = 0.7;
+                end
+            end
+
+            if isempty(opts.eps_sufficient_descent)
+                if strcmp(opts.globalization, 'FUNNEL_L1PEN_LINESEARCH')
+                    opts.eps_sufficient_descent = 1e-6;
+                else
+                    opts.eps_sufficient_descent = 1e-4;
+                end
+            end
+
+            if isempty(opts.eval_residual_at_max_iter)
+                if strcmp(opts.globalization, 'FUNNEL_L1PEN_LINESEARCH')
+                    opts.eval_residual_at_max_iter = true;
+                else
+                    opts.eval_residual_at_max_iter = false;
+                end
+            end
+
+            if isempty(opts.full_step_dual)
+                if strcmp(opts.globalization, 'FUNNEL_L1PEN_LINESEARCH')
+                    opts.full_step_dual = 1;
+                else
+                    opts.full_step_dual = 0;
+                end
+            end
+
+            % sanity check for Funnel globalization and SQP
+            if strcmp(opts.globalization, 'FUNNEL_L1PEN_LINESEARCH') strcmp(opts.nlp_solver_type, 'SQP')
+                error('FUNNEL_L1PEN_LINESEARCH only supports SQP.')
+            end
+
+            % TODO: implement zoRO description processing here!
         end
 
         function [] = detect_cost_and_constraints(self)

--- a/interfaces/acados_matlab_octave/AcadosOcpCost.m
+++ b/interfaces/acados_matlab_octave/AcadosOcpCost.m
@@ -93,7 +93,7 @@ classdef AcadosOcpCost < handle
             obj.cost_source_ext_cost_0 = [];
             obj.cost_function_ext_cost_0 = [];
             % intermediate
-            obj.cost_type   = 'AUTO';
+            obj.cost_type = 'LINEAR_LS';
             obj.W           = [];
             obj.Vx          = [];
             obj.Vu          = [];
@@ -107,7 +107,7 @@ classdef AcadosOcpCost < handle
             obj.cost_source_ext_cost = [];
             obj.cost_function_ext_cost = [];
             % terminal
-            obj.cost_type_e = 'AUTO';
+            obj.cost_type_e = 'LINEAR_LS';
             obj.W_e         = [];
             obj.Vx_e        = [];
             obj.yref_e      = [];

--- a/interfaces/acados_matlab_octave/AcadosOcpOptions.m
+++ b/interfaces/acados_matlab_octave/AcadosOcpOptions.m
@@ -122,7 +122,7 @@ classdef AcadosOcpOptions < handle
             obj.nlp_solver_tol_eq = 1e-6;
             obj.nlp_solver_tol_ineq = 1e-6;
             obj.nlp_solver_tol_comp = 1e-6;
-            obj.nlp_solver_tol_min_step_norm = 1e-12;
+            obj.nlp_solver_tol_min_step_norm = [];
             obj.nlp_solver_max_iter = 100;
             obj.nlp_solver_ext_qp_res = 0;
             obj.nlp_solver_warm_start_first_qp = false;
@@ -158,12 +158,12 @@ classdef AcadosOcpOptions < handle
             obj.exact_hess_constr = 1;
             obj.fixed_hess = 0;
             obj.ext_cost_num_hess = 0;
-            obj.alpha_min = 0.05;
-            obj.alpha_reduction = 0.7;
+            obj.alpha_min = [];
+            obj.alpha_reduction = [];
             obj.line_search_use_sufficient_descent = 0;
             obj.globalization_use_SOC = 0;
-            obj.full_step_dual = 0;
-            obj.eps_sufficient_descent = 1e-4;
+            obj.full_step_dual = [];
+            obj.eps_sufficient_descent = [];
             obj.hpipm_mode = 'BALANCE';
             obj.with_solution_sens_wrt_params = 0;
             obj.with_value_sens_wrt_params = 0;
@@ -174,7 +174,7 @@ classdef AcadosOcpOptions < handle
             obj.adaptive_levenberg_marquardt_mu_min = 1e-16;
             obj.adaptive_levenberg_marquardt_mu0 = 1e-3;
             obj.log_primal_step_norm = 0;
-            obj.eval_residual_at_max_iter = 0;
+            obj.eval_residual_at_max_iter = [];
 
             obj.ext_fun_compile_flags = '-O2';
             obj.model_external_shared_lib_dir = [];

--- a/interfaces/acados_matlab_octave/AcadosOcpOptions.m
+++ b/interfaces/acados_matlab_octave/AcadosOcpOptions.m
@@ -123,7 +123,7 @@ classdef AcadosOcpOptions < handle
             obj.nlp_solver_tol_ineq = 1e-6;
             obj.nlp_solver_tol_comp = 1e-6;
             obj.nlp_solver_tol_min_step_norm = 1e-12;
-            obj.nlp_solver_max_iter = 50;
+            obj.nlp_solver_max_iter = 100;
             obj.nlp_solver_ext_qp_res = 0;
             obj.nlp_solver_warm_start_first_qp = false;
             obj.globalization = 'FIXED_STEP';
@@ -144,8 +144,8 @@ classdef AcadosOcpOptions < handle
             obj.qp_solver_iter_max = 50;
             obj.qp_solver_cond_N = [];
             obj.qp_solver_cond_block_size = [];
-            obj.qp_solver_cond_ric_alg = 0;
-            obj.qp_solver_ric_alg = 0;
+            obj.qp_solver_cond_ric_alg = 1;
+            obj.qp_solver_ric_alg = 1;
             obj.qp_solver_mu0 = 0;
             obj.rti_log_residuals = 0;
             obj.print_level = 0;

--- a/interfaces/acados_matlab_octave/detect_cost_type.m
+++ b/interfaces/acados_matlab_octave/detect_cost_type.m
@@ -62,7 +62,7 @@ function detect_cost_type(model, cost, dims, stage_type)
         disp('Structure detection for initial cost term');
     end
 
-    if ~(isa(expr_cost, 'casadi.SX') || isa(expr_cost, 'casadi.SX'))
+    if ~(isa(expr_cost, 'casadi.SX') || isa(expr_cost, 'casadi.MX'))
         disp('expr_cost =')
         disp(expr_cost)
         error("Cost type detection require definition of cost term as CasADi SX or MX.")


### PR DESCRIPTION
- `AcadosOcpCost`: use "LINEAR_LS" as default cost_type as in Python for 0 cost as default
- `AcadosOcpOptions`:
  - `qp_solver_ric_alg` = 1
  - `qp_solver_cond_ric_alg` = 1
  - `nlp_solver_max_iter` = 100
  - dynamic defaults as in Python for: `alpha_min`, `alpha_reduction`, `eps_sufficient_descent`, `eval_residual_max_iter`, `full_step_dual`