### PR TITLE
No code generation for integrator and related files if dynamics are DISCRETE

### DIFF
--- a/examples/acados_python/generic_dyn_disc/main.py
+++ b/examples/acados_python/generic_dyn_disc/main.py
@@ -30,7 +30,7 @@
 
 import casadi as ca
 import numpy as np
-from acados_template import AcadosOcp, AcadosOcpSolver
+from acados_template import AcadosOcp, AcadosOcpSolver, ocp_get_default_cmake_builder
 import scipy.linalg
 
 def linear_mass_spring_model(casadi_dynamics, casadi_cost):
@@ -167,12 +167,13 @@ def linear_mass_spring_model(casadi_dynamics, casadi_cost):
 
 
 
-def main(casadi_dynamics, casadi_cost):
+def main(casadi_dynamics, casadi_cost, use_cmake = False):
 
     ocp = linear_mass_spring_model(casadi_dynamics, casadi_cost)
 
     # create ocp solver
-    ocp_solver = AcadosOcpSolver(ocp)
+    cmake_builder = ocp_get_default_cmake_builder() if use_cmake else None
+    ocp_solver = AcadosOcpSolver(ocp, cmake_builder=cmake_builder)
 
     # solve
     status = ocp_solver.solve()

--- a/interfaces/acados_matlab_octave/AcadosOcp.m
+++ b/interfaces/acados_matlab_octave/AcadosOcp.m
@@ -962,10 +962,11 @@ classdef AcadosOcp < handle
             template_list{end+1} = {'Makefile.in', ['Makefile']};
 
             % integrator
-            template_list{end+1} = {'acados_sim_solver.in.c', ['acados_sim_solver_', self.name, '.c']};
-            template_list{end+1} = {'acados_sim_solver.in.h', ['acados_sim_solver_', self.name, '.h']};
-            template_list{end+1} = {'main_sim.in.c', ['main_sim_', self.name, '.c']};
-
+            if self.options.integrator_type != 'DISCRETE'
+                template_list{end+1} = {'acados_sim_solver.in.c', ['acados_sim_solver_', self.name, '.c']};
+                template_list{end+1} = {'acados_sim_solver.in.h', ['acados_sim_solver_', self.name, '.h']};
+                template_list{end+1} = {'main_sim.in.c', ['main_sim_', self.name, '.c']};
+            end
             % MEX files
             matlab_template_path = 'matlab_templates';
             template_list{end+1} = {fullfile(matlab_template_path, 'mex_solver.in.m'), [self.name, '_mex_solver.m']};
@@ -987,8 +988,10 @@ classdef AcadosOcp < handle
             if ~isempty(self.simulink_opts)
                 template_list{end+1} = {fullfile(matlab_template_path, 'acados_solver_sfun.in.c'), ['acados_solver_sfunction_', self.name, '.c']};
                 template_list{end+1} = {fullfile(matlab_template_path, 'make_sfun.in.m'), ['make_sfun.m']};
-                template_list{end+1} = {fullfile(matlab_template_path, 'acados_sim_solver_sfun.in.c'), ['acados_sim_solver_sfunction_', self.name, '.c']};
-                template_list{end+1} = {fullfile(matlab_template_path, 'make_sfun_sim.in.m'), ['make_sfun_sim.m']};
+                if self.options.integrator_type != 'DISCRETE'
+                    template_list{end+1} = {fullfile(matlab_template_path, 'acados_sim_solver_sfun.in.c'), ['acados_sim_solver_sfunction_', self.name, '.c']};
+                    template_list{end+1} = {fullfile(matlab_template_path, 'make_sfun_sim.in.m'), ['make_sfun_sim.m']};
+                end
             else
                 disp("not rendering Simulink related templates, as simulink_opts are not specified.")
             end

--- a/interfaces/acados_matlab_octave/AcadosOcp.m
+++ b/interfaces/acados_matlab_octave/AcadosOcp.m
@@ -962,7 +962,7 @@ classdef AcadosOcp < handle
             template_list{end+1} = {'Makefile.in', ['Makefile']};
 
             % integrator
-            if self.options.integrator_type != 'DISCRETE'
+            if strcmp(self.solver_options.integrator_type, 'DISCRETE')
                 template_list{end+1} = {'acados_sim_solver.in.c', ['acados_sim_solver_', self.name, '.c']};
                 template_list{end+1} = {'acados_sim_solver.in.h', ['acados_sim_solver_', self.name, '.h']};
                 template_list{end+1} = {'main_sim.in.c', ['main_sim_', self.name, '.c']};
@@ -988,7 +988,7 @@ classdef AcadosOcp < handle
             if ~isempty(self.simulink_opts)
                 template_list{end+1} = {fullfile(matlab_template_path, 'acados_solver_sfun.in.c'), ['acados_solver_sfunction_', self.name, '.c']};
                 template_list{end+1} = {fullfile(matlab_template_path, 'make_sfun.in.m'), ['make_sfun.m']};
-                if self.options.integrator_type != 'DISCRETE'
+                if strcmp(self.solver_options.integrator_type, 'DISCRETE')
                     template_list{end+1} = {fullfile(matlab_template_path, 'acados_sim_solver_sfun.in.c'), ['acados_sim_solver_sfunction_', self.name, '.c']};
                     template_list{end+1} = {fullfile(matlab_template_path, 'make_sfun_sim.in.m'), ['make_sfun_sim.m']};
                 end

--- a/interfaces/acados_matlab_octave/AcadosOcp.m
+++ b/interfaces/acados_matlab_octave/AcadosOcp.m
@@ -962,7 +962,7 @@ classdef AcadosOcp < handle
             template_list{end+1} = {'Makefile.in', ['Makefile']};
 
             % integrator
-            if strcmp(self.solver_options.integrator_type, 'DISCRETE')
+            if ~strcmp(self.solver_options.integrator_type, 'DISCRETE')
                 template_list{end+1} = {'acados_sim_solver.in.c', ['acados_sim_solver_', self.name, '.c']};
                 template_list{end+1} = {'acados_sim_solver.in.h', ['acados_sim_solver_', self.name, '.h']};
                 template_list{end+1} = {'main_sim.in.c', ['main_sim_', self.name, '.c']};
@@ -988,7 +988,7 @@ classdef AcadosOcp < handle
             if ~isempty(self.simulink_opts)
                 template_list{end+1} = {fullfile(matlab_template_path, 'acados_solver_sfun.in.c'), ['acados_solver_sfunction_', self.name, '.c']};
                 template_list{end+1} = {fullfile(matlab_template_path, 'make_sfun.in.m'), ['make_sfun.m']};
-                if strcmp(self.solver_options.integrator_type, 'DISCRETE')
+                if ~strcmp(self.solver_options.integrator_type, 'DISCRETE')
                     template_list{end+1} = {fullfile(matlab_template_path, 'acados_sim_solver_sfun.in.c'), ['acados_sim_solver_sfunction_', self.name, '.c']};
                     template_list{end+1} = {fullfile(matlab_template_path, 'make_sfun_sim.in.m'), ['make_sfun_sim.m']};
                 end

--- a/interfaces/acados_template/acados_template/acados_ocp.py
+++ b/interfaces/acados_template/acados_template/acados_ocp.py
@@ -935,9 +935,10 @@ class AcadosOcp:
             template_list.append(('Makefile.in', 'Makefile'))
 
         # sim
-        template_list.append(('acados_sim_solver.in.c', f'acados_sim_solver_{name}.c'))
-        template_list.append(('acados_sim_solver.in.h', f'acados_sim_solver_{name}.h'))
-        template_list.append(('main_sim.in.c', f'main_sim_{name}.c'))
+        if self.solver_options.integrator_type != 'DISCRETE':
+            template_list.append(('acados_sim_solver.in.c', f'acados_sim_solver_{name}.c'))
+            template_list.append(('acados_sim_solver.in.h', f'acados_sim_solver_{name}.h'))
+            template_list.append(('main_sim.in.c', f'main_sim_{name}.c'))
 
         # model
         template_list += self._get_external_function_header_templates()

--- a/interfaces/acados_template/acados_template/c_templates_tera/CMakeLists.in.txt
+++ b/interfaces/acados_template/acados_template/c_templates_tera/CMakeLists.in.txt
@@ -178,7 +178,9 @@ endif()
 # object target names
 set(MODEL_OBJ model_{{ model.name }})
 set(OCP_OBJ ocp_{{ model.name }})
+{%- if solver_options.integrator_type != "DISCRETE" %}
 set(SIM_OBJ sim_{{ model.name }})
+{%- endif %}
 
 # model
 set(MODEL_SRC
@@ -474,5 +476,7 @@ endif(${BUILD_ACADOS_SIM_SOLVER_LIB})
 unset(BUILD_ACADOS_SOLVER_LIB CACHE)
 unset(BUILD_ACADOS_OCP_SOLVER_LIB CACHE)
 unset(BUILD_EXAMPLE CACHE)
+{%- if solver_options.integrator_type != "DISCRETE" %}
 unset(BUILD_SIM_EXAMPLE CACHE)
 unset(BUILD_ACADOS_SIM_SOLVER_LIB CACHE)
+{%- endif %}

--- a/interfaces/acados_template/acados_template/c_templates_tera/Makefile.in
+++ b/interfaces/acados_template/acados_template/c_templates_tera/Makefile.in
@@ -391,7 +391,7 @@ LDLIBS+= {{ link_libs }}
 # libraries
 LIBACADOS_SOLVER=libacados_solver_{{ model.name }}{{ shared_lib_ext }}
 LIBACADOS_OCP_SOLVER=libacados_ocp_solver_{{ model.name }}{{ shared_lib_ext }}
-{%- if solver_options.integrator_type != "DISCRETE" -%}
+{%- if solver_options.integrator_type != "DISCRETE" %}
 LIBACADOS_SIM_SOLVER=lib$(SIM_SRC:.c={{ shared_lib_ext }})
 {%- endif %}
 

--- a/interfaces/acados_template/acados_template/c_templates_tera/Makefile.in
+++ b/interfaces/acados_template/acados_template/c_templates_tera/Makefile.in
@@ -307,21 +307,23 @@ OCP_SRC+= {{ solver_options.custom_update_filename }}
 OCP_SRC+= acados_solver_{{ model.name }}.c
 OCP_OBJ := $(OCP_SRC:.c=.o)
 
+{%- if solver_options.integrator_type != "DISCRETE" %}
 # for sim solver
 SIM_SRC= acados_sim_solver_{{ model.name }}.c
 SIM_OBJ := $(SIM_SRC:.c=.o)
+
+# for target example_sim
+EX_SIM_SRC= main_sim_{{ model.name }}.c
+EX_SIM_OBJ := $(EX_SIM_SRC:.c=.o)
+EX_SIM_EXE := $(EX_SIM_SRC:.c=)
+{%- endif %}
 
 # for target example
 EX_SRC= main_{{ model.name }}.c
 EX_OBJ := $(EX_SRC:.c=.o)
 EX_EXE := $(EX_SRC:.c=)
 
-# for target example_sim
-EX_SIM_SRC= main_sim_{{ model.name }}.c
-EX_SIM_OBJ := $(EX_SIM_SRC:.c=.o)
-EX_SIM_EXE := $(EX_SIM_SRC:.c=)
-
-# combine model, sim and ocp object files
+# combine model, (potentially) sim and ocp object files
 OBJ=
 OBJ+= $(MODEL_OBJ)
 {%- if solver_options.integrator_type != "DISCRETE" %}
@@ -389,12 +391,13 @@ LDLIBS+= {{ link_libs }}
 # libraries
 LIBACADOS_SOLVER=libacados_solver_{{ model.name }}{{ shared_lib_ext }}
 LIBACADOS_OCP_SOLVER=libacados_ocp_solver_{{ model.name }}{{ shared_lib_ext }}
+{%- if solver_options.integrator_type != "DISCRETE" -%}
 LIBACADOS_SIM_SOLVER=lib$(SIM_SRC:.c={{ shared_lib_ext }})
+{%- endif %}
 
 # virtual targets
 .PHONY : all clean
 
-#all: clean example_sim example shared_lib
 {% if solver_options.integrator_type == "DISCRETE" -%}
 all: clean example
 shared_lib: ocp_shared_lib
@@ -407,20 +410,20 @@ shared_lib: bundled_shared_lib ocp_shared_lib sim_shared_lib
 example: $(EX_OBJ) $(OBJ)
 	$(CC) $^ -o $(EX_EXE) $(LDFLAGS) $(LDLIBS)
 
+{% if solver_options.integrator_type != "DISCRETE" -%}
 example_sim: $(EX_SIM_OBJ) $(MODEL_OBJ) $(SIM_OBJ)
 	$(CC) $^ -o $(EX_SIM_EXE) $(LDFLAGS) $(LDLIBS)
 
-{% if solver_options.integrator_type != "DISCRETE" -%}
 bundled_shared_lib: $(OBJ)
 	$(CC) -shared $^ -o $(LIBACADOS_SOLVER) $(LDFLAGS) $(LDLIBS)
+
+sim_shared_lib: $(SIM_OBJ) $(MODEL_OBJ)
+	$(CC) -shared $^ -o $(LIBACADOS_SIM_SOLVER) $(LDFLAGS) $(LDLIBS)
 {%- endif %}
 
 ocp_shared_lib: $(OCP_OBJ) $(MODEL_OBJ)
 	$(CC) -shared $^ -o $(LIBACADOS_OCP_SOLVER) $(LDFLAGS) $(LDLIBS) \
 	-L$(EXTERNAL_DIR) -l$(EXTERNAL_LIB)
-
-sim_shared_lib: $(SIM_OBJ) $(MODEL_OBJ)
-	$(CC) -shared $^ -o $(LIBACADOS_SIM_SOLVER) $(LDFLAGS) $(LDLIBS)
 
 
 # Cython targets
@@ -451,6 +454,7 @@ ocp_cython: ocp_cython_o
 	$(abspath .)/libacados_ocp_solver_{{ model.name }}{{ shared_lib_ext }} \
 	$(LDFLAGS) $(LDLIBS)
 
+{% if solver_options.integrator_type != "DISCRETE" -%}
 # Sim Cython targets
 sim_cython_c: sim_shared_lib
 	cython \
@@ -478,6 +482,8 @@ sim_cython: sim_cython_o
 	acados_sim_solver_pyx.o \
 	$(abspath .)/libacados_sim_solver_{{ model.name }}{{ shared_lib_ext }} \
 	$(LDFLAGS) $(LDLIBS)
+{%- endif %}
+
 
 {%- if os and os == "pc" %}
 
@@ -496,18 +502,26 @@ clean_ocp_cython:
 	del \Q acados_ocp_solver_pyx{{ shared_lib_ext }} 2>nul
 	del \Q acados_ocp_solver_pyx.o 2>nul
 
+{% if solver_options.integrator_type != "DISCRETE" -%}
 clean_sim_cython:
 	del \Q libacados_sim_solver_{{ model.name }}{{ shared_lib_ext }} 2>nul
 	del \Q acados_sim_solver_{{ model.name }}.o 2>nul
 	del \Q acados_sim_solver_pyx{{ shared_lib_ext }} 2>nul
 	del \Q acados_sim_solver_pyx.o 2>nul
+{%- endif %}
 
 {%- else %}
 
 clean:
+{%- if solver_options.integrator_type != "DISCRETE" %}
 	$(RM) $(OBJ) $(EX_OBJ) $(EX_SIM_OBJ)
 	$(RM) $(LIBACADOS_SOLVER) $(LIBACADOS_OCP_SOLVER) $(LIBACADOS_SIM_SOLVER)
 	$(RM) $(EX_EXE) $(EX_SIM_EXE)
+{%- else %}
+	$(RM) $(OBJ) $(EX_OBJ)
+	$(RM) $(LIBACADOS_SOLVER) $(LIBACADOS_OCP_SOLVER)
+	$(RM) $(EX_EXE)
+{%- endif %}
 
 clean_ocp_shared_lib:
 	$(RM) $(LIBACADOS_OCP_SOLVER)
@@ -519,10 +533,12 @@ clean_ocp_cython:
 	$(RM) acados_ocp_solver_pyx{{ shared_lib_ext }}
 	$(RM) acados_ocp_solver_pyx.o
 
+{% if solver_options.integrator_type != "DISCRETE" -%}
 clean_sim_cython:
 	$(RM) libacados_sim_solver_{{ model.name }}{{ shared_lib_ext }}
 	$(RM) acados_sim_solver_{{ model.name }}.o
 	$(RM) acados_sim_solver_pyx{{ shared_lib_ext }}
 	$(RM) acados_sim_solver_pyx.o
+{%- endif %}
 
 {%- endif %}

--- a/interfaces/acados_template/acados_template/c_templates_tera/multi_Makefile.in
+++ b/interfaces/acados_template/acados_template/c_templates_tera/multi_Makefile.in
@@ -255,7 +255,6 @@ OCP_SRC+= {{ solver_options.custom_update_filename }}
 {%- endif %}
 
 
-
 OCP_SRC+= acados_solver_{{ name }}.c
 OCP_OBJ := $(OCP_SRC:.c=.o)
 
@@ -328,12 +327,10 @@ LDLIBS+= {{ link_libs }}
 # libraries
 LIBACADOS_SOLVER=libacados_solver_{{ name }}{{ shared_lib_ext }}
 LIBACADOS_OCP_SOLVER=libacados_ocp_solver_{{ name }}{{ shared_lib_ext }}
-LIBACADOS_SIM_SOLVER=lib$(SIM_SRC:.c={{ shared_lib_ext }})
 
 # virtual targets
 .PHONY : all clean
 
-#all: clean example_sim example shared_lib
 all: clean example
 shared_lib: ocp_shared_lib
 
@@ -345,10 +342,6 @@ example: $(EX_OBJ) $(OBJ)
 ocp_shared_lib: $(OCP_OBJ) $(MODEL_OBJ)
 	$(CC) -shared $^ -o $(LIBACADOS_OCP_SOLVER) $(LDFLAGS) $(LDLIBS) \
 	-L$(EXTERNAL_DIR) -l$(EXTERNAL_LIB)
-
-sim_shared_lib: $(SIM_OBJ) $(MODEL_OBJ)
-	$(CC) -shared $^ -o $(LIBACADOS_SIM_SOLVER) $(LDFLAGS) $(LDLIBS)
-
 
 # Cython targets
 ocp_cython_c: ocp_shared_lib
@@ -398,9 +391,9 @@ clean_ocp_cython:
 {%- else %}
 
 clean:
-	$(RM) $(OBJ) $(EX_OBJ) $(EX_SIM_OBJ)
-	$(RM) $(LIBACADOS_SOLVER) $(LIBACADOS_OCP_SOLVER) $(LIBACADOS_SIM_SOLVER)
-	$(RM) $(EX_EXE) $(EX_SIM_EXE)
+	$(RM) $(OBJ) $(EX_OBJ)
+	$(RM) $(LIBACADOS_SOLVER) $(LIBACADOS_OCP_SOLVER)
+	$(RM) $(EX_EXE)
 
 clean_ocp_shared_lib:
 	$(RM) $(LIBACADOS_OCP_SOLVER)


### PR DESCRIPTION
acados does not provide a standalone integrator if discrete dynamics are used. This PR adapts the python and MATLAB interface to not code generate any files related to the integrator if discrete dynamics are used.

- closes https://github.com/acados/acados/issues/1224