### PR TITLE
Include external function needed for ERK adjoints properly in solver templates

### DIFF
--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.c
@@ -528,9 +528,9 @@ void {{ name }}_acados_create_setup_functions({{ name }}_solver_capsule* capsule
     }
 
     {%- if solver_options.hessian_approx == "EXACT" %}
-    capsule->hess_vde_casadi_{{ jj }} = (external_function_external_param_casadi *) malloc(sizeof(external_function_external_param_casadi)*n_path);
+    capsule->expl_ode_hess_{{ jj }} = (external_function_external_param_casadi *) malloc(sizeof(external_function_external_param_casadi)*n_path);
     for (int i = 0; i < n_path; i++) {
-        MAP_CASADI_FNC(hess_vde_casadi_{{ jj }}[i], {{ model[jj].name }}_expl_ode_hess);
+        MAP_CASADI_FNC(expl_ode_hess_{{ jj }}[i], {{ model[jj].name }}_expl_ode_hess);
     }
     {%- endif %}
 
@@ -1203,7 +1203,7 @@ void {{ name }}_acados_create_setup_nlp_in({{ name }}_solver_capsule* capsule, i
         ocp_nlp_dynamics_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, i, "expl_vde_forw", &capsule->forw_vde_casadi_{{ jj }}[i_fun]);
         ocp_nlp_dynamics_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, i, "expl_ode_fun", &capsule->expl_ode_fun_{{ jj }}[i_fun]);
         {%- if solver_options.hessian_approx == "EXACT" %}
-        ocp_nlp_dynamics_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, i, "expl_ode_hess", &capsule->hess_vde_casadi_{{ jj }}[i_fun]);
+        ocp_nlp_dynamics_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, i, "expl_ode_hess", &capsule->expl_ode_hess_{{ jj }}[i_fun]);
         {%- endif %}
     {%- elif mocp_opts.integrator_type[jj] == "IRK" %}
         ocp_nlp_dynamics_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, i, "impl_dae_fun", &capsule->impl_dae_fun_{{ jj }}[i_fun]);
@@ -2726,13 +2726,13 @@ int {{ name }}_acados_free({{ name }}_solver_capsule* capsule)
         external_function_external_param_casadi_free(&capsule->forw_vde_casadi_{{ jj }}[i_fun]);
         external_function_external_param_casadi_free(&capsule->expl_ode_fun_{{ jj }}[i_fun]);
     {%- if solver_options.hessian_approx == "EXACT" %}
-        external_function_external_param_casadi_free(&capsule->hess_vde_casadi_{{ jj }}[i_fun]);
+        external_function_external_param_casadi_free(&capsule->expl_ode_hess_{{ jj }}[i_fun]);
     {%- endif %}
     }
     free(capsule->forw_vde_casadi_{{ jj }});
     free(capsule->expl_ode_fun_{{ jj }});
     {%- if solver_options.hessian_approx == "EXACT" %}
-    free(capsule->hess_vde_casadi_{{ jj }});
+    free(capsule->expl_ode_hess_{{ jj }});
     {%- endif %}
 
 {%- elif mocp_opts.integrator_type[jj] == "GNSF" %}

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.c
@@ -522,6 +522,11 @@ void {{ name }}_acados_create_setup_functions({{ name }}_solver_capsule* capsule
         MAP_CASADI_FNC(expl_vde_forw_{{ jj }}[i], {{ model[jj].name }}_expl_vde_forw);
     }
 
+    capsule->expl_vde_adj_{{ jj }} = (external_function_external_param_casadi *) malloc(sizeof(external_function_external_param_casadi)*n_path);
+    for (int i = 0; i < n_path; i++) {
+        MAP_CASADI_FNC(expl_vde_adj_{{ jj }}[i], {{ model[jj].name }}_expl_vde_adj);
+    }
+
     capsule->expl_ode_fun_{{ jj }} = (external_function_external_param_casadi *) malloc(sizeof(external_function_external_param_casadi)*n_path);
     for (int i = 0; i < n_path; i++) {
         MAP_CASADI_FNC(expl_ode_fun_{{ jj }}[i], {{ model[jj].name }}_expl_ode_fun);
@@ -1201,6 +1206,7 @@ void {{ name }}_acados_create_setup_nlp_in({{ name }}_solver_capsule* capsule, i
         i_fun = i - {{ start_idx[jj] }};
     {%- if mocp_opts.integrator_type[jj] == "ERK" %}
         ocp_nlp_dynamics_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, i, "expl_vde_forw", &capsule->expl_vde_forw_{{ jj }}[i_fun]);
+        ocp_nlp_dynamics_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, i, "expl_vde_adj", &capsule->expl_vde_adj_{{ jj }}[i_fun]);
         ocp_nlp_dynamics_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, i, "expl_ode_fun", &capsule->expl_ode_fun_{{ jj }}[i_fun]);
         {%- if solver_options.hessian_approx == "EXACT" %}
         ocp_nlp_dynamics_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, i, "expl_ode_hess", &capsule->expl_ode_hess_{{ jj }}[i_fun]);
@@ -2724,12 +2730,14 @@ int {{ name }}_acados_free({{ name }}_solver_capsule* capsule)
     for (int i_fun = 0; i_fun < {{ end_idx[jj] - start_idx[jj] }}; i_fun++)
     {
         external_function_external_param_casadi_free(&capsule->expl_vde_forw_{{ jj }}[i_fun]);
+        external_function_external_param_casadi_free(&capsule->expl_vde_adj_{{ jj }}[i_fun]);
         external_function_external_param_casadi_free(&capsule->expl_ode_fun_{{ jj }}[i_fun]);
     {%- if solver_options.hessian_approx == "EXACT" %}
         external_function_external_param_casadi_free(&capsule->expl_ode_hess_{{ jj }}[i_fun]);
     {%- endif %}
     }
     free(capsule->expl_vde_forw_{{ jj }});
+    free(capsule->expl_vde_adj_{{ jj }});
     free(capsule->expl_ode_fun_{{ jj }});
     {%- if solver_options.hessian_approx == "EXACT" %}
     free(capsule->expl_ode_hess_{{ jj }});

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.c
@@ -517,9 +517,9 @@ void {{ name }}_acados_create_setup_functions({{ name }}_solver_capsule* capsule
 
 {% if mocp_opts.integrator_type[jj] == "ERK" %}
     // explicit ode
-    capsule->forw_vde_casadi_{{ jj }} = (external_function_external_param_casadi *) malloc(sizeof(external_function_external_param_casadi)*n_path);
+    capsule->expl_vde_forw_{{ jj }} = (external_function_external_param_casadi *) malloc(sizeof(external_function_external_param_casadi)*n_path);
     for (int i = 0; i < n_path; i++) {
-        MAP_CASADI_FNC(forw_vde_casadi_{{ jj }}[i], {{ model[jj].name }}_expl_vde_forw);
+        MAP_CASADI_FNC(expl_vde_forw_{{ jj }}[i], {{ model[jj].name }}_expl_vde_forw);
     }
 
     capsule->expl_ode_fun_{{ jj }} = (external_function_external_param_casadi *) malloc(sizeof(external_function_external_param_casadi)*n_path);
@@ -1200,7 +1200,7 @@ void {{ name }}_acados_create_setup_nlp_in({{ name }}_solver_capsule* capsule, i
     {
         i_fun = i - {{ start_idx[jj] }};
     {%- if mocp_opts.integrator_type[jj] == "ERK" %}
-        ocp_nlp_dynamics_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, i, "expl_vde_forw", &capsule->forw_vde_casadi_{{ jj }}[i_fun]);
+        ocp_nlp_dynamics_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, i, "expl_vde_forw", &capsule->expl_vde_forw_{{ jj }}[i_fun]);
         ocp_nlp_dynamics_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, i, "expl_ode_fun", &capsule->expl_ode_fun_{{ jj }}[i_fun]);
         {%- if solver_options.hessian_approx == "EXACT" %}
         ocp_nlp_dynamics_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, i, "expl_ode_hess", &capsule->expl_ode_hess_{{ jj }}[i_fun]);
@@ -2723,13 +2723,13 @@ int {{ name }}_acados_free({{ name }}_solver_capsule* capsule)
 {%- elif mocp_opts.integrator_type[jj] == "ERK" %}
     for (int i_fun = 0; i_fun < {{ end_idx[jj] - start_idx[jj] }}; i_fun++)
     {
-        external_function_external_param_casadi_free(&capsule->forw_vde_casadi_{{ jj }}[i_fun]);
+        external_function_external_param_casadi_free(&capsule->expl_vde_forw_{{ jj }}[i_fun]);
         external_function_external_param_casadi_free(&capsule->expl_ode_fun_{{ jj }}[i_fun]);
     {%- if solver_options.hessian_approx == "EXACT" %}
         external_function_external_param_casadi_free(&capsule->expl_ode_hess_{{ jj }}[i_fun]);
     {%- endif %}
     }
-    free(capsule->forw_vde_casadi_{{ jj }});
+    free(capsule->expl_vde_forw_{{ jj }});
     free(capsule->expl_ode_fun_{{ jj }});
     {%- if solver_options.hessian_approx == "EXACT" %}
     free(capsule->expl_ode_hess_{{ jj }});

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.h
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.h
@@ -77,6 +77,7 @@ typedef struct {{ name }}_solver_capsule
     // dynamics
 {% if mocp_opts.integrator_type[jj] == "ERK" %}
     external_function_external_param_casadi *expl_vde_forw_{{ jj }};
+    external_function_external_param_casadi *expl_vde_adj_{{ jj }};
     external_function_external_param_casadi *expl_ode_fun_{{ jj }};
 {% if solver_options.hessian_approx == "EXACT" %}
     external_function_external_param_casadi *expl_ode_hess_{{ jj }};

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.h
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.h
@@ -79,7 +79,7 @@ typedef struct {{ name }}_solver_capsule
     external_function_external_param_casadi *forw_vde_casadi_{{ jj }};
     external_function_external_param_casadi *expl_ode_fun_{{ jj }};
 {% if solver_options.hessian_approx == "EXACT" %}
-    external_function_external_param_casadi *hess_vde_casadi_{{ jj }};
+    external_function_external_param_casadi *expl_ode_hess_{{ jj }};
 {%- endif %}
 {% elif mocp_opts.integrator_type[jj] == "IRK" %}
     external_function_external_param_{{ model[jj].dyn_ext_fun_type }} *impl_dae_fun_{{ jj }};

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.h
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.h
@@ -76,7 +76,7 @@ typedef struct {{ name }}_solver_capsule
     /* external functions phase {{ jj }} */
     // dynamics
 {% if mocp_opts.integrator_type[jj] == "ERK" %}
-    external_function_external_param_casadi *forw_vde_casadi_{{ jj }};
+    external_function_external_param_casadi *expl_vde_forw_{{ jj }};
     external_function_external_param_casadi *expl_ode_fun_{{ jj }};
 {% if solver_options.hessian_approx == "EXACT" %}
     external_function_external_param_casadi *expl_ode_hess_{{ jj }};

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_sim_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_sim_solver.in.c
@@ -139,17 +139,17 @@ int {{ model.name }}_acados_sim_create({{ model.name }}_sim_solver_capsule * cap
 
     {% elif solver_options.integrator_type == "ERK" %}
     // explicit ode
-    capsule->sim_forw_vde_casadi = (external_function_param_{{ model.dyn_ext_fun_type }} *) malloc(sizeof(external_function_param_{{ model.dyn_ext_fun_type }}));
+    capsule->sim_expl_vde_forw = (external_function_param_{{ model.dyn_ext_fun_type }} *) malloc(sizeof(external_function_param_{{ model.dyn_ext_fun_type }}));
     capsule->sim_vde_adj_casadi = (external_function_param_{{ model.dyn_ext_fun_type }} *) malloc(sizeof(external_function_param_{{ model.dyn_ext_fun_type }}));
     capsule->sim_expl_ode_fun_casadi = (external_function_param_{{ model.dyn_ext_fun_type }} *) malloc(sizeof(external_function_param_{{ model.dyn_ext_fun_type }}));
 
-    capsule->sim_forw_vde_casadi->casadi_fun = &{{ model.name }}_expl_vde_forw;
-    capsule->sim_forw_vde_casadi->casadi_n_in = &{{ model.name }}_expl_vde_forw_n_in;
-    capsule->sim_forw_vde_casadi->casadi_n_out = &{{ model.name }}_expl_vde_forw_n_out;
-    capsule->sim_forw_vde_casadi->casadi_sparsity_in = &{{ model.name }}_expl_vde_forw_sparsity_in;
-    capsule->sim_forw_vde_casadi->casadi_sparsity_out = &{{ model.name }}_expl_vde_forw_sparsity_out;
-    capsule->sim_forw_vde_casadi->casadi_work = &{{ model.name }}_expl_vde_forw_work;
-    external_function_param_{{ model.dyn_ext_fun_type }}_create(capsule->sim_forw_vde_casadi, np);
+    capsule->sim_expl_vde_forw->casadi_fun = &{{ model.name }}_expl_vde_forw;
+    capsule->sim_expl_vde_forw->casadi_n_in = &{{ model.name }}_expl_vde_forw_n_in;
+    capsule->sim_expl_vde_forw->casadi_n_out = &{{ model.name }}_expl_vde_forw_n_out;
+    capsule->sim_expl_vde_forw->casadi_sparsity_in = &{{ model.name }}_expl_vde_forw_sparsity_in;
+    capsule->sim_expl_vde_forw->casadi_sparsity_out = &{{ model.name }}_expl_vde_forw_sparsity_out;
+    capsule->sim_expl_vde_forw->casadi_work = &{{ model.name }}_expl_vde_forw_work;
+    external_function_param_{{ model.dyn_ext_fun_type }}_create(capsule->sim_expl_vde_forw, np);
 
     capsule->sim_vde_adj_casadi->casadi_fun = &{{ model.name }}_expl_vde_adj;
     capsule->sim_vde_adj_casadi->casadi_n_in = &{{ model.name }}_expl_vde_adj_n_in;
@@ -325,7 +325,7 @@ int {{ model.name }}_acados_sim_create({{ model.name }}_sim_solver_capsule * cap
 
 {%- elif solver_options.integrator_type == "ERK" %}
     {{ model.name }}_sim_config->model_set({{ model.name }}_sim_in->model,
-                 "expl_vde_forw", capsule->sim_forw_vde_casadi);
+                 "expl_vde_forw", capsule->sim_expl_vde_forw);
     {{ model.name }}_sim_config->model_set({{ model.name }}_sim_in->model,
                  "expl_vde_adj", capsule->sim_vde_adj_casadi);
     {{ model.name }}_sim_config->model_set({{ model.name }}_sim_in->model,
@@ -459,10 +459,10 @@ int {{ model.name }}_acados_sim_free({{ model.name }}_sim_solver_capsule *capsul
     free(capsule->sim_impl_dae_hess);
 {%- endif %}
 {%- elif solver_options.integrator_type == "ERK" %}
-    external_function_param_{{ model.dyn_ext_fun_type }}_free(capsule->sim_forw_vde_casadi);
+    external_function_param_{{ model.dyn_ext_fun_type }}_free(capsule->sim_expl_vde_forw);
     external_function_param_{{ model.dyn_ext_fun_type }}_free(capsule->sim_vde_adj_casadi);
     external_function_param_{{ model.dyn_ext_fun_type }}_free(capsule->sim_expl_ode_fun_casadi);
-    free(capsule->sim_forw_vde_casadi);
+    free(capsule->sim_expl_vde_forw);
     free(capsule->sim_vde_adj_casadi);
     free(capsule->sim_expl_ode_fun_casadi);
 {%- if hessian_approx == "EXACT" %}
@@ -502,7 +502,7 @@ int {{ model.name }}_acados_sim_update_params({{ model.name }}_sim_solver_capsul
     }
 
 {%- if solver_options.integrator_type == "ERK" %}
-    capsule->sim_forw_vde_casadi[0].set_param(capsule->sim_forw_vde_casadi, p);
+    capsule->sim_expl_vde_forw[0].set_param(capsule->sim_expl_vde_forw, p);
     capsule->sim_vde_adj_casadi[0].set_param(capsule->sim_vde_adj_casadi, p);
     capsule->sim_expl_ode_fun_casadi[0].set_param(capsule->sim_expl_ode_fun_casadi, p);
 {%- if hessian_approx == "EXACT" %}

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_sim_solver.in.h
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_sim_solver.in.h
@@ -57,7 +57,7 @@ typedef struct {{ model.name }}_sim_solver_capsule
 
     /* external functions */
     // ERK
-    external_function_param_{{ model.dyn_ext_fun_type }} * sim_forw_vde_casadi;
+    external_function_param_{{ model.dyn_ext_fun_type }} * sim_expl_vde_forw;
     external_function_param_{{ model.dyn_ext_fun_type }} * sim_vde_adj_casadi;
     external_function_param_{{ model.dyn_ext_fun_type }} * sim_expl_ode_fun_casadi;
     external_function_param_{{ model.dyn_ext_fun_type }} * sim_expl_ode_hess;

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -493,9 +493,9 @@ void {{ model.name }}_acados_create_setup_functions({{ model.name }}_solver_caps
 
 {% if solver_options.integrator_type == "ERK" %}
     // explicit ode
-    capsule->forw_vde_casadi = (external_function_external_param_casadi *) malloc(sizeof(external_function_external_param_casadi)*N);
+    capsule->expl_vde_forw = (external_function_external_param_casadi *) malloc(sizeof(external_function_external_param_casadi)*N);
     for (int i = 0; i < N; i++) {
-        MAP_CASADI_FNC(forw_vde_casadi[i], {{ model.name }}_expl_vde_forw);
+        MAP_CASADI_FNC(expl_vde_forw[i], {{ model.name }}_expl_vde_forw);
     }
 
     capsule->expl_ode_fun = (external_function_external_param_casadi *) malloc(sizeof(external_function_external_param_casadi)*N);
@@ -883,7 +883,7 @@ void {{ model.name }}_acados_setup_nlp_in({{ model.name }}_solver_capsule* capsu
     for (int i = 0; i < N; i++)
     {
     {%- if solver_options.integrator_type == "ERK" %}
-        ocp_nlp_dynamics_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, i, "expl_vde_forw", &capsule->forw_vde_casadi[i]);
+        ocp_nlp_dynamics_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, i, "expl_vde_forw", &capsule->expl_vde_forw[i]);
         ocp_nlp_dynamics_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, i, "expl_ode_fun", &capsule->expl_ode_fun[i]);
         ocp_nlp_dynamics_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, i, "expl_vde_adj", &capsule->expl_vde_adj[i]);
         {%- if solver_options.hessian_approx == "EXACT" %}
@@ -2657,15 +2657,15 @@ int {{ model.name }}_acados_free({{ model.name }}_solver_capsule* capsule)
 {%- elif solver_options.integrator_type == "ERK" %}
     for (int i = 0; i < N; i++)
     {
-        external_function_external_param_casadi_free(&capsule->forw_vde_casadi[i]);
+        external_function_external_param_casadi_free(&capsule->expl_vde_forw[i]);
         external_function_external_param_casadi_free(&capsule->expl_ode_fun[i]);
         external_function_external_param_casadi_free(&capsule->expl_vde_adj[i]);
     {%- if solver_options.hessian_approx == "EXACT" %}
         external_function_external_param_casadi_free(&capsule->expl_ode_hess[i]);
     {%- endif %}
     }
-    free(capsule->forw_vde_casadi);
     free(capsule->expl_vde_adj);
+    free(capsule->expl_vde_forw);
     free(capsule->expl_ode_fun);
     {%- if solver_options.hessian_approx == "EXACT" %}
     free(capsule->expl_ode_hess);

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -503,6 +503,11 @@ void {{ model.name }}_acados_create_setup_functions({{ model.name }}_solver_caps
         MAP_CASADI_FNC(expl_ode_fun[i], {{ model.name }}_expl_ode_fun);
     }
 
+    capsule->expl_vde_adj = (external_function_external_param_casadi *) malloc(sizeof(external_function_external_param_casadi)*N);
+    for (int i = 0; i < N; i++) {
+        MAP_CASADI_FNC(expl_vde_adj[i], {{ model.name }}_expl_vde_adj);
+    }
+
     {%- if solver_options.hessian_approx == "EXACT" %}
     capsule->expl_ode_hess = (external_function_external_param_casadi *) malloc(sizeof(external_function_external_param_casadi)*N);
     for (int i = 0; i < N; i++) {
@@ -880,6 +885,7 @@ void {{ model.name }}_acados_setup_nlp_in({{ model.name }}_solver_capsule* capsu
     {%- if solver_options.integrator_type == "ERK" %}
         ocp_nlp_dynamics_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, i, "expl_vde_forw", &capsule->forw_vde_casadi[i]);
         ocp_nlp_dynamics_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, i, "expl_ode_fun", &capsule->expl_ode_fun[i]);
+        ocp_nlp_dynamics_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, i, "expl_vde_adj", &capsule->expl_vde_adj[i]);
         {%- if solver_options.hessian_approx == "EXACT" %}
         ocp_nlp_dynamics_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, i, "expl_ode_hess", &capsule->expl_ode_hess[i]);
         {%- endif %}
@@ -2653,11 +2659,13 @@ int {{ model.name }}_acados_free({{ model.name }}_solver_capsule* capsule)
     {
         external_function_external_param_casadi_free(&capsule->forw_vde_casadi[i]);
         external_function_external_param_casadi_free(&capsule->expl_ode_fun[i]);
+        external_function_external_param_casadi_free(&capsule->expl_vde_adj[i]);
     {%- if solver_options.hessian_approx == "EXACT" %}
         external_function_external_param_casadi_free(&capsule->expl_ode_hess[i]);
     {%- endif %}
     }
     free(capsule->forw_vde_casadi);
+    free(capsule->expl_vde_adj);
     free(capsule->expl_ode_fun);
     {%- if solver_options.hessian_approx == "EXACT" %}
     free(capsule->expl_ode_hess);

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -504,9 +504,9 @@ void {{ model.name }}_acados_create_setup_functions({{ model.name }}_solver_caps
     }
 
     {%- if solver_options.hessian_approx == "EXACT" %}
-    capsule->hess_vde_casadi = (external_function_external_param_casadi *) malloc(sizeof(external_function_external_param_casadi)*N);
+    capsule->expl_ode_hess = (external_function_external_param_casadi *) malloc(sizeof(external_function_external_param_casadi)*N);
     for (int i = 0; i < N; i++) {
-        MAP_CASADI_FNC(hess_vde_casadi[i], {{ model.name }}_expl_ode_hess);
+        MAP_CASADI_FNC(expl_ode_hess[i], {{ model.name }}_expl_ode_hess);
     }
     {%- endif %}
 
@@ -881,7 +881,7 @@ void {{ model.name }}_acados_setup_nlp_in({{ model.name }}_solver_capsule* capsu
         ocp_nlp_dynamics_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, i, "expl_vde_forw", &capsule->forw_vde_casadi[i]);
         ocp_nlp_dynamics_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, i, "expl_ode_fun", &capsule->expl_ode_fun[i]);
         {%- if solver_options.hessian_approx == "EXACT" %}
-        ocp_nlp_dynamics_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, i, "expl_ode_hess", &capsule->hess_vde_casadi[i]);
+        ocp_nlp_dynamics_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, i, "expl_ode_hess", &capsule->expl_ode_hess[i]);
         {%- endif %}
     {%- elif solver_options.integrator_type == "IRK" %}
         ocp_nlp_dynamics_model_set_external_param_fun(nlp_config, nlp_dims, nlp_in, i, "impl_dae_fun", &capsule->impl_dae_fun[i]);
@@ -2654,13 +2654,13 @@ int {{ model.name }}_acados_free({{ model.name }}_solver_capsule* capsule)
         external_function_external_param_casadi_free(&capsule->forw_vde_casadi[i]);
         external_function_external_param_casadi_free(&capsule->expl_ode_fun[i]);
     {%- if solver_options.hessian_approx == "EXACT" %}
-        external_function_external_param_casadi_free(&capsule->hess_vde_casadi[i]);
+        external_function_external_param_casadi_free(&capsule->expl_ode_hess[i]);
     {%- endif %}
     }
     free(capsule->forw_vde_casadi);
     free(capsule->expl_ode_fun);
     {%- if solver_options.hessian_approx == "EXACT" %}
-    free(capsule->hess_vde_casadi);
+    free(capsule->expl_ode_hess);
     {%- endif %}
 
 {%- elif solver_options.integrator_type == "GNSF" %}

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.h
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.h
@@ -103,6 +103,7 @@ typedef struct {{ model.name }}_solver_capsule
 {% if solver_options.integrator_type == "ERK" %}
     external_function_external_param_casadi *forw_vde_casadi;
     external_function_external_param_casadi *expl_ode_fun;
+    external_function_external_param_casadi *expl_vde_adj;
 {% if solver_options.hessian_approx == "EXACT" %}
     external_function_external_param_casadi *expl_ode_hess;
 {%- endif %}

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.h
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.h
@@ -101,7 +101,7 @@ typedef struct {{ model.name }}_solver_capsule
     /* external functions */
     // dynamics
 {% if solver_options.integrator_type == "ERK" %}
-    external_function_external_param_casadi *forw_vde_casadi;
+    external_function_external_param_casadi *expl_vde_forw;
     external_function_external_param_casadi *expl_ode_fun;
     external_function_external_param_casadi *expl_vde_adj;
 {% if solver_options.hessian_approx == "EXACT" %}

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.h
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.h
@@ -104,7 +104,7 @@ typedef struct {{ model.name }}_solver_capsule
     external_function_external_param_casadi *forw_vde_casadi;
     external_function_external_param_casadi *expl_ode_fun;
 {% if solver_options.hessian_approx == "EXACT" %}
-    external_function_external_param_casadi *hess_vde_casadi;
+    external_function_external_param_casadi *expl_ode_hess;
 {%- endif %}
 {% elif solver_options.integrator_type == "IRK" %}
     external_function_external_param_{{ model.dyn_ext_fun_type }} *impl_dae_fun;


### PR DESCRIPTION
and rename ERK related functions for consistency.