### PR TITLE
MATLAB/Octave: add note on interfaces to examples

### DIFF
--- a/examples/acados_matlab_octave/generic_dyn_disc/disc_dyn_example_ocp.m
+++ b/examples/acados_matlab_octave/generic_dyn_disc/disc_dyn_example_ocp.m
@@ -27,9 +27,16 @@
 % ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 % POSSIBILITY OF SUCH DAMAGE.;
 
-%
 
-%% test of native matlab interface
+
+% NOTE: `acados` currently supports both an old MATLAB/Octave interface (< v0.4.0)
+% as well as a new interface (>= v0.4.0).
+
+% THIS EXAMPLE still uses the OLD interface. If you are new to `acados` please start
+% with the examples that have been ported to the new interface already.
+% see https://github.com/acados/acados/issues/1196#issuecomment-2311822122)
+
+
 clear all; clc;
 check_acados_requirements()
 addpath('../linear_mass_spring_model/');
@@ -121,7 +128,7 @@ if (casadi_cost == 0)
     ocp_model.set('cost_source_ext_cost_0', 'generic_ext_cost.c');
     ocp_model.set('cost_function_ext_cost_0', 'ext_cost');
     % Generic stage cost
-    ocp_model.set('cost_ext_fun_type', 'generic');    
+    ocp_model.set('cost_ext_fun_type', 'generic');
     ocp_model.set('cost_source_ext_cost', 'generic_ext_cost.c');
     ocp_model.set('cost_function_ext_cost', 'ext_cost');
     % Generic terminal cost

--- a/examples/acados_matlab_octave/generic_external_cost/external_cost_example_ocp.m
+++ b/examples/acados_matlab_octave/generic_external_cost/external_cost_example_ocp.m
@@ -27,10 +27,17 @@
 % ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 % POSSIBILITY OF SUCH DAMAGE.;
 
-%
+
+
+% NOTE: `acados` currently supports both an old MATLAB/Octave interface (< v0.4.0)
+% as well as a new interface (>= v0.4.0).
+
+% THIS EXAMPLE still uses the OLD interface. If you are new to `acados` please start
+% with the examples that have been ported to the new interface already.
+% see https://github.com/acados/acados/issues/1196#issuecomment-2311822122)
+
 import casadi.*
 
-%% test of native matlab interface
 clear all; clc;
 check_acados_requirements()
 

--- a/examples/acados_matlab_octave/getting_started/extensive_example_ocp.m
+++ b/examples/acados_matlab_octave/getting_started/extensive_example_ocp.m
@@ -27,9 +27,15 @@
 % ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 % POSSIBILITY OF SUCH DAMAGE.;
 
-%
 
-%% test of native matlab interface
+
+% NOTE: `acados` currently supports both an old MATLAB/Octave interface (< v0.4.0)
+% as well as a new interface (>= v0.4.0).
+
+% THIS EXAMPLE still uses the OLD interface. If you are new to `acados` please start
+% with the examples that have been ported to the new interface already.
+% see https://github.com/acados/acados/issues/1196#issuecomment-2311822122)
+
 clear all; clc;
 
 addpath('../pendulum_on_cart_model')
@@ -360,9 +366,9 @@ end
 %     time_linearize = sum(time_lin);
 %     time_regulariz = sum(time_reg);
 %     time_qp_solution = sum(time_qp_sol);
-% 
+%
 %     figure;
-% 
+%
 %     bar_vals = 1000 * [time_linearize; time_regulariz; time_qp_solution; ...
 %         time_total - time_linearize - time_regulariz - time_qp_solution] / n_executions;
 %     bar([1; nan], [bar_vals, nan(size(bar_vals))]' ,'stacked')

--- a/examples/acados_matlab_octave/getting_started/minimal_example_closed_loop.m
+++ b/examples/acados_matlab_octave/getting_started/minimal_example_closed_loop.m
@@ -27,9 +27,15 @@
 % ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 % POSSIBILITY OF SUCH DAMAGE.;
 
-%
 
-%% test of native matlab interface
+
+% NOTE: `acados` currently supports both an old MATLAB/Octave interface (< v0.4.0)
+% as well as a new interface (>= v0.4.0).
+
+% THIS EXAMPLE still uses the OLD interface. If you are new to `acados` please start
+% with the examples that have been ported to the new interface already.
+% see https://github.com/acados/acados/issues/1196#issuecomment-2311822122)
+
 clear all; clc;
 
 model_path = fullfile(pwd,'..','pendulum_on_cart_model');

--- a/examples/acados_matlab_octave/getting_started/minimal_example_ocp.m
+++ b/examples/acados_matlab_octave/getting_started/minimal_example_ocp.m
@@ -27,9 +27,17 @@
 % ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 % POSSIBILITY OF SUCH DAMAGE.;
 
-%
 
-%% test of native matlab interface
+
+
+% NOTE: `acados` currently supports both an old MATLAB/Octave interface (< v0.4.0)
+% as well as a new interface (>= v0.4.0).
+
+% THIS EXAMPLE still uses the OLD interface. If you are new to `acados` please start
+% with the examples that have been ported to the new interface already.
+% see https://github.com/acados/acados/issues/1196#issuecomment-2311822122)
+
+
 % options needed for the Simulink example
 if ~exist('simulink_opts','var')
     disp('using acados simulink default options')

--- a/examples/acados_matlab_octave/getting_started/minimal_example_sim.m
+++ b/examples/acados_matlab_octave/getting_started/minimal_example_sim.m
@@ -27,7 +27,16 @@
 % ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 % POSSIBILITY OF SUCH DAMAGE.;
 
-%
+
+
+
+% NOTE: `acados` currently supports both an old MATLAB/Octave interface (< v0.4.0)
+% as well as a new interface (>= v0.4.0).
+
+% THIS EXAMPLE still uses the OLD interface. If you are new to `acados` please start
+% with the examples that have been ported to the new interface already.
+% see https://github.com/acados/acados/issues/1196#issuecomment-2311822122)
+
 
 %% minimal example of acados integrator matlab interface
 clear all; clc;

--- a/examples/acados_matlab_octave/linear_mass_spring_model/example_closed_loop.m
+++ b/examples/acados_matlab_octave/linear_mass_spring_model/example_closed_loop.m
@@ -27,7 +27,14 @@
 % ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 % POSSIBILITY OF SUCH DAMAGE.;
 
-%
+
+
+% NOTE: `acados` currently supports both an old MATLAB/Octave interface (< v0.4.0)
+% as well as a new interface (>= v0.4.0).
+
+% THIS EXAMPLE still uses the OLD interface. If you are new to `acados` please start
+% with the examples that have been ported to the new interface already.
+% see https://github.com/acados/acados/issues/1196#issuecomment-2311822122)
 
 %% example of closed loop simulation
 clear all; clc;

--- a/examples/acados_matlab_octave/linear_mass_spring_model/example_ocp.m
+++ b/examples/acados_matlab_octave/linear_mass_spring_model/example_ocp.m
@@ -27,9 +27,16 @@
 % ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 % POSSIBILITY OF SUCH DAMAGE.;
 
-%
 
-%% test of native matlab interface
+
+% NOTE: `acados` currently supports both an old MATLAB/Octave interface (< v0.4.0)
+% as well as a new interface (>= v0.4.0).
+
+% THIS EXAMPLE still uses the OLD interface. If you are new to `acados` please start
+% with the examples that have been ported to the new interface already.
+% see https://github.com/acados/acados/issues/1196#issuecomment-2311822122)
+
+
 clear all; clc;
 check_acados_requirements()
 

--- a/examples/acados_matlab_octave/linear_mass_spring_model/example_sim.m
+++ b/examples/acados_matlab_octave/linear_mass_spring_model/example_sim.m
@@ -27,9 +27,16 @@
 % ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 % POSSIBILITY OF SUCH DAMAGE.;
 
-%
 
-%% test of native matlab interface
+
+% NOTE: `acados` currently supports both an old MATLAB/Octave interface (< v0.4.0)
+% as well as a new interface (>= v0.4.0).
+
+% THIS EXAMPLE still uses the OLD interface. If you are new to `acados` please start
+% with the examples that have been ported to the new interface already.
+% see https://github.com/acados/acados/issues/1196#issuecomment-2311822122)
+
+
 clear all; clc;
 check_acados_requirements();
 

--- a/examples/acados_matlab_octave/linear_mass_spring_model/linear_mass_spring_model.m
+++ b/examples/acados_matlab_octave/linear_mass_spring_model/linear_mass_spring_model.m
@@ -27,7 +27,17 @@
 % ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 % POSSIBILITY OF SUCH DAMAGE.;
 
-%
+
+
+
+
+% NOTE: `acados` currently supports both an old MATLAB/Octave interface (< v0.4.0)
+% as well as a new interface (>= v0.4.0).
+
+% THIS EXAMPLE still uses the OLD interface. If you are new to `acados` please start
+% with the examples that have been ported to the new interface already.
+% see https://github.com/acados/acados/issues/1196#issuecomment-2311822122)
+
 
 function model = linear_mass_spring_model()
 

--- a/examples/acados_matlab_octave/linear_mpc/example_closed_loop.m
+++ b/examples/acados_matlab_octave/linear_mpc/example_closed_loop.m
@@ -27,9 +27,16 @@
 % ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 % POSSIBILITY OF SUCH DAMAGE.;
 
-%
 
-%% test of native matlab interface
+
+% NOTE: `acados` currently supports both an old MATLAB/Octave interface (< v0.4.0)
+% as well as a new interface (>= v0.4.0).
+
+% THIS EXAMPLE still uses the OLD interface. If you are new to `acados` please start
+% with the examples that have been ported to the new interface already.
+% see https://github.com/acados/acados/issues/1196#issuecomment-2311822122)
+
+
 clear all; clc; close all;
 check_acados_requirements()
 

--- a/examples/acados_matlab_octave/linear_mpc/quadcopter.m
+++ b/examples/acados_matlab_octave/linear_mpc/quadcopter.m
@@ -28,6 +28,17 @@
 % POSSIBILITY OF SUCH DAMAGE.;
 %
 
+
+
+
+% NOTE: `acados` currently supports both an old MATLAB/Octave interface (< v0.4.0)
+% as well as a new interface (>= v0.4.0).
+
+% THIS EXAMPLE still uses the OLD interface. If you are new to `acados` please start
+% with the examples that have been ported to the new interface already.
+% see https://github.com/acados/acados/issues/1196#issuecomment-2311822122)
+
+
 % this function implements the quadcopter model from https://osqp.org/docs/examples/mpc.html
 % more infomation can be found here: https://github.com/orgs/osqp/discussions/558
 
@@ -80,7 +91,7 @@ cost_expr_ext_cost_e = (sym_x-xr)'*Q*(sym_x-xr);  % terminal cost (only states)
 cost_expr_ext_cost = cost_expr_ext_cost_e + sym_u'*R*sym_u;  % stage cost (states and inputs)
 cost_expr_ext_cost = 1/h * cost_expr_ext_cost;  % scale the stage cost to match the discrete formulation
 cost_expr_ext_cost_0 = 1/h * sym_u'*R*sym_u;  % penalize only the inputs in the first stage
-% more info on discrete cost scaling: 
+% more info on discrete cost scaling:
 % https://docs.acados.org/python_interface/index.html#acados_template.acados_ocp_cost.AcadosOcpCost
 
 % linear least-squares cost formulation (alternative)

--- a/examples/acados_matlab_octave/lorentz/example_mhe.m
+++ b/examples/acados_matlab_octave/lorentz/example_mhe.m
@@ -30,6 +30,16 @@
 %
 % author: Katrin Baumgaertner
 
+
+
+
+% NOTE: `acados` currently supports both an old MATLAB/Octave interface (< v0.4.0)
+% as well as a new interface (>= v0.4.0).
+
+% THIS EXAMPLE still uses the OLD interface. If you are new to `acados` please start
+% with the examples that have been ported to the new interface already.
+% see https://github.com/acados/acados/issues/1196#issuecomment-2311822122)
+
 clear all
 
 %% model

--- a/examples/acados_matlab_octave/lorentz/lorentz_model.m
+++ b/examples/acados_matlab_octave/lorentz/lorentz_model.m
@@ -30,6 +30,19 @@
 %
 % author: Katrin Baumgaertner
 
+
+
+
+
+% NOTE: `acados` currently supports both an old MATLAB/Octave interface (< v0.4.0)
+% as well as a new interface (>= v0.4.0).
+
+% THIS EXAMPLE still uses the OLD interface. If you are new to `acados` please start
+% with the examples that have been ported to the new interface already.
+% see https://github.com/acados/acados/issues/1196#issuecomment-2311822122)
+
+
+
 function [model] = lorentz_model()
 
 import casadi.*

--- a/examples/acados_matlab_octave/lorentz/setup_estimator.m
+++ b/examples/acados_matlab_octave/lorentz/setup_estimator.m
@@ -29,6 +29,14 @@
 
 
 
+% NOTE: `acados` currently supports both an old MATLAB/Octave interface (< v0.4.0)
+% as well as a new interface (>= v0.4.0).
+
+% THIS EXAMPLE still uses the OLD interface. If you are new to `acados` please start
+% with the examples that have been ported to the new interface already.
+% see https://github.com/acados/acados/issues/1196#issuecomment-2311822122)
+
+
 function [estimator] = setup_estimator(model)
 
 N = model.N;

--- a/examples/acados_matlab_octave/lorentz/setup_integrator.m
+++ b/examples/acados_matlab_octave/lorentz/setup_integrator.m
@@ -28,6 +28,16 @@
 % POSSIBILITY OF SUCH DAMAGE.;
 
 
+
+
+% NOTE: `acados` currently supports both an old MATLAB/Octave interface (< v0.4.0)
+% as well as a new interface (>= v0.4.0).
+
+% THIS EXAMPLE still uses the OLD interface. If you are new to `acados` please start
+% with the examples that have been ported to the new interface already.
+% see https://github.com/acados/acados/issues/1196#issuecomment-2311822122)
+
+
 function [sim_solver] = setup_integrator(model)
 
 model_name = 'lorentz_model_integrator';

--- a/examples/acados_matlab_octave/masses_chain_model/example_closed_loop.m
+++ b/examples/acados_matlab_octave/masses_chain_model/example_closed_loop.m
@@ -27,7 +27,16 @@
 % ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 % POSSIBILITY OF SUCH DAMAGE.;
 
-%
+
+
+
+% NOTE: `acados` currently supports both an old MATLAB/Octave interface (< v0.4.0)
+% as well as a new interface (>= v0.4.0).
+
+% THIS EXAMPLE still uses the OLD interface. If you are new to `acados` please start
+% with the examples that have been ported to the new interface already.
+% see https://github.com/acados/acados/issues/1196#issuecomment-2311822122)
+
 
 %% example of closed loop simulation
 clear all

--- a/examples/acados_matlab_octave/masses_chain_model/example_ocp.m
+++ b/examples/acados_matlab_octave/masses_chain_model/example_ocp.m
@@ -27,9 +27,16 @@
 % ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 % POSSIBILITY OF SUCH DAMAGE.;
 
-%
 
-%% test of native matlab interface
+
+
+% NOTE: `acados` currently supports both an old MATLAB/Octave interface (< v0.4.0)
+% as well as a new interface (>= v0.4.0).
+
+% THIS EXAMPLE still uses the OLD interface. If you are new to `acados` please start
+% with the examples that have been ported to the new interface already.
+% see https://github.com/acados/acados/issues/1196#issuecomment-2311822122)
+
 clear all
 
 

--- a/examples/acados_matlab_octave/pendulum_dae/example_closed_loop.m
+++ b/examples/acados_matlab_octave/pendulum_dae/example_closed_loop.m
@@ -27,9 +27,15 @@
 % ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 % POSSIBILITY OF SUCH DAMAGE.;
 
-%
 
-%% test of native matlab interface
+
+% NOTE: `acados` currently supports both an old MATLAB/Octave interface (< v0.4.0)
+% as well as a new interface (>= v0.4.0).
+
+% THIS EXAMPLE still uses the OLD interface. If you are new to `acados` please start
+% with the examples that have been ported to the new interface already.
+% see https://github.com/acados/acados/issues/1196#issuecomment-2311822122)
+
 clear all; clc;
 
 % check that env.sh has been run

--- a/examples/acados_matlab_octave/pendulum_dae/example_sim.m
+++ b/examples/acados_matlab_octave/pendulum_dae/example_sim.m
@@ -27,7 +27,14 @@
 % ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 % POSSIBILITY OF SUCH DAMAGE.;
 
-%
+
+
+% NOTE: `acados` currently supports both an old MATLAB/Octave interface (< v0.4.0)
+% as well as a new interface (>= v0.4.0).
+
+% THIS EXAMPLE still uses the OLD interface. If you are new to `acados` please start
+% with the examples that have been ported to the new interface already.
+% see https://github.com/acados/acados/issues/1196#issuecomment-2311822122)
 
 clear all; clc;
 

--- a/examples/acados_matlab_octave/pendulum_on_cart_model/example_closed_loop.m
+++ b/examples/acados_matlab_octave/pendulum_on_cart_model/example_closed_loop.m
@@ -29,7 +29,14 @@
 
 %
 
-%% test of native matlab interface
+% NOTE: `acados` currently supports both an old MATLAB/Octave interface (< v0.4.0)
+% as well as a new interface (>= v0.4.0).
+
+% THIS EXAMPLE still uses the OLD interface. If you are new to `acados` please start
+% with the examples that have been ported to the new interface already.
+% see https://github.com/acados/acados/issues/1196#issuecomment-2311822122)
+
+
 clear all
 
 model_name = 'ocp_pendulum';

--- a/examples/acados_matlab_octave/pendulum_on_cart_model/example_ocp.m
+++ b/examples/acados_matlab_octave/pendulum_on_cart_model/example_ocp.m
@@ -27,9 +27,16 @@
 % ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 % POSSIBILITY OF SUCH DAMAGE.;
 
-%
 
-%% test of native matlab interface
+
+% NOTE: `acados` currently supports both an old MATLAB/Octave interface (< v0.4.0)
+% as well as a new interface (>= v0.4.0).
+
+% THIS EXAMPLE still uses the OLD interface. If you are new to `acados` please start
+% with the examples that have been ported to the new interface already.
+% see https://github.com/acados/acados/issues/1196#issuecomment-2311822122)
+
+
 clear all; clc;
 
 % check that env.sh has been run

--- a/examples/acados_matlab_octave/pendulum_on_cart_model/example_ocp_custom_hess.m
+++ b/examples/acados_matlab_octave/pendulum_on_cart_model/example_ocp_custom_hess.m
@@ -29,7 +29,14 @@
 
 %
 
-%% test of native matlab interface
+% NOTE: `acados` currently supports both an old MATLAB/Octave interface (< v0.4.0)
+% as well as a new interface (>= v0.4.0).
+
+% THIS EXAMPLE still uses the OLD interface. If you are new to `acados` please start
+% with the examples that have been ported to the new interface already.
+% see https://github.com/acados/acados/issues/1196#issuecomment-2311822122)
+
+
 clear all; clc;
 import casadi.*
 

--- a/examples/acados_matlab_octave/pendulum_on_cart_model/example_ocp_param_sens.m
+++ b/examples/acados_matlab_octave/pendulum_on_cart_model/example_ocp_param_sens.m
@@ -29,7 +29,13 @@
 
 %
 
-%% test of native matlab interface
+% NOTE: `acados` currently supports both an old MATLAB/Octave interface (< v0.4.0)
+% as well as a new interface (>= v0.4.0).
+
+% THIS EXAMPLE still uses the OLD interface. If you are new to `acados` please start
+% with the examples that have been ported to the new interface already.
+% see https://github.com/acados/acados/issues/1196#issuecomment-2311822122)
+
 clear all; clc;
 
 % check that env.sh has been run

--- a/examples/acados_matlab_octave/pendulum_on_cart_model/example_ocp_reg.m
+++ b/examples/acados_matlab_octave/pendulum_on_cart_model/example_ocp_reg.m
@@ -29,7 +29,14 @@
 
 %
 
-%% test of native matlab interface
+% NOTE: `acados` currently supports both an old MATLAB/Octave interface (< v0.4.0)
+% as well as a new interface (>= v0.4.0).
+
+% THIS EXAMPLE still uses the OLD interface. If you are new to `acados` please start
+% with the examples that have been ported to the new interface already.
+% see https://github.com/acados/acados/issues/1196#issuecomment-2311822122)
+
+
 clear all
 
 % check that env.sh has been run

--- a/examples/acados_matlab_octave/pendulum_on_cart_model/example_sim.m
+++ b/examples/acados_matlab_octave/pendulum_on_cart_model/example_sim.m
@@ -29,7 +29,14 @@
 
 %
 
-%% test of native matlab interface
+% NOTE: `acados` currently supports both an old MATLAB/Octave interface (< v0.4.0)
+% as well as a new interface (>= v0.4.0).
+
+% THIS EXAMPLE still uses the OLD interface. If you are new to `acados` please start
+% with the examples that have been ported to the new interface already.
+% see https://github.com/acados/acados/issues/1196#issuecomment-2311822122)
+
+
 clear all
 
 % check that env.sh has been run

--- a/examples/acados_matlab_octave/pendulum_on_cart_model/example_solution_sens_closed_loop.m
+++ b/examples/acados_matlab_octave/pendulum_on_cart_model/example_solution_sens_closed_loop.m
@@ -27,9 +27,16 @@
 % ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 % POSSIBILITY OF SUCH DAMAGE.;
 
-%
 
-%% test of native matlab interface
+
+% NOTE: `acados` currently supports both an old MATLAB/Octave interface (< v0.4.0)
+% as well as a new interface (>= v0.4.0).
+
+% THIS EXAMPLE still uses the OLD interface. If you are new to `acados` please start
+% with the examples that have been ported to the new interface already.
+% see https://github.com/acados/acados/issues/1196#issuecomment-2311822122)
+
+
 clear all; clc;
 
 model_path = fullfile(pwd,'..','pendulum_on_cart_model');
@@ -83,10 +90,10 @@ ocp_model.set('sym_xdot', model.sym_xdot);
 % % nonlinear-least squares cost
 % ocp_model.set('cost_type', 'nonlinear_ls');
 % ocp_model.set('cost_type_e', 'nonlinear_ls');
-% 
+%
 % ocp_model.set('cost_expr_y', model.cost_expr_y);
 % ocp_model.set('cost_expr_y_e', model.cost_expr_y_e);
-% 
+%
 % W_x = diag([1e2, 1e2, 1e-2, 1e-2]);
 % W_u = 1e-3;
 % W = blkdiag(W_x, W_u);
@@ -175,7 +182,7 @@ for i=1:N_sim
         status = ocp_solver.get('status'); % 0 - success
         x_lin = xcurrent;
         u_lin = u0;
-        
+
         sens_u = zeros(nx, N);
         % get sensitivities w.r.t. initial state value with index
         field = 'ex'; % equality constraint on states

--- a/examples/acados_matlab_octave/pendulum_on_cart_model/experiment_dae_formulation.m
+++ b/examples/acados_matlab_octave/pendulum_on_cart_model/experiment_dae_formulation.m
@@ -27,9 +27,16 @@
 % ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 % POSSIBILITY OF SUCH DAMAGE.;
 
-%
 
-%% test of native matlab interface
+
+% NOTE: `acados` currently supports both an old MATLAB/Octave interface (< v0.4.0)
+% as well as a new interface (>= v0.4.0).
+
+% THIS EXAMPLE still uses the OLD interface. If you are new to `acados` please start
+% with the examples that have been ported to the new interface already.
+% see https://github.com/acados/acados/issues/1196#issuecomment-2311822122)
+
+
 clear all
 
 % check that env.sh has been run
@@ -228,7 +235,7 @@ for i = 1:3
         status, sqp_iter, time_tot*1e3, time_lin*1e3, time_qp_sol*1e3, time_reg*1e3 );
 
     ocp_solver.print('stat');
-    
+
     if i == 1
         % save reference
         xref = x;

--- a/examples/acados_matlab_octave/pendulum_on_cart_model/pendulum_on_cart_model.m
+++ b/examples/acados_matlab_octave/pendulum_on_cart_model/pendulum_on_cart_model.m
@@ -27,7 +27,15 @@
 % ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 % POSSIBILITY OF SUCH DAMAGE.;
 
-%
+
+
+% NOTE: `acados` currently supports both an old MATLAB/Octave interface (< v0.4.0)
+% as well as a new interface (>= v0.4.0).
+
+% THIS EXAMPLE still uses the OLD interface. If you are new to `acados` please start
+% with the examples that have been ported to the new interface already.
+% see https://github.com/acados/acados/issues/1196#issuecomment-2311822122)
+
 
 function model = pendulum_on_cart_model()
 

--- a/examples/acados_matlab_octave/pendulum_on_cart_model/pendulum_on_cart_model_dae.m
+++ b/examples/acados_matlab_octave/pendulum_on_cart_model/pendulum_on_cart_model_dae.m
@@ -27,7 +27,16 @@
 % ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 % POSSIBILITY OF SUCH DAMAGE.;
 
-%
+
+
+% NOTE: `acados` currently supports both an old MATLAB/Octave interface (< v0.4.0)
+% as well as a new interface (>= v0.4.0).
+
+% THIS EXAMPLE still uses the OLD interface. If you are new to `acados` please start
+% with the examples that have been ported to the new interface already.
+% see https://github.com/acados/acados/issues/1196#issuecomment-2311822122)
+
+
 
 function model = pendulum_on_cart_model_dae()
 
@@ -64,7 +73,7 @@ expr_f_impl = vertcat(v, ...
                       (- l*m*sym_z + F*cos(theta) + g*m*sin(theta) + M*g*sin(theta))/(l*(M + m - m*cos(theta).^2)), ...
                       cos(theta)*sin(theta)*omega.^2) ...
                   - [sym_xdot; sym_z];
-               
+
 %% constraints
 expr_h = sym_u;
 

--- a/examples/acados_matlab_octave/pendulum_on_cart_model/pendulum_on_cart_model_with_param.m
+++ b/examples/acados_matlab_octave/pendulum_on_cart_model/pendulum_on_cart_model_with_param.m
@@ -27,7 +27,16 @@
 % ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 % POSSIBILITY OF SUCH DAMAGE.;
 
-%
+
+
+% NOTE: `acados` currently supports both an old MATLAB/Octave interface (< v0.4.0)
+% as well as a new interface (>= v0.4.0).
+
+% THIS EXAMPLE still uses the OLD interface. If you are new to `acados` please start
+% with the examples that have been ported to the new interface already.
+% see https://github.com/acados/acados/issues/1196#issuecomment-2311822122)
+
+
 
 function model = pendulum_on_cart_model_with_param()
 

--- a/examples/acados_matlab_octave/race_cars/bicycle_model.m
+++ b/examples/acados_matlab_octave/race_cars/bicycle_model.m
@@ -30,7 +30,16 @@
 %
 % Author: Daniel Kloeser
 % Ported by Thomas Jespersen (thomasj@tkjelectronics.dk), TKJ Electronics
-%
+
+
+
+% NOTE: `acados` currently supports both an old MATLAB/Octave interface (< v0.4.0)
+% as well as a new interface (>= v0.4.0).
+
+% THIS EXAMPLE still uses the OLD interface. If you are new to `acados` please start
+% with the examples that have been ported to the new interface already.
+% see https://github.com/acados/acados/issues/1196#issuecomment-2311822122)
+
 
 function [model, constraint] = bicycle_model(track)
 

--- a/examples/acados_matlab_octave/race_cars/main.m
+++ b/examples/acados_matlab_octave/race_cars/main.m
@@ -30,7 +30,17 @@
 %
 % Author: Daniel Kloeser
 % Ported by Thomas Jespersen (thomasj@tkjelectronics.dk), TKJ Electronics
-%
+
+
+% NOTE: `acados` currently supports both an old MATLAB/Octave interface (< v0.4.0)
+% as well as a new interface (>= v0.4.0).
+
+% THIS EXAMPLE still uses the OLD interface. If you are new to `acados` please start
+% with the examples that have been ported to the new interface already.
+% see https://github.com/acados/acados/issues/1196#issuecomment-2311822122)
+
+
+
 
 %% Example of the frc_racecars in simulation without obstacle avoidance:
 %% This example is for the optimal racing of the frc race cars. The model is a simple bicycle model and the lateral acceleration is constraint in order to validate the model assumptions.

--- a/examples/acados_matlab_octave/simple_dae_model/example_ocp.m
+++ b/examples/acados_matlab_octave/simple_dae_model/example_ocp.m
@@ -27,9 +27,15 @@
 % ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 % POSSIBILITY OF SUCH DAMAGE.;
 
-%
 
-%% test of native matlab interface
+
+% NOTE: `acados` currently supports both an old MATLAB/Octave interface (< v0.4.0)
+% as well as a new interface (>= v0.4.0).
+
+% THIS EXAMPLE still uses the OLD interface. If you are new to `acados` please start
+% with the examples that have been ported to the new interface already.
+% see https://github.com/acados/acados/issues/1196#issuecomment-2311822122)
+
 clear all; clc;
 
 model_name = 'simple_dae';

--- a/examples/acados_matlab_octave/simple_dae_model/simple_dae_model.m
+++ b/examples/acados_matlab_octave/simple_dae_model/simple_dae_model.m
@@ -27,7 +27,16 @@
 % ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 % POSSIBILITY OF SUCH DAMAGE.;
 
-%
+
+
+
+% NOTE: `acados` currently supports both an old MATLAB/Octave interface (< v0.4.0)
+% as well as a new interface (>= v0.4.0).
+
+% THIS EXAMPLE still uses the OLD interface. If you are new to `acados` please start
+% with the examples that have been ported to the new interface already.
+% see https://github.com/acados/acados/issues/1196#issuecomment-2311822122)
+
 
 function model = simple_dae_model()
     %% this function generates an implicit ODE / index-1 DAE model,

--- a/examples/acados_matlab_octave/swarming/example_closed_loop.m
+++ b/examples/acados_matlab_octave/swarming/example_closed_loop.m
@@ -1,4 +1,43 @@
-%% Test of native matlab interface
+%
+% Copyright (c) The acados authors.
+%
+% This file is part of acados.
+%
+% The 2-Clause BSD License
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%
+% 1. Redistributions of source code must retain the above copyright notice,
+% this list of conditions and the following disclaimer.
+%
+% 2. Redistributions in binary form must reproduce the above copyright notice,
+% this list of conditions and the following disclaimer in the documentation
+% and/or other materials provided with the distribution.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.;
+
+% Author: Enrica
+
+
+% NOTE: `acados` currently supports both an old MATLAB/Octave interface (< v0.4.0)
+% as well as a new interface (>= v0.4.0).
+
+% THIS EXAMPLE still uses the OLD interface. If you are new to `acados` please start
+% with the examples that have been ported to the new interface already.
+% see https://github.com/acados/acados/issues/1196#issuecomment-2311822122)
+
+
 clear all
 
 % Check that env.sh has been run

--- a/examples/acados_matlab_octave/swarming/example_ocp.m
+++ b/examples/acados_matlab_octave/swarming/example_ocp.m
@@ -1,4 +1,44 @@
 %
+% Copyright (c) The acados authors.
+%
+% This file is part of acados.
+%
+% The 2-Clause BSD License
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%
+% 1. Redistributions of source code must retain the above copyright notice,
+% this list of conditions and the following disclaimer.
+%
+% 2. Redistributions in binary form must reproduce the above copyright notice,
+% this list of conditions and the following disclaimer in the documentation
+% and/or other materials provided with the distribution.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.;
+
+% Author: Enrica
+
+
+% NOTE: `acados` currently supports both an old MATLAB/Octave interface (< v0.4.0)
+% as well as a new interface (>= v0.4.0).
+
+% THIS EXAMPLE still uses the OLD interface. If you are new to `acados` please start
+% with the examples that have been ported to the new interface already.
+% see https://github.com/acados/acados/issues/1196#issuecomment-2311822122)
+
+
+
 % This file allows the control of a swarm of robots. The swarm is composed
 % by N agents with decoupled, linear dynamics. The goal is to achieve
 % coordinated motion from random position and velocities.

--- a/examples/acados_matlab_octave/swarming/example_sim.m
+++ b/examples/acados_matlab_octave/swarming/example_sim.m
@@ -1,4 +1,44 @@
 %
+% Copyright (c) The acados authors.
+%
+% This file is part of acados.
+%
+% The 2-Clause BSD License
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%
+% 1. Redistributions of source code must retain the above copyright notice,
+% this list of conditions and the following disclaimer.
+%
+% 2. Redistributions in binary form must reproduce the above copyright notice,
+% this list of conditions and the following disclaimer in the documentation
+% and/or other materials provided with the distribution.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.;
+
+% Author: Enrica
+
+
+% NOTE: `acados` currently supports both an old MATLAB/Octave interface (< v0.4.0)
+% as well as a new interface (>= v0.4.0).
+
+% THIS EXAMPLE still uses the OLD interface. If you are new to `acados` please start
+% with the examples that have been ported to the new interface already.
+% see https://github.com/acados/acados/issues/1196#issuecomment-2311822122)
+
+
+
 % This file allows the simulation of the dynamics of a swarm of robots.
 % Here, the swarm is composed by N agents with decoupled, linear dynamics.
 %

--- a/examples/acados_matlab_octave/swarming/swarming_model.m
+++ b/examples/acados_matlab_octave/swarming/swarming_model.m
@@ -1,9 +1,49 @@
+% Copyright (c) The acados authors.
+%
+% This file is part of acados.
+%
+% The 2-Clause BSD License
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%
+% 1. Redistributions of source code must retain the above copyright notice,
+% this list of conditions and the following disclaimer.
+%
+% 2. Redistributions in binary form must reproduce the above copyright notice,
+% this list of conditions and the following disclaimer in the documentation
+% and/or other materials provided with the distribution.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.;
+
+% Author: Enrica
+
+
+% NOTE: `acados` currently supports both an old MATLAB/Octave interface (< v0.4.0)
+% as well as a new interface (>= v0.4.0).
+
+% THIS EXAMPLE still uses the OLD interface. If you are new to `acados` please start
+% with the examples that have been ported to the new interface already.
+% see https://github.com/acados/acados/issues/1196#issuecomment-2311822122)
+
+
+
 function model = swarming_model(S)
 
 % SWARMING_MODEL - Function that describes the dynamics of the swarm and
 % the cost function for controlling it.
 %
-% Swarming  is the behavior of collective and ordered motion. It can be 
+% Swarming  is the behavior of collective and ordered motion. It can be
 % obtained through the combination of the following rules:
 %
 % Separation rule: drives the agents to a reference inter-agent ...
@@ -54,7 +94,7 @@ expr_h = sym_u; % constraints only on control inputs, for now
 %% Nonlinear least squares
 
 % Weights
-W_sep = 1; 
+W_sep = 1;
 W_dir = 1;
 W_nav = 2;
 W_u = 1e-1; % Penalization of high values of the control input variables
@@ -70,10 +110,10 @@ M = ones(N,N) - eye(N,N);
 
 % For every agent define the nonlinear_ls terms
 for agent = 1:N
-    
+
     % Get the index triplet related to the current agent
     agent_idx = [1,2,3]' + 3*(agent-1)*ones(3,1);
-    
+
     % For every neighbor, compute the distance to the current agent
     for neig = 1:(N-1)
         if neig < agent

--- a/examples/acados_matlab_octave/wind_turbine_nx6/example_closed_loop.m
+++ b/examples/acados_matlab_octave/wind_turbine_nx6/example_closed_loop.m
@@ -27,9 +27,16 @@
 % ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 % POSSIBILITY OF SUCH DAMAGE.;
 
-%
 
-%% test of native matlab interface
+
+% NOTE: `acados` currently supports both an old MATLAB/Octave interface (< v0.4.0)
+% as well as a new interface (>= v0.4.0).
+
+% THIS EXAMPLE still uses the OLD interface. If you are new to `acados` please start
+% with the examples that have been ported to the new interface already.
+% see https://github.com/acados/acados/issues/1196#issuecomment-2311822122)
+
+
 clear all
 
 

--- a/examples/acados_matlab_octave/wind_turbine_nx6/example_ocp.m
+++ b/examples/acados_matlab_octave/wind_turbine_nx6/example_ocp.m
@@ -27,12 +27,17 @@
 % ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 % POSSIBILITY OF SUCH DAMAGE.;
 
-%
 
-%% test of native matlab interface
+
+% NOTE: `acados` currently supports both an old MATLAB/Octave interface (< v0.4.0)
+% as well as a new interface (>= v0.4.0).
+
+% THIS EXAMPLE still uses the OLD interface. If you are new to `acados` please start
+% with the examples that have been ported to the new interface already.
+% see https://github.com/acados/acados/issues/1196#issuecomment-2311822122)
+
+
 clear all
-
-
 
 % check that env.sh has been run
 env_run = getenv('ENV_RUN');
@@ -123,7 +128,7 @@ W(2, 2) =  0.0180;
 W(3, 3) =  0.01;
 W(4, 4) =  0.001;
 % weight matrix in mayer term
-W_e = zeros(ny_e, ny_e); 
+W_e = zeros(ny_e, ny_e);
 W_e(1, 1) =  1.5114;
 W_e(2, 1) = -0.0649;
 W_e(1, 2) = -0.0649;

--- a/examples/acados_matlab_octave/wind_turbine_nx6/example_sim.m
+++ b/examples/acados_matlab_octave/wind_turbine_nx6/example_sim.m
@@ -27,9 +27,16 @@
 % ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 % POSSIBILITY OF SUCH DAMAGE.;
 
-%
 
-%% test of native matlab interface
+% NOTE: `acados` currently supports both an old MATLAB/Octave interface (< v0.4.0)
+% as well as a new interface (>= v0.4.0).
+
+% THIS EXAMPLE still uses the OLD interface. If you are new to `acados` please start
+% with the examples that have been ported to the new interface already.
+% see https://github.com/acados/acados/issues/1196#issuecomment-2311822122)
+
+
+
 clear all
 
 

--- a/examples/acados_matlab_octave/wind_turbine_nx6/sim_S02_DefACADOSVarSpace.m
+++ b/examples/acados_matlab_octave/wind_turbine_nx6/sim_S02_DefACADOSVarSpace.m
@@ -32,55 +32,55 @@
 %% States
 import casadi.*
 
-% States 
-x = MX.sym('x',6); 
+% States
+x = MX.sym('x',6);
 
-% Generator Angular Velocity ( rad/s ) 
+% Generator Angular Velocity ( rad/s )
 GEN_agvelSt = x(1);
-% Drivetrain torsional Angular Velocity ( rad/s ) 
+% Drivetrain torsional Angular Velocity ( rad/s )
 DT_agvelTorsSt = x(2);
-% Generator azimuth angle ( rad ) 
+% Generator azimuth angle ( rad )
 GEN_agSt = x(3);
-% Drivetrain torsional angle ( rad ) 
+% Drivetrain torsional angle ( rad )
 DT_agTorsSt = x(4);
-% Blade pitch angle ( rad ) 
+% Blade pitch angle ( rad )
 BLD_agPtchActSt = x(5);
-% Generator torque ( 10kNm ) 
+% Generator torque ( 10kNm )
 GEN_trqActSt = x(6);
 
-%% Differential State Variables 
+%% Differential State Variables
 
-% Differntial States 
-dx = MX.sym('dx',6); 
+% Differntial States
+dx = MX.sym('dx',6);
 
-% Drivetrain angular acceleration ( rad/s^2 ) 
+% Drivetrain angular acceleration ( rad/s^2 )
 dotDT_agaccDyn = dx(1);
-% Drivetrain torsional angular acceleration ( rad/s^2 ) 
+% Drivetrain torsional angular acceleration ( rad/s^2 )
 dotDT_agaccDynTors = dx(2);
-% Drivetrain angular velocity ( rad/s ) 
+% Drivetrain angular velocity ( rad/s )
 dotDT_Dyn_AngVel = dx(3);
-% Drivetrain torsional angular velocity ( rad/s ) 
+% Drivetrain torsional angular velocity ( rad/s )
 dotDT_Dyn_AngVel_Tors = dx(4);
-% pitch dynamics blade PT-1 ( rad/s ) 
+% pitch dynamics blade PT-1 ( rad/s )
 dotBLD_Dyn_PtchAct = dx(5);
-% Generator torque PT-1 ( Nm/s ) 
+% Generator torque PT-1 ( Nm/s )
 dotGEN_Dyn_TrqAct = dx(6);
 
-%% Control inputs 
+%% Control inputs
 
-% Control inputs 
-u = MX.sym('u',2); 
+% Control inputs
+u = MX.sym('u',2);
 
-% Desired pitch angle for Blade ( rad ) 
+% Desired pitch angle for Blade ( rad )
 BLD_agPtchDes = u(1);
-% Desired generator torque ( 10kNm ) 
+% Desired generator torque ( 10kNm )
 GEN_trqDes = u(2);
 
-%% Disturbance 
+%% Disturbance
 
-p = MX.sym('p',1); 
+p = MX.sym('p',1);
 
-% Far upstream effective wind velocity ( m/s ) 
+% Far upstream effective wind velocity ( m/s )
 ENV_velEffWnd = p(1);
 
 

--- a/examples/acados_matlab_octave/wind_turbine_nx6/sim_S03_SetupSysParameters.m
+++ b/examples/acados_matlab_octave/wind_turbine_nx6/sim_S03_SetupSysParameters.m
@@ -31,36 +31,36 @@
 
 %% Parameters
 
-% Parameter ( [-] ) 
+% Parameter ( [-] )
 p_1 = 2 ;
-% Parameter ( [-] ) 
+% Parameter ( [-] )
 p_2 = 5091.5 ;
-% Parameter ( [-] ) 
+% Parameter ( [-] )
 p_3 = 0.35 ;
-% Parameter ( [-] ) 
+% Parameter ( [-] )
 p_4 = 1 ;
-% Parameter ( [-] ) 
+% Parameter ( [-] )
 p_5 = 63 ;
-% Parameter ( [-] ) 
+% Parameter ( [-] )
 p_6 = 2.0944 ;
-% Parameter ( [-] ) 
+% Parameter ( [-] )
 p_7 = 4.1888 ;
-% Parameter ( [-] ) 
+% Parameter ( [-] )
 p_8 = -1 ;
-% Parameter ( [-] ) 
+% Parameter ( [-] )
 p_9 = 31.5 ;
-% Parameter ( [-] ) 
+% Parameter ( [-] )
 p_10 = 3.55638e+07 ;
-% Parameter ( [-] ) 
+% Parameter ( [-] )
 p_11 = 5.0255e+06 ;
-% Parameter ( [-] ) 
+% Parameter ( [-] )
 p_12 = 970000 ;
-% Parameter ( [-] ) 
+% Parameter ( [-] )
 p_13 = 6.215e+07 ;
-% Parameter ( [-] ) 
+% Parameter ( [-] )
 p_14 = 8.67637e+08 ;
-% Parameter ( [-] ) 
+% Parameter ( [-] )
 p_15 = 2.5 ;
-% Parameter ( [-] ) 
+% Parameter ( [-] )
 p_16 = 50 ;
 

--- a/examples/acados_matlab_octave/wind_turbine_nx6/sim_S04_SetupNonlinearStateSpaceDynamics.m
+++ b/examples/acados_matlab_octave/wind_turbine_nx6/sim_S04_SetupNonlinearStateSpaceDynamics.m
@@ -31,78 +31,78 @@
 
 %% Set-up nonlinear state-space model of wind turbine
 
- % Rotor azimuth angle for Blade 1 ( rad ) 
+ % Rotor azimuth angle for Blade 1 ( rad )
 BLD1_agAzi = DT_agTorsSt+GEN_agSt ;
 
- % Rotor azimuth angle for Blade 2 ( rad ) 
+ % Rotor azimuth angle for Blade 2 ( rad )
 BLD2_agAzi = p_6+DT_agTorsSt+GEN_agSt ;
 
- % Rotor azimuth angle for Blade 3 ( rad ) 
+ % Rotor azimuth angle for Blade 3 ( rad )
 BLD3_agAzi = p_7+DT_agTorsSt+GEN_agSt ;
 
- % Blade 1 effective wind speed ( m/s ) 
+ % Blade 1 effective wind speed ( m/s )
 BLD1_velEff = ((p_3*cos(BLD1_agAzi)+p_4)^(0.2))*(ENV_velEffWnd) ;
 
- % Blade 2 effective wind speed ( m/s ) 
+ % Blade 2 effective wind speed ( m/s )
 BLD2_velEff = ((p_3*cos(BLD2_agAzi)+p_4)^(0.2))*(ENV_velEffWnd) ;
 
- % Blade 3 effective wind speed ( m/s ) 
+ % Blade 3 effective wind speed ( m/s )
 BLD3_velEff = ((p_3*cos(BLD3_agAzi)+p_4)^(0.2))*(ENV_velEffWnd) ;
 
- % Rotational speed blade 1 ( - ) 
+ % Rotational speed blade 1 ( - )
 BLD1_agvel = DT_agvelTorsSt+GEN_agvelSt ;
 
- % Rotational speed blade 2 ( - ) 
+ % Rotational speed blade 2 ( - )
 BLD2_agvel = DT_agvelTorsSt+GEN_agvelSt ;
 
- % Rotational speed blade 3 ( - ) 
+ % Rotational speed blade 3 ( - )
 BLD3_agvel = DT_agvelTorsSt+GEN_agvelSt ;
 
- % Tip speed ratio blade 1 ( - ) 
+ % Tip speed ratio blade 1 ( - )
 BLD1_velTipRat = p_5*BLD1_agvel/BLD1_velEff ;
 
- % Tip speed ratio blade 2 ( - ) 
+ % Tip speed ratio blade 2 ( - )
 BLD2_velTipRat = p_5*BLD2_agvel/BLD2_velEff ;
 
- % Tip speed ratio blade 3 ( - ) 
+ % Tip speed ratio blade 3 ( - )
 BLD3_velTipRat = p_5*BLD3_agvel/BLD3_velEff ;
 
- % Individual blade 1 pitch angle ( rad ) 
+ % Individual blade 1 pitch angle ( rad )
 BLD1_agPtch = BLD_agPtchActSt ;
 
- % Individual blade 2 pitch angle ( rad ) 
+ % Individual blade 2 pitch angle ( rad )
 BLD2_agPtch = BLD_agPtchActSt ;
 
- % Individual blade 3 pitch angle ( rad ) 
+ % Individual blade 3 pitch angle ( rad )
 BLD3_agPtch = BLD_agPtchActSt ;
 
- % Tangential aerodynamic force on Blade 1 ( N ) 
+ % Tangential aerodynamic force on Blade 1 ( N )
 BLD1_frTanAero = p_2*BLD1_velEff^p_1*splineCMBL([BLD1_agPtch,BLD1_velTipRat]) ;
 
- % Tangential aerodynamic force on Blade 2 ( N ) 
+ % Tangential aerodynamic force on Blade 2 ( N )
 BLD2_frTanAero = p_2*BLD2_velEff^p_1*splineCMBL([BLD2_agPtch,BLD2_velTipRat]) ;
 
- % Tangential aerodynamic force on Blade 3 ( N ) 
+ % Tangential aerodynamic force on Blade 3 ( N )
 BLD3_frTanAero = p_2*BLD3_velEff^p_1*splineCMBL([BLD3_agPtch,BLD3_velTipRat]) ;
 
 
 
 %% Explicit Nonlinear State-Space Model
- fe = [ ... 
-% Drivetrain angular acceleration ( rad/s^2 ) 
+ fe = [ ...
+% Drivetrain angular acceleration ( rad/s^2 )
  (DT_agTorsSt*p_14+DT_agvelTorsSt*p_13-GEN_trqActSt*p_12)/(p_10+p_11);
-% Drivetrain torsional angular acceleration ( rad/s^2 ) 
+% Drivetrain torsional angular acceleration ( rad/s^2 )
  -(BLD1_frTanAero*p_8*p_9+BLD2_frTanAero*p_8*p_9+BLD3_frTanAero*p_8*p_9+DT_agTorsSt*p_14+DT_agvelTorsSt*p_13)/p_10;
-% Drivetrain angular velocity ( rad/s ) 
+% Drivetrain angular velocity ( rad/s )
  -GEN_agvelSt*p_8;
-% Drivetrain torsional angular velocity ( rad/s ) 
+% Drivetrain torsional angular velocity ( rad/s )
  -DT_agvelTorsSt*p_8;
-% pitch dynamics blade PT-1 ( rad/s ) 
+% pitch dynamics blade PT-1 ( rad/s )
  p_15*(-BLD_agPtchActSt+BLD_agPtchDes);
-% Generator torque PT-1 ( Nm/s ) 
+% Generator torque PT-1 ( Nm/s )
  p_16*(-GEN_trqActSt+GEN_trqDes);
  ];
- 
+
 
 
 %% Implicit Nonlinear State-Space Model

--- a/examples/acados_matlab_octave/wind_turbine_nx6/sim_model_wind_turbine_nx6.m
+++ b/examples/acados_matlab_octave/wind_turbine_nx6/sim_model_wind_turbine_nx6.m
@@ -27,7 +27,15 @@
 % ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 % POSSIBILITY OF SUCH DAMAGE.;
 
-%
+
+
+% NOTE: `acados` currently supports both an old MATLAB/Octave interface (< v0.4.0)
+% as well as a new interface (>= v0.4.0).
+
+% THIS EXAMPLE still uses the OLD interface. If you are new to `acados` please start
+% with the examples that have been ported to the new interface already.
+% see https://github.com/acados/acados/issues/1196#issuecomment-2311822122)
+
 
 function model = sim_model_wind_turbine_nx6()
 


### PR DESCRIPTION
This PR adds a note to all examples still using the old interface (and removes some whitespaces).