### PR TITLE
Add common subexpression elimination to CasADi function creation

### DIFF
--- a/interfaces/acados_matlab_octave/GenerateContext.m
+++ b/interfaces/acados_matlab_octave/GenerateContext.m
@@ -38,6 +38,7 @@ classdef GenerateContext < handle
         casadi_codegen_opts
         list_funname_dir_pairs  % list of (function_name, output_dir), NOTE: this can be used to simplify template based code generation!
         functions_to_generate
+        casadi_fun_opts
     end
 
     methods
@@ -60,6 +61,14 @@ classdef GenerateContext < handle
             obj.list_funname_dir_pairs = {};
             obj.functions_to_generate = {};
 
+            obj.casadi_fun_opts = struct();
+
+            import casadi.*
+            try
+                dummy = MX.sym('dummy');
+                cse(dummy); % Check if cse exists
+                obj.casadi_fun_opts.cse = true;
+            end
         end
 
         function obj = add_function_definition(obj, name, inputs, outputs, output_dir)
@@ -67,7 +76,7 @@ classdef GenerateContext < handle
 
             if isempty(obj.p_global) || length(obj.p_global) == 0
                 % normal behavior (p_global is empty)
-                fun = Function(name, inputs, outputs);
+                fun = Function(name, inputs, outputs, obj.casadi_fun_opts);
                 obj = obj.add_function(name, output_dir, fun);
             else
                 check_casadi_version_supports_p_global();
@@ -85,7 +94,7 @@ classdef GenerateContext < handle
                 outputs_ret = substitute(outputs_ret, symbols, pools);
                 obj.p_global_expressions = [obj.p_global_expressions, param.primitives()];
 
-                fun_mod = Function(name, inputs, outputs_ret);
+                fun_mod = Function(name, inputs, outputs_ret, obj.casadi_fun_opts);
                 obj = obj.add_function(name, output_dir, fun_mod);
             end
         end

--- a/interfaces/acados_matlab_octave/GenerateContext.m
+++ b/interfaces/acados_matlab_octave/GenerateContext.m
@@ -68,6 +68,8 @@ classdef GenerateContext < handle
                 dummy = MX.sym('dummy');
                 cse(dummy); % Check if cse exists
                 obj.casadi_fun_opts.cse = true;
+            catch
+                disp("NOTE: Please consider updating to CasADi 3.6.6 which supports common subexpression elimination. \nThis might speed up external function evaluation.");
             end
         end
 

--- a/interfaces/acados_template/acados_template/casadi_function_generation.py
+++ b/interfaces/acados_template/acados_template/casadi_function_generation.py
@@ -63,6 +63,16 @@ class GenerateContext:
         self.list_funname_dir_pairs = []  # list of (function_name, output_dir), NOTE: this can be used to simplify template based code generation!
         self.functions_to_generate: List[ca.Function] = []
 
+        # check if CasADi version supports cse
+        try:
+            from casadi import cse
+            casadi_fun_opts = {"cse": True}
+        except:
+            casadi_fun_opts = {}
+
+        self.__casadi_fun_opts = casadi_fun_opts
+
+
     def __add_function(self, name: str, output_dir: str, fun: ca.Function):
         self.list_funname_dir_pairs.append((name, output_dir))
         self.functions_to_generate.append(fun)
@@ -94,7 +104,7 @@ class GenerateContext:
 
         if self.p_global is None:
             # normal behaviour (p_global is empty)
-            fun = ca.Function(name, inputs, outputs)
+            fun = ca.Function(name, inputs, outputs, self.__casadi_fun_opts)
             self.__add_function(name, output_dir, fun)
         else:
             check_casadi_version_supports_p_global()
@@ -113,7 +123,7 @@ class GenerateContext:
             outputs_ret = ca.substitute(outputs_ret, symbols, pools)
             self.p_global_expressions += param.primitives()
 
-            fun_mod = ca.Function(name, inputs, outputs_ret)
+            fun_mod = ca.Function(name, inputs, outputs_ret, self.__casadi_fun_opts)
             self.__add_function(name, output_dir, fun_mod)
 
     def finalize(self):

--- a/interfaces/acados_template/acados_template/casadi_function_generation.py
+++ b/interfaces/acados_template/acados_template/casadi_function_generation.py
@@ -68,6 +68,7 @@ class GenerateContext:
             from casadi import cse
             casadi_fun_opts = {"cse": True}
         except:
+            print("NOTE: Please consider updating to CasADi 3.6.6 which supports common subexpression elimination. \nThis might speed up external function evaluation.")
             casadi_fun_opts = {}
 
         self.__casadi_fun_opts = casadi_fun_opts


### PR DESCRIPTION
If the CasADi version supports common subexpression elimination, the corresponding option is set when creating CasADi functions.

Closes https://github.com/acados/acados/issues/1207