### PR TITLE
MATLAB: remove codgen_model

### DIFF
--- a/examples/acados_matlab_octave/legacy_interface/simple_dae_model/example_ocp.m
+++ b/examples/acados_matlab_octave/legacy_interface/simple_dae_model/example_ocp.m
@@ -48,9 +48,6 @@ end
 
 %% options
 compile_interface = 'auto'; % true, false
-codgen_model = 'true'; % true, false
-% compile_interface = 'auto'; % true, false
-% codgen_model = 'false'; % true, false
 
 % ocp
 N = 20;
@@ -165,7 +162,6 @@ end
 ocp_opts = acados_ocp_opts();
 
 ocp_opts.set('compile_interface', compile_interface);
-ocp_opts.set('codgen_model', codgen_model);
 ocp_opts.set('param_scheme_N', N);
 ocp_opts.set('nlp_solver', nlp_solver);
 ocp_opts.set('nlp_solver_exact_hessian', nlp_solver_exact_hessian);

--- a/examples/acados_matlab_octave/linear_mass_spring_model/example_closed_loop.m
+++ b/examples/acados_matlab_octave/linear_mass_spring_model/example_closed_loop.m
@@ -42,7 +42,6 @@ check_acados_requirements()
 
 %% handy arguments
 compile_interface = 'auto';
-codgen_model = 'true';
 % simulation
 sim_method = 'irk';
 sim_sens_forw = 'false';
@@ -159,7 +158,6 @@ ocp_model.set('constr_ubu', ubu);
 %% acados ocp opts
 ocp_opts = acados_ocp_opts();
 ocp_opts.set('compile_interface', compile_interface);
-ocp_opts.set('codgen_model', codgen_model);
 ocp_opts.set('param_scheme_N', ocp_N);
 ocp_opts.set('nlp_solver', ocp_nlp_solver);
 ocp_opts.set('qp_solver', ocp_qp_solver);
@@ -200,7 +198,6 @@ end
 %% acados sim opts
 sim_opts = acados_sim_opts();
 sim_opts.set('compile_interface', compile_interface);
-sim_opts.set('codgen_model', codgen_model);
 sim_opts.set('num_stages', sim_num_stages);
 sim_opts.set('num_steps', sim_num_steps);
 sim_opts.set('method', sim_method);

--- a/examples/acados_matlab_octave/linear_mass_spring_model/example_ocp.m
+++ b/examples/acados_matlab_octave/linear_mass_spring_model/example_ocp.m
@@ -42,7 +42,6 @@ check_acados_requirements()
 
 %% arguments
 compile_interface = 'auto';
-codgen_model = 'true';
 %shooting_nodes = [0 0.1 0.2 0.3 0.5 1];
 N = 20;
 model_name = 'lin_mass';
@@ -226,7 +225,6 @@ end
 %% acados ocp opts
 ocp_opts = acados_ocp_opts();
 ocp_opts.set('compile_interface', compile_interface);
-ocp_opts.set('codgen_model', codgen_model);
 ocp_opts.set('param_scheme_N', N);
 if (exist('shooting_nodes', 'var'))
 	ocp_opts.set('param_scheme_shooting_nodes', shooting_nodes);

--- a/examples/acados_matlab_octave/linear_mass_spring_model/example_sim.m
+++ b/examples/acados_matlab_octave/linear_mass_spring_model/example_sim.m
@@ -42,7 +42,6 @@ check_acados_requirements();
 
 %% arguments
 compile_interface = 'auto';
-codgen_model = 'true';
 %method = 'erk';
 method = 'irk';
 method = 'irk_gnsf';
@@ -80,7 +79,6 @@ end
 %% acados sim opts
 sim_opts = acados_sim_opts();
 sim_opts.set('compile_interface', compile_interface);
-sim_opts.set('codgen_model', codgen_model);
 sim_opts.set('num_stages', num_stages);
 sim_opts.set('num_steps', num_steps);
 sim_opts.set('method', method);

--- a/examples/acados_matlab_octave/masses_chain_model/example_closed_loop.m
+++ b/examples/acados_matlab_octave/masses_chain_model/example_closed_loop.m
@@ -49,7 +49,6 @@ end
 
 %% handy arguments
 compile_interface = 'auto';
-codgen_model = 'true';
 % simulation
 sim_method = 'irk';
 sim_sens_forw = 'false';
@@ -185,7 +184,6 @@ end
 %% acados ocp opts
 ocp_opts = acados_ocp_opts();
 ocp_opts.set('compile_interface', compile_interface);
-ocp_opts.set('codgen_model', codgen_model);
 ocp_opts.set('param_scheme_N', ocp_N);
 ocp_opts.set('nlp_solver', ocp_nlp_solver);
 ocp_opts.set('nlp_solver_exact_hessian', ocp_nlp_solver_exact_hessian);
@@ -240,7 +238,6 @@ end
 %% acados sim opts
 sim_opts = acados_sim_opts();
 sim_opts.set('compile_interface', compile_interface);
-sim_opts.set('codgen_model', codgen_model);
 sim_opts.set('num_stages', sim_num_stages);
 sim_opts.set('num_steps', sim_num_steps);
 sim_opts.set('method', sim_method);

--- a/examples/acados_matlab_octave/masses_chain_model/example_ocp.m
+++ b/examples/acados_matlab_octave/masses_chain_model/example_ocp.m
@@ -49,7 +49,6 @@ end
 
 %% arguments
 compile_interface = 'auto';
-codgen_model = 'true';
 gnsf_detect_struct = 'true';
 model_name = 'masses_chain';
 
@@ -193,7 +192,6 @@ end
 %% acados ocp opts
 ocp_opts = acados_ocp_opts();
 ocp_opts.set('compile_interface', compile_interface);
-ocp_opts.set('codgen_model', codgen_model);
 ocp_opts.set('param_scheme_N', N);
 ocp_opts.set('nlp_solver', nlp_solver);
 ocp_opts.set('nlp_solver_exact_hessian', nlp_solver_exact_hessian);

--- a/examples/acados_matlab_octave/pendulum_dae/example_closed_loop.m
+++ b/examples/acados_matlab_octave/pendulum_dae/example_closed_loop.m
@@ -46,7 +46,6 @@ end
 
 %% options
 compile_interface = 'auto'; % true, false
-codgen_model = 'true'; % true, false
 % simulation
 gnsf_detect_struct = 'true'; % true, false
 sim_method = 'irk'; % irk, irk_gnsf, [erk]
@@ -205,7 +204,6 @@ end
 %% acados ocp opts
 ocp_opts = acados_ocp_opts();
 ocp_opts.set('compile_interface', compile_interface);
-ocp_opts.set('codgen_model', codgen_model);
 ocp_opts.set('param_scheme_N', ocp_N);
 ocp_opts.set('nlp_solver', nlp_solver);
 ocp_opts.set('nlp_solver_exact_hessian', nlp_solver_exact_hessian);
@@ -254,7 +252,6 @@ end
 %% acados sim opts
 sim_opts = acados_sim_opts();
 sim_opts.set('compile_interface', compile_interface);
-sim_opts.set('codgen_model', codgen_model);
 sim_opts.set('num_stages', sim_num_stages);
 sim_opts.set('num_steps', sim_num_steps);
 sim_opts.set('newton_iter', sim_newton_iter);

--- a/examples/acados_matlab_octave/pendulum_dae/example_sim.m
+++ b/examples/acados_matlab_octave/pendulum_dae/example_sim.m
@@ -46,8 +46,6 @@ end
 
 %% options
 compile_interface = 'auto'; % true, false
-% codgen_model = 'true'; % true, false
-codgen_model = 'true';
 gnsf_detect_struct = 'true'; % true, false
 method = 'irk'; % irk, irk_gnsf, [erk]
 sens_forw = 'true'; % true, false
@@ -105,7 +103,6 @@ end
 %% acados sim opts
 sim_opts = acados_sim_opts();
 sim_opts.set('compile_interface', compile_interface);
-sim_opts.set('codgen_model', codgen_model);
 sim_opts.set('num_stages', num_stages);
 sim_opts.set('num_steps', num_steps);
 sim_opts.set('newton_iter', newton_iter);

--- a/examples/acados_matlab_octave/pendulum_on_cart_model/example_closed_loop.m
+++ b/examples/acados_matlab_octave/pendulum_on_cart_model/example_closed_loop.m
@@ -50,7 +50,6 @@ end
 
 %% options
 compile_interface = 'auto'; % true, false
-codgen_model = 'true'; % true, false
 % simulation
 sim_method = 'irk'; % erk, irk, irk_gnsf
 sim_sens_forw = 'false'; % true, false
@@ -206,7 +205,6 @@ end
 %% acados ocp opts
 ocp_opts = acados_ocp_opts();
 ocp_opts.set('compile_interface', compile_interface);
-ocp_opts.set('codgen_model', codgen_model);
 ocp_opts.set('param_scheme_N', ocp_N);
 ocp_opts.set('nlp_solver', nlp_solver);
 ocp_opts.set('nlp_solver_exact_hessian', nlp_solver_exact_hessian);
@@ -253,7 +251,6 @@ end
 %% acados sim opts
 sim_opts = acados_sim_opts();
 sim_opts.set('compile_interface', compile_interface);
-sim_opts.set('codgen_model', codgen_model);
 sim_opts.set('num_stages', sim_num_stages);
 sim_opts.set('num_steps', sim_num_steps);
 sim_opts.set('method', sim_method);

--- a/examples/acados_matlab_octave/pendulum_on_cart_model/example_ocp.m
+++ b/examples/acados_matlab_octave/pendulum_on_cart_model/example_ocp.m
@@ -47,7 +47,6 @@ end
 
 %% arguments
 compile_interface = 'true'; %'auto';
-codgen_model = 'true';
 gnsf_detect_struct = 'true';
 
 % discretization
@@ -202,7 +201,6 @@ end
 %% acados ocp opts
 ocp_opts = acados_ocp_opts();
 ocp_opts.set('compile_interface', compile_interface);
-ocp_opts.set('codgen_model', codgen_model);
 ocp_opts.set('param_scheme_N', N);
 ocp_opts.set('nlp_solver', nlp_solver);
 ocp_opts.set('nlp_solver_exact_hessian', nlp_solver_exact_hessian);

--- a/examples/acados_matlab_octave/pendulum_on_cart_model/example_ocp_param_sens.m
+++ b/examples/acados_matlab_octave/pendulum_on_cart_model/example_ocp_param_sens.m
@@ -46,7 +46,6 @@ end
 
 %% arguments
 compile_interface = 'auto'; %'auto';
-codgen_model = 'true';
 gnsf_detect_struct = 'true';
 
 % discretization
@@ -200,7 +199,6 @@ end
 %% acados ocp opts
 ocp_opts = acados_ocp_opts();
 ocp_opts.set('compile_interface', compile_interface);
-ocp_opts.set('codgen_model', codgen_model);
 ocp_opts.set('param_scheme_N', N);
 ocp_opts.set('nlp_solver', nlp_solver);
 ocp_opts.set('nlp_solver_exact_hessian', nlp_solver_exact_hessian);

--- a/examples/acados_matlab_octave/pendulum_on_cart_model/example_ocp_reg.m
+++ b/examples/acados_matlab_octave/pendulum_on_cart_model/example_ocp_reg.m
@@ -47,7 +47,6 @@ end
 
 %% arguments
 compile_interface = 'true'; %'auto';
-codgen_model = 'true';
 gnsf_detect_struct = 'true';
 
 % discretization
@@ -208,7 +207,6 @@ end
 %% acados ocp opts
 ocp_opts = acados_ocp_opts();
 ocp_opts.set('compile_interface', compile_interface);
-ocp_opts.set('codgen_model', codgen_model);
 ocp_opts.set('param_scheme_N', N);
 ocp_opts.set('nlp_solver', nlp_solver);
 ocp_opts.set('nlp_solver_exact_hessian', nlp_solver_exact_hessian);

--- a/examples/acados_matlab_octave/pendulum_on_cart_model/example_sim.m
+++ b/examples/acados_matlab_octave/pendulum_on_cart_model/example_sim.m
@@ -47,7 +47,6 @@ end
 
 %% arguments
 compile_interface = 'auto';
-codgen_model = 'true';
 gnsf_detect_struct = 'true';
 %method = 'erk';
 % method = 'irk';
@@ -98,7 +97,6 @@ end
 %% acados sim opts
 sim_opts = acados_sim_opts();
 sim_opts.set('compile_interface', compile_interface);
-sim_opts.set('codgen_model', codgen_model);
 sim_opts.set('num_stages', num_stages);
 sim_opts.set('num_steps', num_steps);
 sim_opts.set('newton_iter', newton_iter);

--- a/examples/acados_matlab_octave/pendulum_on_cart_model/experiment_dae_formulation.m
+++ b/examples/acados_matlab_octave/pendulum_on_cart_model/experiment_dae_formulation.m
@@ -57,7 +57,6 @@ for i = 1:3
     %% arguments
     compile_interface = 'auto';
 
-    codgen_model = 'true';
     gnsf_detect_struct = 'true';
 
     % discretization
@@ -176,7 +175,6 @@ for i = 1:3
     %% acados ocp opts
     ocp_opts = acados_ocp_opts();
     ocp_opts.set('compile_interface', compile_interface);
-    ocp_opts.set('codgen_model', codgen_model);
     ocp_opts.set('param_scheme_N', N);
     ocp_opts.set('nlp_solver', nlp_solver);
     ocp_opts.set('nlp_solver_exact_hessian', nlp_solver_exact_hessian);

--- a/examples/acados_matlab_octave/race_cars/main.m
+++ b/examples/acados_matlab_octave/race_cars/main.m
@@ -55,7 +55,6 @@ track_file = 'LMS_Track.txt';
 
 %% Solver parameters
 compile_interface = 'auto';
-codgen_model = 'true';
 nlp_solver = 'sqp'; % sqp, sqp_rti
 qp_solver = 'partial_condensing_hpipm';
     % full_condensing_hpipm, partial_condensing_hpipm, full_condensing_qpoases
@@ -199,7 +198,6 @@ ocp_model.set('cost_y_ref_e', y_ref_e);
 %% acados ocp set opts
 ocp_opts = acados_ocp_opts();
 %ocp_opts.set('compile_interface', compile_interface);
-%ocp_opts.set('codgen_model', codgen_model);
 ocp_opts.set('param_scheme_N', N);
 ocp_opts.set('nlp_solver', nlp_solver);
 ocp_opts.set('nlp_solver_exact_hessian', nlp_solver_exact_hessian);

--- a/examples/acados_matlab_octave/swarming/example_closed_loop.m
+++ b/examples/acados_matlab_octave/swarming/example_closed_loop.m
@@ -72,11 +72,9 @@ max_a = S.max_a;
 
 if 1
 	compile_interface = 'auto';
-	codgen_model = 'true';
 	gnsf_detect_struct = 'true';
 else
 	compile_interface = 'auto';
-	codgen_model = 'false';
 	gnsf_detect_struct = 'false';
 end
 
@@ -202,7 +200,6 @@ ocp_model.set('constr_uh', uh);
 %% Acados ocp options
 ocp_opts = acados_ocp_opts();
 ocp_opts.set('compile_interface', compile_interface);
-ocp_opts.set('codgen_model', codgen_model);
 ocp_opts.set('param_scheme_N', nb_steps);
 if (exist('shooting_nodes', 'var'))
 	ocp_opts.set('param_scheme_shooting_nodes', shooting_nodes);
@@ -261,7 +258,6 @@ end
 %% Acados simulation options
 sim_opts = acados_sim_opts();
 sim_opts.set('compile_interface', compile_interface);
-sim_opts.set('codgen_model', codgen_model);
 sim_opts.set('num_stages', sim_num_stages);
 sim_opts.set('num_steps', sim_num_steps);
 sim_opts.set('method', sim_method);

--- a/examples/acados_matlab_octave/swarming/example_ocp.m
+++ b/examples/acados_matlab_octave/swarming/example_ocp.m
@@ -78,11 +78,9 @@ max_a = S.max_a;
 
 if 1
 	compile_interface = 'auto';
-	codgen_model = 'true';
 	gnsf_detect_struct = 'true';
 else
 	compile_interface = 'auto';
-	codgen_model = 'false';
 	gnsf_detect_struct = 'false';
 end
 
@@ -211,7 +209,6 @@ ocp_model.set('constr_uh', uh);
 
 ocp_opts = acados_ocp_opts();
 ocp_opts.set('compile_interface', compile_interface);
-ocp_opts.set('codgen_model', codgen_model);
 ocp_opts.set('param_scheme_N', nb_steps);
 if (exist('shooting_nodes', 'var'))
 	ocp_opts.set('shooting_nodes', shooting_nodes);

--- a/examples/acados_matlab_octave/swarming/example_sim.m
+++ b/examples/acados_matlab_octave/swarming/example_sim.m
@@ -77,7 +77,6 @@ u = zeros(N*3,1); % control input is null (acceleration)
 
 % Simulation parameters
 compile_interface = 'auto';
-codgen_model = 'true';
 %gnsf_detect_struct = 'true';
 method = 'erk';
 %method = 'irk';
@@ -122,7 +121,6 @@ end
 %% Acados simutation options
 sim_opts = acados_sim_opts();
 sim_opts.set('compile_interface', compile_interface);
-sim_opts.set('codgen_model', codgen_model);
 sim_opts.set('num_stages', num_stages);
 sim_opts.set('num_steps', num_steps);
 sim_opts.set('method', method);

--- a/examples/acados_matlab_octave/test/test_checks.m
+++ b/examples/acados_matlab_octave/test/test_checks.m
@@ -36,7 +36,6 @@ addpath('../linear_mass_spring_model/');
 
 %% arguments
 compile_interface = 'auto';
-codgen_model = 'true';
 method = 'irk';
 sens_forw = 'true';
 num_stages = 4;
@@ -78,7 +77,6 @@ end
 %% acados sim opts
 sim_opts = acados_sim_opts();
 sim_opts.set('compile_interface', compile_interface);
-sim_opts.set('codgen_model', codgen_model);
 sim_opts.set('num_stages', num_stages);
 sim_opts.set('num_steps', num_steps);
 sim_opts.set('method', method);

--- a/examples/acados_matlab_octave/test/test_ocp_linear_mass_spring.m
+++ b/examples/acados_matlab_octave/test/test_ocp_linear_mass_spring.m
@@ -36,7 +36,6 @@ addpath('../linear_mass_spring_model/');
 
 %% arguments
 compile_interface = 'auto';
-codgen_model = 'true';
 N = 20;
 shooting_nodes = [ linspace(0,1,N/2) linspace(1.1,5,N/2+1) ];
 
@@ -200,7 +199,6 @@ end
 %% acados ocp opts
 ocp_opts = acados_ocp_opts();
 ocp_opts.set('compile_interface', compile_interface);
-ocp_opts.set('codgen_model', codgen_model);
 ocp_opts.set('param_scheme_N', N);
 ocp_opts.set('ext_fun_compile_flags', '');
 if (exist('shooting_nodes', 'var'))

--- a/examples/acados_matlab_octave/test/test_ocp_pendulum_on_cart.m
+++ b/examples/acados_matlab_octave/test/test_ocp_pendulum_on_cart.m
@@ -37,7 +37,6 @@ addpath('../pendulum_on_cart_model/');
 for itest = 1:3
     %% arguments
     compile_interface = 'auto';
-    codgen_model = 'true';
     gnsf_detect_struct = 'true';
 
     % discretization
@@ -195,7 +194,6 @@ for itest = 1:3
     %% acados ocp opts
     ocp_opts = acados_ocp_opts();
     ocp_opts.set('compile_interface', compile_interface);
-    ocp_opts.set('codgen_model', codgen_model);
     ocp_opts.set('param_scheme_N', N);
     ocp_opts.set('nlp_solver', nlp_solver);
     ocp_opts.set('nlp_solver_exact_hessian', nlp_solver_exact_hessian);

--- a/examples/acados_matlab_octave/test/test_ocp_wtnx6.m
+++ b/examples/acados_matlab_octave/test/test_ocp_wtnx6.m
@@ -38,7 +38,6 @@ for itest = 1:3
 
 %% arguments
 compile_interface = 'auto';
-codgen_model = 'true';
 % simulation
 sim_method = 'irk';
 sim_sens_forw = 'false';
@@ -258,7 +257,6 @@ ocp_model.set('constr_x0', x0_ref);
 %% acados ocp opts
 ocp_opts = acados_ocp_opts();
 ocp_opts.set('compile_interface', compile_interface);
-ocp_opts.set('codgen_model', codgen_model);
 ocp_opts.set('param_scheme_N', ocp_N);
 ocp_opts.set('nlp_solver', ocp_nlp_solver);
 ocp_opts.set('nlp_solver_exact_hessian', ocp_nlp_solver_exact_hessian);
@@ -322,7 +320,6 @@ end
 %% acados sim opts
 sim_opts = acados_sim_opts();
 sim_opts.set('compile_interface', compile_interface);
-sim_opts.set('codgen_model', codgen_model);
 sim_opts.set('num_stages', sim_num_stages);
 sim_opts.set('num_steps', sim_num_steps);
 sim_opts.set('method', sim_method);

--- a/examples/acados_matlab_octave/test/test_sens_adj.m
+++ b/examples/acados_matlab_octave/test/test_sens_adj.m
@@ -37,7 +37,6 @@ addpath('../pendulum_on_cart_model/');
 for integrator = {'irk_gnsf', 'irk', 'erk'}
     %% arguments
     compile_interface = 'auto';
-    codgen_model = 'true';
     method = integrator{1}; %'irk'; 'irk_gnsf'; 'erk';
     sens_forw = 'false';
     num_stages = 4;
@@ -81,7 +80,6 @@ for integrator = {'irk_gnsf', 'irk', 'erk'}
 	%% acados sim opts
 	sim_opts = acados_sim_opts();
 	sim_opts.set('compile_interface', compile_interface);
-	sim_opts.set('codgen_model', codgen_model);
 	sim_opts.set('num_stages', num_stages);
 	sim_opts.set('num_steps', num_steps);
 	sim_opts.set('method', method);

--- a/examples/acados_matlab_octave/test/test_sens_forw.m
+++ b/examples/acados_matlab_octave/test/test_sens_forw.m
@@ -39,7 +39,6 @@ for integrator = {'irk_gnsf', 'irk', 'erk'}
 
     %% arguments
     compile_interface = 'auto';
-    codgen_model = 'true';
     sens_forw = 'true';
     jac_reuse = 'true';
     num_stages = 3;
@@ -49,10 +48,10 @@ for integrator = {'irk_gnsf', 'irk', 'erk'}
 
     Ts = 0.1;
     FD_epsilon = 1e-6;
-    
+
     %% model
     model = linear_mass_spring_model();
-    
+
     model_name = ['lin_mass_' method];
     nx = model.nx;
     nu = model.nu;
@@ -92,7 +91,6 @@ for integrator = {'irk_gnsf', 'irk', 'erk'}
     %% acados sim opts
     sim_opts = acados_sim_opts();
     sim_opts.set('compile_interface', compile_interface);
-    sim_opts.set('codgen_model', codgen_model);
     sim_opts.set('num_stages', num_stages);
     sim_opts.set('num_steps', num_steps);
     sim_opts.set('newton_iter', newton_iter);

--- a/examples/acados_matlab_octave/test/test_sens_hess.m
+++ b/examples/acados_matlab_octave/test/test_sens_hess.m
@@ -37,7 +37,6 @@ addpath('../pendulum_on_cart_model/');
 for integrator = {'erk', 'irk'} %, 'irk_gnsf'}
 	%% arguments
 	compile_interface = 'auto';
-	codgen_model = 'true';
 	method = integrator{1}; %'irk'; 'irk_gnsf'; 'erk';
 	sens_forw = 'true';
 	sens_adj = 'true';
@@ -86,7 +85,6 @@ for integrator = {'erk', 'irk'} %, 'irk_gnsf'}
 	%% acados sim opts
 	sim_opts = acados_sim_opts();
 	sim_opts.set('compile_interface', compile_interface);
-	sim_opts.set('codgen_model', codgen_model);
 	sim_opts.set('num_stages', num_stages);
 	sim_opts.set('num_steps', num_steps);
 	sim_opts.set('method', method);

--- a/examples/acados_matlab_octave/test/test_sim_dae.m
+++ b/examples/acados_matlab_octave/test/test_sim_dae.m
@@ -41,7 +41,6 @@ for integrator = {'irk_gnsf', 'irk'}
 
     %% arguments
     compile_interface = 'auto'; % true, false
-    codgen_model = 'true'; % true, false
     gnsf_detect_struct = 'true'; % true, false
     % method = 'irk'; % irk, irk_gnsf, [erk]
     sens_forw = 'true'; % true, false
@@ -92,7 +91,6 @@ for integrator = {'irk_gnsf', 'irk'}
     %% acados sim opts
     sim_opts = acados_sim_opts();
     sim_opts.set('compile_interface', compile_interface);
-    sim_opts.set('codgen_model', codgen_model);
     sim_opts.set('num_stages', num_stages);
     sim_opts.set('num_steps', num_steps);
     sim_opts.set('newton_iter', newton_iter);

--- a/examples/acados_matlab_octave/wind_turbine_nx6/example_closed_loop.m
+++ b/examples/acados_matlab_octave/wind_turbine_nx6/example_closed_loop.m
@@ -54,7 +54,6 @@ compute_setup;
 
 %% arguments
 compile_interface = 'auto';
-codgen_model = 'true';
 % simulation
 sim_method = 'irk';
 sim_sens_forw = 'false';
@@ -269,7 +268,6 @@ ocp_model.set('constr_x0', x0_ref);
 %% acados ocp opts
 ocp_opts = acados_ocp_opts();
 ocp_opts.set('compile_interface', compile_interface);
-ocp_opts.set('codgen_model', codgen_model);
 ocp_opts.set('param_scheme_N', ocp_N);
 ocp_opts.set('nlp_solver', ocp_nlp_solver);
 ocp_opts.set('nlp_solver_exact_hessian', ocp_nlp_solver_exact_hessian);
@@ -325,7 +323,6 @@ end
 %% acados sim opts
 sim_opts = acados_sim_opts();
 sim_opts.set('compile_interface', compile_interface);
-sim_opts.set('codgen_model', codgen_model);
 sim_opts.set('num_stages', sim_num_stages);
 sim_opts.set('num_steps', sim_num_steps);
 sim_opts.set('method', sim_method);

--- a/examples/acados_matlab_octave/wind_turbine_nx6/example_ocp.m
+++ b/examples/acados_matlab_octave/wind_turbine_nx6/example_ocp.m
@@ -49,7 +49,6 @@ end
 
 %% arguments
 compile_interface = 'auto';
-codgen_model = 'true';
 N = 40;
 nlp_solver = 'sqp';
 %nlp_solver = 'sqp_rti';
@@ -258,7 +257,6 @@ ocp_model.set('constr_x0', zeros(nx,1));
 %% acados ocp opts
 ocp_opts = acados_ocp_opts();
 ocp_opts.set('compile_interface', compile_interface);
-ocp_opts.set('codgen_model', codgen_model);
 ocp_opts.set('param_scheme_N', N);
 ocp_opts.set('nlp_solver', nlp_solver);
 ocp_opts.set('nlp_solver_exact_hessian', nlp_solver_exact_hessian);

--- a/examples/acados_matlab_octave/wind_turbine_nx6/example_sim.m
+++ b/examples/acados_matlab_octave/wind_turbine_nx6/example_sim.m
@@ -52,7 +52,6 @@ load testSim.mat
 
 %% arguments
 compile_interface = 'auto';
-codgen_model = 'true';
 method = 'irk'; % irk, erk, irk_gnsf
 % method = 'irk_gnsf';
 sens_forw = 'true';
@@ -94,7 +93,6 @@ end
 %% acados sim opts
 sim_opts = acados_sim_opts();
 sim_opts.set('compile_interface', compile_interface);
-sim_opts.set('codgen_model', codgen_model);
 sim_opts.set('num_stages', num_stages);
 sim_opts.set('num_steps', num_steps);
 sim_opts.set('method', method);

--- a/interfaces/acados_matlab_octave/acados_ocp_opts.m
+++ b/interfaces/acados_matlab_octave/acados_ocp_opts.m
@@ -45,7 +45,6 @@ classdef acados_ocp_opts < handle
             obj.opts_struct = struct;
             % default values
             obj.opts_struct.compile_interface = 'auto'; % auto, true, false
-            obj.opts_struct.codgen_model = 'true';
             obj.opts_struct.compile_model = 'true';
             obj.opts_struct.param_scheme_N = 10;
             % set one of the following for nonuniform grid
@@ -116,7 +115,7 @@ classdef acados_ocp_opts < handle
             if (strcmp(field, 'compile_interface'))
                 obj.opts_struct.compile_interface = value;
             elseif (strcmp(field, 'codgen_model'))
-                obj.opts_struct.codgen_model = value;
+                warning('codgen_model is deprecated and has no effect.');
             elseif (strcmp(field, 'compile_model'))
                 obj.opts_struct.compile_model = value;
             elseif (strcmp(field, 'param_scheme'))

--- a/interfaces/acados_matlab_octave/acados_sim_opts.m
+++ b/interfaces/acados_matlab_octave/acados_sim_opts.m
@@ -44,7 +44,6 @@ classdef acados_sim_opts < handle
         function obj = acados_sim_opts()
             obj.opts_struct = struct;
             obj.opts_struct.compile_interface = 'auto'; % auto, true, false
-            obj.opts_struct.codgen_model = 'true';
             obj.opts_struct.compile_model = 'true';
             obj.opts_struct.method = 'irk';
             obj.opts_struct.collocation_type = 'gauss_legendre';
@@ -76,7 +75,7 @@ classdef acados_sim_opts < handle
             elseif (strcmp(field, 'ext_fun_compile_flags'))
                 obj.opts_struct.ext_fun_compile_flags = value;
             elseif (strcmp(field, 'codgen_model'))
-                obj.opts_struct.codgen_model = value;
+                warning('codgen_model is deprecated and has no effect.');
             elseif (strcmp(field, 'compile_model'))
                 obj.opts_struct.compile_model = value;
             elseif (strcmp(field, 'num_stages'))


### PR DESCRIPTION
The option ` codgen_model` is no longer supported.
It effectively does not work anymore since the migration to a fully template based backend, i.e. in https://github.com/acados/acados/pull/934