### PR TITLE
Remove `rti_phase` from DDP and SQP

### DIFF
--- a/acados/ocp_nlp/ocp_nlp_ddp.c
+++ b/acados/ocp_nlp/ocp_nlp_ddp.c
@@ -123,7 +123,6 @@ void ocp_nlp_ddp_opts_initialize_default(void *config_, void *dims_, void *opts_
     opts->qp_warm_start = 0;
     opts->warm_start_first_qp = false;
     opts->eval_residual_at_max_iter = false;
-    opts->rti_phase = 0;
 
     // overwrite default submodules opts
     // qp tolerance
@@ -234,16 +233,6 @@ void ocp_nlp_ddp_opts_set(void *config_, void *opts_, const char *field, void* v
         {
             bool* eval_residual_at_max_iter = (bool *) value;
             opts->eval_residual_at_max_iter = *eval_residual_at_max_iter;
-        }
-        else if (!strcmp(field, "rti_phase"))
-        {
-            int* rti_phase = (int *) value;
-            if (*rti_phase < 0 || *rti_phase > 0) {
-                printf("\nerror: ocp_nlp_sqp_opts_set: invalid value for rti_phase field.");
-                printf("possible values are: 0\n");
-                exit(1);
-            }
-            opts->rti_phase = *rti_phase;
         }
         else
         {

--- a/acados/ocp_nlp/ocp_nlp_ddp.h
+++ b/acados/ocp_nlp/ocp_nlp_ddp.h
@@ -66,7 +66,6 @@ typedef struct
     int qp_warm_start;   // qp_warm_start in all but the first ddp iterations
     bool warm_start_first_qp; // to set qp_warm_start in first iteration
     bool eval_residual_at_max_iter; // if convergence should be checked after last iterations or only throw max_iter reached
-    int rti_phase; // only phase 0 at the moment
 } ocp_nlp_ddp_opts;
 
 //

--- a/acados/ocp_nlp/ocp_nlp_sqp.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp.c
@@ -122,7 +122,6 @@ void ocp_nlp_sqp_opts_initialize_default(void *config_, void *dims_, void *opts_
 
     opts->qp_warm_start = 0;
     opts->warm_start_first_qp = false;
-    opts->rti_phase = 0;
     opts->eval_residual_at_max_iter = false;
 
     // overwrite default submodules opts
@@ -229,16 +228,6 @@ void ocp_nlp_sqp_opts_set(void *config_, void *opts_, const char *field, void* v
         {
             bool* warm_start_first_qp = (bool *) value;
             opts->warm_start_first_qp = *warm_start_first_qp;
-        }
-        else if (!strcmp(field, "rti_phase"))
-        {
-            int* rti_phase = (int *) value;
-            if (*rti_phase < 0 || *rti_phase > 0) {
-                printf("\nerror: ocp_nlp_sqp_opts_set: invalid value for rti_phase field.");
-                printf("possible values are: 0\n");
-                exit(1);
-            }
-            opts->rti_phase = *rti_phase;
         }
         else if (!strcmp(field, "eval_residual_at_max_iter"))
         {

--- a/acados/ocp_nlp/ocp_nlp_sqp.h
+++ b/acados/ocp_nlp/ocp_nlp_sqp.h
@@ -67,7 +67,6 @@ typedef struct
     int log_primal_step_norm; // compute and log the max norm of the primal steps
     int qp_warm_start;   // qp_warm_start in all but the first sqp iterations
     bool warm_start_first_qp; // to set qp_warm_start in first iteration
-    int rti_phase;       // only phase 0 at the moment
     bool eval_residual_at_max_iter; // if convergence should be checked after last iterations or only throw max_iter reached
 } ocp_nlp_sqp_opts;
 

--- a/examples/c_ext_dep_off/pendulum/main_pendulum_ode.c
+++ b/examples/c_ext_dep_off/pendulum/main_pendulum_ode.c
@@ -107,8 +107,6 @@ int main()
     double utraj[NU * N];
 
     // solve ocp in loop
-    int rti_phase = 0;
-
     for (int ii = 0; ii < NTIMINGS; ii++)
     {
         // initialize solution
@@ -118,7 +116,6 @@ int main()
             ocp_nlp_out_set(nlp_config, nlp_dims, nlp_out, i, "u", u0);
         }
         ocp_nlp_out_set(nlp_config, nlp_dims, nlp_out, N, "x", x_init);
-        ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "rti_phase", &rti_phase);
         status = pendulum_ode_acados_solve(acados_ocp_capsule);
         ocp_nlp_get(nlp_config, nlp_solver, "time_tot", &elapsed_time);
         min_time = MIN(elapsed_time, min_time);

--- a/interfaces/acados_matlab_octave/AcadosOcp.m
+++ b/interfaces/acados_matlab_octave/AcadosOcp.m
@@ -1034,6 +1034,9 @@ classdef AcadosOcp < handle
                     template_list{end+1} = {fullfile(matlab_template_path, 'acados_sim_solver_sfun.in.c'), ['acados_sim_solver_sfunction_', self.name, '.c']};
                     template_list{end+1} = {fullfile(matlab_template_path, 'make_sfun_sim.in.m'), ['make_sfun_sim.m']};
                 end
+                if self.simulink_opts.inputs.rti_phase && self.solver_options.nlp_solver_type ~= 'SQP_RTI'
+                    error('rti_phase is only supported for SQP_RTI');
+                end
             else
                 disp("not rendering Simulink related templates, as simulink_opts are not specified.")
             end

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -1460,7 +1460,7 @@ class AcadosOcpSolver:
             - qp_tau_min: for HPIPM QP solvers: minimum value of barrier parameter in HPIPM
             - qp_mu0: for HPIPM QP solvers: initial value for complementarity slackness
             - warm_start_first_qp: indicates if first QP in SQP is warm_started
-            - rti_phase: 0: PREPARATION_AND_FEEDBACK, 1: PREPARATION, 2: FEEDBACK
+            - rti_phase: 0: PREPARATION_AND_FEEDBACK, 1: PREPARATION, 2: FEEDBACK; only support for nlp_solver = 'SQP_RTI'
         """
         int_fields = ['print_level', 'rti_phase', 'qp_warm_start',
                       'globalization_line_search_use_sufficient_descent', 'globalization_full_step_dual', 'globalization_use_SOC', 'warm_start_first_qp', "as_rti_level", "max_iter", "qp_print_level"]

--- a/interfaces/acados_template/acados_template/acados_ocp_solver_pyx.pyx
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver_pyx.pyx
@@ -909,7 +909,7 @@ cdef class AcadosOcpSolverCython:
                 if value_ < 0 or value_ > 2:
                     raise Exception('AcadosOcpSolverCython.solve(): argument \'rti_phase\' can '
                         'take only values 0, 1, 2 for SQP-RTI-type solvers')
-                if self.nlp_solver_type != 'SQP_RTI' and value_ > 0:
+                if self.nlp_solver_type != 'SQP_RTI':
                     raise Exception('AcadosOcpSolverCython.solve(): argument \'rti_phase\' can '
                         'take only value 0 for SQP-type solvers')
 

--- a/interfaces/acados_template/acados_template/c_templates_tera/main_multi.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/main_multi.in.c
@@ -102,8 +102,6 @@ int main()
     int sqp_iter;
 
     // solve ocp in loop
-    int rti_phase = 0;
-
     for (int ii = 0; ii < NTIMINGS; ii++)
     {
         // initialize solution
@@ -113,7 +111,6 @@ int main()
             ocp_nlp_out_set(nlp_config, nlp_dims, nlp_out, i, "u", u_init);
         }
         ocp_nlp_out_set(nlp_config, nlp_dims, nlp_out, N, "x", x_init);
-        ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "rti_phase", &rti_phase);
         status = {{ name }}_acados_solve(acados_ocp_capsule);
         ocp_nlp_get(nlp_config, nlp_solver, "time_tot", &elapsed_time);
 

--- a/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_mex_set.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_mex_set.in.c
@@ -652,7 +652,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         acados_size = 1;
         MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
         int rti_phase = (int) value[0];
-        if (plan->nlp_solver == SQP && rti_phase != 0)
+        if (plan->nlp_solver == SQP)
         {
             MEX_FIELD_ONLY_SUPPORTED_FOR_SOLVER(fun_name, field, "sqp_rti")
         }

--- a/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_solver_sfun.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_solver_sfun.in.c
@@ -369,10 +369,6 @@ static void mdlInitializeSizes (SimStruct *S)
   {%- endif -%}
 
   {%- if simulink_opts.inputs.rti_phase -%}  {#- rti_phase #}
-      {% if solver_options.nlp_solver_type != "SQP_RTI" %}
-    rti_phase input only supported for nlp_solver_type == "SQP_RTI"!
-      {%- endif -%}
-
     {%- set i_input = i_input + 1 %}
     // rti_phase
     ssSetInputPortVectorDimension(S, {{ i_input }}, 1);

--- a/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_solver_sfun.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_solver_sfun.in.c
@@ -369,6 +369,10 @@ static void mdlInitializeSizes (SimStruct *S)
   {%- endif -%}
 
   {%- if simulink_opts.inputs.rti_phase -%}  {#- rti_phase #}
+      {% if solver_options.nlp_solver_type != "SQP_RTI" %}
+    rti_phase input only supported for nlp_solver_type == "SQP_RTI"!
+      {%- endif -%}
+
     {%- set i_input = i_input + 1 %}
     // rti_phase
     ssSetInputPortVectorDimension(S, {{ i_input }}, 1);

--- a/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_solver_sfun.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_solver_sfun.in.c
@@ -922,8 +922,6 @@ static void mdlOutputs(SimStruct *S, int_T tid)
 
     /* call solver */
   {%- if custom_update_filename == "" and not simulink_opts.inputs.rti_phase %}
-    int rti_phase = 0;
-    ocp_nlp_solver_opts_set(nlp_config, capsule->nlp_opts, "rti_phase", &rti_phase);
     int acados_status = {{ name }}_acados_solve(capsule);
     // get time
     ocp_nlp_get(nlp_config, capsule->nlp_solver, "time_tot", (void *) buffer);


### PR DESCRIPTION
closes #1255 

BREAKING: setting option `rti_phase` for NLP solvers other than `SQP_RTI` is not supported anymore.