### PR TITLE
MATLAB: compile only OCP solver lib in `compile_ocp_shared_lib`

### DIFF
--- a/interfaces/acados_matlab_octave/acados_template_mex/+acados_template_mex/compile_ocp_shared_lib.m
+++ b/interfaces/acados_matlab_octave/acados_template_mex/+acados_template_mex/compile_ocp_shared_lib.m
@@ -36,7 +36,7 @@ function compile_ocp_shared_lib(export_dir)
         %% old code for make
         if ~is_octave()
             % use Make build system
-            [ status, result ] = system('make shared_lib');
+            [ status, result ] = system('make ocp_shared_lib');
             if status
                 cd(return_dir);
                 error('Building templated code as shared library failed.\nGot status %d, result: %s',...


### PR DESCRIPTION
relevant only for MATLAB on linux