### PR TITLE
Fix for `extract_module_name`

### DIFF
--- a/acados/ocp_nlp/ocp_nlp_common.c
+++ b/acados/ocp_nlp/ocp_nlp_common.c
@@ -1152,8 +1152,7 @@ void ocp_nlp_opts_set(void *config_, void *opts_, const char *field, void* value
     char *ptr_module = NULL;
     int module_length = 0;
     char module[MAX_STR_LEN];
-    extract_module_name(field, module, &module_length);
-    ptr_module = module;
+    extract_module_name(field, module, &module_length, &ptr_module);
 
     // pass options to QP module
     if ( ptr_module!=NULL && (!strcmp(ptr_module, "qp")) )
@@ -1340,8 +1339,7 @@ void ocp_nlp_opts_set_at_stage(void *config_, void *opts_, int stage, const char
     char *ptr_module = NULL;
     int module_length = 0;
     char module[MAX_STR_LEN];
-    extract_module_name(field, module, &module_length);
-    ptr_module = module;
+    extract_module_name(field, module, &module_length, &ptr_module);
 
     // pass options to dynamics module
     if ( ptr_module!=NULL && (!strcmp(ptr_module, "dynamics")) )

--- a/acados/ocp_nlp/ocp_nlp_ddp.c
+++ b/acados/ocp_nlp/ocp_nlp_ddp.c
@@ -158,8 +158,7 @@ void ocp_nlp_ddp_opts_set(void *config_, void *opts_, const char *field, void* v
     char *ptr_module = NULL;
     int module_length = 0;
     char module[MAX_STR_LEN];
-    extract_module_name(field, module, &module_length);
-    ptr_module = module;
+    extract_module_name(field, module, &module_length, &ptr_module);
 
     // pass options to QP module
     if ( ptr_module!=NULL && (!strcmp(ptr_module, "qp")) )
@@ -988,8 +987,7 @@ void ocp_nlp_ddp_get(void *config_, void *dims_, void *mem_, const char *field, 
     char *ptr_module = NULL;
     int module_length = 0;
     char module[MAX_STR_LEN];
-    extract_module_name(field, module, &module_length);
-    ptr_module = module;
+    extract_module_name(field, module, &module_length, &ptr_module);
 
     if ( ptr_module!=NULL && (!strcmp(ptr_module, "time")) )
     {

--- a/acados/ocp_nlp/ocp_nlp_sqp.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp.c
@@ -160,8 +160,7 @@ void ocp_nlp_sqp_opts_set(void *config_, void *opts_, const char *field, void* v
     char *ptr_module = NULL;
     int module_length = 0;
     char module[MAX_STR_LEN];
-    extract_module_name(field, module, &module_length);
-    ptr_module = module;
+    extract_module_name(field, module, &module_length, &ptr_module);
 
     // pass options to QP module
     if ( ptr_module!=NULL && (!strcmp(ptr_module, "qp")) )
@@ -885,8 +884,7 @@ void ocp_nlp_sqp_get(void *config_, void *dims_, void *mem_, const char *field, 
     char *ptr_module = NULL;
     int module_length = 0;
     char module[MAX_STR_LEN];
-    extract_module_name(field, module, &module_length);
-    ptr_module = module;
+    extract_module_name(field, module, &module_length, &ptr_module);
 
     if ( ptr_module!=NULL && (!strcmp(ptr_module, "time")) )
     {

--- a/acados/ocp_nlp/ocp_nlp_sqp_rti.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp_rti.c
@@ -150,8 +150,7 @@ void ocp_nlp_sqp_rti_opts_set(void *config_, void *opts_,
     char *ptr_module = NULL;
     int module_length = 0;
     char module[MAX_STR_LEN];
-    extract_module_name(field, module, &module_length);
-    ptr_module = module;
+    extract_module_name(field, module, &module_length, &ptr_module);
 
     // pass options to QP module
     if ( ptr_module!=NULL && (!strcmp(ptr_module, "qp")) )
@@ -1278,8 +1277,7 @@ void ocp_nlp_sqp_rti_get(void *config_, void *dims_, void *mem_,
     char *ptr_module = NULL;
     int module_length = 0;
     char module[MAX_STR_LEN];
-    extract_module_name(field, module, &module_length);
-    ptr_module = module;
+    extract_module_name(field, module, &module_length, &ptr_module);
 
     if ( ptr_module!=NULL && (!strcmp(ptr_module, "time")) )
     {

--- a/acados/ocp_qp/ocp_qp_xcond_solver.c
+++ b/acados/ocp_qp/ocp_qp_xcond_solver.c
@@ -147,8 +147,7 @@ void ocp_qp_xcond_solver_dims_get_(void *config_, ocp_qp_xcond_solver_dims *dims
     char *ptr_module = NULL;
     int module_length = 0;
     char module[MAX_STR_LEN];
-    extract_module_name(field, module, &module_length);
-    ptr_module = module;
+    extract_module_name(field, module, &module_length, &ptr_module);
 
     // pass options to QP module
     if ( ptr_module!=NULL && (!strcmp(ptr_module, "pcond")) )
@@ -276,8 +275,7 @@ void ocp_qp_xcond_solver_opts_set_(void *config_, void *opts_, const char *field
     char *ptr_module = NULL;
     int module_length = 0;
     char module[MAX_STR_LEN];
-    extract_module_name(field, module, &module_length);
-    ptr_module = module;
+    extract_module_name(field, module, &module_length, &ptr_module);
 
     if( ptr_module!=NULL && (!strcmp(ptr_module, "cond")) ) // pass options to condensing module // TODO rename xcond ???
     {

--- a/acados/utils/strsep.h
+++ b/acados/utils/strsep.h
@@ -39,7 +39,7 @@ extern "C" {
 #include <string.h>
 
 // Inline function definition
-static inline void extract_module_name(const char *field, char *module, int *module_length)
+static inline void extract_module_name(const char *field, char *module, int *module_length, char **ptr_module)
 {
     // extract module name
     char *char_ = strchr(field, '_');
@@ -49,6 +49,7 @@ static inline void extract_module_name(const char *field, char *module, int *mod
         // Copy the module name into the module array
         strncpy(module, field, *module_length);
         module[*module_length] = '\0'; // add end of string
+        *ptr_module = module;
     }
 }
 


### PR DESCRIPTION
`ptr_module` was used uninitialized if no `_` was given