### PR TITLE
CMake always uses / separators

### DIFF
--- a/interfaces/acados_matlab_octave/GenerateContext.m
+++ b/interfaces/acados_matlab_octave/GenerateContext.m
@@ -141,7 +141,7 @@ classdef GenerateContext < handle
                 if ocp_specific ~= is_ocp_specific
                     continue;
                 end
-                out{end+1} = fullfile(rel_fun_dir, [fun_name, '.c']);
+                out{end+1} = [rel_fun_dir, '/', fun_name, '.c'];
             end
             for i = 1:numel(obj.list_funname_dir_pairs)
                 fun_name = obj.list_funname_dir_pairs{i}{1};
@@ -151,7 +151,7 @@ classdef GenerateContext < handle
                 if ocp_specific ~= is_ocp_specific
                     continue;
                 end
-                out{end+1} = fullfile(rel_fun_dir, [fun_name, '.c']);
+                out{end+1} = [rel_fun_dir, '/', fun_name, '.c'];
             end
         end
     end


### PR DESCRIPTION
Issue was reported in https://discourse.acados.org/t/problems-with-external-qp-solvers-qpoaes-osqp-qpdunes/1801