### PR TITLE
Set `sim_method_newton_tol` in solver templates 

### DIFF
--- a/interfaces/acados_matlab_octave/acados_ocp_opts.m
+++ b/interfaces/acados_matlab_octave/acados_ocp_opts.m
@@ -196,6 +196,8 @@ classdef acados_ocp_opts < handle
                 obj.opts_struct.sim_method_num_steps = value;
             elseif (strcmp(field, 'sim_method_newton_iter'))
                 obj.opts_struct.sim_method_newton_iter = value;
+            elseif (strcmp(field, 'sim_method_newton_tol'))
+                obj.opts_struct.sim_method_newton_tol = value;
             elseif (strcmp(field, 'sim_method_exact_z_output'))
                 obj.opts_struct.sim_method_exact_z_output = value;
             elseif (strcmp(field, 'sim_method_jac_reuse'))

--- a/interfaces/acados_matlab_octave/acados_ocp_opts.m
+++ b/interfaces/acados_matlab_octave/acados_ocp_opts.m
@@ -94,6 +94,7 @@ classdef acados_ocp_opts < handle
             obj.opts_struct.sim_method_num_stages = 4;
             obj.opts_struct.sim_method_num_steps = 1;
             obj.opts_struct.sim_method_newton_iter = 3;
+            obj.opts_struct.sim_method_newton_tol = 0;
             obj.opts_struct.sim_method_jac_reuse = 0;
             obj.opts_struct.gnsf_detect_struct = 'true';
             obj.opts_struct.regularize_method = 'no_regularize';

--- a/interfaces/acados_matlab_octave/setup_AcadosOcp_from_legacy_ocp_description.m
+++ b/interfaces/acados_matlab_octave/setup_AcadosOcp_from_legacy_ocp_description.m
@@ -66,6 +66,7 @@ function ocp = setup_AcadosOcp_from_legacy_ocp_description(model_old, opts_old, 
     ocp.solver_options.sim_method_jac_reuse = opts_struct.sim_method_jac_reuse;
 
     ocp.solver_options.sim_method_newton_iter = opts_struct.sim_method_newton_iter;
+    ocp.solver_options.sim_method_newton_tol = opts_struct.sim_method_newton_tol;
     ocp.solver_options.nlp_solver_max_iter = opts_struct.nlp_solver_max_iter;
     ocp.solver_options.nlp_solver_tol_stat = opts_struct.nlp_solver_tol_stat;
     ocp.solver_options.nlp_solver_tol_eq = opts_struct.nlp_solver_tol_eq;

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.c
@@ -2106,6 +2106,7 @@ void {{ name }}_acados_create_set_opts({{ name }}_solver_capsule* capsule)
     // declare
     bool tmp_bool;
     int newton_iter_val;
+    double newton_tol_val;
     /************************************************
     *  opts
     ************************************************/
@@ -2348,6 +2349,11 @@ void {{ name }}_acados_create_set_opts({{ name }}_solver_capsule* capsule)
     newton_iter_val = {{ solver_options.sim_method_newton_iter }};
     for (int i = {{ start_idx[jj] }}; i < {{ end_idx[jj] }}; i++)
         ocp_nlp_solver_opts_set_at_stage(nlp_config, nlp_opts, i, "dynamics_newton_iter", &newton_iter_val);
+
+    // sim_method_newton_tol
+    newton_tol_val = {{ solver_options.sim_method_newton_tol }};
+    for (int i = {{ start_idx[jj] }}; i < {{ end_idx[jj] }}; i++)
+        ocp_nlp_solver_opts_set_at_stage(nlp_config, nlp_opts, i, "dynamics_newton_tol", &newton_tol_val);
 
     // possibly varying: sim_method_num_steps, sim_method_num_stages, sim_method_jac_reuse
     for (int i = {{ start_idx[jj] }}; i < {{ end_idx[jj] }}; i++)

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -2209,6 +2209,10 @@ static void {{ model.name }}_acados_create_set_opts({{ model.name }}_solver_caps
     for (int i = 0; i < N; i++)
         ocp_nlp_solver_opts_set_at_stage(nlp_config, nlp_opts, i, "dynamics_newton_iter", &newton_iter_val);
 
+    int newton_tol_val = {{ solver_options.sim_method_newton_tol }};
+    for (int i = 0; i < N; i++)
+        ocp_nlp_solver_opts_set_at_stage(nlp_config, nlp_opts, i, "dynamics_newton_tol", &newton_tol_val);
+
     // set up sim_method_jac_reuse
     {%- set all_equal = true %}
     {%- set val = solver_options.sim_method_jac_reuse[0] %}

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -2209,7 +2209,7 @@ static void {{ model.name }}_acados_create_set_opts({{ model.name }}_solver_caps
     for (int i = 0; i < N; i++)
         ocp_nlp_solver_opts_set_at_stage(nlp_config, nlp_opts, i, "dynamics_newton_iter", &newton_iter_val);
 
-    int newton_tol_val = {{ solver_options.sim_method_newton_tol }};
+    double newton_tol_val = {{ solver_options.sim_method_newton_tol }};
     for (int i = 0; i < N; i++)
         ocp_nlp_solver_opts_set_at_stage(nlp_config, nlp_opts, i, "dynamics_newton_tol", &newton_tol_val);
 


### PR DESCRIPTION
This PR
* adds `sim_method_newton_tol` to the old MATLAB interface
* sets the option in the (M)OCP solver templates