### PR TITLE
Include integrator residual in termination criterion

### DIFF
--- a/acados/ocp_nlp/ocp_nlp_common.h
+++ b/acados/ocp_nlp/ocp_nlp_common.h
@@ -317,11 +317,13 @@ typedef struct ocp_nlp_res
     struct blasfeo_dvec *res_eq;  // dynamics
     struct blasfeo_dvec *res_ineq;  // inequality constraints
     struct blasfeo_dvec *res_comp;  // complementarity
+    struct blasfeo_dvec *res_integrator;  // integrator residual
     struct blasfeo_dvec tmp;  // tmp
     double inf_norm_res_stat;
     double inf_norm_res_eq;
     double inf_norm_res_ineq;
     double inf_norm_res_comp;
+    double inf_norm_res_integrator;
     acados_size_t memsize;
 } ocp_nlp_res;
 


### PR DESCRIPTION
This PR adds the integrator residual into the termination criterion.
* add integrator residuals to `ocp_nlp_res`