### PR TITLE
get_iterate: check if `nlp_solver_type` is supported in interfaces

### DIFF
--- a/interfaces/acados_matlab_octave/AcadosOcpSolver.m
+++ b/interfaces/acados_matlab_octave/AcadosOcpSolver.m
@@ -190,6 +190,10 @@ classdef AcadosOcpSolver < handle
                 error("get_iterate: the solver option store_iterates needs to be true in order to get iterates.");
             end
 
+            if strcmp(obj.ocp.solver_options.nlp_solver_type, 'SQP_RTI')
+                error("get_iterate: SQP_RTI not supported.");
+            end
+
             N_horizon = obj.ocp.solver_options.N_horizon;
 
             x_traj = cell(N_horizon + 1, 1);

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -1473,6 +1473,9 @@ class AcadosOcpSolver:
         if not self.acados_ocp.solver_options.store_iterates:
             raise Exception("get_iterate: the solver option store_iterates needs to be true in order to get iterates.")
 
+        if self.acados_ocp.solver_options.nlp_solver_type == "SQP_RTI":
+            raise Exception("get_iterate: SQP_RTI not supported.")
+
         x_traj = []
         u_traj = []
         z_traj = []


### PR DESCRIPTION
Before, MATLAB crashes without error when switching to `SQP_RTI` in `examples/acados_matlab_octave/getting_started/extensive_example_ocp.m`.