### PR TITLE
Fix RTI residuals

### DIFF
--- a/.github/workflows/full_build.yml
+++ b/.github/workflows/full_build.yml
@@ -149,13 +149,21 @@ jobs:
       shell: bash
       run: ${{runner.workspace}}/acados/.github/linux/install_new_casadi_python.sh''
 
-    - name: Run CMake python tests (ctest)
+    - name: Run Python tests that need new CasADi
       working-directory: ${{runner.workspace}}/acados/build
       shell: bash
       run: |
         source ${{runner.workspace}}/acados/acadosenv/bin/activate
         cd ${{runner.workspace}}/acados/examples/acados_python/p_global_example
         python example_p_global.py
+
+    - name: Run more Python tests
+      working-directory: ${{runner.workspace}}/acados/build
+      shell: bash
+      run: |
+        source ${{runner.workspace}}/acados/acadosenv/bin/activate
+        cd ${{runner.workspace}}/acados/examples/acados_python/tests
+        python test_rti_sqp_residuals.py
 
   MATLAB_test:
     needs: core_build

--- a/acados/ocp_nlp/ocp_nlp_sqp_rti.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp_rti.c
@@ -120,6 +120,7 @@ void ocp_nlp_sqp_rti_opts_initialize_default(void *config_,
     opts->as_rti_advancement_strategy = SIMULATE_ADVANCE;
     opts->as_rti_iter = 0;
     opts->rti_log_residuals = 0;
+    opts->rti_log_only_available_residuals = 0;
 
     return;
 }
@@ -195,6 +196,11 @@ void ocp_nlp_sqp_rti_opts_set(void *config_, void *opts_,
         {
             int* rti_log_residuals = (int *) value;
             opts->rti_log_residuals = *rti_log_residuals;
+        }
+        else if (!strcmp(field, "rti_log_only_available_residuals"))
+        {
+            int* rti_log_only_available_residuals = (int *) value;
+            opts->rti_log_only_available_residuals = *rti_log_only_available_residuals;
         }
         else if (!strcmp(field, "as_rti_level"))
         {
@@ -650,7 +656,7 @@ static void ocp_nlp_sqp_rti_feedback_step(ocp_nlp_config *config, ocp_nlp_dims *
     }
     mem->nlp_mem->status = ACADOS_SUCCESS;
 
-    if (opts->rti_log_residuals)
+    if (opts->rti_log_residuals && !opts->rti_log_only_available_residuals)
     {
         prepare_full_residual_computation(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work);
         ocp_nlp_res_compute(dims, nlp_in, nlp_out, nlp_mem->nlp_res, nlp_mem);
@@ -834,8 +840,8 @@ static void ocp_nlp_sqp_rti_preparation_advanced_step(ocp_nlp_config *config, oc
         // load iterate from tmp
         copy_ocp_nlp_out(dims, tmp_nlp_out, nlp_out);
         // perform QP solve (implemented as feedback)
-        // similar to  ocp_nlp_sqp_rti_feedback_step
-        if (opts->rti_log_residuals)
+        // similar to ocp_nlp_sqp_rti_feedback_step
+        if (opts->rti_log_residuals && !opts->rti_log_only_available_residuals)
         {
             // NOTE: redo all residual computations after loading iterate from tmp to undo changes to memory in modules
             prepare_full_residual_computation(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work);
@@ -898,7 +904,7 @@ static void ocp_nlp_sqp_rti_preparation_advanced_step(ocp_nlp_config *config, oc
             ocp_nlp_zero_order_qp_update(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work);
             timings->time_lin += acados_toc(&timer1);
 
-            if (opts->rti_log_residuals)
+            if (opts->rti_log_residuals && !opts->rti_log_only_available_residuals)
             {
                 // evaluate additional functions and compute residuals
                 prepare_full_residual_computation(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work);
@@ -968,7 +974,7 @@ static void ocp_nlp_sqp_rti_preparation_advanced_step(ocp_nlp_config *config, oc
             ocp_nlp_level_c_update(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work);
             timings->time_lin += acados_toc(&timer1);
 
-            if (opts->rti_log_residuals)
+            if (opts->rti_log_residuals && !opts->rti_log_only_available_residuals)
             {
                 // evaluate additional functions and compute residuals
                 level_c_prepare_residual_computation(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work);

--- a/acados/ocp_nlp/ocp_nlp_sqp_rti.h
+++ b/acados/ocp_nlp/ocp_nlp_sqp_rti.h
@@ -88,6 +88,7 @@ typedef struct
     as_rti_advancement_strategy_t as_rti_advancement_strategy;
     int as_rti_iter;
     int rti_log_residuals;
+    int rti_log_only_available_residuals;
 
 } ocp_nlp_sqp_rti_opts;
 

--- a/examples/acados_python/tests/test_rti_sqp_residuals.py
+++ b/examples/acados_python/tests/test_rti_sqp_residuals.py
@@ -130,6 +130,9 @@ def main(nlp_solver_type="SQP"):
             res_eq_all.append(solver.get_stats("res_eq_all")[0])
             res_ineq_all.append(solver.get_stats("res_ineq_all")[0])
             res_comp_all.append(solver.get_stats("res_comp_all")[0])
+            #
+            # quick way to get all residuals
+            # res_all = solver.get_stats('statistics')[3:,0]
 
             if max([res_stat_all[-1], res_eq_all[-1], res_ineq_all[-1], res_comp_all[-1]]) < TOL:
                 break

--- a/examples/acados_python/tests/test_rti_sqp_residuals.py
+++ b/examples/acados_python/tests/test_rti_sqp_residuals.py
@@ -1,0 +1,166 @@
+# -*- coding: future_fstrings -*-
+#
+# Copyright (c) The acados authors.
+#
+# This file is part of acados.
+#
+# The 2-Clause BSD License
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.;
+#
+
+import sys, json, os
+sys.path.insert(0, '../pendulum_on_cart/common')
+
+from acados_template import AcadosOcp, AcadosOcpSolver, acados_dae_model_json_dump, get_acados_path, get_simulink_default_opts
+from pendulum_model import export_pendulum_ode_model
+import numpy as np
+import scipy.linalg
+from utils import plot_pendulum
+
+import matplotlib.pyplot as plt
+
+import casadi as ca
+
+TOL = 1e-7
+
+def main(nlp_solver_type="SQP"):
+    # create ocp object to formulate the OCP
+    ocp = AcadosOcp()
+
+    # set model
+    model = export_pendulum_ode_model()
+    ocp.model = model
+
+    integrator_type = 'ERK'
+
+    Tf = 1.0
+    nx = model.x.rows()
+    nu = model.u.rows()
+    ny = nx + nu
+    ny_e = nx
+    N = 15
+
+    # discretization
+    ocp.solver_options.N_horizon = N
+    ocp.solver_options.tf = Tf
+
+    # set cost
+    Q = 2*np.diag([1e3, 1e3, 1e-2, 1e-2])
+    R = 2*np.diag([1e-2])
+
+    ocp.cost.W_e = Q
+    ocp.cost.W = scipy.linalg.block_diag(Q, R)
+
+    ocp.cost.cost_type = 'LINEAR_LS'
+    ocp.cost.cost_type_e = 'LINEAR_LS'
+
+    ocp.cost.Vx = np.zeros((ny, nx))
+    ocp.cost.Vx[:nx,:nx] = np.eye(nx)
+
+    Vu = np.zeros((ny, nu))
+    Vu[4,0] = 1.0
+    ocp.cost.Vu = Vu
+
+    ocp.cost.Vx_e = np.eye(nx)
+
+    ocp.cost.yref  = np.zeros((ny, ))
+    ocp.cost.yref_e = np.zeros((ny_e, ))
+
+    # set constraints
+    Fmax = 80
+    ocp.constraints.lbu = np.array([-Fmax])
+    ocp.constraints.ubu = np.array([+Fmax])
+
+    x0 = np.array([0.0, np.pi, 0.0, 0.0])
+    ocp.constraints.x0 = x0
+    ocp.constraints.idxbu = np.array([0])
+
+    ocp.solver_options.qp_solver = 'PARTIAL_CONDENSING_HPIPM'
+
+    ocp.solver_options.hessian_approx = 'GAUSS_NEWTON'
+    ocp.solver_options.integrator_type = integrator_type
+    ocp.solver_options.print_level = 0
+    ocp.solver_options.nlp_solver_type = nlp_solver_type
+
+    ocp.solver_options.rti_log_residuals = 1
+    ocp.solver_options.rti_log_only_available_residuals = 1
+
+    # create ocp solver
+    solver = AcadosOcpSolver(ocp)
+
+    if nlp_solver_type == "SQP":
+        solver.solve()
+        solver.print_statistics()
+        res_stat_all = solver.get_stats("res_stat_all")
+        res_eq_all = solver.get_stats("res_eq_all")
+        res_ineq_all = solver.get_stats("res_ineq_all")
+        res_comp_all = solver.get_stats("res_comp_all")
+        nlp_iter = solver.get_stats('nlp_iter')
+    elif nlp_solver_type == "SQP_RTI":
+        TOL = 1e-6
+        res_stat_all = []
+        res_eq_all = []
+        res_ineq_all = []
+        res_comp_all = []
+        for nlp_iter in range(20):
+            solver.solve()
+            solver.print_statistics()
+            res_stat_all.append(solver.get_stats("res_stat_all")[0])
+            res_eq_all.append(solver.get_stats("res_eq_all")[0])
+            res_ineq_all.append(solver.get_stats("res_ineq_all")[0])
+            res_comp_all.append(solver.get_stats("res_comp_all")[0])
+
+            if max([res_stat_all[-1], res_eq_all[-1], res_ineq_all[-1], res_comp_all[-1]]) < TOL:
+                break
+
+    print(f"obtained residuals after {nlp_iter} iterations")
+    for i in range(nlp_iter):
+        print(f"{i}: {res_stat_all[i]:e} {res_eq_all[i]:e} {res_ineq_all[i]:e} {res_comp_all[i]:e}")
+
+    del solver
+    return res_stat_all, res_eq_all, res_ineq_all, res_comp_all
+
+
+
+if __name__ == "__main__":
+    res_stat_all_rti, res_eq_all_rti, res_ineq_all_rti, res_comp_all_rti = main(nlp_solver_type="SQP_RTI")
+    res_stat_all_sqp, res_eq_all_sqp, res_ineq_all_sqp, res_comp_all_sqp = main(nlp_solver_type="SQP")
+
+    # check that number of iterations coincide
+    n_iter_rti = len(res_stat_all_rti)
+    n_iter_sqp = len(res_stat_all_sqp)
+    if n_iter_rti != n_iter_sqp:
+        raise Exception(f"number of iterations differ: rti {n_iter_rti}, sqp {n_iter_sqp}")
+
+    # check that residuals conincide
+    for name, r_rti, r_sqp in [("stat", res_stat_all_rti, res_stat_all_sqp),
+                         ("eq", res_eq_all_rti, res_eq_all_sqp),
+                         ("ineq", res_ineq_all_rti, res_ineq_all_sqp),
+                         ("comp", res_comp_all_rti, res_comp_all_sqp)]:
+        if not np.allclose(r_rti, r_sqp, atol=1e-6):
+            print(f"rti: {r_rti}")
+            print(f"sqp: {r_sqp}")
+            raise Exception(f"residuals {name} do not coincide")
+
+    print("SUCCESS: residuals of SQP and SQP_RTI coincide")

--- a/interfaces/acados_matlab_octave/AcadosOcpOptions.m
+++ b/interfaces/acados_matlab_octave/AcadosOcpOptions.m
@@ -70,6 +70,7 @@ classdef AcadosOcpOptions < handle
         qp_solver_ric_alg
         qp_solver_mu0
         rti_log_residuals
+        rti_log_only_available_residuals
         print_level
         cost_discretization
         regularize_method
@@ -151,6 +152,7 @@ classdef AcadosOcpOptions < handle
             obj.qp_solver_ric_alg = 1;
             obj.qp_solver_mu0 = 0;
             obj.rti_log_residuals = 0;
+            obj.rti_log_only_available_residuals = 0;
             obj.print_level = 0;
             obj.cost_discretization = 'EULER';
             obj.regularize_method = 'NO_REGULARIZE';

--- a/interfaces/acados_template/acados_template/acados_ocp_options.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_options.py
@@ -78,6 +78,7 @@ class AcadosOcpOptions:
         self.__qp_solver_ric_alg = 1
         self.__qp_solver_mu0 = 0.0
         self.__rti_log_residuals = 0
+        self.__rti_log_only_available_residuals = 0
         self.__print_level = 0
         self.__cost_discretization = 'EULER'
         self.__regularize_method = 'NO_REGULARIZE'
@@ -826,6 +827,16 @@ class AcadosOcpOptions:
         """
         return self.__rti_log_residuals
 
+    @property
+    def rti_log_only_available_residuals(self):
+        """
+        Relevant if rti_log_residuals is set to 1.
+        If rti_log_only_available_residuals is set to 1, only residuals that do not require additional function evaluations are logged.
+
+        Type: int; 0 or 1;
+        Default: 0.
+        """
+        return self.__rti_log_only_available_residuals
 
     @property
     def nlp_solver_tol_comp(self):
@@ -1529,6 +1540,13 @@ class AcadosOcpOptions:
             self.__rti_log_residuals = rti_log_residuals
         else:
             raise Exception('Invalid rti_log_residuals value. rti_log_residuals must be in [0, 1].')
+
+    @rti_log_only_available_residuals.setter
+    def rti_log_only_available_residuals(self, rti_log_only_available_residuals):
+        if rti_log_only_available_residuals in [0, 1]:
+            self.__rti_log_only_available_residuals = rti_log_only_available_residuals
+        else:
+            raise Exception('Invalid rti_log_only_available_residuals value. rti_log_only_available_residuals must be in [0, 1].')
 
     @nlp_solver_tol_comp.setter
     def nlp_solver_tol_comp(self, nlp_solver_tol_comp):

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -805,7 +805,7 @@ class AcadosOcpSolver:
             if self.__solver_options['nlp_solver_ext_qp_res'] == 1:
                 header += '\tqp_res_stat\tqp_res_eq\tqp_res_ineq\tqp_res_comp'
             if self.__solver_options['rti_log_residuals'] == 1:
-                header += '\tres_stat\tres_eq\tres_ineq\tres_comp'
+                header += '\tres_stat\tres_eq\t\tres_ineq\tres_comp'
             print(header)
             for jj in range(stat.shape[1]):
                 line = '{:d}\t{:d}\t{:d}'.format( int(stat[0][jj]), int(stat[1][jj]), int(stat[2][jj]))

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -1096,6 +1096,8 @@ class AcadosOcpSolver:
                     return full_stats[4, :]
                 else:
                     raise Exception("res_eq_all is not available for SQP_RTI if rti_log_residuals is not enabled.")
+            else:
+                raise Exception(f"res_eq_all is not available for nlp_solver_type {self.__solver_options['nlp_solver_type']}.")
 
         elif field_ == 'res_stat_all':
             full_stats = self.get_stats('statistics')
@@ -1106,6 +1108,32 @@ class AcadosOcpSolver:
                     return full_stats[3, :]
                 else:
                     raise Exception("res_stat_all is not available for SQP_RTI if rti_log_residuals is not enabled.")
+            else:
+                raise Exception(f"res_stat_all is not available for nlp_solver_type {self.__solver_options['nlp_solver_type']}.")
+
+        elif field_ == 'res_ineq_all':
+            full_stats = self.get_stats('statistics')
+            if self.__solver_options['nlp_solver_type'] == 'SQP':
+                return full_stats[3, :]
+            elif self.__solver_options['nlp_solver_type'] == 'SQP_RTI':
+                if self.__solver_options['rti_log_residuals'] == 1:
+                    return full_stats[5, :]
+                else:
+                    raise Exception("res_ineq_all is not available for SQP_RTI if rti_log_residuals is not enabled.")
+            else:
+                raise Exception(f"res_ineq_all is not available for nlp_solver_type {self.__solver_options['nlp_solver_type']}.")
+
+        elif field_ == 'res_comp_all':
+            full_stats = self.get_stats('statistics')
+            if self.__solver_options['nlp_solver_type'] == 'SQP':
+                return full_stats[4, :]
+            elif self.__solver_options['nlp_solver_type'] == 'SQP_RTI':
+                if self.__solver_options['rti_log_residuals'] == 1:
+                    return full_stats[6, :]
+                else:
+                    raise Exception("res_comp_all is not available for SQP_RTI if rti_log_residuals is not enabled.")
+            else:
+                raise Exception(f"res_comp_all is not available for nlp_solver_type {self.__solver_options['nlp_solver_type']}.")
 
         else:
             raise Exception(f'AcadosOcpSolver.get_stats(): \'{field}\' is not a valid argument.'

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.c
@@ -2261,6 +2261,9 @@ void {{ name }}_acados_create_set_opts({{ name }}_solver_capsule* capsule)
 
     int rti_log_residuals = {{ solver_options.rti_log_residuals }};
     ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "rti_log_residuals", &rti_log_residuals);
+
+    int rti_log_only_available_residuals = {{ solver_options.rti_log_only_available_residuals }};
+    ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "rti_log_only_available_residuals", &rti_log_only_available_residuals);
 {%- endif %}
 
     int qp_solver_iter_max = {{ solver_options.qp_solver_iter_max }};

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -2356,6 +2356,9 @@ static void {{ model.name }}_acados_create_set_opts({{ model.name }}_solver_caps
 
     int rti_log_residuals = {{ solver_options.rti_log_residuals }};
     ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "rti_log_residuals", &rti_log_residuals);
+
+    int rti_log_only_available_residuals = {{ solver_options.rti_log_only_available_residuals }};
+    ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "rti_log_only_available_residuals", &rti_log_only_available_residuals);
 {%- endif %}
 
     int qp_solver_iter_max = {{ solver_options.qp_solver_iter_max }};


### PR DESCRIPTION
- add option `rti_log_only_available_residuals`: 
"""Relevant if rti_log_residuals is set to 1.
If `rti_log_only_available_residuals` is set to 1, only residuals that do not require additional function evaluations are logged."""
- Python: add fields res_ineq_all, res_comp_all to get_stats
- add test_rti_sqp_residuals and run on CI: test consistency between RTI and SQP residuals