### PR TITLE
MATLAB/python: Default value for `ext_fun_compile_flag` from environment variable

### DIFF
--- a/interfaces/acados_matlab_octave/AcadosOcpOptions.m
+++ b/interfaces/acados_matlab_octave/AcadosOcpOptions.m
@@ -189,6 +189,7 @@ classdef AcadosOcpOptions < handle
             else
                 obj.ext_fun_compile_flags = env_var;
             end
+
             obj.model_external_shared_lib_dir = [];
             obj.model_external_shared_lib_name = [];
             obj.custom_update_filename = '';

--- a/interfaces/acados_matlab_octave/AcadosOcpOptions.m
+++ b/interfaces/acados_matlab_octave/AcadosOcpOptions.m
@@ -182,7 +182,13 @@ classdef AcadosOcpOptions < handle
             obj.store_iterates = false;
             obj.eval_residual_at_max_iter = [];
 
-            obj.ext_fun_compile_flags = '-O2';
+            % check whether flags are provided by environment variable
+            env_var = getenv("ACADOS_EXT_FUN_COMPILE_FLAGS");
+            if isempty(env_var)
+                obj.ext_fun_compile_flags = '-O2';
+            else
+                obj.ext_fun_compile_flags = env_var;
+            end
             obj.model_external_shared_lib_dir = [];
             obj.model_external_shared_lib_name = [];
             obj.custom_update_filename = '';

--- a/interfaces/acados_matlab_octave/AcadosSimOptions.m
+++ b/interfaces/acados_matlab_octave/AcadosSimOptions.m
@@ -70,7 +70,8 @@ classdef AcadosSimOptions < handle
                 obj.opts_struct.ext_fun_compile_flags = '-O2';
             else
                 obj.opts_struct.ext_fun_compile_flags = env_var;
-            end            obj.num_threads_in_batch_solve = 1;
+            end
+            obj.num_threads_in_batch_solve = 1;
             obj.compile_interface = []; % corresponds to automatic detection, possible values: true, false, []
         end
 

--- a/interfaces/acados_matlab_octave/AcadosSimOptions.m
+++ b/interfaces/acados_matlab_octave/AcadosSimOptions.m
@@ -67,9 +67,9 @@ classdef AcadosSimOptions < handle
             % check whether flags are provided by environment variable
             env_var = getenv("ACADOS_EXT_FUN_COMPILE_FLAGS");
             if isempty(env_var)
-                obj.opts_struct.ext_fun_compile_flags = '-O2';
+                obj.ext_fun_compile_flags = '-O2';
             else
-                obj.opts_struct.ext_fun_compile_flags = env_var;
+                obj.ext_fun_compile_flags = env_var;
             end
             obj.num_threads_in_batch_solve = 1;
             obj.compile_interface = []; % corresponds to automatic detection, possible values: true, false, []

--- a/interfaces/acados_matlab_octave/AcadosSimOptions.m
+++ b/interfaces/acados_matlab_octave/AcadosSimOptions.m
@@ -64,8 +64,13 @@ classdef AcadosSimOptions < handle
             obj.sens_hess = false;
             obj.output_z = true;
             obj.jac_reuse = 0;
-            obj.ext_fun_compile_flags = '-O2';
-            obj.num_threads_in_batch_solve = 1;
+            % check whether flags are provided by environment variable
+            env_var = getenv("ACADOS_EXT_FUN_COMPILE_FLAGS");
+            if isempty(env_var)
+                obj.opts_struct.ext_fun_compile_flags = '-O2';
+            else
+                obj.opts_struct.ext_fun_compile_flags = env_var;
+            end            obj.num_threads_in_batch_solve = 1;
             obj.compile_interface = []; % corresponds to automatic detection, possible values: true, false, []
         end
 

--- a/interfaces/acados_matlab_octave/acados_ocp_opts.m
+++ b/interfaces/acados_matlab_octave/acados_ocp_opts.m
@@ -109,7 +109,6 @@ classdef acados_ocp_opts < handle
 
             % check whether flags are provided by environment variable
             env_var = getenv("ACADOS_EXT_FUN_COMPILE_FLAGS");
-
             if isempty(env_var)
                 obj.opts_struct.ext_fun_compile_flags = '-O2';
             else

--- a/interfaces/acados_matlab_octave/acados_ocp_opts.m
+++ b/interfaces/acados_matlab_octave/acados_ocp_opts.m
@@ -106,7 +106,15 @@ classdef acados_ocp_opts < handle
             obj.opts_struct.exact_hess_cost = 1;
             obj.opts_struct.exact_hess_constr = 1;
             obj.opts_struct.fixed_hess = 0;
-            obj.opts_struct.ext_fun_compile_flags = '-O2';
+
+            % check whether flags are provided by environment variable
+            env_var = getenv("ACADOS_EXT_FUN_COMPILE_FLAGS");
+
+            if isempty(env_var)
+                obj.opts_struct.ext_fun_compile_flags = '-O2';
+            else
+                obj.opts_struct.ext_fun_compile_flags = env_var;
+            end
 
             obj.opts_struct.output_dir = fullfile(pwd, 'build');
             obj.opts_struct.json_file = 'acados_ocp_nlp.json';

--- a/interfaces/acados_matlab_octave/acados_sim_opts.m
+++ b/interfaces/acados_matlab_octave/acados_sim_opts.m
@@ -59,7 +59,13 @@ classdef acados_sim_opts < handle
             obj.opts_struct.jac_reuse = 'false';
             obj.opts_struct.gnsf_detect_struct = 'true';
             obj.opts_struct.output_dir = fullfile(pwd, 'build');
-            obj.opts_struct.ext_fun_compile_flags = '-O2';
+            % check whether flags are provided by environment variable
+            env_var = getenv("ACADOS_EXT_FUN_COMPILE_FLAGS");
+            if isempty(env_var)
+                obj.opts_struct.ext_fun_compile_flags = '-O2';
+            else
+                obj.opts_struct.ext_fun_compile_flags = env_var;
+            end
             obj.opts_struct.parameter_values = [];
         end
 

--- a/interfaces/acados_matlab_octave/acados_sim_opts.m
+++ b/interfaces/acados_matlab_octave/acados_sim_opts.m
@@ -62,9 +62,9 @@ classdef acados_sim_opts < handle
             % check whether flags are provided by environment variable
             env_var = getenv("ACADOS_EXT_FUN_COMPILE_FLAGS");
             if isempty(env_var)
-                obj.ext_fun_compile_flags = '-O2';
+                obj.opts_struct.ext_fun_compile_flags = '-O2';
             else
-                obj.ext_fun_compile_flags = env_var;
+                obj.opts_struct.ext_fun_compile_flags = env_var;
             end
             obj.opts_struct.parameter_values = [];
         end

--- a/interfaces/acados_matlab_octave/acados_sim_opts.m
+++ b/interfaces/acados_matlab_octave/acados_sim_opts.m
@@ -62,9 +62,9 @@ classdef acados_sim_opts < handle
             % check whether flags are provided by environment variable
             env_var = getenv("ACADOS_EXT_FUN_COMPILE_FLAGS");
             if isempty(env_var)
-                obj.opts_struct.ext_fun_compile_flags = '-O2';
+                obj.ext_fun_compile_flags = '-O2';
             else
-                obj.opts_struct.ext_fun_compile_flags = env_var;
+                obj.ext_fun_compile_flags = env_var;
             end
             obj.opts_struct.parameter_values = [];
         end

--- a/interfaces/acados_template/acados_template/acados_ocp_options.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_options.py
@@ -29,7 +29,7 @@
 # POSSIBILITY OF SUCH DAMAGE.;
 #
 
-import numpy as np
+import os
 from .utils import check_if_nparray_and_flatten
 
 
@@ -115,7 +115,9 @@ class AcadosOcpOptions:
         self.__log_primal_step_norm: bool = False
         self.__store_iterates: bool = False
         # TODO: move those out? they are more about generation than about the acados OCP solver.
-        self.__ext_fun_compile_flags = '-O2'
+
+        env = os.environ
+        self.__ext_fun_compile_flags = '-O2' if 'ACADOS_EXT_FUN_COMPILE_FLAGS' not in env else env['ACADOS_EXT_FUN_COMPILE_FLAGS']
         self.__model_external_shared_lib_dir = None
         self.__model_external_shared_lib_name = None
         self.__custom_update_filename = ''
@@ -136,7 +138,7 @@ class AcadosOcpOptions:
     def ext_fun_compile_flags(self):
         """
         String with compiler flags for external function compilation.
-        Default: '-O2'.
+        Default: '-O2' if environment variable ACADOS_EXT_FUN_COMPILE_FLAGS is not set, else ACADOS_EXT_FUN_COMPILE_FLAGS is used as default.
         """
         return self.__ext_fun_compile_flags
 

--- a/interfaces/acados_template/acados_template/acados_sim.py
+++ b/interfaces/acados_template/acados_template/acados_sim.py
@@ -56,7 +56,8 @@ class AcadosSimOptions:
         self.__sens_hess = False
         self.__output_z = True
         self.__sim_method_jac_reuse = 0
-        self.__ext_fun_compile_flags = '-O2'
+        env = os.environ
+        self.__ext_fun_compile_flags = '-O2' if 'ACADOS_EXT_FUN_COMPILE_FLAGS' not in env else env['ACADOS_EXT_FUN_COMPILE_FLAGS']
         self.__num_threads_in_batch_solve: int = 1
 
     @property
@@ -136,7 +137,7 @@ class AcadosSimOptions:
     def ext_fun_compile_flags(self):
         """
         String with compiler flags for external function compilation.
-        Default: '-O2'.
+        Default: '-O2' if environment variable ACADOS_EXT_FUN_COMPILE_FLAGS is not set, else ACADOS_EXT_FUN_COMPILE_FLAGS is used as default.
         """
         return self.__ext_fun_compile_flags
 


### PR DESCRIPTION
This PR changes the default value for  `ext_fun_compile_flag`:

-  If the environment variable `ACADOS_EXT_FUN_COMPILE_FLAG` is set, it is used as default.
- Otherwise, the old default `-O2` is used.