### PR TITLE
Github Actions: use Release in full_build, and Debug in ext_dep_off

### DIFF
--- a/.github/workflows/ext_dep_off.yml
+++ b/.github/workflows/ext_dep_off.yml
@@ -10,7 +10,7 @@ on:
       - '*'
 
 env:
-  BUILD_TYPE: Release
+  BUILD_TYPE: Debug
   ACADOS_UNIT_TESTS: OFF
   ACADOS_PYTHON: OFF
   ACADOS_OCTAVE: OFF

--- a/.github/workflows/full_build.yml
+++ b/.github/workflows/full_build.yml
@@ -10,7 +10,7 @@ on:
       - '*'
 
 env:
-  BUILD_TYPE: Debug
+  BUILD_TYPE: Release
   ACADOS_PYTHON: ON
   ACADOS_OCTAVE: ON
   ACADOS_WITH_OSQP: ON


### PR DESCRIPTION
In this way the artifacts uploaded are compiled with Release which is nice when using them in other projects.