### PR TITLE
C cleanup

### DIFF
--- a/acados/ocp_nlp/ocp_nlp_constraints_bgh.c
+++ b/acados/ocp_nlp/ocp_nlp_constraints_bgh.c
@@ -636,15 +636,7 @@ int ocp_nlp_constraints_bgh_model_set(void *config_, void *dims_,
     int nge = dims->nge;
     int nhe = dims->nhe;
 
-    if (!strcmp(field, "lb")) // NOTE: should not be used, but is still in C examplex, remove.
-    {
-        blasfeo_pack_dvec(nb, value, 1, &model->d, 0);
-    }
-    else if (!strcmp(field, "ub")) // NOTE: should not be used, but is still in C examplex, remove.
-    {
-        blasfeo_pack_dvec(nb, value, 1, &model->d, nb+ng+nh);
-    }
-    else if (!strcmp(field, "idxbx"))
+    if (!strcmp(field, "idxbx"))
     {
         ptr_i = (int *) value;
         for (ii=0; ii < nbx; ii++)

--- a/acados/ocp_nlp/ocp_nlp_constraints_bgp.c
+++ b/acados/ocp_nlp/ocp_nlp_constraints_bgp.c
@@ -629,15 +629,7 @@ int ocp_nlp_constraints_bgp_model_set(void *config_, void *dims_,
     int nge = dims->nge;
     int nphie = dims->nphie;
 
-    if (!strcmp(field, "lb"))
-    {
-        blasfeo_pack_dvec(nb, value, 1, &model->d, 0);
-    }
-    else if (!strcmp(field, "ub"))
-    {
-        blasfeo_pack_dvec(nb, value, 1, &model->d, nb+ng+nphi);
-    }
-    else if (!strcmp(field, "idxbx"))
+    if (!strcmp(field, "idxbx"))
     {
         ptr_i = (int *) value;
         for (ii=0; ii < nbx; ii++)

--- a/examples/c/engine_model/engine_nmpc.c
+++ b/examples/c/engine_model/engine_nmpc.c
@@ -302,21 +302,26 @@ static void mdlStart(SimStruct *S)
 	ocp_nlp_constraints_bgh_model **constraints = (ocp_nlp_constraints_bgh_model **) nlp_in->constraints;
 	ocp_nlp_constraints_bgh_dims **constraints_dims = (ocp_nlp_constraints_bgh_dims **) dims->constraints;
 
-    ocp_nlp_constraints_bounds_set(config, dims, nlp_in, 0, "lb", lb_0);
-    ocp_nlp_constraints_bounds_set(config, dims, nlp_in, 0, "ub", ub_0);
+    ocp_nlp_constraints_bounds_set(config, dims, nlp_in, 0, "lbu", lb_0);
+    ocp_nlp_constraints_bounds_set(config, dims, nlp_in, 0, "lbx", lb_0+NUM_CONTROLS);
+    ocp_nlp_constraints_bounds_set(config, dims, nlp_in, 0, "ubu", ub_0);
+    ocp_nlp_constraints_bounds_set(config, dims, nlp_in, 0, "ubx", ub_0+NUM_CONTROLS);
+
     for (i = 0; i < nb[0]; ++i)
         constraints[0]->idxb[i] = idxb[i];
 
     for (i = 1; i < NUM_STAGES; ++i)
     {
-        ocp_nlp_constraints_bounds_set(config, dims, nlp_in, i, "lb", lb);
-        ocp_nlp_constraints_bounds_set(config, dims, nlp_in, i, "ub", ub);
+        ocp_nlp_constraints_bounds_set(config, dims, nlp_in, i, "lbu", lb);
+        ocp_nlp_constraints_bounds_set(config, dims, nlp_in, i, "lbx", lb+NUM_CONTROLS);
+        ocp_nlp_constraints_bounds_set(config, dims, nlp_in, i, "ubu", ub);
+        ocp_nlp_constraints_bounds_set(config, dims, nlp_in, i, "ubx", ub+NUM_CONTROLS);
         for (j = 0; j < nb[i]; ++j)
             constraints[i]->idxb[j] = idxb[j];
     }
 
-    ocp_nlp_constraints_bounds_set(config, dims, nlp_in, NUM_STAGES, "lb", lb_N);
-    ocp_nlp_constraints_bounds_set(config, dims, nlp_in, NUM_STAGES, "ub", ub_N);
+    ocp_nlp_constraints_bounds_set(config, dims, nlp_in, NUM_STAGES, "lbx", lb_N);
+    ocp_nlp_constraints_bounds_set(config, dims, nlp_in, NUM_STAGES, "ubx", ub_N);
 
     for (i = 0; i < nb[NUM_STAGES]; ++i)
         constraints[NUM_STAGES]->idxb[i] = idxb[i];
@@ -370,16 +375,18 @@ static void mdlOutputs(SimStruct *S, int_T tid)
     for (j = 0; j < NUM_STATES; ++j) {
         lb_0[NUM_CONTROLS+j] = x0[j];
         ub_0[NUM_CONTROLS+j] = x0[j];
-    } 
+    }
 
-    ocp_nlp_constraints_bounds_set(config, dims, nlp_in, 0, "lb", lb_0);
-    ocp_nlp_constraints_bounds_set(config, dims, nlp_in, 0, "ub", ub_0);
-    
+    ocp_nlp_constraints_bounds_set(config, dims, nlp_in, 0, "lbu", lb_0);
+    ocp_nlp_constraints_bounds_set(config, dims, nlp_in, 0, "lbx", lb_0+NUM_CONTROLS);
+    ocp_nlp_constraints_bounds_set(config, dims, nlp_in, 0, "ubu", ub_0);
+    ocp_nlp_constraints_bounds_set(config, dims, nlp_in, 0, "ubx", ub_0+NUM_CONTROLS);
+
     for (j = 0; j <= NUM_STAGES; ++j)
         BLASFEO_DVECEL(&cost[j]->y_ref, 0) = *reference;
 
     int status = ocp_nlp_solve(nlp_solver, nlp_in, nlp_out);
-    
+
     double *u0_opt = ssGetOutputPortRealSignal(S, 0);
     double *x1 = ssGetOutputPortRealSignal(S, 1);
     double *status_out = ssGetOutputPortRealSignal(S, 2);

--- a/examples/c/nonlinear_chain_ocp_nlp.c
+++ b/examples/c/nonlinear_chain_ocp_nlp.c
@@ -1384,7 +1384,7 @@ int main()
     double time = acados_toc(&timer)/NREP;
 
     ocp_nlp_res *residual;
-    ocp_nlp_get(config, solver, "nlp_res", &residual);
+    ocp_nlp_get(solver, "nlp_res", &residual);
     printf("\nresiduals\n");
     ocp_nlp_res_print(dims, residual);
 
@@ -1394,10 +1394,10 @@ int main()
 	int sqp_iter;
     double time_lin, time_qp_sol, time_tot;
 
-    ocp_nlp_get(config, solver, "sqp_iter", &sqp_iter);
-    ocp_nlp_get(config, solver, "time_tot", &time_tot);
-    ocp_nlp_get(config, solver, "time_qp_sol", &time_qp_sol);
-    ocp_nlp_get(config, solver, "time_lin", &time_lin);
+    ocp_nlp_get(solver, "sqp_iter", &sqp_iter);
+    ocp_nlp_get(solver, "time_tot", &time_tot);
+    ocp_nlp_get(solver, "time_qp_sol", &time_qp_sol);
+    ocp_nlp_get(solver, "time_lin", &time_lin);
 
     printf("\n\nstatus = %i, iterations (max %d) = %d, total time = %f ms\n", status, MAX_SQP_ITERS, sqp_iter, time*1e3);
 	printf("\nlinearization time = %f ms\n", time_lin*1e3);

--- a/examples/c/nonlinear_chain_ocp_nlp.c
+++ b/examples/c/nonlinear_chain_ocp_nlp.c
@@ -1113,7 +1113,7 @@ int main()
 
 			default:
 				printf("\ninvalid cost module\n\n");
-				exit(1);	
+				exit(1);
 		}
 	}
 
@@ -1206,7 +1206,7 @@ int main()
 
 			default:
 				printf("\ninvalid cost module\n\n");
-				exit(1);	
+				exit(1);
 		}
 	}
 
@@ -1259,9 +1259,11 @@ int main()
 
 	// fist stage
 #if CONSTRAINTS==0 // box constraints
-	ocp_nlp_constraints_model_set(config, dims, nlp_in, 0, "lb", lb0);
-	ocp_nlp_constraints_model_set(config, dims, nlp_in, 0, "ub", ub0);
-    constraints[0]->idxb = idxb0;
+	ocp_nlp_constraints_model_set(config, dims, nlp_in, 0, "lbu", lb0);
+	ocp_nlp_constraints_model_set(config, dims, nlp_in, 0, "lbx", lb0+NU);
+	ocp_nlp_constraints_model_set(config, dims, nlp_in, 0, "ubu", ub0);
+	ocp_nlp_constraints_model_set(config, dims, nlp_in, 0, "ubx", ub0+NU);
+	constraints[0]->idxb = idxb0;
 #elif CONSTRAINTS==1 // general constraints
 	double *Cu0; d_zeros(&Cu0, ng[0], nu[0]);
 	for (int ii=0; ii<nu[0]; ii++)
@@ -1295,12 +1297,14 @@ int main()
 	// other stages
     for (int i = 1; i < NN; i++)
 	{
-		ocp_nlp_constraints_model_set(config, dims, nlp_in, i, "lb", lb1);
-		ocp_nlp_constraints_model_set(config, dims, nlp_in, i, "ub", ub1);
+		ocp_nlp_constraints_model_set(config, dims, nlp_in, i, "lbu", lb1);
+		ocp_nlp_constraints_model_set(config, dims, nlp_in, i, "lbx", lb1+NU);
+		ocp_nlp_constraints_model_set(config, dims, nlp_in, i, "ubu", ub1);
+		ocp_nlp_constraints_model_set(config, dims, nlp_in, i, "ubx", ub1+NU);
         constraints[i]->idxb = idxb1;
     }
-	ocp_nlp_constraints_model_set(config, dims, nlp_in, NN, "lb", lbN);
-	ocp_nlp_constraints_model_set(config, dims, nlp_in, NN, "ub", ubN);
+	ocp_nlp_constraints_model_set(config, dims, nlp_in, NN, "lbx", lbN);
+	ocp_nlp_constraints_model_set(config, dims, nlp_in, NN, "ubx", ubN);
 
     constraints[NN]->idxb = idxbN;
 

--- a/examples/c/simple_dae_example.c
+++ b/examples/c/simple_dae_example.c
@@ -49,9 +49,9 @@
 #include "simple_dae_model/simple_dae_model.h"
 #include "simple_dae_model/simple_dae_constr.h"
 
-#define FORMULATION 1 
-// 0: without Vz*z term 
-// 1: with Vz*z and without Vx*x 
+#define FORMULATION 1
+// 0: without Vz*z term
+// 1: with Vz*z and without Vx*x
 // 2: same as (1) + nonlinear constraint on z: h(x,u,z(x,u)) = [2, -2] \leq [z_1, z_2] \leq [4, 2]
 
 int main() {
@@ -82,8 +82,8 @@ int main() {
 	int idxb[2] = {2, 3};
 	double x0[num_states];
 
-    x0[0] =  3;  
-    x0[1] =  -1.8;  
+    x0[0] =  3;
+    x0[1] =  -1.8;
 
 	int max_num_sqp_iterations = 100;
 
@@ -310,10 +310,10 @@ int main() {
 
     ocp_nlp_cost_model_set(config, dims, nlp_in, N, "Vx", VxN);
     // ocp_nlp_cost_model_set(config, dims, nlp_in, N, "Vz", Vz);
-    
+
 	// W
 	for (int i = 0; i < N; ++i) ocp_nlp_cost_model_set(config, dims, nlp_in, i, "W", W);
-    
+
 	// WN
     ocp_nlp_cost_model_set(config, dims, nlp_in, N, "W", WN);
 
@@ -327,7 +327,7 @@ int main() {
 		irk_model *model = dynamics->sim_model;
 		model->impl_ode_fun = (external_function_generic *) &impl_ode_fun[i];
 		model->impl_ode_fun_jac_x_xdot_z = (external_function_generic *) &impl_ode_fun_jac_x_xdot_z[i];
-		model->impl_ode_jac_x_xdot_u_z = (external_function_generic *) &impl_ode_jac_x_xdot_u_z[i]; 
+		model->impl_ode_jac_x_xdot_u_z = (external_function_generic *) &impl_ode_jac_x_xdot_u_z[i];
 	}
 
 	// bounds
@@ -353,7 +353,7 @@ int main() {
             ocp_nlp_constraints_model_set(config, dims, nlp_in, ii, "uh", uh);
 			ocp_nlp_constraints_model_set(config, dims, nlp_in, ii, "nl_constr_h_fun_jac", &nl_constr_h_fun_jac[ii]);
         }
-    } else { 
+    } else {
 		for (int ii = 1; ii < N; ++ii) {
 			ocp_nlp_constraints_model_set(config, dims, nlp_in, ii, "ubx", uh);
 			ocp_nlp_constraints_model_set(config, dims, nlp_in, ii, "lbx", lh);
@@ -363,11 +363,11 @@ int main() {
 
 
 	void *nlp_opts = ocp_nlp_solver_opts_create(config, dims);
-   
-    bool output_z_val = true; 
-    bool sens_algebraic_val = true; 
-    bool reuse_val = true; 
-    int num_steps_val = 5; 
+
+    bool output_z_val = true;
+    bool sens_algebraic_val = true;
+    bool reuse_val = true;
+    int num_steps_val = 5;
     for (int i = 0; i < N; i++) ocp_nlp_solver_opts_set_at_stage(config, nlp_opts, i, "dynamics_output_z", &output_z_val);
     for (int i = 0; i < N; i++) ocp_nlp_solver_opts_set_at_stage(config, nlp_opts, i, "dynamics_sens_algebraic", &sens_algebraic_val);
     for (int i = 0; i < N; i++) ocp_nlp_solver_opts_set_at_stage(config, nlp_opts, i, "dynamics_jac_reuse", &reuse_val);
@@ -413,7 +413,7 @@ int main() {
 	ocp_nlp_out_print(dims, nlp_out);
 
     int sqp_iter;
-    ocp_nlp_get(config, solver, "sqp_iter", &sqp_iter);
+    ocp_nlp_get(solver, "sqp_iter", &sqp_iter);
     printf("\n\nstatus = %i, avg time = %f ms, iters = %d\n\n", solver_status, elapsed_time, sqp_iter);
 
     free(Vx);

--- a/examples/c/wind_turbine_nmpc.c
+++ b/examples/c/wind_turbine_nmpc.c
@@ -893,9 +893,6 @@ int main()
         ocp_nlp_solver_opts_set(config, nlp_opts, "qp_cond_N", &cond_N);
     }
 
-    // update opts after manual changes
-    ocp_nlp_solver_opts_update(config, dims, nlp_opts);
-
     /************************************************
     * ocp_nlp_out & solver
     ************************************************/

--- a/examples/c/wind_turbine_nmpc.c
+++ b/examples/c/wind_turbine_nmpc.c
@@ -810,17 +810,17 @@ int main()
     if (plan->nlp_solver == SQP)
     {
 
-		int max_iter = MAX_SQP_ITERS;
-		double tol_stat = 1e-6;
-		double tol_eq   = 1e-8;
-		double tol_ineq = 1e-8;
-		double tol_comp = 1e-8;
+        int max_iter = MAX_SQP_ITERS;
+        double tol_stat = 1e-6;
+        double tol_eq   = 1e-8;
+        double tol_ineq = 1e-8;
+        double tol_comp = 1e-8;
 
-		ocp_nlp_solver_opts_set(config, nlp_opts, "max_iter", &max_iter);
-		ocp_nlp_solver_opts_set(config, nlp_opts, "tol_stat", &tol_stat);
-		ocp_nlp_solver_opts_set(config, nlp_opts, "tol_eq", &tol_eq);
-		ocp_nlp_solver_opts_set(config, nlp_opts, "tol_ineq", &tol_ineq);
-		ocp_nlp_solver_opts_set(config, nlp_opts, "tol_comp", &tol_comp);
+        ocp_nlp_solver_opts_set(config, nlp_opts, "max_iter", &max_iter);
+        ocp_nlp_solver_opts_set(config, nlp_opts, "tol_stat", &tol_stat);
+        ocp_nlp_solver_opts_set(config, nlp_opts, "tol_eq", &tol_eq);
+        ocp_nlp_solver_opts_set(config, nlp_opts, "tol_ineq", &tol_ineq);
+        ocp_nlp_solver_opts_set(config, nlp_opts, "tol_comp", &tol_comp);
     }
     else if (plan->nlp_solver == SQP_RTI)
     {
@@ -915,8 +915,8 @@ int main()
 
     int n_sim = 40;
 
-	double *x_sim = malloc(nx_*(n_sim+1)*sizeof(double));
-	double *u_sim = malloc(nu_*(n_sim+0)*sizeof(double));
+    double *x_sim = malloc(nx_*(n_sim+1)*sizeof(double));
+    double *u_sim = malloc(nu_*(n_sim+0)*sizeof(double));
 
     acados_timer timer;
     acados_tic(&timer);
@@ -935,8 +935,8 @@ int main()
         ocp_nlp_constraints_model_set(config, dims, nlp_in, 0, "lbx", x0_ref);
         ocp_nlp_constraints_model_set(config, dims, nlp_in, 0, "ubx", x0_ref);
 
-		// store x0
-		for(int ii=0; ii<nx_; ii++) x_sim[ii] = x0_ref[ii];
+        // store x0
+        for(int ii=0; ii<nx_; ii++) x_sim[ii] = x0_ref[ii];
 
         for (int idx = 0; idx < n_sim; idx++)
         {
@@ -976,10 +976,10 @@ int main()
             // solve NLP
             status = ocp_nlp_solve(solver, nlp_in, nlp_out);
 
-			// evaluate parametric sensitivity of solution
-//			ocp_nlp_out_print(dims, nlp_out);
-			ocp_nlp_eval_param_sens(solver, "ex", 0, 0, sens_nlp_out);
-//			ocp_nlp_out_print(dims, nlp_out);
+            // evaluate parametric sensitivity of solution
+//            ocp_nlp_out_print(dims, nlp_out);
+            ocp_nlp_eval_param_sens(solver, "ex", 0, 0, sens_nlp_out);
+//            ocp_nlp_out_print(dims, nlp_out);
 
             // update initial condition
             // TODO(dimitris): maybe simulate system instead of passing x[1] as next state
@@ -987,7 +987,7 @@ int main()
             ocp_nlp_constraints_model_set(config, dims, nlp_in, 0, "lbx", specific_x);
             ocp_nlp_constraints_model_set(config, dims, nlp_in, 0, "ubx", specific_x);
 
-			// store trajectory
+            // store trajectory
             ocp_nlp_out_get(config, dims, nlp_out, 1, "x", x_sim+(idx+1)*nx_);
             ocp_nlp_out_get(config, dims, nlp_out, 0, "u", u_sim+idx*nu_);
 
@@ -1039,8 +1039,8 @@ int main()
     printf("\n\ntotal time (including printing) = %f ms (time per SQP = %f)\n\n", time*1e3, time*1e3/n_sim);
 
 #if 0
-	d_print_mat(nx_, n_sim+1, x_sim, nx_);
-	d_print_mat(nu_, n_sim, u_sim, nu_);
+    d_print_mat(nx_, n_sim+1, x_sim, nx_);
+    d_print_mat(nu_, n_sim, u_sim, nu_);
 #endif
 
     /************************************************
@@ -1049,15 +1049,15 @@ int main()
 
     external_function_casadi_free(&get_matrices_fun);
 
-     external_function_param_casadi_free(expl_vde_for);
-     external_function_param_casadi_free(impl_ode_fun);
-     external_function_param_casadi_free(impl_ode_fun_jac_x_xdot);
-     external_function_param_casadi_free(impl_ode_jac_x_xdot_u);
-     external_function_param_casadi_free(impl_ode_fun_jac_x_xdot_u);
-     external_function_param_casadi_free(phi_fun);
-     external_function_param_casadi_free(phi_fun_jac_y);
-     external_function_param_casadi_free(phi_jac_y_uhat);
-     external_function_param_casadi_free(f_lo_jac_x1_x1dot_u_z);
+    external_function_param_casadi_free(expl_vde_for);
+    external_function_param_casadi_free(impl_ode_fun);
+    external_function_param_casadi_free(impl_ode_fun_jac_x_xdot);
+    external_function_param_casadi_free(impl_ode_jac_x_xdot_u);
+    external_function_param_casadi_free(impl_ode_fun_jac_x_xdot_u);
+    external_function_param_casadi_free(phi_fun);
+    external_function_param_casadi_free(phi_fun_jac_y);
+    external_function_param_casadi_free(phi_jac_y_uhat);
+    external_function_param_casadi_free(f_lo_jac_x1_x1dot_u_z);
 
     free(expl_vde_for);
     free(impl_ode_fun);
@@ -1082,8 +1082,8 @@ int main()
     free(specific_x);
     free(specific_u);
 
-	free(x_sim);
-	free(u_sim);
+    free(x_sim);
+    free(u_sim);
 
     free(lZ0);
     free(uZ0);

--- a/examples/c/wind_turbine_nmpc.c
+++ b/examples/c/wind_turbine_nmpc.c
@@ -997,10 +997,10 @@ int main()
                 int sqp_iter;
                 double time_lin, time_qp_sol, time_tot;
 
-                ocp_nlp_get(config, solver, "sqp_iter", &sqp_iter);
-                ocp_nlp_get(config, solver, "time_tot", &time_tot);
-                ocp_nlp_get(config, solver, "time_qp_sol", &time_qp_sol);
-                ocp_nlp_get(config, solver, "time_lin", &time_lin);
+                ocp_nlp_get(solver, "sqp_iter", &sqp_iter);
+                ocp_nlp_get(solver, "time_tot", &time_tot);
+                ocp_nlp_get(solver, "time_qp_sol", &time_qp_sol);
+                ocp_nlp_get(solver, "time_lin", &time_lin);
 
                 printf("\nproblem #%d, status %d, iters %d, time (total %f, lin %f, qp_sol %f) ms\n",
                     idx, status, sqp_iter, time_tot*1e3, time_lin*1e3, time_qp_sol*1e3);
@@ -1015,7 +1015,7 @@ int main()
                 if (plan->nlp_solver == SQP)  // RTI has no residual
                 {
                     ocp_nlp_res *residual;
-                    ocp_nlp_get(config, solver, "nlp_res", &residual);
+                    ocp_nlp_get(solver, "nlp_res", &residual);
                     printf("\nresiduals\n");
                     ocp_nlp_res_print(dims, residual);
                     exit(1);

--- a/examples/c/wind_turbine_nmpc_soft.c
+++ b/examples/c/wind_turbine_nmpc_soft.c
@@ -238,24 +238,24 @@ int main()
     // int nh[NN+1] = {}; // nonlinear constraints
     // int nsh[NN+1] = {}; // softed nonlinear constraints
 
-	
-	int *nx = malloc(sizeof(int)*(NN+1));
-	int *nu = malloc(sizeof(int)*(NN+1));
-	int *nz = malloc(sizeof(int)*(NN+1));
-	int *ns = malloc(sizeof(int)*(NN+1));
-	int *ny = malloc(sizeof(int)*(NN+1));
-	int *nbx = malloc(sizeof(int)*(NN+1));
-	int *nsbx = malloc(sizeof(int)*(NN+1)); // Added for testing soft constraints
-	int *nbu = malloc(sizeof(int)*(NN+1));
-	int *ng = malloc(sizeof(int)*(NN+1));
-	int *nh = malloc(sizeof(int)*(NN+1));
-	int *nsh = malloc(sizeof(int)*(NN+1));
+
+    int *nx = malloc(sizeof(int)*(NN+1));
+    int *nu = malloc(sizeof(int)*(NN+1));
+    int *nz = malloc(sizeof(int)*(NN+1));
+    int *ns = malloc(sizeof(int)*(NN+1));
+    int *ny = malloc(sizeof(int)*(NN+1));
+    int *nbx = malloc(sizeof(int)*(NN+1));
+    int *nsbx = malloc(sizeof(int)*(NN+1)); // Added for testing soft constraints
+    int *nbu = malloc(sizeof(int)*(NN+1));
+    int *ng = malloc(sizeof(int)*(NN+1));
+    int *nh = malloc(sizeof(int)*(NN+1));
+    int *nsh = malloc(sizeof(int)*(NN+1));
 
     // TODO(dimitris): setup bounds on states and controls based on ACADO controller
     nx[0] = nx_;
     nu[0] = nu_;
     nbx[0] = nx_;
-	nsbx[0] = 0; // Added for testing soft constraints
+    nsbx[0] = 0; // Added for testing soft constraints
     nbu[0] = nu_;
     ng[0] = 0;
     // TODO(dimitris): add bilinear constraints later
@@ -270,7 +270,7 @@ int main()
         nx[i] = nx_;
         nu[i] = nu_;
         nbx[i] = 3;
-		nsbx[i] = 1; // Added for testing soft constraints
+        nsbx[i] = 1; // Added for testing soft constraints
         nbu[i] = nu_;
         ng[i] = 0;
         nh[i] = 1;
@@ -283,7 +283,7 @@ int main()
     nx[NN] = nx_;
     nu[NN] = 0;
     nbx[NN] = 3;
-	nsbx[NN] = 0; // Added for testing soft constraints
+    nsbx[NN] = 0; // Added for testing soft constraints
     nbu[NN] = 0;
     ng[NN] = 0;
     nh[NN] = 0;
@@ -392,10 +392,10 @@ int main()
     int *idxbx1 = malloc(nbx[1]*sizeof(int));
     double *lbx1 = malloc((nbx[1])*sizeof(double));
     double *ubx1 = malloc((nbx[1])*sizeof(double));
-		
-	int *idxsbx1 = malloc(nsbx[1]*sizeof(int));; // Added for testing soft constraints
-	double *lsbx1 = malloc((nsbx[1])*sizeof(double)); // Added for testing soft constraints
-	double *usbx1 = malloc((nsbx[1])*sizeof(double)); // Added for testing soft constraints
+
+    int *idxsbx1 = malloc(nsbx[1]*sizeof(int));; // Added for testing soft constraints
+    double *lsbx1 = malloc((nsbx[1])*sizeof(double)); // Added for testing soft constraints
+    double *usbx1 = malloc((nsbx[1])*sizeof(double)); // Added for testing soft constraints
 
     // generator angular velocity
     idxbx1[0] = 0;
@@ -411,11 +411,11 @@ int main()
     idxbx1[2] = 7;
     lbx1[2] = M_gen_min;
     ubx1[2] = M_gen_max;
-	
-	// soft state 
-	idxsbx1[0] = 0; // Added for testing soft constraints
-	lsbx1[0] = 0.0; // Added for testing soft constraints
-	usbx1[0] = 0.0; // Added for testing soft constraints
+
+    // soft state
+    idxsbx1[0] = 0; // Added for testing soft constraints
+    lsbx1[0] = 0.0; // Added for testing soft constraints
+    usbx1[0] = 0.0; // Added for testing soft constraints
 
     // last stage
 
@@ -423,10 +423,10 @@ int main()
     int *idxbxN = malloc(nbx[NN]*sizeof(int));
     double *lbxN = malloc((nbx[NN])*sizeof(double));
     double *ubxN = malloc((nbx[NN])*sizeof(double));
-	
-	// int *idxsbxN = malloc(nsbx[NN]*sizeof(int));; // Added for testing soft constraints
-	// double *lsbxN = malloc((nsbx[NN])*sizeof(double)); // Added for testing soft constraints
-	// double *usbxN = malloc((nsbx[NN])*sizeof(double)); // Added for testing soft constraints
+
+    // int *idxsbxN = malloc(nsbx[NN]*sizeof(int));; // Added for testing soft constraints
+    // double *lsbxN = malloc((nsbx[NN])*sizeof(double)); // Added for testing soft constraints
+    // double *usbxN = malloc((nsbx[NN])*sizeof(double)); // Added for testing soft constraints
 
     // generator angular velocity
     idxbxN[0] = 0;
@@ -442,11 +442,11 @@ int main()
     idxbxN[2] = 7;
     lbxN[2] = M_gen_min;
     ubxN[2] = M_gen_max;
-	
-	// // soft state 
-	// idxsbxN[0] = 0; // Added for testing soft constraints
-	// lsbxN[0] = 0.0; // Added for testing soft constraints
-	// usbxN[0] = 0.0; // Added for testing soft constraints
+
+    // // soft state
+    // idxsbxN[0] = 0; // Added for testing soft constraints
+    // lsbxN[0] = 0.0; // Added for testing soft constraints
+    // usbxN[0] = 0.0; // Added for testing soft constraints
 
     // to shift
     //double *specific_u = malloc(nu_*sizeof(double));
@@ -553,8 +553,8 @@ int main()
     uZ1[0] = 1e2;
     lz1[0] = 0e1;
     uz1[0] = 0e1;
-	
-	lZ1[1] = 1e2; // Added for testing soft constraints
+
+    lZ1[1] = 1e2; // Added for testing soft constraints
     uZ1[1] = 1e2; // Added for testing soft constraints
     lz1[1] = 0e1; // Added for testing soft constraints
     uz1[1] = 0e1; // Added for testing soft constraints
@@ -564,8 +564,8 @@ int main()
     // double *uZN = malloc(ns[NN]*sizeof(double));
     // double *lzN = malloc(ns[NN]*sizeof(double));
     // double *uzN = malloc(ns[NN]*sizeof(double));
-	
-	// lZN[1] = 1e-2; // Added for testing soft constraints
+
+    // lZN[1] = 1e-2; // Added for testing soft constraints
     // uZN[1] = 1e-2; // Added for testing soft constraints
     // lzN[1] = 0e1; // Added for testing soft constraints
     // uzN[1] = 0e1; // Added for testing soft constraints
@@ -624,7 +624,7 @@ int main()
         ocp_nlp_dims_set_cost(config, dims, i, "ny", &ny[i]);
 
         ocp_nlp_dims_set_constraints(config, dims, i, "nbx", &nbx[i]);
-		ocp_nlp_dims_set_constraints(config, dims, i, "nsbx", &nsbx[i]); // Added for testing soft constraints
+        ocp_nlp_dims_set_constraints(config, dims, i, "nsbx", &nsbx[i]); // Added for testing soft constraints
         ocp_nlp_dims_set_constraints(config, dims, i, "nbu", &nbu[i]);
         ocp_nlp_dims_set_constraints(config, dims, i, "ng", &ng[i]);
         ocp_nlp_dims_set_constraints(config, dims, i, "nh", &nh[i]);
@@ -673,7 +673,7 @@ int main()
     get_matrices_fun.casadi_n_out          = &wt_nx6p2_get_matrices_fun_n_out;
     external_function_casadi_create(&get_matrices_fun);
 
-    /* initialize additional gnsf dimensions */            
+    /* initialize additional gnsf dimensions */
     int gnsf_nx1 = 8;
     int gnsf_nz1 = 0;
     int gnsf_nout = 1;
@@ -736,10 +736,10 @@ int main()
         ocp_nlp_cost_model_set(config, dims, nlp_in, ii, "zl", lz1);
         ocp_nlp_cost_model_set(config, dims, nlp_in, ii, "zu", uz1);
     }
-	// ocp_nlp_cost_model_set(config, dims, nlp_in, NN, "Zl", lZN); // Added for testing soft constraints
-	// ocp_nlp_cost_model_set(config, dims, nlp_in, NN, "Zu", uZN); // Added for testing soft constraints
-	// ocp_nlp_cost_model_set(config, dims, nlp_in, NN, "zl", lzN); // Added for testing soft constraints
-	// ocp_nlp_cost_model_set(config, dims, nlp_in, NN, "zu", uzN); // Added for testing soft constraints
+    // ocp_nlp_cost_model_set(config, dims, nlp_in, NN, "Zl", lZN); // Added for testing soft constraints
+    // ocp_nlp_cost_model_set(config, dims, nlp_in, NN, "Zu", uZN); // Added for testing soft constraints
+    // ocp_nlp_cost_model_set(config, dims, nlp_in, NN, "zl", lzN); // Added for testing soft constraints
+    // ocp_nlp_cost_model_set(config, dims, nlp_in, NN, "zu", uzN); // Added for testing soft constraints
 
     /* dynamics */
 
@@ -839,15 +839,15 @@ int main()
             ocp_nlp_constraints_model_set(config, dims, nlp_in, i, "ush", ush1);
             ocp_nlp_constraints_model_set(config, dims, nlp_in, i, "idxsh", idxsh1);
         }
-		
-		ocp_nlp_constraints_model_set(config, dims, nlp_in, i, "idxsbx", idxsbx1); // Added for testing soft constraints
-		ocp_nlp_constraints_model_set(config, dims, nlp_in, i, "lsbx", lsbx1); // Added for testing soft constraints
-		ocp_nlp_constraints_model_set(config, dims, nlp_in, i, "usbx", usbx1); // Added for testing soft constraints
+
+        ocp_nlp_constraints_model_set(config, dims, nlp_in, i, "idxsbx", idxsbx1); // Added for testing soft constraints
+        ocp_nlp_constraints_model_set(config, dims, nlp_in, i, "lsbx", lsbx1); // Added for testing soft constraints
+        ocp_nlp_constraints_model_set(config, dims, nlp_in, i, "usbx", usbx1); // Added for testing soft constraints
     }
-	
-	// ocp_nlp_constraints_model_set(config, dims, nlp_in, NN, "idxsbx", idxsbxN); // Added for testing soft constraints
-	// ocp_nlp_constraints_model_set(config, dims, nlp_in, NN, "lsbx", lsbxN); // Added for testing soft constraints
-	// ocp_nlp_constraints_model_set(config, dims, nlp_in, NN, "usbx", usbxN); // Added for testing soft constraints
+
+    // ocp_nlp_constraints_model_set(config, dims, nlp_in, NN, "idxsbx", idxsbxN); // Added for testing soft constraints
+    // ocp_nlp_constraints_model_set(config, dims, nlp_in, NN, "lsbx", lsbxN); // Added for testing soft constraints
+    // ocp_nlp_constraints_model_set(config, dims, nlp_in, NN, "usbx", usbxN); // Added for testing soft constraints
 
 
     /************************************************
@@ -861,17 +861,17 @@ int main()
     if (plan->nlp_solver == SQP)
     {
 
-		int max_iter = MAX_SQP_ITERS;
-		double tol_stat = 1e-6;
-		double tol_eq   = 1e-8;
-		double tol_ineq = 1e-8;
-		double tol_comp = 1e-8;
+        int max_iter = MAX_SQP_ITERS;
+        double tol_stat = 1e-6;
+        double tol_eq   = 1e-8;
+        double tol_ineq = 1e-8;
+        double tol_comp = 1e-8;
 
-		ocp_nlp_solver_opts_set(config, nlp_opts, "max_iter", &max_iter);
-		ocp_nlp_solver_opts_set(config, nlp_opts, "tol_stat", &tol_stat);
-		ocp_nlp_solver_opts_set(config, nlp_opts, "tol_eq", &tol_eq);
-		ocp_nlp_solver_opts_set(config, nlp_opts, "tol_ineq", &tol_ineq);
-		ocp_nlp_solver_opts_set(config, nlp_opts, "tol_comp", &tol_comp);
+        ocp_nlp_solver_opts_set(config, nlp_opts, "max_iter", &max_iter);
+        ocp_nlp_solver_opts_set(config, nlp_opts, "tol_stat", &tol_stat);
+        ocp_nlp_solver_opts_set(config, nlp_opts, "tol_eq", &tol_eq);
+        ocp_nlp_solver_opts_set(config, nlp_opts, "tol_ineq", &tol_ineq);
+        ocp_nlp_solver_opts_set(config, nlp_opts, "tol_comp", &tol_comp);
     }
     else if (plan->nlp_solver == SQP_RTI)
     {
@@ -964,8 +964,8 @@ int main()
 
     int n_sim = 40;
 
-	double *x_sim = malloc(nx_*(n_sim+1)*sizeof(double));
-	double *u_sim = malloc(nu_*(n_sim+0)*sizeof(double));
+    double *x_sim = malloc(nx_*(n_sim+1)*sizeof(double));
+    double *u_sim = malloc(nu_*(n_sim+0)*sizeof(double));
 
     acados_timer timer;
     acados_tic(&timer);
@@ -984,8 +984,8 @@ int main()
         ocp_nlp_constraints_model_set(config, dims, nlp_in, 0, "lbx", x0_ref);
         ocp_nlp_constraints_model_set(config, dims, nlp_in, 0, "ubx", x0_ref);
 
-		// store x0
-		for(int ii=0; ii<nx_; ii++) x_sim[ii] = x0_ref[ii];
+        // store x0
+        for(int ii=0; ii<nx_; ii++) x_sim[ii] = x0_ref[ii];
 
         for (int idx = 0; idx < n_sim; idx++)
         {
@@ -1023,15 +1023,15 @@ int main()
             }
 
             // solve NLP
-            status = ocp_nlp_solve(solver, nlp_in, nlp_out);		
-			
+            status = ocp_nlp_solve(solver, nlp_in, nlp_out);
+
             // update initial condition
             // TODO(dimitris): maybe simulate system instead of passing x[1] as next state
             ocp_nlp_out_get(config, dims, nlp_out, 1, "x", specific_x);
             ocp_nlp_constraints_model_set(config, dims, nlp_in, 0, "lbx", specific_x);
             ocp_nlp_constraints_model_set(config, dims, nlp_in, 0, "ubx", specific_x);
 
-			// store trajectory
+            // store trajectory
             ocp_nlp_out_get(config, dims, nlp_out, 1, "x", x_sim+(idx+1)*nx_);
             ocp_nlp_out_get(config, dims, nlp_out, 0, "u", u_sim+idx*nu_);
 
@@ -1040,18 +1040,18 @@ int main()
             {
                 int sqp_iter;
                 double time_lin, time_qp_sol, time_tot;
-				double kkt_norm_inf;
+                double kkt_norm_inf;
 
                 ocp_nlp_get(config, solver, "sqp_iter", &sqp_iter);
                 ocp_nlp_get(config, solver, "time_tot", &time_tot);
                 ocp_nlp_get(config, solver, "time_qp_sol", &time_qp_sol);
                 ocp_nlp_get(config, solver, "time_lin", &time_lin);
-				kkt_norm_inf = nlp_out->inf_norm_res;
+                kkt_norm_inf = nlp_out->inf_norm_res;
 
                 // printf("\nproblem #%d, status %d, iters %d, time (total %f, lin %f, qp_sol %f) ms\n",
                     // idx, status, sqp_iter, time_tot*1e3, time_lin*1e3, time_qp_sol*1e3);
-					
-				printf("\nproblem #%d, status %d, iters %d, kkt_value %.4e, time (total %f, lin %f, qp_sol %f) ms\n",
+
+                printf("\nproblem #%d, status %d, iters %d, kkt_value %.4e, time (total %f, lin %f, qp_sol %f) ms\n",
                     idx, status, sqp_iter, kkt_norm_inf, time_tot*1e3, time_lin*1e3, time_qp_sol*1e3);
 
                 printf("xsim = \n");
@@ -1088,8 +1088,8 @@ int main()
     printf("\n\ntotal time (including printing) = %f ms (time per SQP = %f)\n\n", time*1e3, time*1e3/n_sim);
 
 #if 0
-	d_print_mat(nx_, n_sim+1, x_sim, nx_);
-	d_print_mat(nu_, n_sim, u_sim, nu_);
+    d_print_mat(nx_, n_sim+1, x_sim, nx_);
+    d_print_mat(nu_, n_sim, u_sim, nu_);
 #endif
 
     /************************************************
@@ -1129,8 +1129,8 @@ int main()
     free(specific_x);
     //free(specific_u);
 
-	free(x_sim);
-	free(u_sim);
+    free(x_sim);
+    free(u_sim);
 
     // free(lZ0);
     // free(uZ0);
@@ -1177,18 +1177,18 @@ int main()
 
     free(x_end);
     free(u_end);
-	
-	free(nx);
-	free(nu);
-	free(nz);
-	free(ns);
-	free(ny);
-	free(nbx);
-	free(nbu);
-	free(ng);
-	free(nh);
-	free(nsh);
-	
+
+    free(nx);
+    free(nu);
+    free(nz);
+    free(ns);
+    free(ny);
+    free(nbx);
+    free(nbu);
+    free(ng);
+    free(nh);
+    free(nsh);
+
 
     /************************************************
     * return

--- a/examples/c/wind_turbine_nmpc_soft.c
+++ b/examples/c/wind_turbine_nmpc_soft.c
@@ -55,7 +55,7 @@
 #define MAX_SQP_ITERS 10
 #define NREP 1
 
-
+// TODO This example is broken.
 
 static void shift_states(ocp_nlp_dims *dims, ocp_nlp_out *out, double *x_end)
 {
@@ -1042,10 +1042,10 @@ int main()
                 double time_lin, time_qp_sol, time_tot;
                 double kkt_norm_inf;
 
-                ocp_nlp_get(config, solver, "sqp_iter", &sqp_iter);
-                ocp_nlp_get(config, solver, "time_tot", &time_tot);
-                ocp_nlp_get(config, solver, "time_qp_sol", &time_qp_sol);
-                ocp_nlp_get(config, solver, "time_lin", &time_lin);
+                ocp_nlp_get(solver, "sqp_iter", &sqp_iter);
+                ocp_nlp_get(solver, "time_tot", &time_tot);
+                ocp_nlp_get(solver, "time_qp_sol", &time_qp_sol);
+                ocp_nlp_get(solver, "time_lin", &time_lin);
                 kkt_norm_inf = nlp_out->inf_norm_res;
 
                 // printf("\nproblem #%d, status %d, iters %d, time (total %f, lin %f, qp_sol %f) ms\n",
@@ -1064,7 +1064,7 @@ int main()
                 // if (plan->nlp_solver == SQP)  // RTI has no residual
                 // {
                     // ocp_nlp_res *residual;
-                    // ocp_nlp_get(config, solver, "nlp_res", &residual);
+                    // ocp_nlp_get(solver, "nlp_res", &residual);
                     // printf("\nresiduals\n");
                     // ocp_nlp_res_print(dims, residual);
                     // exit(1);

--- a/examples/c/wind_turbine_nmpc_soft.c
+++ b/examples/c/wind_turbine_nmpc_soft.c
@@ -944,9 +944,6 @@ int main()
         ocp_nlp_solver_opts_set(config, nlp_opts, "qp_cond_N", &cond_N);
     }
 
-    // update opts after manual changes
-    ocp_nlp_solver_opts_update(config, dims, nlp_opts);
-
     /************************************************
     * ocp_nlp out
     ************************************************/
@@ -969,9 +966,7 @@ int main()
 
 	double *x_sim = malloc(nx_*(n_sim+1)*sizeof(double));
 	double *u_sim = malloc(nu_*(n_sim+0)*sizeof(double));
-	
-	
-	
+
     acados_timer timer;
     acados_tic(&timer);
 

--- a/examples/c_ext_dep_off/pendulum/acados_solver_pendulum_ode.c
+++ b/examples/c_ext_dep_off/pendulum/acados_solver_pendulum_ode.c
@@ -758,13 +758,13 @@ int pendulum_ode_acados_reset(pendulum_ode_solver_capsule* capsule, int reset_qp
         if (i<N)
         {
             ocp_nlp_out_set(nlp_config, nlp_dims, nlp_out, i, "pi", buffer);
-            ocp_nlp_set(nlp_config, nlp_solver, i, "xdot_guess", buffer);
-            ocp_nlp_set(nlp_config, nlp_solver, i, "z_guess", buffer);
+            ocp_nlp_set(nlp_solver, i, "xdot_guess", buffer);
+            ocp_nlp_set(nlp_solver, i, "z_guess", buffer);
         }
     }
     // get qp_status: if NaN -> reset memory
     int qp_status;
-    ocp_nlp_get(capsule->nlp_config, capsule->nlp_solver, "qp_status", &qp_status);
+    ocp_nlp_get(capsule->nlp_solver, "qp_status", &qp_status);
     if (reset_qp_solver_mem || (qp_status == 3))
     {
         // printf("\nin reset qp_status %d -> resetting QP memory\n", qp_status);
@@ -876,12 +876,12 @@ int pendulum_ode_acados_free(pendulum_ode_solver_capsule* capsule)
 void pendulum_ode_acados_print_stats(pendulum_ode_solver_capsule* capsule)
 {
     int nlp_iter, stat_m, stat_n, tmp_int;
-    ocp_nlp_get(capsule->nlp_config, capsule->nlp_solver, "nlp_iter", &nlp_iter);
-    ocp_nlp_get(capsule->nlp_config, capsule->nlp_solver, "stat_n", &stat_n);
-    ocp_nlp_get(capsule->nlp_config, capsule->nlp_solver, "stat_m", &stat_m);
+    ocp_nlp_get(capsule->nlp_solver, "nlp_iter", &nlp_iter);
+    ocp_nlp_get(capsule->nlp_solver, "stat_n", &stat_n);
+    ocp_nlp_get(capsule->nlp_solver, "stat_m", &stat_m);
 
     double stat[1200];
-    ocp_nlp_get(capsule->nlp_config, capsule->nlp_solver, "statistics", stat);
+    ocp_nlp_get(capsule->nlp_solver, "statistics", stat);
 
     int nrow = nlp_iter+1 < stat_m ? nlp_iter+1 : stat_m;
 

--- a/examples/c_ext_dep_off/pendulum/main_pendulum_ode.c
+++ b/examples/c_ext_dep_off/pendulum/main_pendulum_ode.c
@@ -117,7 +117,7 @@ int main()
         }
         ocp_nlp_out_set(nlp_config, nlp_dims, nlp_out, N, "x", x_init);
         status = pendulum_ode_acados_solve(acados_ocp_capsule);
-        ocp_nlp_get(nlp_config, nlp_solver, "time_tot", &elapsed_time);
+        ocp_nlp_get(nlp_solver, "time_tot", &elapsed_time);
         min_time = MIN(elapsed_time, min_time);
     }
 
@@ -140,7 +140,7 @@ int main()
 
     // get solution
     ocp_nlp_out_get(nlp_config, nlp_dims, nlp_out, 0, "kkt_norm_inf", &kkt_norm_inf);
-    ocp_nlp_get(nlp_config, nlp_solver, "sqp_iter", &sqp_iter);
+    ocp_nlp_get(nlp_solver, "sqp_iter", &sqp_iter);
 
     pendulum_ode_acados_print_stats(acados_ocp_capsule);
 

--- a/interfaces/acados_c/ocp_nlp_interface.c
+++ b/interfaces/acados_c/ocp_nlp_interface.c
@@ -1246,8 +1246,7 @@ void ocp_nlp_eval_params_jac(ocp_nlp_solver *solver, ocp_nlp_in *nlp_in, ocp_nlp
 
 
 
-void ocp_nlp_get(ocp_nlp_config *config, ocp_nlp_solver *solver,
-                 const char *field, void *return_value_)
+void ocp_nlp_get(ocp_nlp_solver *solver, const char *field, void *return_value_)
 {
     solver->config->get(solver->config, solver->dims, solver->mem, field, return_value_);
 }
@@ -1414,19 +1413,19 @@ void ocp_nlp_get_at_stage(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_so
     else if (!strcmp(field, "pcond_Q"))
     {
         ocp_qp_in *pcond_qp_in;
-        ocp_nlp_get(config, solver, "qp_xcond_in", &pcond_qp_in);
+        ocp_nlp_get(solver, "qp_xcond_in", &pcond_qp_in);
         d_ocp_qp_get_Q(stage, pcond_qp_in, value);
     }
     else if (!strcmp(field, "pcond_R"))
     {
         ocp_qp_in *pcond_qp_in;
-        ocp_nlp_get(config, solver, "qp_xcond_in", &pcond_qp_in);
+        ocp_nlp_get(solver, "qp_xcond_in", &pcond_qp_in);
         d_ocp_qp_get_R(stage, pcond_qp_in, value);
     }
     else if (!strcmp(field, "pcond_S"))
     {
         ocp_qp_in *pcond_qp_in;
-        ocp_nlp_get(config, solver, "qp_xcond_in", &pcond_qp_in);
+        ocp_nlp_get(solver, "qp_xcond_in", &pcond_qp_in);
         d_ocp_qp_get_S(stage, pcond_qp_in, value);
     }
     else

--- a/interfaces/acados_c/ocp_nlp_interface.c
+++ b/interfaces/acados_c/ocp_nlp_interface.c
@@ -1320,16 +1320,6 @@ void ocp_nlp_get_at_stage(ocp_nlp_solver *solver, int stage, const char *field, 
         double *double_values = value;
         d_ocp_qp_get_ubu(stage, nlp_mem->qp_in, double_values);
     }
-    else if (!strcmp(field, "lb"))
-    {
-        double *double_values = value;
-        d_ocp_qp_get_lb(stage, nlp_mem->qp_in, double_values);
-    }
-    else if (!strcmp(field, "ub"))
-    {
-        double *double_values = value;
-        d_ocp_qp_get_ub(stage, nlp_mem->qp_in, double_values);
-    }
     else if (!strcmp(field, "C"))
     {
         double *double_values = value;

--- a/interfaces/acados_c/ocp_nlp_interface.c
+++ b/interfaces/acados_c/ocp_nlp_interface.c
@@ -1456,11 +1456,10 @@ void ocp_nlp_get_from_iterate(ocp_nlp_solver *solver, int iter, int stage, const
     ocp_nlp_out_get(config, dims, nlp_mem->iterates[iter], stage, field, value);
 }
 
-void ocp_nlp_set(ocp_nlp_config *config, ocp_nlp_solver *solver,
-        int stage, const char *field, void *value)
+void ocp_nlp_set(ocp_nlp_solver *solver, int stage, const char *field, void *value)
 {
-    // TODO only solver, no config
     ocp_nlp_memory *mem;
+    ocp_nlp_config *config = solver->config;
     config->get(config, solver->dims, solver->mem, "nlp_mem", &mem);
     // printf("called getter: nlp_mem %p\n", mem);
 

--- a/interfaces/acados_c/ocp_nlp_interface.c
+++ b/interfaces/acados_c/ocp_nlp_interface.c
@@ -1095,14 +1095,6 @@ void ocp_nlp_solver_opts_set_at_stage(ocp_nlp_config *config, void *opts_, int s
 }
 
 
-
-void ocp_nlp_solver_opts_update(ocp_nlp_config *config, ocp_nlp_dims *dims, void *opts_)
-{
-    config->opts_update(config, dims, opts_);
-}
-
-
-
 void ocp_nlp_solver_opts_destroy(void *opts)
 {
     free(opts);

--- a/interfaces/acados_c/ocp_nlp_interface.c
+++ b/interfaces/acados_c/ocp_nlp_interface.c
@@ -1253,9 +1253,10 @@ void ocp_nlp_get(ocp_nlp_solver *solver, const char *field, void *return_value_)
 
 
 
-void ocp_nlp_get_at_stage(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_solver *solver,
-        int stage, const char *field, void *value)
+void ocp_nlp_get_at_stage(ocp_nlp_solver *solver, int stage, const char *field, void *value)
 {
+    ocp_nlp_dims *dims = solver->dims;
+    ocp_nlp_config *config = solver->config;
     ocp_nlp_memory *nlp_mem;
     config->get(config, dims, solver->mem, "nlp_mem", &nlp_mem);
 

--- a/interfaces/acados_c/ocp_nlp_interface.c
+++ b/interfaces/acados_c/ocp_nlp_interface.c
@@ -1437,11 +1437,12 @@ void ocp_nlp_get_at_stage(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_so
 }
 
 
-void ocp_nlp_get_from_iterate(ocp_nlp_dims *dims, ocp_nlp_solver *solver,
-        int iter, int stage, const char *field, void *value)
+void ocp_nlp_get_from_iterate(ocp_nlp_solver *solver, int iter, int stage, const char *field, void *value)
 {
     ocp_nlp_config *config = solver->config;
     ocp_nlp_memory *nlp_mem;
+    ocp_nlp_dims *dims = solver->dims;
+
     config->get(config, solver->dims, solver->mem, "nlp_mem", &nlp_mem);
 
     ocp_nlp_opts *nlp_opts;
@@ -1458,6 +1459,7 @@ void ocp_nlp_get_from_iterate(ocp_nlp_dims *dims, ocp_nlp_solver *solver,
 void ocp_nlp_set(ocp_nlp_config *config, ocp_nlp_solver *solver,
         int stage, const char *field, void *value)
 {
+    // TODO only solver, no config
     ocp_nlp_memory *mem;
     config->get(config, solver->dims, solver->mem, "nlp_mem", &mem);
     // printf("called getter: nlp_mem %p\n", mem);

--- a/interfaces/acados_c/ocp_nlp_interface.h
+++ b/interfaces/acados_c/ocp_nlp_interface.h
@@ -349,15 +349,6 @@ ACADOS_SYMBOL_EXPORT void ocp_nlp_solver_opts_set(ocp_nlp_config *config, void *
 ACADOS_SYMBOL_EXPORT void ocp_nlp_solver_opts_set_at_stage(ocp_nlp_config *config, void *opts_, int stage, const char *field, void* value);
 
 
-/// TBC
-/// Updates the options.
-///
-/// \param config The configuration struct.
-/// \param dims The dimension struct.
-/// \param opts_ The options struct.
-ACADOS_SYMBOL_EXPORT void ocp_nlp_solver_opts_update(ocp_nlp_config *config, ocp_nlp_dims *dims, void *opts_);
-
-
 /* solver */
 
 /// Creates an ocp solver.

--- a/interfaces/acados_c/ocp_nlp_interface.h
+++ b/interfaces/acados_c/ocp_nlp_interface.h
@@ -139,7 +139,7 @@ typedef struct ocp_nlp_plan_t
 typedef struct ocp_nlp_solver
 {
     ocp_nlp_config *config;
-    void *dims;
+    ocp_nlp_dims *dims;
     void *opts;
     void *mem;
     void *work;
@@ -305,8 +305,7 @@ ACADOS_SYMBOL_EXPORT void ocp_nlp_out_get(ocp_nlp_config *config, ocp_nlp_dims *
 ACADOS_SYMBOL_EXPORT void ocp_nlp_get_at_stage(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_solver *solver,
         int stage, const char *field, void *value);
 
-ACADOS_SYMBOL_EXPORT void ocp_nlp_get_from_iterate(ocp_nlp_dims *dims, ocp_nlp_solver *solver,
-        int iter, int stage, const char *field, void *value);
+ACADOS_SYMBOL_EXPORT void ocp_nlp_get_from_iterate(ocp_nlp_solver *solver, int iter, int stage, const char *field, void *value);
 
 // TODO(andrea): remove this once/if the MATLAB interface uses the new setters below?
 ACADOS_SYMBOL_EXPORT int ocp_nlp_dims_get_from_attr(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_out *out,

--- a/interfaces/acados_c/ocp_nlp_interface.h
+++ b/interfaces/acados_c/ocp_nlp_interface.h
@@ -302,8 +302,7 @@ ACADOS_SYMBOL_EXPORT void ocp_nlp_out_get(ocp_nlp_config *config, ocp_nlp_dims *
         int stage, const char *field, void *value);
 
 //
-ACADOS_SYMBOL_EXPORT void ocp_nlp_get_at_stage(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_solver *solver,
-        int stage, const char *field, void *value);
+ACADOS_SYMBOL_EXPORT void ocp_nlp_get_at_stage(ocp_nlp_solver *solver, int stage, const char *field, void *value);
 
 ACADOS_SYMBOL_EXPORT void ocp_nlp_get_from_iterate(ocp_nlp_solver *solver, int iter, int stage, const char *field, void *value);
 

--- a/interfaces/acados_c/ocp_nlp_interface.h
+++ b/interfaces/acados_c/ocp_nlp_interface.h
@@ -421,12 +421,10 @@ ACADOS_SYMBOL_EXPORT void ocp_nlp_eval_param_sens(ocp_nlp_solver *solver, char *
 ACADOS_SYMBOL_EXPORT void ocp_nlp_eval_lagrange_grad_p(ocp_nlp_solver *solver, ocp_nlp_in *nlp_in, const char *field, double *out);
 
 /* get */
-/// \param config The configuration struct.
 /// \param solver The solver struct.
 /// \param field Supports "sqp_iter", "status", "nlp_res", "time_tot", ...
 /// \param return_value_ Pointer to the output memory.
-ACADOS_SYMBOL_EXPORT void ocp_nlp_get(ocp_nlp_config *config, ocp_nlp_solver *solver,
-        const char *field, void *return_value_);
+ACADOS_SYMBOL_EXPORT void ocp_nlp_get(ocp_nlp_solver *solver, const char *field, void *return_value_);
 
 /* set */
 /// Sets the initial guesses for the integrator for the given stage.

--- a/interfaces/acados_c/ocp_nlp_interface.h
+++ b/interfaces/acados_c/ocp_nlp_interface.h
@@ -431,13 +431,11 @@ ACADOS_SYMBOL_EXPORT void ocp_nlp_get(ocp_nlp_config *config, ocp_nlp_solver *so
 /* set */
 /// Sets the initial guesses for the integrator for the given stage.
 ///
-/// \param config The configuration struct.
 /// \param solver The ocp_nlp_solver struct.
 /// \param stage Stage number.
 /// \param field Supports "z_guess", "xdot_guess" (IRK), "phi_guess" (GNSF-IRK)
 /// \param value The initial guess for the algebraic variables in the integrator (if continuous model is used).
-ACADOS_SYMBOL_EXPORT void ocp_nlp_set(ocp_nlp_config *config, ocp_nlp_solver *solver,
-        int stage, const char *field, void *value);
+ACADOS_SYMBOL_EXPORT void ocp_nlp_set(ocp_nlp_solver *solver, int stage, const char *field, void *value);
 
 
 

--- a/interfaces/acados_matlab_octave/ocp_get.c
+++ b/interfaces/acados_matlab_octave/ocp_get.c
@@ -104,7 +104,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     {
         iteration = mxGetScalar(prhs[3]);
         int nlp_iter;
-        ocp_nlp_get(config, solver, "nlp_iter", &nlp_iter);
+        ocp_nlp_get(solver, "nlp_iter", &nlp_iter);
         if (iteration < 0 || iteration > nlp_iter)
         {
             sprintf(buffer, "\nocp_get: invalid iteration index, got stage = %d, should be nonnegative and <= nlp_iter = %d\n", iteration, nlp_iter);
@@ -453,7 +453,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         plhs[0] = mxCreateNumericMatrix(1, 1, mxDOUBLE_CLASS, mxREAL);
         double *mat_ptr = mxGetPr( plhs[0] );
         int status;
-        ocp_nlp_get(config, solver, "status", &status);
+        ocp_nlp_get(solver, "status", &status);
         *mat_ptr = (double) status;
     }
     else if (!strcmp(field, "sqp_iter") || !strcmp(field, "nlp_iter"))
@@ -461,21 +461,21 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         plhs[0] = mxCreateNumericMatrix(1, 1, mxDOUBLE_CLASS, mxREAL);
         double *mat_ptr = mxGetPr( plhs[0] );
         int nlp_iter;
-        ocp_nlp_get(config, solver, "nlp_iter", &nlp_iter);
+        ocp_nlp_get(solver, "nlp_iter", &nlp_iter);
         *mat_ptr = (double) nlp_iter;
     }
     else if (!strcmp(field, "time_tot") || !strcmp(field, "time_lin") || !strcmp(field, "time_glob") || !strcmp(field, "time_reg") || !strcmp(field, "time_qp_sol") || !strcmp(field, "time_qp_solver_call") || !strcmp(field, "time_qp_solver") || !strcmp(field, "time_qp_xcond") || !strcmp(field, "time_sim") || !strcmp(field, "time_sim_la") || !strcmp(field, "time_sim_ad"))
     {
         plhs[0] = mxCreateNumericMatrix(1, 1, mxDOUBLE_CLASS, mxREAL);
         double *mat_ptr = mxGetPr( plhs[0] );
-        ocp_nlp_get(config, solver, field, mat_ptr);
+        ocp_nlp_get(solver, field, mat_ptr);
     }
     else if (!strcmp(field, "qp_iter"))
     {
         plhs[0] = mxCreateNumericMatrix(1, 1, mxDOUBLE_CLASS, mxREAL);
         double *mat_ptr = mxGetPr( plhs[0] );
         int qp_iter;
-        ocp_nlp_get(config, solver, "qp_iter", &qp_iter);
+        ocp_nlp_get(solver, "qp_iter", &qp_iter);
         *mat_ptr = (double) qp_iter;
     }
     else if (!strcmp(field, "stat"))
@@ -483,10 +483,10 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         int nlp_iter;
         int stat_m, stat_n;
         double *stat;
-        ocp_nlp_get(config, solver, "nlp_iter", &nlp_iter);
-        ocp_nlp_get(config, solver, "stat_m", &stat_m);
-        ocp_nlp_get(config, solver, "stat_n", &stat_n);
-        ocp_nlp_get(config, solver, "stat", &stat);
+        ocp_nlp_get(solver, "nlp_iter", &nlp_iter);
+        ocp_nlp_get(solver, "stat_m", &stat_m);
+        ocp_nlp_get(solver, "stat_n", &stat_n);
+        ocp_nlp_get(solver, "stat", &stat);
         int min_size = stat_m<nlp_iter+1 ? stat_m : nlp_iter+1;
         plhs[0] = mxCreateNumericMatrix(min_size, stat_n+1, mxDOUBLE_CLASS, mxREAL);
         double *mat_ptr = mxGetPr( plhs[0] );
@@ -503,15 +503,15 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
             ocp_nlp_eval_residuals(solver, in, out);
         plhs[0] = mxCreateNumericMatrix(4, 1, mxDOUBLE_CLASS, mxREAL);
         double *mat_ptr = mxGetPr( plhs[0] );
-        ocp_nlp_get(config, solver, "res_stat", &mat_ptr[0]);
-        ocp_nlp_get(config, solver, "res_eq", &mat_ptr[1]);
-        ocp_nlp_get(config, solver, "res_ineq", &mat_ptr[2]);
-        ocp_nlp_get(config, solver, "res_comp", &mat_ptr[3]);
+        ocp_nlp_get(solver, "res_stat", &mat_ptr[0]);
+        ocp_nlp_get(solver, "res_eq", &mat_ptr[1]);
+        ocp_nlp_get(solver, "res_ineq", &mat_ptr[2]);
+        ocp_nlp_get(solver, "res_comp", &mat_ptr[3]);
     }
     else if (!strcmp(field, "qp_solver_cond_H"))
     {
         void *qp_in_;
-        ocp_nlp_get(config, solver, "qp_xcond_in", &qp_in_);
+        ocp_nlp_get(solver, "qp_xcond_in", &qp_in_);
         int solver_type = 0;
         if (plan->ocp_qp_solver_plan.qp_solver==PARTIAL_CONDENSING_HPIPM)
             solver_type=1;

--- a/interfaces/acados_matlab_octave/ocp_get.c
+++ b/interfaces/acados_matlab_octave/ocp_get.c
@@ -582,7 +582,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
                 ocp_nlp_qp_dims_get_from_attr(config, dims, out, ii, &field[3], out_dims);
                 tmp_mat = mxCreateNumericMatrix(out_dims[0], out_dims[1], mxDOUBLE_CLASS, mxREAL);
                 double *mat_ptr = mxGetPr( tmp_mat );
-                ocp_nlp_get_at_stage(config, dims, solver, ii, &field[3], mat_ptr);
+                ocp_nlp_get_at_stage(solver, ii, &field[3], mat_ptr);
                 mxSetCell(cell_array, ii, tmp_mat);
             }
         }
@@ -591,7 +591,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
             ocp_nlp_qp_dims_get_from_attr(config, dims, out, stage, &field[3], out_dims);
             plhs[0] = mxCreateNumericMatrix(out_dims[0], out_dims[1], mxDOUBLE_CLASS, mxREAL);
             double *mat_ptr = mxGetPr( plhs[0] );
-            ocp_nlp_get_at_stage(config, dims, solver, stage, &field[3], mat_ptr);
+            ocp_nlp_get_at_stage(solver, stage, &field[3], mat_ptr);
         }
     }
     else

--- a/interfaces/acados_matlab_octave/ocp_get.c
+++ b/interfaces/acados_matlab_octave/ocp_get.c
@@ -143,7 +143,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
             nx = ocp_nlp_dims_get_from_attr(config, dims, out, stage, "x");
             plhs[0] = mxCreateNumericMatrix(nx, 1, mxDOUBLE_CLASS, mxREAL);
             double *x = mxGetPr(plhs[0]);
-            ocp_nlp_get_from_iterate(dims, solver, iteration, stage, "x", x);
+            ocp_nlp_get_from_iterate(solver, iteration, stage, "x", x);
         }
         else
         {
@@ -182,7 +182,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
             nu = ocp_nlp_dims_get_from_attr(config, dims, out, stage, "u");
             plhs[0] = mxCreateNumericMatrix(nu, 1, mxDOUBLE_CLASS, mxREAL);
             double *u = mxGetPr(plhs[0]);
-            ocp_nlp_get_from_iterate(dims, solver, iteration, stage, "u", u);
+            ocp_nlp_get_from_iterate(solver, iteration, stage, "u", u);
         }
         else
         {
@@ -209,7 +209,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
             length = ocp_nlp_dims_get_from_attr(config, dims, out, stage, field);
             plhs[0] = mxCreateNumericMatrix(length, 1, mxDOUBLE_CLASS, mxREAL);
             double *value = mxGetPr(plhs[0]);
-            ocp_nlp_get_from_iterate(dims, solver, iteration, stage, field, value);
+            ocp_nlp_get_from_iterate(solver, iteration, stage, field, value);
         }
         else
         {
@@ -248,7 +248,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
             nz = ocp_nlp_dims_get_from_attr(config, dims, out, stage, "z");
             plhs[0] = mxCreateNumericMatrix(nz, 1, mxDOUBLE_CLASS, mxREAL);
             double *z = mxGetPr(plhs[0]);
-            ocp_nlp_get_from_iterate(dims, solver, iteration, stage, "z", z);
+            ocp_nlp_get_from_iterate(solver, iteration, stage, "z", z);
         }
         else
         {
@@ -288,7 +288,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
             npi = ocp_nlp_dims_get_from_attr(config, dims, out, stage, "pi");
             plhs[0] = mxCreateNumericMatrix(npi, 1, mxDOUBLE_CLASS, mxREAL);
             double *pi = mxGetPr(plhs[0]);
-            ocp_nlp_get_from_iterate(dims, solver, iteration, stage, "pi", pi);
+            ocp_nlp_get_from_iterate(solver, iteration, stage, "pi", pi);
         }
         else
         {
@@ -335,7 +335,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
             int nlam = ocp_nlp_dims_get_from_attr(config, dims, out, stage, "lam");
             plhs[0] = mxCreateNumericMatrix(nlam, 1, mxDOUBLE_CLASS, mxREAL);
             double *lam = mxGetPr(plhs[0]);
-            ocp_nlp_get_from_iterate(dims, solver, iteration, stage, "lam", lam);
+            ocp_nlp_get_from_iterate(solver, iteration, stage, "lam", lam);
         }
         else
         {

--- a/interfaces/acados_matlab_octave/ocp_get_cost.c
+++ b/interfaces/acados_matlab_octave/ocp_get_cost.c
@@ -60,7 +60,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     double *out_data = mxGetPr( plhs[0] );
 
     ocp_nlp_eval_cost(solver, in, out);
-    ocp_nlp_get(config, solver, "cost_value", out_data);
+    ocp_nlp_get(solver, "cost_value", out_data);
 
     return;
 

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -1289,13 +1289,11 @@ class AcadosOcpSolver:
                 self.__acados_lib.ocp_nlp_out_set(self.nlp_config, \
                     self.nlp_dims, self.nlp_out, stage, field, value_data_p)
             elif field_ in mem_fields:
-                self.__acados_lib.ocp_nlp_set(self.nlp_config, \
-                    self.nlp_solver, stage, field, value_data_p)
+                self.__acados_lib.ocp_nlp_set(self.nlp_solver, stage, field, value_data_p)
             # also set z_guess, when setting z.
             if field_ == 'z':
                 field = 'z_guess'.encode('utf-8')
-                self.__acados_lib.ocp_nlp_set(self.nlp_config, \
-                    self.nlp_solver, stage, field, value_data_p)
+                self.__acados_lib.ocp_nlp_set(self.nlp_solver, stage, field, value_data_p)
         return
 
 

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -297,7 +297,7 @@ class AcadosOcpSolver:
 
         self.__acados_lib.ocp_nlp_get_at_stage.argtypes = [c_void_p, c_void_p, c_void_p, c_int, c_char_p, c_void_p]
 
-        self.__acados_lib.ocp_nlp_get_from_iterate.argtypes = [c_void_p, c_void_p, c_int, c_int, c_char_p, c_void_p]
+        self.__acados_lib.ocp_nlp_get_from_iterate.argtypes = [c_void_p, c_int, c_int, c_char_p, c_void_p]
         self.__acados_lib.ocp_nlp_get_from_iterate.restypes = c_void_p
 
         getattr(self.shared_lib, f"{self.name}_acados_solve").argtypes = [c_void_p]
@@ -1519,7 +1519,7 @@ class AcadosOcpSolver:
         out = np.ascontiguousarray(np.zeros((dim,)), dtype=np.float64)
         out_data = cast(out.ctypes.data, POINTER(c_double))
         out_data_p = cast((out_data), c_void_p)
-        self.__acados_lib.ocp_nlp_get_from_iterate(self.nlp_dims, self.nlp_solver, iteration, stage, field, out_data_p)
+        self.__acados_lib.ocp_nlp_get_from_iterate(self.nlp_solver, iteration, stage, field, out_data_p)
         return out
 
     def get_iterate(self, iteration: int) -> AcadosOcpIterate:

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -276,7 +276,7 @@ class AcadosOcpSolver:
         self.__acados_lib.ocp_nlp_eval_param_sens.restype = None
 
         self.__acados_lib.ocp_nlp_solver_opts_set.argtypes = [c_void_p, c_void_p, c_char_p, c_void_p]
-        self.__acados_lib.ocp_nlp_get.argtypes = [c_void_p, c_void_p, c_char_p, c_void_p]
+        self.__acados_lib.ocp_nlp_get.argtypes = [c_void_p, c_char_p, c_void_p]
 
         self.__acados_lib.ocp_nlp_eval_cost.argtypes = [c_void_p, c_void_p, c_void_p]
         self.__acados_lib.ocp_nlp_eval_residuals.argtypes = [c_void_p, c_void_p, c_void_p]
@@ -284,7 +284,7 @@ class AcadosOcpSolver:
         self.__acados_lib.ocp_nlp_cost_model_set.argtypes =  [c_void_p, c_void_p, c_void_p, c_int, c_char_p, c_void_p]
 
         self.__acados_lib.ocp_nlp_out_set.argtypes = [c_void_p, c_void_p, c_void_p, c_int, c_char_p, c_void_p]
-        self.__acados_lib.ocp_nlp_set.argtypes = [c_void_p, c_void_p, c_int, c_char_p, c_void_p]
+        self.__acados_lib.ocp_nlp_set.argtypes = [c_void_p, c_int, c_char_p, c_void_p]
 
         self.__acados_lib.ocp_nlp_cost_dims_get_from_attr.argtypes = [c_void_p, c_void_p, c_void_p, c_int, c_char_p, POINTER(c_int)]
         self.__acados_lib.ocp_nlp_cost_dims_get_from_attr.restype = c_int
@@ -1067,12 +1067,12 @@ class AcadosOcpSolver:
 
         if field_ in ['ddp_iter', 'sqp_iter', 'nlp_iter', 'stat_m', 'stat_n']:
             out = c_int(0)
-            self.__acados_lib.ocp_nlp_get(self.nlp_config, self.nlp_solver, field, byref(out))
+            self.__acados_lib.ocp_nlp_get(self.nlp_solver, field, byref(out))
             return out.value
 
         elif field_ in double_fields:
             out = c_double(0)
-            self.__acados_lib.ocp_nlp_get(self.nlp_config, self.nlp_solver, field, byref(out))
+            self.__acados_lib.ocp_nlp_get(self.nlp_solver, field, byref(out))
             return out.value
 
         elif field_ == 'statistics':
@@ -1082,14 +1082,14 @@ class AcadosOcpSolver:
             min_size = min([stat_m, nlp_iter+1])
             out = np.ascontiguousarray(np.zeros((stat_n+1, min_size)), dtype=np.float64)
             out_data = cast(out.ctypes.data, POINTER(c_double))
-            self.__acados_lib.ocp_nlp_get(self.nlp_config, self.nlp_solver, field, out_data)
+            self.__acados_lib.ocp_nlp_get(self.nlp_solver, field, out_data)
             return out
 
         elif field_ == 'primal_step_norm':
             nlp_iter = self.get_stats("nlp_iter")
             out = np.ascontiguousarray(np.zeros((nlp_iter,)), dtype=np.float64)
             out_data = cast(out.ctypes.data, POINTER(c_double))
-            self.__acados_lib.ocp_nlp_get(self.nlp_config, self.nlp_solver, field, out_data)
+            self.__acados_lib.ocp_nlp_get(self.nlp_solver, field, out_data)
             return out
 
         elif field_ == 'qp_stat':
@@ -1182,7 +1182,7 @@ class AcadosOcpSolver:
 
         # call getter
         field = "cost_value".encode('utf-8')
-        self.__acados_lib.ocp_nlp_get(self.nlp_config, self.nlp_solver, field, out_data)
+        self.__acados_lib.ocp_nlp_get(self.nlp_solver, field, out_data)
 
         return out[0]
 
@@ -1207,19 +1207,19 @@ class AcadosOcpSolver:
 
         # call getters
         field = "res_stat".encode('utf-8')
-        self.__acados_lib.ocp_nlp_get(self.nlp_config, self.nlp_solver, field, out_data)
+        self.__acados_lib.ocp_nlp_get(self.nlp_solver, field, out_data)
 
         out_data = cast(out[1].ctypes.data, POINTER(c_double))
         field = "res_eq".encode('utf-8')
-        self.__acados_lib.ocp_nlp_get(self.nlp_config, self.nlp_solver, field, out_data)
+        self.__acados_lib.ocp_nlp_get(self.nlp_solver, field, out_data)
 
         out_data = cast(out[2].ctypes.data, POINTER(c_double))
         field = "res_ineq".encode('utf-8')
-        self.__acados_lib.ocp_nlp_get(self.nlp_config, self.nlp_solver, field, out_data)
+        self.__acados_lib.ocp_nlp_get(self.nlp_solver, field, out_data)
 
         out_data = cast(out[3].ctypes.data, POINTER(c_double))
         field = "res_comp".encode('utf-8')
-        self.__acados_lib.ocp_nlp_get(self.nlp_config, self.nlp_solver, field, out_data)
+        self.__acados_lib.ocp_nlp_get(self.nlp_solver, field, out_data)
         return out.flatten()
 
 

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -295,7 +295,7 @@ class AcadosOcpSolver:
         self.__acados_lib.ocp_nlp_qp_dims_get_from_attr.argtypes = [c_void_p, c_void_p, c_void_p, c_int, c_char_p, POINTER(c_int)]
         self.__acados_lib.ocp_nlp_qp_dims_get_from_attr.restype = c_int
 
-        self.__acados_lib.ocp_nlp_get_at_stage.argtypes = [c_void_p, c_void_p, c_void_p, c_int, c_char_p, c_void_p]
+        self.__acados_lib.ocp_nlp_get_at_stage.argtypes = [c_void_p, c_int, c_char_p, c_void_p]
 
         self.__acados_lib.ocp_nlp_get_from_iterate.argtypes = [c_void_p, c_int, c_int, c_char_p, c_void_p]
         self.__acados_lib.ocp_nlp_get_from_iterate.restypes = c_void_p
@@ -1497,8 +1497,7 @@ class AcadosOcpSolver:
         out_data_p = cast((out_data), c_void_p)
 
         # call getter
-        self.__acados_lib.ocp_nlp_get_at_stage(self.nlp_config, \
-            self.nlp_dims, self.nlp_solver, stage, field, out_data_p)
+        self.__acados_lib.ocp_nlp_get_at_stage(self.nlp_solver, stage, field, out_data_p)
 
         if field_ in ["Q", "R"]:
             # make symmetric: copy lower triangular part to upper triangular part

--- a/interfaces/acados_template/acados_template/acados_ocp_solver_pyx.pyx
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver_pyx.pyx
@@ -865,7 +865,7 @@ cdef class AcadosOcpSolverCython:
         cdef cnp.ndarray[cnp.float64_t, ndim=2] out = np.zeros((dims[0], dims[1]), order='F')
 
         # call getter
-        acados_solver_common.ocp_nlp_get_at_stage(self.nlp_config, self.nlp_dims, self.nlp_solver, stage, field, <void *> out.data)
+        acados_solver_common.ocp_nlp_get_at_stage(self.nlp_solver, stage, field, <void *> out.data)
 
         return out
 

--- a/interfaces/acados_template/acados_template/acados_ocp_solver_pyx.pyx
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver_pyx.pyx
@@ -650,17 +650,17 @@ cdef class AcadosOcpSolverCython:
 
     def __get_stat_int(self, field):
         cdef int out
-        acados_solver_common.ocp_nlp_get(self.nlp_config, self.nlp_solver, field, <void *> &out)
+        acados_solver_common.ocp_nlp_get(self.nlp_solver, field, <void *> &out)
         return out
 
     def __get_stat_double(self, field):
         cdef double out
-        acados_solver_common.ocp_nlp_get(self.nlp_config, self.nlp_solver, field, <void *> &out)
+        acados_solver_common.ocp_nlp_get(self.nlp_solver, field, <void *> &out)
         return out
 
     def __get_stat_matrix(self, field, n, m):
         cdef cnp.ndarray[cnp.float64_t, ndim=2] out_mat = np.ascontiguousarray(np.zeros((n, m)), dtype=np.float64)
-        acados_solver_common.ocp_nlp_get(self.nlp_config, self.nlp_solver, field, <void *> out_mat.data)
+        acados_solver_common.ocp_nlp_get(self.nlp_solver, field, <void *> out_mat.data)
         return out_mat
 
 
@@ -675,7 +675,7 @@ cdef class AcadosOcpSolverCython:
         cdef double out
 
         # call getter
-        acados_solver_common.ocp_nlp_get(self.nlp_config, self.nlp_solver, "cost_value", <void *> &out)
+        acados_solver_common.ocp_nlp_get(self.nlp_solver, "cost_value", <void *> &out)
 
         return out
 
@@ -693,19 +693,19 @@ cdef class AcadosOcpSolverCython:
         cdef double double_value
 
         field = "res_stat".encode('utf-8')
-        acados_solver_common.ocp_nlp_get(self.nlp_config, self.nlp_solver, field, <void *> &double_value)
+        acados_solver_common.ocp_nlp_get(self.nlp_solver, field, <void *> &double_value)
         out[0] = double_value
 
         field = "res_eq".encode('utf-8')
-        acados_solver_common.ocp_nlp_get(self.nlp_config, self.nlp_solver, field, <void *> &double_value)
+        acados_solver_common.ocp_nlp_get(self.nlp_solver, field, <void *> &double_value)
         out[1] = double_value
 
         field = "res_ineq".encode('utf-8')
-        acados_solver_common.ocp_nlp_get(self.nlp_config, self.nlp_solver, field, <void *> &double_value)
+        acados_solver_common.ocp_nlp_get(self.nlp_solver, field, <void *> &double_value)
         out[2] = double_value
 
         field = "res_comp".encode('utf-8')
-        acados_solver_common.ocp_nlp_get(self.nlp_config, self.nlp_solver, field, <void *> &double_value)
+        acados_solver_common.ocp_nlp_get(self.nlp_solver, field, <void *> &double_value)
         out[3] = double_value
 
         return out

--- a/interfaces/acados_template/acados_template/acados_ocp_solver_pyx.pyx
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver_pyx.pyx
@@ -768,13 +768,11 @@ cdef class AcadosOcpSolverCython:
                 acados_solver_common.ocp_nlp_out_set(self.nlp_config,
                     self.nlp_dims, self.nlp_out, stage, field, <void *> value.data)
             elif field_ in mem_fields:
-                acados_solver_common.ocp_nlp_set(self.nlp_config, \
-                    self.nlp_solver, stage, field, <void *> value.data)
+                acados_solver_common.ocp_nlp_set(self.nlp_solver, stage, field, <void *> value.data)
 
             if field_ == 'z':
                 field = 'z_guess'.encode('utf-8')
-                acados_solver_common.ocp_nlp_set(self.nlp_config, \
-                    self.nlp_solver, stage, field, <void *> value.data)
+                acados_solver_common.ocp_nlp_set(self.nlp_solver, stage, field, <void *> value.data)
         return
 
     def cost_set(self, int stage, str field_, value_):

--- a/interfaces/acados_template/acados_template/acados_solver_common.pxd
+++ b/interfaces/acados_template/acados_template/acados_solver_common.pxd
@@ -76,8 +76,7 @@ cdef extern from "acados_c/ocp_nlp_interface.h":
         int stage, const char *field, void *value)
     void ocp_nlp_out_get(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_out *out,
         int stage, const char *field, void *value)
-    void ocp_nlp_get_at_stage(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_solver *solver,
-        int stage, const char *field, void *value)
+    void ocp_nlp_get_at_stage(ocp_nlp_solver *solver, int stage, const char *field, void *value)
     int ocp_nlp_dims_get_from_attr(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_out *out,
         int stage, const char *field)
     void ocp_nlp_constraint_dims_get_from_attr(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_out *out,

--- a/interfaces/acados_template/acados_template/acados_solver_common.pxd
+++ b/interfaces/acados_template/acados_template/acados_solver_common.pxd
@@ -103,5 +103,5 @@ cdef extern from "acados_c/ocp_nlp_interface.h":
     void ocp_nlp_eval_params_jac(ocp_nlp_solver *solver, ocp_nlp_in *nlp_in_, ocp_nlp_out *nlp_out)
     void ocp_nlp_eval_lagrange_grad_p(ocp_nlp_solver *solver, ocp_nlp_in *nlp_in_, const char *field, void* value)
     # get/set
-    void ocp_nlp_get(ocp_nlp_config *config, ocp_nlp_solver *solver, const char *field, void *return_value_)
+    void ocp_nlp_get(ocp_nlp_solver *solver, const char *field, void *return_value_)
     void ocp_nlp_set(ocp_nlp_solver *solver, int stage, const char *field, void *value)

--- a/interfaces/acados_template/acados_template/acados_solver_common.pxd
+++ b/interfaces/acados_template/acados_template/acados_solver_common.pxd
@@ -104,4 +104,4 @@ cdef extern from "acados_c/ocp_nlp_interface.h":
     void ocp_nlp_eval_lagrange_grad_p(ocp_nlp_solver *solver, ocp_nlp_in *nlp_in_, const char *field, void* value)
     # get/set
     void ocp_nlp_get(ocp_nlp_config *config, ocp_nlp_solver *solver, const char *field, void *return_value_)
-    void ocp_nlp_set(ocp_nlp_config *config, ocp_nlp_solver *solver, int stage, const char *field, void *value)
+    void ocp_nlp_set(ocp_nlp_solver *solver, int stage, const char *field, void *value)

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.c
@@ -2595,7 +2595,7 @@ int {{ name }}_acados_reset({{ name }}_solver_capsule* capsule, int reset_qp_sol
 {%- if solver_options.qp_solver == 'PARTIAL_CONDENSING_HPIPM' %}
     // get qp_status: if NaN -> reset memory
     int qp_status;
-    ocp_nlp_get(capsule->nlp_config, capsule->nlp_solver, "qp_status", &qp_status);
+    ocp_nlp_get(capsule->nlp_solver, "qp_status", &qp_status);
     if (reset_qp_solver_mem || (qp_status == 3))
     {
         // printf("\nin reset qp_status %d -> resetting QP memory\n", qp_status);
@@ -2679,13 +2679,13 @@ int {{ name }}_acados_solve({{ name }}_solver_capsule* capsule)
 void {{ name }}_acados_print_stats({{ name }}_solver_capsule* capsule)
 {
     int sqp_iter, stat_m, stat_n, tmp_int;
-    ocp_nlp_get(capsule->nlp_config, capsule->nlp_solver, "sqp_iter", &sqp_iter);
-    ocp_nlp_get(capsule->nlp_config, capsule->nlp_solver, "stat_n", &stat_n);
-    ocp_nlp_get(capsule->nlp_config, capsule->nlp_solver, "stat_m", &stat_m);
+    ocp_nlp_get(capsule->nlp_solver, "sqp_iter", &sqp_iter);
+    ocp_nlp_get(capsule->nlp_solver, "stat_n", &stat_n);
+    ocp_nlp_get(capsule->nlp_solver, "stat_m", &stat_m);
 
 {% set stat_n_max = 12 %}
     double stat[{{ solver_options.nlp_solver_max_iter * stat_n_max }}];
-    ocp_nlp_get(capsule->nlp_config, capsule->nlp_solver, "statistics", stat);
+    ocp_nlp_get(capsule->nlp_solver, "statistics", stat);
 
     int nrow = sqp_iter+1 < stat_m ? sqp_iter+1 : stat_m;
 

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.c
@@ -2581,12 +2581,12 @@ int {{ name }}_acados_reset({{ name }}_solver_capsule* capsule, int reset_qp_sol
         {
             ocp_nlp_out_set(nlp_config, nlp_dims, nlp_out, i, "pi", buffer);
         {%- if mocp_opts.integrator_type[jj] == "IRK" %}
-            ocp_nlp_set(nlp_config, nlp_solver, i, "xdot_guess", buffer);
-            ocp_nlp_set(nlp_config, nlp_solver, i, "z_guess", buffer);
+            ocp_nlp_set(nlp_solver, i, "xdot_guess", buffer);
+            ocp_nlp_set(nlp_solver, i, "z_guess", buffer);
         {%- elif mocp_opts.integrator_type[jj] == "LIFTED_IRK" %}
-            ocp_nlp_set(nlp_config, nlp_solver, i, "xdot_guess", buffer);
+            ocp_nlp_set(nlp_solver, i, "xdot_guess", buffer);
         {%- elif mocp_opts.integrator_type[jj] == "GNSF" %}
-            ocp_nlp_set(nlp_config, nlp_solver, i, "gnsf_phi_guess", buffer);
+            ocp_nlp_set(nlp_solver, i, "gnsf_phi_guess", buffer);
         {%- endif %}
         }
     }

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -2620,7 +2620,7 @@ int {{ model.name }}_acados_reset({{ model.name }}_solver_capsule* capsule, int 
 {%- if solver_options.qp_solver == 'PARTIAL_CONDENSING_HPIPM' %}
     // get qp_status: if NaN -> reset memory
     int qp_status;
-    ocp_nlp_get(capsule->nlp_config, capsule->nlp_solver, "qp_status", &qp_status);
+    ocp_nlp_get(capsule->nlp_solver, "qp_status", &qp_status);
     if (reset_qp_solver_mem || (qp_status == 3))
     {
         // printf("\nin reset qp_status %d -> resetting QP memory\n", qp_status);
@@ -2974,13 +2974,13 @@ int {{ model.name }}_acados_free({{ model.name }}_solver_capsule* capsule)
 void {{ model.name }}_acados_print_stats({{ model.name }}_solver_capsule* capsule)
 {
     int nlp_iter, stat_m, stat_n, tmp_int;
-    ocp_nlp_get(capsule->nlp_config, capsule->nlp_solver, "nlp_iter", &nlp_iter);
-    ocp_nlp_get(capsule->nlp_config, capsule->nlp_solver, "stat_n", &stat_n);
-    ocp_nlp_get(capsule->nlp_config, capsule->nlp_solver, "stat_m", &stat_m);
+    ocp_nlp_get(capsule->nlp_solver, "nlp_iter", &nlp_iter);
+    ocp_nlp_get(capsule->nlp_solver, "stat_n", &stat_n);
+    ocp_nlp_get(capsule->nlp_solver, "stat_m", &stat_m);
 
 {% set stat_n_max = 12 %}
     double stat[{{ solver_options.nlp_solver_max_iter * stat_n_max }}];
-    ocp_nlp_get(capsule->nlp_config, capsule->nlp_solver, "statistics", stat);
+    ocp_nlp_get(capsule->nlp_solver, "statistics", stat);
 
     int nrow = nlp_iter+1 < stat_m ? nlp_iter+1 : stat_m;
 

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -2607,12 +2607,12 @@ int {{ model.name }}_acados_reset({{ model.name }}_solver_capsule* capsule, int 
         {
             ocp_nlp_out_set(nlp_config, nlp_dims, nlp_out, i, "pi", buffer);
         {%- if solver_options.integrator_type == "IRK" %}
-            ocp_nlp_set(nlp_config, nlp_solver, i, "xdot_guess", buffer);
-            ocp_nlp_set(nlp_config, nlp_solver, i, "z_guess", buffer);
+            ocp_nlp_set(nlp_solver, i, "xdot_guess", buffer);
+            ocp_nlp_set(nlp_solver, i, "z_guess", buffer);
         {%- elif solver_options.integrator_type == "LIFTED_IRK" %}
-            ocp_nlp_set(nlp_config, nlp_solver, i, "xdot_guess", buffer);
+            ocp_nlp_set(nlp_solver, i, "xdot_guess", buffer);
         {%- elif solver_options.integrator_type == "GNSF" %}
-            ocp_nlp_set(nlp_config, nlp_solver, i, "gnsf_phi_guess", buffer);
+            ocp_nlp_set(nlp_solver, i, "gnsf_phi_guess", buffer);
         {%- endif %}
         }
     }

--- a/interfaces/acados_template/acados_template/c_templates_tera/main.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/main.in.c
@@ -120,7 +120,7 @@ int main()
         }
         ocp_nlp_out_set(nlp_config, nlp_dims, nlp_out, N, "x", x_init);
         status = {{ name }}_acados_solve(acados_ocp_capsule);
-        ocp_nlp_get(nlp_config, nlp_solver, "time_tot", &elapsed_time);
+        ocp_nlp_get(nlp_solver, "time_tot", &elapsed_time);
         min_time = MIN(elapsed_time, min_time);
     }
 
@@ -154,7 +154,7 @@ int main()
 
     // get solution
     ocp_nlp_out_get(nlp_config, nlp_dims, nlp_out, 0, "kkt_norm_inf", &kkt_norm_inf);
-    ocp_nlp_get(nlp_config, nlp_solver, "sqp_iter", &sqp_iter);
+    ocp_nlp_get(nlp_solver, "sqp_iter", &sqp_iter);
 
     {{ name }}_acados_print_stats(acados_ocp_capsule);
 

--- a/interfaces/acados_template/acados_template/c_templates_tera/main_multi.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/main_multi.in.c
@@ -112,7 +112,7 @@ int main()
         }
         ocp_nlp_out_set(nlp_config, nlp_dims, nlp_out, N, "x", x_init);
         status = {{ name }}_acados_solve(acados_ocp_capsule);
-        ocp_nlp_get(nlp_config, nlp_solver, "time_tot", &elapsed_time);
+        ocp_nlp_get(nlp_solver, "time_tot", &elapsed_time);
 
         min_time = MIN(elapsed_time, min_time);
     }
@@ -151,7 +151,7 @@ int main()
 
     // get solution
     ocp_nlp_out_get(nlp_config, nlp_dims, nlp_out, 0, "kkt_norm_inf", &kkt_norm_inf);
-    ocp_nlp_get(nlp_config, nlp_solver, "sqp_iter", &sqp_iter);
+    ocp_nlp_get(nlp_solver, "sqp_iter", &sqp_iter);
 
     {{ name }}_acados_print_stats(acados_ocp_capsule);
 

--- a/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_mex_set.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_mex_set.in.c
@@ -441,14 +441,14 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
                 MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
                 for (int ii=0; ii<N; ii++)
                 {
-                    ocp_nlp_set(config, solver, ii, "z_guess", value+ii*nz);
+                    ocp_nlp_set(solver, ii, "z_guess", value+ii*nz);
                 }
             }
             else // (nrhs == min_nrhs+1)
             {
                 acados_size = nz;
                 MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
-                ocp_nlp_set(config, solver, s0, "z_guess", value);
+                ocp_nlp_set(solver, s0, "z_guess", value);
             }
         }
         else
@@ -473,14 +473,14 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
                 MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
                 for (int ii=0; ii<N; ii++)
                 {
-                    ocp_nlp_set(config, solver, ii, "xdot_guess", value+ii*nx);
+                    ocp_nlp_set(solver, ii, "xdot_guess", value+ii*nx);
                 }
             }
             else // nrhs == min_nrhs+1)
             {
                 acados_size = nx;
                 MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
-                ocp_nlp_set(config, solver, s0, "xdot_guess", value);
+                ocp_nlp_set(solver, s0, "xdot_guess", value);
             }
         }
         else
@@ -507,14 +507,14 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
                 MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
                 for (int ii=0; ii<N; ii++)
                 {
-                    ocp_nlp_set(config, solver, ii, "gnsf_phi_guess", value+ii*nout);
+                    ocp_nlp_set(solver, ii, "gnsf_phi_guess", value+ii*nout);
                 }
             }
             else // (nrhs == min_nrhs+1)
             {
                 acados_size = nout;
                 MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
-                ocp_nlp_set(config, solver, s0, "gnsf_phi_guess", value);
+                ocp_nlp_set(solver, s0, "gnsf_phi_guess", value);
             }
         }
         else

--- a/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_solver_sfun.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_solver_sfun.in.c
@@ -1199,7 +1199,7 @@ static void mdlOutputs(SimStruct *S, int_T tid)
   {%- if custom_update_filename == "" and not simulink_opts.inputs.rti_phase %}
     int acados_status = {{ name }}_acados_solve(capsule);
     // get time
-    ocp_nlp_get(nlp_config, capsule->nlp_solver, "time_tot", (void *) buffer);
+    ocp_nlp_get(capsule->nlp_solver, "time_tot", (void *) buffer);
     tmp_double = buffer[0];
 
   {%- elif simulink_opts.inputs.rti_phase %}{# SPLIT RTI PHASE#}
@@ -1211,7 +1211,7 @@ static void mdlOutputs(SimStruct *S, int_T tid)
     ocp_nlp_solver_opts_set(nlp_config, capsule->nlp_opts, "rti_phase", &rti_phase);
     int acados_status = {{ name }}_acados_solve(capsule);
     // get time
-    ocp_nlp_get(nlp_config, capsule->nlp_solver, "time_tot", (void *) buffer);
+    ocp_nlp_get(capsule->nlp_solver, "time_tot", (void *) buffer);
     tmp_double = buffer[0];
     {%- endif %}
   {%- elif solver_options.nlp_solver_type == "SQP_RTI" %}{# if custom_update_filename != "" #}
@@ -1221,7 +1221,7 @@ static void mdlOutputs(SimStruct *S, int_T tid)
     int acados_status = {{ name }}_acados_solve(capsule);
 
     // preparation time
-    ocp_nlp_get(nlp_config, capsule->nlp_solver, "time_tot", (void *) buffer);
+    ocp_nlp_get(capsule->nlp_solver, "time_tot", (void *) buffer);
     tmp_double = buffer[0];
 
     // call custom update function
@@ -1234,7 +1234,7 @@ static void mdlOutputs(SimStruct *S, int_T tid)
     ocp_nlp_solver_opts_set(nlp_config, capsule->nlp_opts, "rti_phase", &rti_phase);
     acados_status = {{ name }}_acados_solve(capsule);
     // feedback time
-    ocp_nlp_get(nlp_config, capsule->nlp_solver, "time_tot", (void *) buffer);
+    ocp_nlp_get(capsule->nlp_solver, "time_tot", (void *) buffer);
     tmp_double += buffer[0];
   {%- else -%}
     Simulink block with custom solver template only works with SQP_RTI!
@@ -1321,7 +1321,7 @@ static void mdlOutputs(SimStruct *S, int_T tid)
     {%- set i_output = i_output + 1 %}
     out_ptr = ssGetOutputPortRealSignal(S, {{ i_output }});
     ocp_nlp_eval_cost(capsule->nlp_solver, nlp_in, nlp_out);
-    ocp_nlp_get(nlp_config, capsule->nlp_solver, "cost_value", (void *) out_ptr);
+    ocp_nlp_get(capsule->nlp_solver, "cost_value", (void *) out_ptr);
   {%- endif %}
 
   {%- if simulink_opts.outputs.KKT_residual == 1 %}
@@ -1337,10 +1337,10 @@ static void mdlOutputs(SimStruct *S, int_T tid)
     {%- if solver_options.nlp_solver_type == "SQP_RTI" %}
     ocp_nlp_eval_residuals(capsule->nlp_solver, nlp_in, nlp_out);
     {%- endif %}
-    ocp_nlp_get(nlp_config, capsule->nlp_solver, "res_stat", (void *) &out_ptr[0]);
-    ocp_nlp_get(nlp_config, capsule->nlp_solver, "res_eq", (void *) &out_ptr[1]);
-    ocp_nlp_get(nlp_config, capsule->nlp_solver, "res_ineq", (void *) &out_ptr[2]);
-    ocp_nlp_get(nlp_config, capsule->nlp_solver, "res_comp", (void *) &out_ptr[3]);
+    ocp_nlp_get(capsule->nlp_solver, "res_stat", (void *) &out_ptr[0]);
+    ocp_nlp_get(capsule->nlp_solver, "res_eq", (void *) &out_ptr[1]);
+    ocp_nlp_get(capsule->nlp_solver, "res_ineq", (void *) &out_ptr[2]);
+    ocp_nlp_get(capsule->nlp_solver, "res_comp", (void *) &out_ptr[3]);
   {%- endif %}
 
   {%- if solver_options.N_horizon > 0 and simulink_opts.outputs.x1 == 1 %}
@@ -1358,26 +1358,26 @@ static void mdlOutputs(SimStruct *S, int_T tid)
   {%- if simulink_opts.outputs.CPU_time_sim == 1 %}
     {%- set i_output = i_output + 1 %}
     out_ptr = ssGetOutputPortRealSignal(S, {{ i_output }});
-    ocp_nlp_get(nlp_config, capsule->nlp_solver, "time_sim", (void *) out_ptr);
+    ocp_nlp_get(capsule->nlp_solver, "time_sim", (void *) out_ptr);
   {%- endif -%}
 
   {%- if simulink_opts.outputs.CPU_time_qp == 1 %}
     {%- set i_output = i_output + 1 %}
     out_ptr = ssGetOutputPortRealSignal(S, {{ i_output }});
-    ocp_nlp_get(nlp_config, capsule->nlp_solver, "time_qp", (void *) out_ptr);
+    ocp_nlp_get(capsule->nlp_solver, "time_qp", (void *) out_ptr);
   {%- endif -%}
 
   {%- if simulink_opts.outputs.CPU_time_lin == 1 %}
     {%- set i_output = i_output + 1 %}
     out_ptr = ssGetOutputPortRealSignal(S, {{ i_output }});
-    ocp_nlp_get(nlp_config, capsule->nlp_solver, "time_lin", (void *) out_ptr);
+    ocp_nlp_get(capsule->nlp_solver, "time_lin", (void *) out_ptr);
   {%- endif -%}
 
   {%- if simulink_opts.outputs.sqp_iter == 1 %}
     {%- set i_output = i_output + 1 %}
     out_ptr = ssGetOutputPortRealSignal(S, {{ i_output }});
     // get sqp iter
-    ocp_nlp_get(nlp_config, capsule->nlp_solver, "sqp_iter", (void *) &tmp_int);
+    ocp_nlp_get(capsule->nlp_solver, "sqp_iter", (void *) &tmp_int);
     *out_ptr = (double) tmp_int;
   {%- endif %}
 

--- a/interfaces/acados_template/acados_template/custom_update_templates/custom_update_function_zoro_template.in.c
+++ b/interfaces/acados_template/acados_template/custom_update_templates/custom_update_function_zoro_template.in.c
@@ -689,9 +689,9 @@ static void uncertainty_propagate_and_update(ocp_nlp_solver *solver, ocp_nlp_in 
     for (int ii = 0; ii < N-1; ii++)
     {
         // get and pack: A, B
-        ocp_nlp_get_at_stage(nlp_config, nlp_dims, solver, ii, "A", custom_mem->d_A_mat);
+        ocp_nlp_get_at_stage(solver, ii, "A", custom_mem->d_A_mat);
         blasfeo_pack_dmat(nx, nx, custom_mem->d_A_mat, nx, &custom_mem->A_mat, 0, 0);
-        ocp_nlp_get_at_stage(nlp_config, nlp_dims, solver, ii, "B", custom_mem->d_B_mat);
+        ocp_nlp_get_at_stage(solver, ii, "B", custom_mem->d_B_mat);
         blasfeo_pack_dmat(nx, nu, custom_mem->d_B_mat, nx, &custom_mem->B_mat, 0, 0);
 
 {% if zoro_description.input_W_add_diag %}
@@ -780,8 +780,8 @@ static void uncertainty_propagate_and_update(ocp_nlp_solver *solver, ocp_nlp_in 
 {%- if zoro_description.nlh_t + zoro_description.nuh_t > 0 %}
         // nonlinear constraints: h
         // Get C_{k+1} and D_{k+1}
-        ocp_nlp_get_at_stage(solver->config, nlp_dims, solver, ii+1, "C", custom_mem->d_Cgh_mat);
-        ocp_nlp_get_at_stage(solver->config, nlp_dims, solver, ii+1, "D", custom_mem->d_Dgh_mat);
+        ocp_nlp_get_at_stage(solver, ii+1, "C", custom_mem->d_Cgh_mat);
+        ocp_nlp_get_at_stage(solver, ii+1, "D", custom_mem->d_Dgh_mat);
         // NOTE: the d_Cgh_mat is column-major, the first ng rows are the Jacobians of the linear constraints
         blasfeo_pack_dmat(nh, nx, custom_mem->d_Cgh_mat+ng, ng+nh, &custom_mem->Ch_mat, 0, 0);
         blasfeo_pack_dmat(nh, nu, custom_mem->d_Dgh_mat+ng, ng+nh, &custom_mem->Dh_mat, 0, 0);
@@ -822,9 +822,9 @@ static void uncertainty_propagate_and_update(ocp_nlp_solver *solver, ocp_nlp_in 
 
     // Last stage
     // get and pack: A, B
-    ocp_nlp_get_at_stage(nlp_config, nlp_dims, solver, N-1, "A", custom_mem->d_A_mat);
+    ocp_nlp_get_at_stage(solver, N-1, "A", custom_mem->d_A_mat);
     blasfeo_pack_dmat(nx, nx, custom_mem->d_A_mat, nx, &custom_mem->A_mat, 0, 0);
-    ocp_nlp_get_at_stage(nlp_config, nlp_dims, solver, N-1, "B", custom_mem->d_B_mat);
+    ocp_nlp_get_at_stage(solver, N-1, "B", custom_mem->d_B_mat);
     blasfeo_pack_dmat(nx, nu, custom_mem->d_B_mat, nx, &custom_mem->B_mat, 0, 0);
 
 {% if zoro_description.input_W_add_diag %}
@@ -890,7 +890,7 @@ static void uncertainty_propagate_and_update(ocp_nlp_solver *solver, ocp_nlp_in 
 {%- if zoro_description.nlh_e_t + zoro_description.nuh_e_t > 0 %}
     // nonlinear constraints: h
     // Get C_{k+1} and D_{k+1}
-    ocp_nlp_get_at_stage(solver->config, nlp_dims, solver, N, "C", custom_mem->d_Cgh_mat);
+    ocp_nlp_get_at_stage(solver, N, "C", custom_mem->d_Cgh_mat);
     // NOTE: the d_Cgh_mat is column-major, the first ng rows are the Jacobians of the linear constraints
     blasfeo_pack_dmat(nh, nx, custom_mem->d_Cgh_mat+ng, ng+nh, &custom_mem->Ch_mat, 0, 0);
 

--- a/test/ocp_nlp/test_chain.cpp
+++ b/test/ocp_nlp/test_chain.cpp
@@ -1413,10 +1413,10 @@ void setup_and_solve_nlp(int NN,
     double max_res = 0.0;
 
     double inf_norm_res_stat, inf_norm_res_eq, inf_norm_res_ineq, inf_norm_res_comp;
-    ocp_nlp_get(config, solver, "res_stat", &inf_norm_res_stat);
-    ocp_nlp_get(config, solver, "res_eq", &inf_norm_res_eq);
-    ocp_nlp_get(config, solver, "res_ineq", &inf_norm_res_ineq);
-    ocp_nlp_get(config, solver, "res_comp", &inf_norm_res_comp);
+    ocp_nlp_get(solver, "res_stat", &inf_norm_res_stat);
+    ocp_nlp_get(solver, "res_eq", &inf_norm_res_eq);
+    ocp_nlp_get(solver, "res_ineq", &inf_norm_res_ineq);
+    ocp_nlp_get(solver, "res_comp", &inf_norm_res_comp);
 
     max_res = (inf_norm_res_stat > max_res) ? inf_norm_res_stat : max_res;
     max_res = (inf_norm_res_eq > max_res) ? inf_norm_res_eq : max_res;

--- a/test/ocp_nlp/test_chain.cpp
+++ b/test/ocp_nlp/test_chain.cpp
@@ -486,89 +486,89 @@ static void select_dynamics_casadi(int N, int num_free_masses,
 
 static void select_external_stage_cost_casadi(int indx, int N, int num_free_masses, external_function_casadi *external_cost)
 {
-	switch (num_free_masses)
-	{
-		case 1:
-			if (indx < N)
-			{
-				external_cost->casadi_fun = &chain_nm_2_external_cost;
-				external_cost->casadi_work = &chain_nm_2_external_cost_work;
-				external_cost->casadi_sparsity_in = &chain_nm_2_external_cost_sparsity_in;
-				external_cost->casadi_sparsity_out = &chain_nm_2_external_cost_sparsity_out;
-				external_cost->casadi_n_in = &chain_nm_2_external_cost_n_in;
-				external_cost->casadi_n_out = &chain_nm_2_external_cost_n_out;
-			}
-			else
-			{
-				printf("external cost not implemented for final stage");
-				exit(1);
-			}
-			break;
-		case 2:
-			if (indx < N)
-			{
-				external_cost->casadi_fun = &chain_nm_3_external_cost;
-				external_cost->casadi_work = &chain_nm_3_external_cost_work;
-				external_cost->casadi_sparsity_in = &chain_nm_3_external_cost_sparsity_in;
-				external_cost->casadi_sparsity_out = &chain_nm_3_external_cost_sparsity_out;
-				external_cost->casadi_n_in = &chain_nm_3_external_cost_n_in;
-				external_cost->casadi_n_out = &chain_nm_3_external_cost_n_out;
-			}
-			else
-			{
-				printf("external cost not implemented for final stage");
-				exit(1);
-			}
-			break;
-		case 3:
-			if (indx < N)
-			{
-				external_cost->casadi_fun = &chain_nm_4_external_cost;
-				external_cost->casadi_work = &chain_nm_4_external_cost_work;
-				external_cost->casadi_sparsity_in = &chain_nm_4_external_cost_sparsity_in;
-				external_cost->casadi_sparsity_out = &chain_nm_4_external_cost_sparsity_out;
-				external_cost->casadi_n_in = &chain_nm_4_external_cost_n_in;
-				external_cost->casadi_n_out = &chain_nm_4_external_cost_n_out;
-			}
-			else
-			{
-				printf("external cost not implemented for final stage");
-				exit(1);
-			}
-			break;
-		case 4:
-			if (indx < N)
-			{
-				external_cost->casadi_fun = &chain_nm_5_external_cost;
-				external_cost->casadi_work = &chain_nm_5_external_cost_work;
-				external_cost->casadi_sparsity_in = &chain_nm_5_external_cost_sparsity_in;
-				external_cost->casadi_sparsity_out = &chain_nm_5_external_cost_sparsity_out;
-				external_cost->casadi_n_in = &chain_nm_5_external_cost_n_in;
-				external_cost->casadi_n_out = &chain_nm_5_external_cost_n_out;
-			}
-			else
-			{
-				printf("external cost not implemented for final stage");
-				exit(1);
-			}
-			break;
-		// case 5:
-		// 	if (indx < N)
-		// 	{
-		// 		external_cost->casadi_fun = &chain_nm_6_external_cost;
-		// 		external_cost->casadi_work = &chain_nm_6_external_cost_work;
-		// 		external_cost->casadi_sparsity_in = &chain_nm_6_external_cost_sparsity_in;
-		// 		external_cost->casadi_sparsity_out = &chain_nm_6_external_cost_sparsity_out;
-		// 		external_cost->casadi_n_in = &chain_nm_6_external_cost_n_in;
-		// 		external_cost->casadi_n_out = &chain_nm_6_external_cost_n_out;
-		// 	}
-		// 	else
-		// 	{
-		// 		printf("external cost not implemented for final stage");
-		// 		exit(1);
-		// 	}
-			break;
-	}
+    switch (num_free_masses)
+    {
+        case 1:
+            if (indx < N)
+            {
+                external_cost->casadi_fun = &chain_nm_2_external_cost;
+                external_cost->casadi_work = &chain_nm_2_external_cost_work;
+                external_cost->casadi_sparsity_in = &chain_nm_2_external_cost_sparsity_in;
+                external_cost->casadi_sparsity_out = &chain_nm_2_external_cost_sparsity_out;
+                external_cost->casadi_n_in = &chain_nm_2_external_cost_n_in;
+                external_cost->casadi_n_out = &chain_nm_2_external_cost_n_out;
+            }
+            else
+            {
+                printf("external cost not implemented for final stage");
+                exit(1);
+            }
+            break;
+        case 2:
+            if (indx < N)
+            {
+                external_cost->casadi_fun = &chain_nm_3_external_cost;
+                external_cost->casadi_work = &chain_nm_3_external_cost_work;
+                external_cost->casadi_sparsity_in = &chain_nm_3_external_cost_sparsity_in;
+                external_cost->casadi_sparsity_out = &chain_nm_3_external_cost_sparsity_out;
+                external_cost->casadi_n_in = &chain_nm_3_external_cost_n_in;
+                external_cost->casadi_n_out = &chain_nm_3_external_cost_n_out;
+            }
+            else
+            {
+                printf("external cost not implemented for final stage");
+                exit(1);
+            }
+            break;
+        case 3:
+            if (indx < N)
+            {
+                external_cost->casadi_fun = &chain_nm_4_external_cost;
+                external_cost->casadi_work = &chain_nm_4_external_cost_work;
+                external_cost->casadi_sparsity_in = &chain_nm_4_external_cost_sparsity_in;
+                external_cost->casadi_sparsity_out = &chain_nm_4_external_cost_sparsity_out;
+                external_cost->casadi_n_in = &chain_nm_4_external_cost_n_in;
+                external_cost->casadi_n_out = &chain_nm_4_external_cost_n_out;
+            }
+            else
+            {
+                printf("external cost not implemented for final stage");
+                exit(1);
+            }
+            break;
+        case 4:
+            if (indx < N)
+            {
+                external_cost->casadi_fun = &chain_nm_5_external_cost;
+                external_cost->casadi_work = &chain_nm_5_external_cost_work;
+                external_cost->casadi_sparsity_in = &chain_nm_5_external_cost_sparsity_in;
+                external_cost->casadi_sparsity_out = &chain_nm_5_external_cost_sparsity_out;
+                external_cost->casadi_n_in = &chain_nm_5_external_cost_n_in;
+                external_cost->casadi_n_out = &chain_nm_5_external_cost_n_out;
+            }
+            else
+            {
+                printf("external cost not implemented for final stage");
+                exit(1);
+            }
+            break;
+        // case 5:
+        //     if (indx < N)
+        //     {
+        //         external_cost->casadi_fun = &chain_nm_6_external_cost;
+        //         external_cost->casadi_work = &chain_nm_6_external_cost_work;
+        //         external_cost->casadi_sparsity_in = &chain_nm_6_external_cost_sparsity_in;
+        //         external_cost->casadi_sparsity_out = &chain_nm_6_external_cost_sparsity_out;
+        //         external_cost->casadi_n_in = &chain_nm_6_external_cost_n_in;
+        //         external_cost->casadi_n_out = &chain_nm_6_external_cost_n_out;
+        //     }
+        //     else
+        //     {
+        //         printf("external cost not implemented for final stage");
+        //         exit(1);
+        //     }
+            break;
+    }
 }
 
 
@@ -1123,7 +1123,7 @@ void setup_and_solve_nlp(int NN,
 
     external_function_casadi *ls_cost_jac_casadi = (external_function_casadi *)
                                                     malloc((NN+1)*sizeof(external_function_casadi));
-	external_function_casadi *external_cost = (external_function_casadi *)
+    external_function_casadi *external_cost = (external_function_casadi *)
                                               malloc(NN*sizeof(external_function_casadi));
 
     for (int i = 0; i <= NN; i++)
@@ -1139,12 +1139,12 @@ void setup_and_solve_nlp(int NN,
                 external_function_casadi_create(&ls_cost_jac_casadi[i], &ext_fun_opts);
                 break;
 
-			case EXTERNAL:
-				select_external_stage_cost_casadi(i, NN, NMF, &external_cost[i]);
-				external_function_casadi_create(&external_cost[i], &ext_fun_opts);
-				break;
+            case EXTERNAL:
+                select_external_stage_cost_casadi(i, NN, NMF, &external_cost[i]);
+                external_function_casadi_create(&external_cost[i], &ext_fun_opts);
+                break;
 
-			default:
+            default:
                 printf("\ncost not correctly specified\n\n");
                 exit(1);
         }
@@ -1219,7 +1219,7 @@ void setup_and_solve_nlp(int NN,
 
             case EXTERNAL:
 
-				ocp_nlp_cost_model_set(config, dims, nlp_in, i, "ext_cost_fun_jac_hes", &external_cost[i]);
+                ocp_nlp_cost_model_set(config, dims, nlp_in, i, "ext_cost_fun_jac_hes", &external_cost[i]);
 
                 assert(i < NN && "externally provided cost not implemented for last stage!");
                 break;
@@ -1470,22 +1470,22 @@ void setup_and_solve_nlp(int NN,
     free(idxb1);
     free(idxbN);
 
-	for (int i = 0; i <= NN; i++)
-	{
-		switch (plan->nlp_cost[i])
-		{
-			case NONLINEAR_LS:
-				external_function_casadi_free(&ls_cost_jac_casadi[i]);
-				break;
-			case EXTERNAL:
-				external_function_casadi_free(&external_cost[i]);
-			default:
-				break;
-		}
-	}
+    for (int i = 0; i <= NN; i++)
+    {
+        switch (plan->nlp_cost[i])
+        {
+            case NONLINEAR_LS:
+                external_function_casadi_free(&ls_cost_jac_casadi[i]);
+                break;
+            case EXTERNAL:
+                external_function_casadi_free(&external_cost[i]);
+            default:
+                break;
+        }
+    }
 
     free(ls_cost_jac_casadi);
-	free(external_cost);
+    free(external_cost);
 
     free(plan);
 

--- a/test/ocp_nlp/test_wind_turbine.cpp
+++ b/test/ocp_nlp/test_wind_turbine.cpp
@@ -1053,7 +1053,7 @@ void setup_and_solve_nlp(std::string const& integrator_str, std::string const& q
         status = ocp_nlp_solve(solver, nlp_in, nlp_out);
 
         ocp_nlp_res *residual;
-        ocp_nlp_get(config, solver, "nlp_res", &residual);
+        ocp_nlp_get(solver, "nlp_res", &residual);
 
         double max_res = 0.0;
         double inf_norm_res_stat = residual->inf_norm_res_stat;
@@ -1074,10 +1074,10 @@ void setup_and_solve_nlp(std::string const& integrator_str, std::string const& q
         int sqp_iter;
         double time_lin, time_qp_sol, time_tot;
 
-        ocp_nlp_get(config, solver, "sqp_iter", &sqp_iter);
-        ocp_nlp_get(config, solver, "time_tot", &time_tot);
-        ocp_nlp_get(config, solver, "time_qp_sol", &time_qp_sol);
-        ocp_nlp_get(config, solver, "time_lin", &time_lin);
+        ocp_nlp_get(solver, "sqp_iter", &sqp_iter);
+        ocp_nlp_get(solver, "time_tot", &time_tot);
+        ocp_nlp_get(solver, "time_qp_sol", &time_qp_sol);
+        ocp_nlp_get(solver, "time_lin", &time_lin);
 
         printf("\nproblem #%d, status %d, iters %d, time (total %f, lin %f, qp_sol %f) ms\n",
             idx, status, sqp_iter, time_tot*1e3, time_lin*1e3, time_qp_sol*1e3);


### PR DESCRIPTION
Breaking changes in C interface
- remove `ocp_nlp_solver_opts_update`, `opts_update` is called in `ocp_nlp_solver_create`
- cleanup of redundant signatures:
  - signature of `ocp_nlp_get_from_iterate` changes (takes solver and not solver AND dims) 
  - signature of `ocp_nlp_set` changes (takes solver and not solver AND config) 
  - signature of `ocp_nlp_get` changes (takes solver and not solver AND config)
  - signature of `ocp_nlp_get_at_stage` changes (takes solver and not solver AND dims AND config)
- setters for `lb` and `ub` have been removed

Other
- formatting wind_turbine C examples, chain example

