### PR TITLE
Migrate sensitivities of solution and value function of parameters to `p_global`

### DIFF
--- a/.github/workflows/full_build.yml
+++ b/.github/workflows/full_build.yml
@@ -165,6 +165,16 @@ jobs:
         cd ${{runner.workspace}}/acados/examples/acados_python/tests
         python test_rti_sqp_residuals.py
 
+    - name: Python sensitivity examples
+      working-directory: ${{runner.workspace}}/acados/build
+      shell: bash
+      run: |
+        source ${{runner.workspace}}/acados/acadosenv/bin/activate
+        cd ${{runner.workspace}}/acados/examples/acados_python/pendulum_on_cart/solution_sensitivities
+        python value_gradient_example.py
+        python policy_gradient_example.py
+        python test_solution_sens_and_exact_hess.py
+
   MATLAB_test:
     needs: core_build
     runs-on: ubuntu-22.04

--- a/acados/ocp_nlp/ocp_nlp_common.c
+++ b/acados/ocp_nlp/ocp_nlp_common.c
@@ -3180,7 +3180,7 @@ void ocp_nlp_common_eval_param_sens(ocp_nlp_config *config, ocp_nlp_dims *dims,
         exit(1);
 
     }
-    else if (!strcmp("params_global", field))
+    else if (!strcmp("p_global", field))
     {
         for (i = 0; i < N; i++)
         {
@@ -3236,7 +3236,7 @@ void ocp_nlp_common_eval_lagr_grad_p(ocp_nlp_config *config, ocp_nlp_dims *dims,
         printf("\nerror: field %s not available in ocp_nlp_common_eval_lagr_grad_p\n", field);
         exit(1);
     }
-    else if (!strcmp("params_global", field))
+    else if (!strcmp("p_global", field))
     {
         // initialize to zero
         blasfeo_dvecse(np_global, 0., &work->out_np_global, 0);

--- a/acados/ocp_nlp/ocp_nlp_common.c
+++ b/acados/ocp_nlp/ocp_nlp_common.c
@@ -1742,7 +1742,7 @@ acados_size_t ocp_nlp_workspace_calculate_size(ocp_nlp_config *config, ocp_nlp_d
     int *nx = dims->nx;
     // int *nu = dims->nu;
     int *ni = dims->ni;
-    int *np = dims->np;
+    // int *np = dims->np;
     // int *ns = dims->ns;
     int *nv = dims->nv;
 
@@ -1964,7 +1964,7 @@ ocp_nlp_workspace *ocp_nlp_workspace_assign(ocp_nlp_config *config, ocp_nlp_dims
     // int *nu = dims->nu;
     int *ni = dims->ni;
     // int *nz = dims->nz;
-    int *np = dims->np;
+    // int *np = dims->np;
     int nv_max = 0;
     int nx_max = 0;
     int ni_max = 0;

--- a/acados/ocp_nlp/ocp_nlp_common.c
+++ b/acados/ocp_nlp/ocp_nlp_common.c
@@ -3174,12 +3174,6 @@ void ocp_nlp_common_eval_param_sens(ocp_nlp_config *config, ocp_nlp_dims *dims,
         d_ocp_qp_set_el("lbx", stage, index, &one, tmp_qp_in);
         d_ocp_qp_set_el("ubx", stage, index, &one, tmp_qp_in);
     }
-    else if (!strcmp("params_stage", field))
-    {
-        printf("\nerror: field %s at stage %d not available in ocp_nlp_sqp_eval_param_sens\n", field, stage);
-        exit(1);
-
-    }
     else if (!strcmp("p_global", field))
     {
         for (i = 0; i < N; i++)
@@ -3199,7 +3193,7 @@ void ocp_nlp_common_eval_param_sens(ocp_nlp_config *config, ocp_nlp_dims *dims,
     }
     else
     {
-        printf("\nerror: field %s at stage %d not available in ocp_nlp_sqp_eval_param_sens\n", field, stage);
+        printf("\nerror: field %s at stage %d not available in ocp_nlp_common_eval_param_sens\n", field, stage);
         exit(1);
     }
 
@@ -3231,12 +3225,7 @@ void ocp_nlp_common_eval_lagr_grad_p(ocp_nlp_config *config, ocp_nlp_dims *dims,
     // int *nx = dims->nx;
     int np_global = dims->np_global;
 
-    if (!strcmp("params_stage", field))
-    {
-        printf("\nerror: field %s not available in ocp_nlp_common_eval_lagr_grad_p\n", field);
-        exit(1);
-    }
-    else if (!strcmp("p_global", field))
+    if (!strcmp("p_global", field))
     {
         // initialize to zero
         blasfeo_dvecse(np_global, 0., &work->out_np_global, 0);
@@ -3265,7 +3254,7 @@ void ocp_nlp_common_eval_lagr_grad_p(ocp_nlp_config *config, ocp_nlp_dims *dims,
     }
     else
     {
-        printf("\nerror: field %s not available in ocp_nlp_sqp_eval_param_sens\n", field);
+        printf("\nerror: field %s not available in ocp_nlp_common_eval_lagr_grad_p\n", field);
         exit(1);
     }
 }

--- a/acados/ocp_nlp/ocp_nlp_common.h
+++ b/acados/ocp_nlp/ocp_nlp_common.h
@@ -458,8 +458,8 @@ typedef struct ocp_nlp_workspace
     struct blasfeo_dvec dxnext_dy;
 
     // optimal value gradient wrt params
-    struct blasfeo_dvec tmp_np;
-    struct blasfeo_dvec out_np;
+    struct blasfeo_dvec tmp_np_global;
+    struct blasfeo_dvec out_np_global;
     // AS-RTI
     double *tmp_nv_double;
 

--- a/acados/ocp_nlp/ocp_nlp_cost_conl.c
+++ b/acados/ocp_nlp/ocp_nlp_cost_conl.c
@@ -100,6 +100,10 @@ void ocp_nlp_cost_conl_dims_set(void *config_, void *dims_, const char *field, i
     {
         // np dimension not needed
     }
+    else if (!strcmp(field, "np_global"))
+    {
+        // np dimension not needed
+    }
     else
     {
         printf("\nerror: dimension type: %s not available in module\n", field);

--- a/acados/ocp_nlp/ocp_nlp_cost_external.c
+++ b/acados/ocp_nlp/ocp_nlp_cost_external.c
@@ -101,6 +101,10 @@ void ocp_nlp_cost_external_dims_set(void *config_, void *dims_, const char *fiel
     {
         dims->np = *value;
     }
+    else if (!strcmp(field, "np_global"))
+    {
+        dims->np_global = *value;
+    }
     else
     {
         printf("\nerror: ocp_nlp_cost_external_dims_set: dimension type %s not available.\n", field);
@@ -886,7 +890,7 @@ void ocp_nlp_cost_external_compute_jac_p(void *config_, void *dims_, void *model
     int nu = dims->nu;
     int nx = dims->nx;
     int nz = dims->nz;
-    int np = dims->np;
+    int np_global = dims->np_global;
 
     /* specify input types and pointers for external cost function */
     ext_fun_arg_t ext_fun_type_in[3];
@@ -926,7 +930,7 @@ void ocp_nlp_cost_external_compute_jac_p(void *config_, void *dims_, void *model
     // scale
     if(model->scaling != 1.0)
     {
-        blasfeo_dgesc(nu + nx + nz, np, model->scaling, &memory->cost_grad_params_jac, 0, 0);
+        blasfeo_dgesc(nu + nx + nz, np_global, model->scaling, &memory->cost_grad_params_jac, 0, 0);
     }
 
     return;
@@ -945,7 +949,7 @@ void ocp_nlp_cost_external_eval_grad_p(void *config_, void *dims_, void *model_,
     int nu = dims->nu;
     // int nx = dims->nx;
     // int nz = dims->nz;
-    int np = dims->np;
+    int np_global = dims->np_global;
 
     /* specify input types and pointers for external cost function */
     ext_fun_arg_t ext_fun_type_in[3];
@@ -980,7 +984,7 @@ void ocp_nlp_cost_external_eval_grad_p(void *config_, void *dims_, void *model_,
     // scale
     if(model->scaling != 1.0)
     {
-        blasfeo_dvecsc(np, model->scaling, out, 0);
+        blasfeo_dvecsc(np_global, model->scaling, out, 0);
     }
 
     return;

--- a/acados/ocp_nlp/ocp_nlp_cost_external.h
+++ b/acados/ocp_nlp/ocp_nlp_cost_external.h
@@ -55,6 +55,7 @@ typedef struct
     int nu;  // number of inputs
     int ns;  // number of slacks
     int np; // number of parameters
+    int np_global; // number of global parameters
 } ocp_nlp_cost_external_dims;
 
 //

--- a/acados/ocp_nlp/ocp_nlp_cost_ls.c
+++ b/acados/ocp_nlp/ocp_nlp_cost_ls.c
@@ -153,6 +153,10 @@ void ocp_nlp_cost_ls_dims_set(void *config_, void *dims_, const char *field, int
     {
         // np dimension not needed
     }
+    else if (!strcmp(field, "np_global"))
+    {
+        // np_global dimension not needed
+    }
     else
     {
         printf("\nerror: dimension type not available in module\n");

--- a/acados/ocp_nlp/ocp_nlp_cost_nls.c
+++ b/acados/ocp_nlp/ocp_nlp_cost_nls.c
@@ -99,6 +99,10 @@ void ocp_nlp_cost_nls_dims_set(void *config_, void *dims_, const char *field, in
     {
         // np dimension not needed
     }
+    else if (!strcmp(field, "np_global"))
+    {
+        // np_global dimension not needed
+    }
     else
     {
         printf("\nerror: dimension type: %s not available in module\n", field);

--- a/acados/ocp_nlp/ocp_nlp_dynamics_disc.h
+++ b/acados/ocp_nlp/ocp_nlp_dynamics_disc.h
@@ -60,6 +60,7 @@ typedef struct
     int nx1;  // number of states at the next stage
     int nu1;  // number of inputes at the next stage
     int np;   // number of parameters
+    int np_global;   // number of global parameters
 
 } ocp_nlp_dynamics_disc_dims;
 

--- a/acados/sim/sim_erk_integrator.c
+++ b/acados/sim/sim_erk_integrator.c
@@ -96,6 +96,10 @@ void sim_erk_dims_set(void *config_, void *dims_, const char *field, const int *
     {
         // np dimension not needed
     }
+    else if (!strcmp(field, "np_global"))
+    {
+        // np_global dimension not needed
+    }
     else
     {
         printf("\nerror: sim_erk_dims_set: dim type not available: %s\n", field);

--- a/acados/sim/sim_gnsf.c
+++ b/acados/sim/sim_gnsf.c
@@ -109,6 +109,10 @@ void sim_gnsf_dims_set(void *config_, void *dims_, const char *field, const int 
     {
         // np dimension not needed
     }
+    else if (!strcmp(field, "np_global"))
+    {
+        // np_global dimension not needed
+    }
     else if (!strcmp(field, "nx1") || !strcmp(field, "gnsf_nx1"))
     {
         dims->nx1 = *value;

--- a/acados/sim/sim_irk_integrator.c
+++ b/acados/sim/sim_irk_integrator.c
@@ -104,6 +104,10 @@ void sim_irk_dims_set(void *config_, void *dims_, const char *field, const int *
     {
         // np dimension not needed
     }
+    else if (!strcmp(field, "np_global"))
+    {
+        // np_global dimension not needed
+    }
     else
     {
         printf("\nerror: sim_irk_dims_set: field not available: %s\n", field);

--- a/acados/sim/sim_lifted_irk_integrator.c
+++ b/acados/sim/sim_lifted_irk_integrator.c
@@ -98,6 +98,10 @@ void sim_lifted_irk_dims_set(void *config_, void *dims_, const char *field, cons
     {
         // np dimension not needed
     }
+    else if (!strcmp(field, "np_global"))
+    {
+        // np_global dimension not needed
+    }
     else
     {
         printf("\nerror: sim_lifted_irk_dims_set: field not available: %s\n", field);

--- a/examples/acados_python/chain_mass/solution_sensitivity_example.py
+++ b/examples/acados_python/chain_mass/solution_sensitivity_example.py
@@ -441,7 +441,7 @@ def main_parametric(qp_solver_ric_alg: int = 0, chain_params_: dict = get_chain_
         print(f"sensitivity_solver status {sensitivity_solver.status}")
 
         # Calculate the policy gradient
-        _, sens_u_ = sensitivity_solver.eval_solution_sensitivity(0, "params_global")
+        _, sens_u_ = sensitivity_solver.eval_solution_sensitivity(0, "p_global")
         timings_lin_params[i] = sensitivity_solver.get_stats("time_solution_sens_lin")
         timings_solve_params[i] = sensitivity_solver.get_stats("time_solution_sens_solve")
 

--- a/examples/acados_python/pendulum_on_cart/solution_sensitivities/policy_gradient_example.py
+++ b/examples/acados_python/pendulum_on_cart/solution_sensitivities/policy_gradient_example.py
@@ -103,7 +103,7 @@ def main_parametric(qp_solver_ric_alg: int, eigen_analysis=True, use_cython=Fals
             min_eig_full[i], min_abs_eig_full[i], min_abs_eig_proj_hess[i], min_eig_proj_hess[i], min_eig_P[i], min_abs_eig_P[i] = evaluate_hessian_eigenvalues(sensitivity_solver, N_horizon)
 
         # Calculate the policy gradient
-        _, sens_u_ = sensitivity_solver.eval_solution_sensitivity(0, "params_global")
+        _, sens_u_ = sensitivity_solver.eval_solution_sensitivity(0, "p_global")
         sens_u[i] = sens_u_.item()
 
     # Compare to numerical gradients

--- a/examples/acados_python/pendulum_on_cart/solution_sensitivities/policy_gradient_example.py
+++ b/examples/acados_python/pendulum_on_cart/solution_sensitivities/policy_gradient_example.py
@@ -119,8 +119,11 @@ def main_parametric(qp_solver_ric_alg: int, eigen_analysis=True, use_cython=Fals
                  min_abs_eig_full, min_abs_eig_proj_hess, min_abs_eig_P,
                  eigen_analysis, qp_solver_ric_alg, parameter_name="mass")
 
+    test_tol = 1e-2
+    median_diff = np.median(np.abs(sens_u - sens_u_fd))
+    print(f"Median difference between policy gradient obtained by acados and via FD is {median_diff} should be < {test_tol}.")
     # test: check median since derivative cannot be compared at active set changes
-    assert np.median(np.abs(sens_u - sens_u_fd)) <= 1e-2
+    assert median_diff <= test_tol
 
 
 if __name__ == "__main__":

--- a/examples/acados_python/pendulum_on_cart/solution_sensitivities/policy_gradient_example.py
+++ b/examples/acados_python/pendulum_on_cart/solution_sensitivities/policy_gradient_example.py
@@ -85,9 +85,8 @@ def main_parametric(qp_solver_ric_alg: int, eigen_analysis=True, use_cython=Fals
     for i, p in enumerate(p_test):
         p_val = np.array([p])
 
-        for n in range(N_horizon+1):
-            acados_ocp_solver.set(n, 'p', p_val)
-            sensitivity_solver.set(n, 'p', p_val)
+        acados_ocp_solver.set_p_global_and_precompute_dependencies(p_val)
+        sensitivity_solver.set_p_global_and_precompute_dependencies(p_val)
         u_opt[i] = acados_ocp_solver.solve_for_x0(x0)[0]
 
         acados_ocp_solver.store_iterate(filename='iterate.json', overwrite=True, verbose=False)

--- a/examples/acados_python/pendulum_on_cart/solution_sensitivities/sensitivity_utils.py
+++ b/examples/acados_python/pendulum_on_cart/solution_sensitivities/sensitivity_utils.py
@@ -5,7 +5,7 @@ from acados_template import AcadosModel, AcadosOcp, AcadosOcpSolver, latexify_pl
 
 latexify_plot()
 
-def export_pendulum_ode_model_with_mass_as_param(dt) -> AcadosModel:
+def export_pendulum_ode_model_with_mass_as_p_global(dt) -> AcadosModel:
 
     model_name = 'pendulum_parametric'
 
@@ -66,7 +66,7 @@ def export_pendulum_ode_model_with_mass_as_param(dt) -> AcadosModel:
     model.x = x
     model.xdot = xdot
     model.u = u
-    model.p = p
+    model.p_global = p
     model.name = model_name
 
     return model
@@ -79,7 +79,7 @@ def export_parametric_ocp(
 
     ocp = AcadosOcp()
     dt = T_horizon/N_horizon
-    ocp.model = export_pendulum_ode_model_with_mass_as_param(dt=dt)
+    ocp.model = export_pendulum_ode_model_with_mass_as_p_global(dt=dt)
 
     ocp.solver_options.N_horizon = N_horizon
 
@@ -90,8 +90,8 @@ def export_parametric_ocp(
     ocp.cost.cost_type_e = "EXTERNAL"
 
     # NOTE here we make the cost parametric
-    ocp.model.cost_expr_ext_cost = ca.exp(ocp.model.p) * ocp.model.x.T @ Q_mat @ ocp.model.x + ocp.model.u.T @ R_mat @ ocp.model.u
-    ocp.model.cost_expr_ext_cost_e = ca.exp(ocp.model.p) * ocp.model.x.T @ Q_mat @ ocp.model.x
+    ocp.model.cost_expr_ext_cost = ca.exp(ocp.model.p_global) * ocp.model.x.T @ Q_mat @ ocp.model.x + ocp.model.u.T @ R_mat @ ocp.model.u
+    ocp.model.cost_expr_ext_cost_e = ca.exp(ocp.model.p_global) * ocp.model.x.T @ Q_mat @ ocp.model.x
 
     ocp.constraints.lbu = np.array([-Fmax])
     ocp.constraints.ubu = np.array([+Fmax])
@@ -100,7 +100,7 @@ def export_parametric_ocp(
     ocp.constraints.x0 = x0
 
     # set mass to one
-    ocp.parameter_values = np.ones((1,))
+    ocp.p_global_values = np.ones((1,))
 
     ocp.solver_options.qp_solver = "PARTIAL_CONDENSING_HPIPM"
     ocp.solver_options.integrator_type = "DISCRETE"

--- a/examples/acados_python/pendulum_on_cart/solution_sensitivities/value_gradient_example.py
+++ b/examples/acados_python/pendulum_on_cart/solution_sensitivities/value_gradient_example.py
@@ -58,9 +58,7 @@ def main():
 
     pi = np.zeros(np_test)
     for i, p in enumerate(p_test):
-
-        for n in range(N_horizon+1):
-            acados_ocp_solver.set(n, 'p', p)
+        acados_ocp_solver.set_p_global_and_precompute_dependencies(p)
         pi[i] = acados_ocp_solver.solve_for_x0(x0)[0]
         optimal_value[i] = acados_ocp_solver.get_cost()
         optimal_value_grad[i] = acados_ocp_solver.eval_and_get_optimal_value_gradient("params_global").item()

--- a/examples/acados_python/pendulum_on_cart/solution_sensitivities/value_gradient_example.py
+++ b/examples/acados_python/pendulum_on_cart/solution_sensitivities/value_gradient_example.py
@@ -68,7 +68,12 @@ def main():
     cost_reconstructed_np_grad = np.cumsum(optimal_value_grad_via_fd) * delta_p + optimal_value[0]
 
     plot_cost_gradient_results(p_test, optimal_value, optimal_value_grad, optimal_value_grad_via_fd, cost_reconstructed_np_grad)
-    assert np.median(np.abs(optimal_value_grad - optimal_value_grad_via_fd)) <= 1e-1
+
+    # checks
+    test_tol = 1e-1
+    median_diff = np.median(np.abs(optimal_value_grad - optimal_value_grad_via_fd))
+    print(f"Median difference between value function gradient obtained by acados and via FD is {median_diff} should be < {test_tol}.")
+    assert median_diff <= test_tol
 
 
 

--- a/examples/acados_python/pendulum_on_cart/solution_sensitivities/value_gradient_example.py
+++ b/examples/acados_python/pendulum_on_cart/solution_sensitivities/value_gradient_example.py
@@ -61,7 +61,7 @@ def main():
         acados_ocp_solver.set_p_global_and_precompute_dependencies(p)
         pi[i] = acados_ocp_solver.solve_for_x0(x0)[0]
         optimal_value[i] = acados_ocp_solver.get_cost()
-        optimal_value_grad[i] = acados_ocp_solver.eval_and_get_optimal_value_gradient("params_global").item()
+        optimal_value_grad[i] = acados_ocp_solver.eval_and_get_optimal_value_gradient("p_global").item()
 
     # evaluate cost gradient
     optimal_value_grad_via_fd = np.gradient(optimal_value, delta_p)

--- a/interfaces/CMakeLists.txt
+++ b/interfaces/CMakeLists.txt
@@ -169,17 +169,17 @@ if(ACADOS_PYTHON)
         COMMAND "${CMAKE_COMMAND}" -E chdir ${PROJECT_SOURCE_DIR}/examples/acados_python/pendulum_on_cart/ocp
         python minimal_example_ocp_reuse_code.py)
 
-    add_test(NAME python_solution_sensitivities_and_exact_hess
-        COMMAND "${CMAKE_COMMAND}" -E chdir ${PROJECT_SOURCE_DIR}/examples/acados_python/pendulum_on_cart/solution_sensitivities
-        python test_solution_sens_and_exact_hess.py)
+    # add_test(NAME python_solution_sensitivities_and_exact_hess
+    #     COMMAND "${CMAKE_COMMAND}" -E chdir ${PROJECT_SOURCE_DIR}/examples/acados_python/pendulum_on_cart/solution_sensitivities
+    #     python test_solution_sens_and_exact_hess.py)
 
-    add_test(NAME python_value_function_gradient
-        COMMAND "${CMAKE_COMMAND}" -E chdir ${PROJECT_SOURCE_DIR}/examples/acados_python/pendulum_on_cart/solution_sensitivities
-        python value_gradient_example.py)
+    # add_test(NAME python_value_function_gradient
+    #     COMMAND "${CMAKE_COMMAND}" -E chdir ${PROJECT_SOURCE_DIR}/examples/acados_python/pendulum_on_cart/solution_sensitivities
+    #     python value_gradient_example.py)
 
-    add_test(NAME python_policy_gradient
-        COMMAND "${CMAKE_COMMAND}" -E chdir ${PROJECT_SOURCE_DIR}/examples/acados_python/pendulum_on_cart/solution_sensitivities
-        python policy_gradient_example.py)
+    # add_test(NAME python_policy_gradient
+    #     COMMAND "${CMAKE_COMMAND}" -E chdir ${PROJECT_SOURCE_DIR}/examples/acados_python/pendulum_on_cart/solution_sensitivities
+    #     python policy_gradient_example.py)
 
     add_test(NAME python_time_varying_irk
         COMMAND "${CMAKE_COMMAND}" -E chdir ${PROJECT_SOURCE_DIR}/examples/acados_python/time_varying
@@ -425,9 +425,9 @@ add_test(NAME python_pendulum_ocp_example_cmake
     set_tests_properties(python_pendulum_mhe_example_noisy_param PROPERTIES DEPENDS python_pendulum_mhe_example_param)
     set_tests_properties(python_pendulum_mhe_example_param PROPERTIES DEPENDS python_pendulum_mhe_ocp_closed_loop_example)
 
-    # Directory  pendulum_on_cart/solution_sensitivities
-    set_tests_properties(python_solution_sensitivities_and_exact_hess PROPERTIES DEPENDS python_value_function_gradient)
-    set_tests_properties(python_value_function_gradient PROPERTIES DEPENDS python_policy_gradient)
+    # # Directory  pendulum_on_cart/solution_sensitivities
+    # set_tests_properties(python_solution_sensitivities_and_exact_hess PROPERTIES DEPENDS python_value_function_gradient)
+    # set_tests_properties(python_value_function_gradient PROPERTIES DEPENDS python_policy_gradient)
 
     # Directory time_varying
     set_tests_properties(python_time_varying_irk PROPERTIES DEPENDS test_polynomial_controls_and_penalties)

--- a/interfaces/acados_c/ocp_nlp_interface.c
+++ b/interfaces/acados_c/ocp_nlp_interface.c
@@ -738,6 +738,10 @@ int ocp_nlp_dims_get_from_attr(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_n
     {
         return dims->np[stage];
     }
+    else if (!strcmp(field, "p_global") || !strcmp(field, "np_global"))
+    {
+        return dims->np_global;
+    }
     else if (!strcmp(field, "lam"))
     {
         return 2*dims->ni[stage];

--- a/interfaces/acados_template/acados_template/acados_ocp.py
+++ b/interfaces/acados_template/acados_template/acados_ocp.py
@@ -836,6 +836,8 @@ class AcadosOcp:
                                  ("path", model.con_r_expr), ("initial", model.con_r_expr_0), ("terminal", model.con_r_expr_e)]
 
         if opts.with_solution_sens_wrt_params:
+            if dims.np_global == 0:
+                raise Exception('with_solution_sens_wrt_params is only compatible if global parameters `p_global` are provided. Sensitivities wrt parameters have been refactored to use p_global instead of p in https://github.com/acados/acados/pull/1316. Got emty p_global.')
             if cost.cost_type != "EXTERNAL" or cost.cost_type_0 != "EXTERNAL" or cost.cost_type_e != "EXTERNAL":
                 raise Exception('with_solution_sens_wrt_params is only compatible with EXTERNAL cost_type.')
             if opts.integrator_type != "DISCRETE":
@@ -845,6 +847,8 @@ class AcadosOcp:
                     raise Exception(f'with_solution_sens_wrt_params is only implemented if constraints depend not on parameters. Got parameter dependency for {horizon_type} constraint.')
 
         if opts.with_value_sens_wrt_params:
+            if dims.np_global == 0:
+                raise Exception('with_value_sens_wrt_params is only compatible if global parameters `p_global` are provided. Sensitivities wrt parameters have been refactored to use p_global instead of p in https://github.com/acados/acados/pull/1316. Got emty p_global.')
             if cost.cost_type != "EXTERNAL" or cost.cost_type_0 != "EXTERNAL" or cost.cost_type_e != "EXTERNAL":
                 raise Exception('with_value_sens_wrt_params is only compatible with EXTERNAL cost_type.')
             if opts.integrator_type != "DISCRETE":

--- a/interfaces/acados_template/acados_template/acados_ocp.py
+++ b/interfaces/acados_template/acados_template/acados_ocp.py
@@ -844,7 +844,7 @@ class AcadosOcp:
                 raise Exception('with_solution_sens_wrt_params is only compatible with DISCRETE dynamics.')
             for horizon_type, constraint in type_constraint_pairs:
                 if constraint is not None and any(ca.which_depends(constraint, model.p)):
-                    raise Exception(f'with_solution_sens_wrt_params is only implemented if constraints depend not on parameters. Got parameter dependency for {horizon_type} constraint.')
+                    raise Exception(f"with_solution_sens_wrt_params is only implemented if don't constraints depend on parameters. Got parameter dependency for {horizon_type} constraint.")
 
         if opts.with_value_sens_wrt_params:
             if dims.np_global == 0:
@@ -855,7 +855,7 @@ class AcadosOcp:
                 raise Exception('with_value_sens_wrt_params is only compatible with DISCRETE dynamics.')
             for horizon_type, constraint in type_constraint_pairs:
                 if constraint is not None and any(ca.which_depends(constraint, model.p)):
-                    raise Exception(f'with_value_sens_wrt_params is only implemented if constraints depend not on parameters. Got parameter dependency for {horizon_type} constraint.')
+                    raise Exception(f"with_value_sens_wrt_params is only implemented if don't constraints depend on parameters. Got parameter dependency for {horizon_type} constraint.")
 
         if opts.qp_solver_cond_N is None:
             opts.qp_solver_cond_N = opts.N_horizon

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -510,7 +510,7 @@ class AcadosOcpSolver:
 
         Notes:
         - for field `initial_state`, the gradient is the Lagrange multiplier of the initial state constraint.
-        The gradient computation consist of adding the Lagrange multipliers corresponding to the upper and lower bound of the initial state.
+        The gradient computation consists of adding the Lagrange multipliers corresponding to the upper and lower bound of the initial state.
 
         - for field `params_global`, the gradient of the Lagrange function w.r.t. the global parameters is computed in acados.
 

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -514,8 +514,12 @@ class AcadosOcpSolver:
 
         - for field `params_global`, the gradient of the Lagrange function w.r.t. the global parameters is computed in acados.
 
-        :param with_respect_to: string in ["initial_state", "params_global"]
+        :param with_respect_to: string in ["initial_state", "p_global"]
         """
+
+        if with_respect_to == "params_global":
+            print("Deprecation warning: 'params_global' is deprecated and has been renamed to 'p_global'.")
+            with_respect_to = "p_global"
 
         if with_respect_to == "initial_state":
             if not self.acados_ocp.constraints.has_x0:
@@ -528,10 +532,10 @@ class AcadosOcpSolver:
             nlam_non_slack = lam.shape[0]//2 - self.acados_ocp.dims.ns_0
             grad = lam[nbu:nbu+nx] - lam[nlam_non_slack+nbu : nlam_non_slack+nbu+nx]
 
-        elif with_respect_to == "params_global":
+        elif with_respect_to == "p_global":
             np_global = self.__acados_lib.ocp_nlp_dims_get_from_attr(self.nlp_config, self.nlp_dims, self.nlp_out, 0, "p_global".encode('utf-8'))
 
-            field = "params_global".encode('utf-8')
+            field = "p_global".encode('utf-8')
             t0 = time.time()
             grad = np.zeros((np_global,))
             grad_p = np.ascontiguousarray(grad, dtype=np.float64)
@@ -555,7 +559,7 @@ class AcadosOcpSolver:
         Evaluate the sensitivity of the current solution x_i, u_i with respect to the initial state or the parameters for all stages i in `stages`.
 
             :param stages: stages for which the sensitivities are returned, int or list of int
-            :param with_respect_to: string in ["initial_state", "params_global"]
+            :param with_respect_to: string in ["initial_state", "p_global"]
             :returns: a tuple (sens_x, sens_u) with the solution sensitivities.
                     If stages is a list, sens_x is a list of the same length.
                     For sens_u, the list has length len(stages) or len(stages)-1 depending on whether N is included or not.
@@ -576,6 +580,10 @@ class AcadosOcpSolver:
         .. note:: Solution sensitivities with respect to parameters are currently implemented assuming the parameter vector p is global within the OCP, i.e. p=p_i with i=0, ..., N.
         .. note:: Solution sensitivities with respect to parameters are currently implemented only for parametric discrete dynamics and parametric external costs (in particular, parametric constraints are not covered).
         """
+
+        if with_respect_to == "params_global":
+            print("Deprecation warning: 'params_global' is deprecated and has been renamed to 'p_global'.")
+            with_respect_to = "p_global"
 
         if not (self.acados_ocp.solver_options.qp_solver == 'FULL_CONDENSING_HPIPM' or
                 self.acados_ocp.solver_options.qp_solver == 'PARTIAL_CONDENSING_HPIPM'):
@@ -612,10 +620,10 @@ class AcadosOcpSolver:
             ngrad = nx
             field = "ex"
 
-        elif with_respect_to == "params_global":
+        elif with_respect_to == "p_global":
             np_global = self.__acados_lib.ocp_nlp_dims_get_from_attr(self.nlp_config, self.nlp_dims, self.nlp_out, 0, "p_global".encode('utf-8'))
             ngrad = np_global
-            field = "params_global"
+            field = "p_global"
 
             # compute jacobians wrt params in all modules
             t0 = time.time()
@@ -705,7 +713,7 @@ class AcadosOcpSolver:
             if index < 0 or index > nx:
                 raise Exception(f'AcadosOcpSolver.eval_param_sens(): index must be in [0, nx-1], got: {index}.')
 
-        elif field == "params_global":
+        elif field == "p_global":
             nparam = self.__acados_lib.ocp_nlp_dims_get_from_attr(self.nlp_config, self.nlp_dims, self.nlp_out, 0, "p".encode('utf-8'))
 
             if index < 0 or index > nparam:

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -510,7 +510,7 @@ class AcadosOcpSolver:
 
         Notes:
         - for field `initial_state`, the gradient is the Lagrange multiplier of the initial state constraint.
-        The gradient computation consist of adding the Lagrange multipliers correspondin to the upper and lower bound of the initial state.
+        The gradient computation consist of adding the Lagrange multipliers corresponding to the upper and lower bound of the initial state.
 
         - for field `params_global`, the gradient of the Lagrange function w.r.t. the global parameters is computed in acados.
 
@@ -529,11 +529,11 @@ class AcadosOcpSolver:
             grad = lam[nbu:nbu+nx] - lam[nlam_non_slack+nbu : nlam_non_slack+nbu+nx]
 
         elif with_respect_to == "params_global":
-            nparam = self.__acados_lib.ocp_nlp_dims_get_from_attr(self.nlp_config, self.nlp_dims, self.nlp_out, 0, "p".encode('utf-8'))
+            np_global = self.__acados_lib.ocp_nlp_dims_get_from_attr(self.nlp_config, self.nlp_dims, self.nlp_out, 0, "p_global".encode('utf-8'))
 
             field = "params_global".encode('utf-8')
             t0 = time.time()
-            grad = np.zeros((nparam,))
+            grad = np.zeros((np_global,))
             grad_p = np.ascontiguousarray(grad, dtype=np.float64)
             c_grad_p = cast(grad_p.ctypes.data, POINTER(c_double))
             self.__acados_lib.ocp_nlp_eval_lagrange_grad_p(self.nlp_solver, self.nlp_in, field, c_grad_p)
@@ -613,8 +613,8 @@ class AcadosOcpSolver:
             field = "ex"
 
         elif with_respect_to == "params_global":
-            nparam = self.__acados_lib.ocp_nlp_dims_get_from_attr(self.nlp_config, self.nlp_dims, self.nlp_out, 0, "p".encode('utf-8'))
-            ngrad = nparam
+            np_global = self.__acados_lib.ocp_nlp_dims_get_from_attr(self.nlp_config, self.nlp_dims, self.nlp_out, 0, "p_global".encode('utf-8'))
+            ngrad = np_global
             field = "params_global"
 
             # compute jacobians wrt params in all modules

--- a/interfaces/acados_template/acados_template/acados_ocp_solver_pyx.pyx
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver_pyx.pyx
@@ -255,7 +255,7 @@ cdef class AcadosOcpSolverCython:
 
         Notes:
         - for field `initial_state`, the gradient is the Lagrange multiplier of the initial state constraint.
-        The gradient computation consist of adding the Lagrange multipliers correspondin to the upper and lower bound of the initial state.
+        The gradient computation consist of adding the Lagrange multipliers corresponding to the upper and lower bound of the initial state.
 
         - for field `params_global`, the gradient of the Lagrange function w.r.t. the global parameters is computed in acados.
 
@@ -265,7 +265,7 @@ cdef class AcadosOcpSolverCython:
 
         cdef int nx
         cdef int nbu
-        cdef int nparam
+        cdef int np_global
         cdef int ns_0
 
         cdef cnp.ndarray[cnp.float64_t, ndim=1] grad
@@ -282,11 +282,11 @@ cdef class AcadosOcpSolverCython:
             grad = lam[nbu:nbu+nx] - lam[nlam_non_slack+nbu : nlam_non_slack+nbu+nx]
 
         elif with_respect_to == "params_global":
-            nparam = acados_solver_common.ocp_nlp_dims_get_from_attr(self.nlp_config, self.nlp_dims, self.nlp_out, 0, "p".encode('utf-8'))
+            np_global = acados_solver_common.ocp_nlp_dims_get_from_attr(self.nlp_config, self.nlp_dims, self.nlp_out, 0, "p_global".encode('utf-8'))
 
             field = "params_global".encode('utf-8')
             t0 = time.time()
-            grad = np.ascontiguousarray(np.zeros((nparam,)), dtype=np.float64)
+            grad = np.ascontiguousarray(np.zeros((np_global,)), dtype=np.float64)
             acados_solver_common.ocp_nlp_eval_lagrange_grad_p(self.nlp_solver, self.nlp_in, field, <void *> grad.data)
             self.time_value_grad = time.time() - t0
 
@@ -344,7 +344,7 @@ cdef class AcadosOcpSolverCython:
 
         cdef int nx
         cdef int nu
-        cdef int nparam
+        cdef int np_global
 
         # for s in stages_:
         #     if not isinstance(s, int) or s < 0 or s > N:
@@ -357,9 +357,9 @@ cdef class AcadosOcpSolverCython:
             field = "ex"
 
         elif with_respect_to == "params_global":
-            nparam = acados_solver_common.ocp_nlp_dims_get_from_attr(self.nlp_config, self.nlp_dims, self.nlp_out, 0, "p".encode('utf-8'))
+            np_global = acados_solver_common.ocp_nlp_dims_get_from_attr(self.nlp_config, self.nlp_dims, self.nlp_out, 0, "p_global".encode('utf-8'))
 
-            ngrad = nparam
+            ngrad = np_global
             field = "params_global"
 
             # compute jacobians wrt params in all modules

--- a/interfaces/acados_template/acados_template/acados_ocp_solver_pyx.pyx
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver_pyx.pyx
@@ -979,6 +979,19 @@ cdef class AcadosOcpSolverCython:
         return
 
 
+    def set_p_global_and_precompute_dependencies(self, data_):
+        """
+        Sets values of p_global and precomputes all parts of the CasADi graphs of all other functions that only depend on p_global.
+        """
+        cdef cnp.ndarray[cnp.float64_t, ndim=1] value = np.ascontiguousarray(data_, dtype=np.float64)
+
+        cdef int data_len = value.shape[0]
+
+        cdef int status = acados_solver.acados_set_p_global_and_precompute_dependencies(self.capsule, <double *> value.data, data_len)
+
+        return status
+
+
     def __del__(self):
         if self.solver_created:
             acados_solver.acados_free(self.capsule)

--- a/interfaces/acados_template/acados_template/acados_ocp_solver_pyx.pyx
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver_pyx.pyx
@@ -255,7 +255,7 @@ cdef class AcadosOcpSolverCython:
 
         Notes:
         - for field `initial_state`, the gradient is the Lagrange multiplier of the initial state constraint.
-        The gradient computation consist of adding the Lagrange multipliers corresponding to the upper and lower bound of the initial state.
+        The gradient computation consists of adding the Lagrange multipliers corresponding to the upper and lower bound of the initial state.
 
         - for field `params_global`, the gradient of the Lagrange function w.r.t. the global parameters is computed in acados.
 

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.pxd
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.pxd
@@ -45,6 +45,7 @@ cdef extern from "acados_solver_{{ model.name }}.h":
 
     int acados_update_params "{{ model.name }}_acados_update_params"(nlp_solver_capsule * capsule, int stage, double *value, int np_)
     int acados_update_params_sparse "{{ model.name }}_acados_update_params_sparse"(nlp_solver_capsule * capsule, int stage, int *idx, double *p, int n_update)
+    int acados_set_p_global_and_precompute_dependencies "{{ model.name }}_acados_set_p_global_and_precompute_dependencies"(nlp_solver_capsule * capsule, double *value, int data_len)
     int acados_solve "{{ model.name }}_acados_solve"(nlp_solver_capsule * capsule)
     int acados_reset "{{ model.name }}_acados_reset"(nlp_solver_capsule * capsule, int reset_qp_solver_mem)
     int acados_free "{{ model.name }}_acados_free"(nlp_solver_capsule * capsule)

--- a/interfaces/acados_template/acados_template/casadi_function_generation.py
+++ b/interfaces/acados_template/acados_template/casadi_function_generation.py
@@ -181,9 +181,9 @@ def generate_c_code_discrete_dynamics(context: GenerateContext, model: AcadosMod
     x = model.x
     u = model.u
     p = model.p
+    p_global = model.p_global
     phi = model.disc_dyn_expr
     model_name = model.name
-    nx = casadi_length(x)
 
     symbol = get_casadi_symbol(x)
     nx1 = casadi_length(phi)
@@ -210,14 +210,14 @@ def generate_c_code_discrete_dynamics(context: GenerateContext, model: AcadosMod
 
     if opts["with_solution_sens_wrt_params"]:
         # generate jacobian of lagrange gradient wrt p
-        jac_p = ca.jacobian(phi, p)
+        jac_p = ca.jacobian(phi, p_global)
         # hess_xu_p_old = ca.jacobian((lam.T @ jac_ux).T, p)
-        hess_xu_p = ca.jacobian(adj_ux, p) # using adjoint
+        hess_xu_p = ca.jacobian(adj_ux, p_global) # using adjoint
         fun_name = model_name + '_dyn_disc_phi_jac_p_hess_xu_p'
         context.add_function_definition(fun_name, [x, u, lam, p], [jac_p, hess_xu_p], model_dir)
 
     if opts["with_value_sens_wrt_params"]:
-        adj_p = ca.jtimes(phi, p, lam, True)
+        adj_p = ca.jtimes(phi, p_global, lam, True)
         fun_name = model_name + '_dyn_disc_phi_adj_p'
         context.add_function_definition(fun_name, [x, u, lam, p], [adj_p], model_dir)
 
@@ -400,6 +400,7 @@ def generate_c_code_external_cost(context: GenerateContext, model: AcadosModel, 
     p = model.p
     u = model.u
     z = model.z
+    p_global = model.p_global
     symbol = get_casadi_symbol(x)
 
     if stage_type == 'terminal':
@@ -458,11 +459,11 @@ def generate_c_code_external_cost(context: GenerateContext, model: AcadosModel, 
     context.add_function_definition(fun_name_jac, [x, u, z, p], [ext_cost, grad_uxz], cost_dir)
 
     if opts["with_solution_sens_wrt_params"]:
-        hess_xu_p = ca.jacobian(grad_uxz, p)
+        hess_xu_p = ca.jacobian(grad_uxz, p_global)
         context.add_function_definition(fun_name_param, [x, u, z, p], [hess_xu_p], cost_dir)
 
     if opts["with_value_sens_wrt_params"]:
-        grad_p = ca.jacobian(ext_cost, p)
+        grad_p = ca.jacobian(ext_cost, p_global)
         context.add_function_definition(fun_name_value_sens, [x, u, z, p], [grad_p], cost_dir)
 
     return

--- a/interfaces/acados_template/acados_template/utils.py
+++ b/interfaces/acados_template/acados_template/utils.py
@@ -143,7 +143,7 @@ def check_casadi_version():
 
 def check_casadi_version_supports_p_global():
     try:
-        from casadi import extract_parametric, cse, blazing_spline
+        from casadi import extract_parametric, cse
     except:
         raise Exception("CasADi version does not support extract_parametric or cse functions.\nNeeds nightly-se2 release or later, see: https://github.com/casadi/casadi/releases/tag/nightly-se2")
 


### PR DESCRIPTION
Solution sensitivities with respect to parameters and derivatives of the value function with respect to parameters are now computed with respect to `p_global` instead of `p`. This is anyway what was implemented conceptually. However, if different parameter values for stages were used, these sensitivities were not clearly defined.
The precomputations and the fact that the parameter vector is only defined once makes this implementation more efficient.

- added support for `p_global` in Cython

Breaking:
- concerns options `with_solution_sens_wrt_params`, `with_solution_sens_wrt_params`
- `eval_solution_sensitivity` with argument `with_respect_to = "params_global"`
- `eval_and_get_optimal_value_gradient` with argument `with_respect_to = "params_global"`
- rename option `with_respect_to='params_global'` to `'p_global'` with deprecation warning