### PR TITLE
Fix escape-warnings in acados_template

### DIFF
--- a/interfaces/acados_template/acados_template/acados_dims.py
+++ b/interfaces/acados_template/acados_template/acados_dims.py
@@ -172,7 +172,7 @@ class AcadosOcpDims:
 
     @property
     def nx_next(self):
-        """:math:`n_{x, \\text{next}}` - state dimension of next state.
+        r""":math:`n_{x, \\text{next}}` - state dimension of next state.
         Type: int; default: None"""
         return self.__nx_next
 
@@ -214,37 +214,37 @@ class AcadosOcpDims:
 
     @property
     def nr(self):
-        """:math:`n_{\pi}` - dimension of the image of the inner nonlinear function in positive definite constraints.
+        r""":math:`n_{\pi}` - dimension of the image of the inner nonlinear function in positive definite constraints.
         Type: int; default: 0"""
         return self.__nr
 
     @property
     def nr_e(self):
-        """:math:`n_{\pi}^e` - dimension of the image of the inner nonlinear function in positive definite constraints.
+        r""":math:`n_{\pi}^e` - dimension of the image of the inner nonlinear function in positive definite constraints.
         Type: int; default: 0"""
         return self.__nr_e
 
     @property
     def nr_0(self):
-        """:math:`n_{\pi}^0` - dimension of the image of the inner nonlinear function in positive definite constraints.
+        r""":math:`n_{\pi}^0` - dimension of the image of the inner nonlinear function in positive definite constraints.
         Type: int; default: 0"""
         return self.__nr_0
 
     @property
     def nphi(self):
-        """:math:`n_{\phi}` - number of convex-over-nonlinear constraints.
+        r""":math:`n_{\phi}` - number of convex-over-nonlinear constraints.
         Type: int; default: 0"""
         return self.__nphi
 
     @property
     def nphi_0(self):
-        """:math:`n_{\phi}^0` - number of convex-over-nonlinear constraints at initial shooting node 0.
+        r""":math:`n_{\phi}^0` - number of convex-over-nonlinear constraints at initial shooting node 0.
         Type: int; default: 0"""
         return self.__nphi_0
 
     @property
     def nphi_e(self):
-        """:math:`n_{\phi}^e` - number of convex-over-nonlinear constraints at terminal shooting node N.
+        r""":math:`n_{\phi}^e` - number of convex-over-nonlinear constraints at terminal shooting node N.
         Type: int; default: 0"""
         return self.__nphi_e
 
@@ -328,19 +328,19 @@ class AcadosOcpDims:
 
     @property
     def nsphi_0(self):
-        """:math:`n_{{s\phi}^0}` - number of soft convex-over-nonlinear constraints at shooting node 0.
+        r""":math:`n_{{s\phi}^0}` - number of soft convex-over-nonlinear constraints at shooting node 0.
         Type: int; default: 0"""
         return self.__nsphi_0
 
     @property
     def nsphi(self):
-        """:math:`n_{{s\phi}}` - number of soft convex-over-nonlinear constraints.
+        r""":math:`n_{{s\phi}}` - number of soft convex-over-nonlinear constraints.
         Type: int; default: 0"""
         return self.__nsphi
 
     @property
     def nsphi_e(self):
-        """:math:`n_{{s\phi}^e}` - number of soft convex-over-nonlinear constraints at terminal shooting node N.
+        r""":math:`n_{{s\phi}^e}` - number of soft convex-over-nonlinear constraints at terminal shooting node N.
         Type: int; default: 0"""
         return self.__nsphi_e
 

--- a/interfaces/acados_template/acados_template/acados_model.py
+++ b/interfaces/acados_template/acados_template/acados_model.py
@@ -83,19 +83,19 @@ class AcadosModel():
 
         ## dynamics
         self.f_impl_expr = None
-        """
+        r"""
         CasADi expression for the implicit dynamics :math:`f_\\text{impl}(\dot{x}, x, u, z, p) = 0`.
         Used if :py:attr:`acados_template.acados_ocp_options.AcadosOcpOptions.integrator_type` == 'IRK'.
         Default: :code:`None`
         """
         self.f_expl_expr = None
-        """
+        r"""
         CasADi expression for the explicit dynamics :math:`\dot{x} = f_\\text{expl}(x, u, p)`.
         Used if :py:attr:`acados_template.acados_ocp_options.AcadosOcpOptions.integrator_type` == 'ERK'.
         Default: :code:`None`
         """
         self.disc_dyn_expr = None
-        """
+        r"""
         CasADi expression for the discrete dynamics :math:`x_{+} = f_\\text{disc}(x, u, p)`.
         Used if :py:attr:`acados_template.acados_ocp_options.AcadosOcpOptions.integrator_type` == 'DISCRETE'.
         Default: :code:`None`
@@ -133,12 +133,12 @@ class AcadosModel():
         self.con_h_expr_0 = None
         """CasADi expression for the initial constraint :math:`h^0`; Default: :code:`None`"""
         self.con_phi_expr_0 = None
-        """CasADi expression for the terminal constraint :math:`\phi_0`; Default: :code:`None`"""
+        r"""CasADi expression for the terminal constraint :math:`\phi_0`; Default: :code:`None`"""
         self.con_r_expr_0 = None
-        """CasADi expression for the terminal constraint :math:`\phi_0(r)`,
+        r"""CasADi expression for the terminal constraint :math:`\phi_0(r)`,
         dummy input for outer function; Default: :code:`None`"""
         self.con_r_in_phi_0 = None
-        """CasADi expression for the terminal constraint :math:`\phi_0(r)`, input for outer function; Default: :code:`None`"""
+        r"""CasADi expression for the terminal constraint :math:`\phi_0(r)`, input for outer function; Default: :code:`None`"""
 
 
         # path constraints
@@ -152,19 +152,19 @@ class AcadosModel():
         """CasADi expression for the constraint phi(r),
         dummy input for outer function; Default: :code:`None`"""
         self.con_r_in_phi = None
-        """CasADi expression for the terminal constraint :math:`\phi(r)`,
+        r"""CasADi expression for the terminal constraint :math:`\phi(r)`,
         input for outer function; Default: :code:`None`"""
 
         # terminal
         self.con_h_expr_e = None
         """CasADi expression for the terminal constraint :math:`h^e`; Default: :code:`None`"""
         self.con_phi_expr_e = None
-        """CasADi expression for the terminal constraint :math:`\phi_e`; Default: :code:`None`"""
+        r"""CasADi expression for the terminal constraint :math:`\phi_e`; Default: :code:`None`"""
         self.con_r_expr_e = None
-        """CasADi expression for the terminal constraint :math:`\phi_e(r)`,
+        r"""CasADi expression for the terminal constraint :math:`\phi_e(r)`,
         dummy input for outer function; Default: :code:`None`"""
         self.con_r_in_phi_e = None
-        """CasADi expression for the terminal constraint :math:`\phi_e(r)`, input for outer function; Default: :code:`None`"""
+        r"""CasADi expression for the terminal constraint :math:`\phi_e(r)`, input for outer function; Default: :code:`None`"""
 
         # cost
         self.cost_y_expr = None
@@ -188,32 +188,32 @@ class AcadosModel():
 
         ## CONVEX_OVER_NONLINEAR convex-over-nonlinear cost: psi(y(x, u, p) - y_ref; p)
         self.cost_psi_expr_0 = None
-        """
+        r"""
         CasADi expression for the outer loss function :math:`\psi(r - yref, t, p)`, initial; Default: :code:`None`
         Used if :py:attr:`acados_template.acados_ocp_options.AcadosOcpOptions.cost_type_0` is 'CONVEX_OVER_NONLINEAR'.
         """
         self.cost_psi_expr = None
-        """
+        r"""
         CasADi expression for the outer loss function :math:`\psi(r - yref, t, p)`; Default: :code:`None`
         Used if :py:attr:`acados_template.acados_ocp_options.AcadosOcpOptions.cost_type` is 'CONVEX_OVER_NONLINEAR'.
         """
         self.cost_psi_expr_e = None
-        """
+        r"""
         CasADi expression for the outer loss function :math:`\psi(r - yref, p)`, terminal; Default: :code:`None`
         Used if :py:attr:`acados_template.acados_ocp_options.AcadosOcpOptions.cost_type_e` is 'CONVEX_OVER_NONLINEAR'.
         """
         self.cost_r_in_psi_expr_0 = None
-        """
+        r"""
         CasADi symbolic input variable for the argument :math:`r` to the outer loss function :math:`\psi(r, t, p)`, initial; Default: :code:`None`
         Used if :py:attr:`acados_template.acados_ocp_options.AcadosOcpOptions.cost_type_0` is 'CONVEX_OVER_NONLINEAR'.
         """
         self.cost_r_in_psi_expr = None
-        """
+        r"""
         CasADi symbolic input variable for the argument :math:`r` to the outer loss function :math:`\psi(r, t, p)`; Default: :code:`None`
         Used if :py:attr:`acados_template.acados_ocp_options.AcadosOcpOptions.cost_type` is 'CONVEX_OVER_NONLINEAR'.
         """
         self.cost_r_in_psi_expr_e = None
-        """
+        r"""
         CasADi symbolic input variable for the argument :math:`r` to the outer loss function :math:`\psi(r, p)`, terminal; Default: :code:`None`
         Used if :py:attr:`acados_template.acados_ocp_options.AcadosOcpOptions.cost_type_e` is 'CONVEX_OVER_NONLINEAR'.
         """
@@ -374,7 +374,7 @@ class AcadosModel():
 
 
     def reformulate_with_polynomial_control(self, degree: int) -> None:
-        """
+        r"""
         Augment the model with polynomial control.
 
         Replace the original control input :math:`u` with a polynomial control input :math:`v_{\\text{poly}} = \\sum_{i=0}^d u_i t^i`

--- a/interfaces/acados_template/acados_template/acados_multiphase_ocp.py
+++ b/interfaces/acados_template/acados_template/acados_multiphase_ocp.py
@@ -196,7 +196,7 @@ class AcadosMultiphaseOcp:
 
     @property
     def p_global_values(self):
-        """initial values for :math:`p_\\text{global}` vector, see `AcadosModel.p_global` - can be updated.
+        r"""initial values for :math:`p_\\text{global}` vector, see `AcadosModel.p_global` - can be updated.
         NOTE: `p_global` is shared between all phases.
         Type: `numpy.ndarray` of shape `(np_global, )`.
         """

--- a/interfaces/acados_template/acados_template/acados_ocp_constraints.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_constraints.py
@@ -158,13 +158,13 @@ class AcadosOcpConstraints:
     # initial bounds on x
     @property
     def lbx_0(self):
-        """:math:`\\underline{x_0}` - lower bounds on x at initial stage 0.
+        r""":math:`\\underline{x_0}` - lower bounds on x at initial stage 0.
         Type: :code:`np.ndarray`; default: :code:`np.array([])`."""
         return self.__lbx_0
 
     @property
     def ubx_0(self):
-        """:math:`\\bar{x_0}` - upper bounds on x at initial stage 0.
+        r""":math:`\\bar{x_0}` - upper bounds on x at initial stage 0.
         Type: :code:`np.ndarray`; default: :code:`np.array([])`"""
         return self.__ubx_0
 
@@ -192,13 +192,13 @@ class AcadosOcpConstraints:
     # bounds on x
     @property
     def lbx(self):
-        """:math:`\\underline{x}` - lower bounds on x at intermediate shooting nodes (1 to N-1).
+        r""":math:`\\underline{x}` - lower bounds on x at intermediate shooting nodes (1 to N-1).
         Type: :code:`np.ndarray`; default: :code:`np.array([])`"""
         return self.__lbx
 
     @property
     def ubx(self):
-        """:math:`\\bar{x}` - upper bounds on x at intermediate shooting nodes (1 to N-1).
+        r""":math:`\\bar{x}` - upper bounds on x at intermediate shooting nodes (1 to N-1).
         Type: :code:`np.ndarray`; default: :code:`np.array([])`"""
         return self.__ubx
 
@@ -220,13 +220,13 @@ class AcadosOcpConstraints:
     # bounds on x at shooting node N
     @property
     def lbx_e(self):
-        """:math:`\\underline{x}^e` - lower bounds on x at terminal shooting node N.
+        r""":math:`\\underline{x}^e` - lower bounds on x at terminal shooting node N.
         Type: :code:`np.ndarray`; default: :code:`np.array([])`"""
         return self.__lbx_e
 
     @property
     def ubx_e(self):
-        """:math:`\\bar{x}^e` - upper bounds on x at terminal shooting node N.
+        r""":math:`\\bar{x}^e` - upper bounds on x at terminal shooting node N.
         Type: :code:`np.ndarray`; default: :code:`np.array([])`"""
         return self.__ubx_e
 
@@ -247,14 +247,14 @@ class AcadosOcpConstraints:
     # bounds on u
     @property
     def lbu(self):
-        """:math:`\\underline{u}` - lower bounds on u at shooting nodes (0 to N-1).
+        r""":math:`\\underline{u}` - lower bounds on u at shooting nodes (0 to N-1).
         Type: :code:`np.ndarray`; default: :code:`np.array([])`
         """
         return self.__lbu
 
     @property
     def ubu(self):
-        """:math:`\\bar{u}` - upper bounds on u at shooting nodes (0 to N-1).
+        r""":math:`\\bar{u}` - upper bounds on u at shooting nodes (0 to N-1).
         Type: :code:`np.ndarray`; default: :code:`np.array([])`
         """
         return self.__ubu
@@ -278,7 +278,7 @@ class AcadosOcpConstraints:
     # polytopic constraints
     @property
     def C(self):
-        """:math:`C` - C matrix in :math:`\\underline{g} \\leq D \, u + C \, x \\leq \\bar{g}`
+        r""":math:`C` - C matrix in :math:`\\underline{g} \\leq D \, u + C \, x \\leq \\bar{g}`
         at shooting nodes (0 to N-1).
         Type: :code:`np.ndarray`; default: :code:`np.array((0,0))`.
         """
@@ -286,7 +286,7 @@ class AcadosOcpConstraints:
 
     @property
     def D(self):
-        """:math:`D` - D matrix in :math:`\\underline{g} \\leq D \, u + C \, x \\leq \\bar{g}`
+        r""":math:`D` - D matrix in :math:`\\underline{g} \\leq D \, u + C \, x \\leq \\bar{g}`
         at shooting nodes (0 to N-1).
         Type: :code:`np.ndarray`; default: :code:`np.array((0,0))`
         """
@@ -294,7 +294,7 @@ class AcadosOcpConstraints:
 
     @property
     def lg(self):
-        """:math:`\\underline{g}` - lower bound for general polytopic inequalities
+        r""":math:`\\underline{g}` - lower bound for general polytopic inequalities
         at shooting nodes (0 to N-1).
         Type: :code:`np.ndarray`; default: :code:`np.array([])`
         """
@@ -302,7 +302,7 @@ class AcadosOcpConstraints:
 
     @property
     def ug(self):
-        """:math:`\\bar{g}` - upper bound for general polytopic inequalities
+        r""":math:`\\bar{g}` - upper bound for general polytopic inequalities
         at shooting nodes (0 to N-1).
         Type: :code:`np.ndarray`; default: :code:`np.array([])`.
         """
@@ -318,7 +318,7 @@ class AcadosOcpConstraints:
 
     @property
     def lg_e(self):
-        """:math:`\\underline{g}^e` - lower bound on general polytopic inequalities
+        r""":math:`\\underline{g}^e` - lower bound on general polytopic inequalities
         at terminal shooting node N.
         Type: :code:`np.ndarray`; default: :code:`np.array([])`.
         """
@@ -326,7 +326,7 @@ class AcadosOcpConstraints:
 
     @property
     def ug_e(self):
-        """:math:`\\bar{g}^e` - upper bound on general polytopic inequalities
+        r""":math:`\\bar{g}^e` - upper bound on general polytopic inequalities
         at terminal shooting node N.
         Type: :code:`np.ndarray`; default: :code:`np.array([])`.
         """
@@ -336,7 +336,7 @@ class AcadosOcpConstraints:
     # nonlinear constraints
     @property
     def lh(self):
-        """:math:`\\underline{h}` - lower bound for nonlinear inequalities
+        r""":math:`\\underline{h}` - lower bound for nonlinear inequalities
         at intermediate shooting nodes (1 to N-1).
         Type: :code:`np.ndarray`; default: :code:`np.array([])`.
         """
@@ -344,7 +344,7 @@ class AcadosOcpConstraints:
 
     @property
     def uh(self):
-        """:math:`\\bar{h}` - upper bound for nonlinear inequalities
+        r""":math:`\\bar{h}` - upper bound for nonlinear inequalities
         at intermediate shooting nodes (1 to N-1).
         Type: :code:`np.ndarray`; default: :code:`np.array([])`.
         """
@@ -353,7 +353,7 @@ class AcadosOcpConstraints:
     # nonlinear constraints at initial shooting node
     @property
     def lh_0(self):
-        """:math:`\\underline{h}^0` - lower bound on nonlinear inequalities
+        r""":math:`\\underline{h}^0` - lower bound on nonlinear inequalities
         at initial shooting node (0).
         Type: :code:`np.ndarray`; default: :code:`np.array([])`.
         """
@@ -361,7 +361,7 @@ class AcadosOcpConstraints:
 
     @property
     def uh_0(self):
-        """:math:`\\bar{h}^0` - upper bound on nonlinear inequalities
+        r""":math:`\\bar{h}^0` - upper bound on nonlinear inequalities
         at initial shooting node (0).
         Type: :code:`np.ndarray`; default: :code:`np.array([])`.
         """
@@ -370,7 +370,7 @@ class AcadosOcpConstraints:
     # nonlinear constraints at shooting node N
     @property
     def lh_e(self):
-        """:math:`\\underline{h}^e` - lower bound on nonlinear inequalities
+        r""":math:`\\underline{h}^e` - lower bound on nonlinear inequalities
         at terminal shooting node N.
         Type: :code:`np.ndarray`; default: :code:`np.array([])`.
         """
@@ -378,7 +378,7 @@ class AcadosOcpConstraints:
 
     @property
     def uh_e(self):
-        """:math:`\\bar{h}^e` - upper bound on nonlinear inequalities
+        r""":math:`\\bar{h}^e` - upper bound on nonlinear inequalities
         at terminal shooting node N.
         Type: :code:`np.ndarray`; default: :code:`np.array([])`.
         """
@@ -387,7 +387,7 @@ class AcadosOcpConstraints:
     # convex-over-nonlinear constraints
     @property
     def lphi(self):
-        """:math:`\\underline{\phi}` - lower bound for convex-over-nonlinear inequalities
+        r""":math:`\\underline{\phi}` - lower bound for convex-over-nonlinear inequalities
         at shooting nodes (0 to N-1).
         Type: :code:`np.ndarray`; default: :code:`np.array([])`.
         """
@@ -395,7 +395,7 @@ class AcadosOcpConstraints:
 
     @property
     def uphi(self):
-        """:math:`\\bar{\phi}` - upper bound for convex-over-nonlinear inequalities
+        r""":math:`\\bar{\phi}` - upper bound for convex-over-nonlinear inequalities
         at shooting nodes (0 to N-1).
         Type: :code:`np.ndarray`; default: :code:`np.array([])`.
         """
@@ -404,7 +404,7 @@ class AcadosOcpConstraints:
     # convex-over-nonlinear constraints at shooting node N
     @property
     def lphi_e(self):
-        """:math:`\\underline{\phi}^e` - lower bound on convex-over-nonlinear inequalities
+        r""":math:`\\underline{\phi}^e` - lower bound on convex-over-nonlinear inequalities
         at terminal shooting node N.
         Type: :code:`np.ndarray`; default: :code:`np.array([])`.
         """
@@ -412,7 +412,7 @@ class AcadosOcpConstraints:
 
     @property
     def uphi_e(self):
-        """:math:`\\bar{\phi}^e` - upper bound on convex-over-nonlinear inequalities
+        r""":math:`\\bar{\phi}^e` - upper bound on convex-over-nonlinear inequalities
         at terminal shooting node N.
         Type: :code:`np.ndarray`; default: :code:`np.array([])`.
         """
@@ -420,7 +420,7 @@ class AcadosOcpConstraints:
 
     @property
     def lphi_0(self):
-        """:math:`\\underline{\phi}^0` - lower bound on convex-over-nonlinear inequalities
+        r""":math:`\\underline{\phi}^0` - lower bound on convex-over-nonlinear inequalities
         at shooting node 0.
         Type: :code:`np.ndarray`; default: :code:`np.array([])`.
         """
@@ -428,7 +428,7 @@ class AcadosOcpConstraints:
 
     @property
     def uphi_0(self):
-        """:math:`\\bar{\phi}^0` - upper bound on convex-over-nonlinear inequalities
+        r""":math:`\\bar{\phi}^0` - upper bound on convex-over-nonlinear inequalities
         at shooting node 0.
         Type: :code:`np.ndarray`; default: :code:`np.array([])`.
         """
@@ -603,7 +603,7 @@ class AcadosOcpConstraints:
 
     @property
     def Jsphi(self):
-        """:math:`J_{s, \phi}` - matrix coefficient for soft bounds on convex-over-nonlinear constraints.
+        r""":math:`J_{s, \phi}` - matrix coefficient for soft bounds on convex-over-nonlinear constraints.
         Translated internally into :py:attr:`idxsphi`."""
         print_J_to_idx_note()
         return self.__idxsphi
@@ -743,7 +743,7 @@ class AcadosOcpConstraints:
 
     @property
     def x0(self):
-        """
+        r"""
         :math:`x_0 \\in \mathbb{R}^{n_x}` - initial state --
         Translated internally to :py:attr:`idxbx_0`, :py:attr:`lbx_0`, :py:attr:`ubx_0`, :py:attr:`idxbxe_0`
         """

--- a/interfaces/acados_template/acados_template/acados_ocp_cost.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_cost.py
@@ -33,7 +33,7 @@ import numpy as np
 from .utils import check_if_nparray_and_flatten, check_if_2d_nparray
 
 class AcadosOcpCost:
-    """
+    r"""
     Class containing the numerical data of the cost:
 
     NOTE: By default, the Lagrange cost term provided in continuous time is internally integrated using the explicit Euler method, cost_discretization = 'EULER',
@@ -152,7 +152,7 @@ class AcadosOcpCost:
 
     @property
     def yref_0(self):
-        """:math:`y_\\text{ref}^0` - reference at initial shooting node (0).
+        r""":math:`y_\\text{ref}^0` - reference at initial shooting node (0).
         Default: :code:`None`.
         """
         return self.__yref_0
@@ -239,7 +239,7 @@ class AcadosOcpCost:
 
     @property
     def yref(self):
-        """:math:`y_\\text{ref}` - reference at intermediate shooting nodes (1 to N-1).
+        r""":math:`y_\\text{ref}` - reference at intermediate shooting nodes (1 to N-1).
         Default: :code:`np.array([])`.
         """
         return self.__yref
@@ -383,7 +383,7 @@ class AcadosOcpCost:
 
     @property
     def yref_e(self):
-        """:math:`y_\\text{ref}^e` - cost reference at terminal shooting node (N).
+        r""":math:`y_\\text{ref}^e` - cost reference at terminal shooting node (N).
         Default: :code:`np.array([])`.
         """
         return self.__yref_e


### PR DESCRIPTION
This PR addresses the escaping-related warnings in acados_template by using r-strings.