### PR TITLE
Adjoint solution sensitivities with respect to global parameters

### DIFF
--- a/.github/workflows/full_build.yml
+++ b/.github/workflows/full_build.yml
@@ -174,6 +174,7 @@ jobs:
         python value_gradient_example.py
         python policy_gradient_example.py
         python test_solution_sens_and_exact_hess.py
+        python forw_vs_adj_param_sens.py
 
   MATLAB_test:
     needs: core_build

--- a/acados/ocp_nlp/ocp_nlp_common.c
+++ b/acados/ocp_nlp/ocp_nlp_common.c
@@ -3244,6 +3244,71 @@ void ocp_nlp_common_eval_param_sens(ocp_nlp_config *config, ocp_nlp_dims *dims,
     }
 }
 
+void ocp_nlp_common_eval_solution_sens_adj_p(ocp_nlp_config *config, ocp_nlp_dims *dims,
+                        ocp_nlp_opts *opts, ocp_nlp_memory *mem, ocp_nlp_workspace *work,
+                        char *field, int stage, int index, void *grad_p)
+{
+    int i, k;
+    int N = dims->N;
+    int np_global = dims->np_global;
+
+    int *nv = dims->nv;
+    int *ni = dims->ni;
+    int *nu = dims->nu;
+    int *nx = dims->nx;
+    struct blasfeo_dmat *tmp_nvninx_np_global = work->tmp_nvninx_np_global;
+
+    ocp_qp_in *tmp_qp_in = work->tmp_qp_in;
+    ocp_qp_out *tmp_qp_out = work->tmp_qp_out;
+
+    d_ocp_qp_copy_all(mem->qp_in, tmp_qp_in);
+    d_ocp_qp_set_rhs_zero(tmp_qp_in);
+    config->qp_solver->eval_sens(config->qp_solver, dims->qp_solver, tmp_qp_in, tmp_qp_out,
+                            opts->qp_solver_opts, mem->qp_solver_mem, work->qp_work);
+    if (!strcmp("params_stage", field))
+    {
+        printf("\nerror: field %s at stage %d not available in ocp_nlp_sqp_eval_param_sens\n", field, stage);
+        exit(1);
+    }
+    else if (!strcmp("params_global", field))
+    {
+        // NOTE we assume that np is the same for all stages if params_global is used
+        blasfeo_dvecse(np_global, 0., &mem->out_np_global, 0);
+        for (i = 0; i < N; i++)
+        {
+            blasfeo_dgese(nv[i]+ni[i]+nx[i], np_global, 0., &tmp_nvninx_np_global[i], 0, 0);
+            for (k = 0; k < np_global; k++)
+            {
+                config->dynamics[i]->memory_get_params_grad(config->dynamics[i], dims->dynamics[i], opts,
+                                        mem->dynamics[i], k, &tmp_qp_in->b[i], 0);
+                config->dynamics[i]->memory_get_params_lag_grad(config->dynamics[i], dims->dynamics[i], opts,
+                            mem->dynamics[i], k, &tmp_qp_in->rqz[i], 0);
+                config->cost[i]->memory_get_params_grad(config->cost[i], dims->cost[i], opts,
+                            mem->cost[i], k, &work->tmp_nv, 0);
+                blasfeo_dvecad(nu[i] + nx[i], 1., &work->tmp_nv, 0, &tmp_qp_in->rqz[i], 0);
+                // copy gradient to correct column in jacobian
+                blasfeo_dcolad(nx[i], 1.0, &tmp_qp_in->b[i], 0, &tmp_nvninx_np_global[i], nv[i]+ni[i], k);
+                blasfeo_dcolad(nx[i] + nu[i], 1.0, &tmp_qp_in->rqz[i], 0, &tmp_nvninx_np_global[i], 0, k);
+            }
+            // TODO multiply J.T with result of backsolve and add to in mem->out_np_global
+        }
+        blasfeo_dgese(nv[N]+ni[N]+nx[N], np_global, 0., &tmp_nvninx_np_global[N], 0, 0);
+        for (k = 0; k < np_global; k++)
+        {
+            config->cost[N]->memory_get_params_grad(config->cost[N], dims->cost[N], opts,
+                            mem->cost[N], index, &work->tmp_nv, 0);
+            blasfeo_dvecad(nu[N] + nx[N], 1., &work->tmp_nv, 0, &tmp_qp_in->rqz[N], 0);
+            blasfeo_dcolad(nx[N] + nu[N], 1.0, &tmp_qp_in->rqz[N], 0, &tmp_nvninx_np_global[N], 0, k);
+        }
+        // TODO multiply J.T with result of backsolve and add to in mem->out_np_global
+    }
+    else
+    {
+        printf("\nerror: field %s at stage %d not available in ocp_nlp_sqp_eval_param_sens\n", field, stage);
+        exit(1);
+    }
+}
+
 
 void ocp_nlp_common_eval_lagr_grad_p(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in,
                         ocp_nlp_opts *opts, ocp_nlp_memory *mem, ocp_nlp_workspace *work,

--- a/acados/ocp_nlp/ocp_nlp_common.h
+++ b/acados/ocp_nlp/ocp_nlp_common.h
@@ -91,6 +91,9 @@ typedef struct ocp_nlp_config
                             char *field, int stage, int index, void *sens_nlp_out);
     void (*eval_lagr_grad_p)(void *config, void *dims, void *nlp_in, void *opts_, void *mem, void *work,
                             const char *field, void *grad_p);
+    void (*eval_solution_sens_adj_p)(void *config_, void *dims_,
+                        void *opts_, void *mem_, void *work_, void *sens_nlp_out,
+                        const char *field, int stage, void *grad_p);
     void (*step_update)(void *config, void *dims, void *in,
             void *out_start, void *opts, void *mem, void *work,
             void *out_destination, void* solver_mem, double alpha, bool full_step_dual);
@@ -531,6 +534,11 @@ void ocp_nlp_common_eval_param_sens(ocp_nlp_config *config, ocp_nlp_dims *dims,
 void ocp_nlp_common_eval_lagr_grad_p(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in,
                         ocp_nlp_opts *opts, ocp_nlp_memory *mem, ocp_nlp_workspace *work,
                         const char *field, void *grad_p);
+//
+void ocp_nlp_common_eval_solution_sens_adj_p(ocp_nlp_config *config, ocp_nlp_dims *dims,
+                        ocp_nlp_opts *opts, ocp_nlp_memory *mem, ocp_nlp_workspace *work,
+                        ocp_nlp_out *sens_nlp_out, const char *field, int stage, void *grad_p);
+
 //
 void ocp_nlp_add_levenberg_marquardt_term(ocp_nlp_config *config, ocp_nlp_dims *dims,
     ocp_nlp_in *in, ocp_nlp_out *out, ocp_nlp_opts *opts, ocp_nlp_memory *mem,

--- a/acados/ocp_nlp/ocp_nlp_common.h
+++ b/acados/ocp_nlp/ocp_nlp_common.h
@@ -461,6 +461,7 @@ typedef struct ocp_nlp_workspace
     struct blasfeo_dvec dxnext_dy;
 
     // optimal value gradient wrt params
+    struct blasfeo_dmat *tmp_nvninx_np_global;
     struct blasfeo_dvec tmp_np_global;
     // AS-RTI
     double *tmp_nv_double;

--- a/acados/ocp_nlp/ocp_nlp_common.h
+++ b/acados/ocp_nlp/ocp_nlp_common.h
@@ -406,6 +406,9 @@ typedef struct ocp_nlp_memory
     struct blasfeo_dvec *dyn_fun;
     struct blasfeo_dvec *dyn_adj;
 
+    // optimal value gradient wrt params
+    struct blasfeo_dvec out_np_global;
+
     double cost_value;
     double qp_cost_value;
     int compute_hess;
@@ -459,7 +462,6 @@ typedef struct ocp_nlp_workspace
 
     // optimal value gradient wrt params
     struct blasfeo_dvec tmp_np_global;
-    struct blasfeo_dvec out_np_global;
     // AS-RTI
     double *tmp_nv_double;
 

--- a/acados/ocp_nlp/ocp_nlp_sqp.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp.c
@@ -877,6 +877,23 @@ void ocp_nlp_sqp_eval_lagr_grad_p(void *config_, void *dims_, void *nlp_in_, voi
 }
 
 
+void ocp_nlp_sqp_eval_solution_sens_adj_p(void *config_, void *dims_,
+                        void *opts_, void *mem_, void *work_, void *sens_nlp_out,
+                        const char *field, int stage, void *grad_p)
+{
+    ocp_nlp_dims *dims = dims_;
+    ocp_nlp_config *config = config_;
+    ocp_nlp_sqp_opts *opts = opts_;
+    ocp_nlp_sqp_memory *mem = mem_;
+    ocp_nlp_memory *nlp_mem = mem->nlp_mem;
+    ocp_nlp_sqp_workspace *work = work_;
+    ocp_nlp_workspace *nlp_work = work->nlp_work;
+    ocp_nlp_common_eval_solution_sens_adj_p(config, dims,
+                        opts->nlp_opts, nlp_mem, nlp_work,
+                        sens_nlp_out, field, stage, grad_p);
+}
+
+
 // TODO: write getter for things in nlp_mem
 void ocp_nlp_sqp_get(void *config_, void *dims_, void *mem_, const char *field, void *return_value_)
 {
@@ -979,6 +996,7 @@ void ocp_nlp_sqp_config_initialize_default(void *config_)
     config->memory_reset_qp_solver = &ocp_nlp_sqp_memory_reset_qp_solver;
     config->eval_param_sens = &ocp_nlp_sqp_eval_param_sens;
     config->eval_lagr_grad_p = &ocp_nlp_sqp_eval_lagr_grad_p;
+    config->eval_solution_sens_adj_p = &ocp_nlp_sqp_eval_solution_sens_adj_p;
     config->config_initialize_default = &ocp_nlp_sqp_config_initialize_default;
     config->precompute = &ocp_nlp_sqp_precompute;
     config->get = &ocp_nlp_sqp_get;

--- a/acados/ocp_nlp/ocp_nlp_sqp.h
+++ b/acados/ocp_nlp/ocp_nlp_sqp.h
@@ -143,6 +143,12 @@ int ocp_nlp_sqp_precompute(void *config_, void *dims_, void *nlp_in_, void *nlp_
 //
 void ocp_nlp_sqp_eval_lagr_grad_p(void *config_, void *dims_, void *nlp_in_, void *opts_, void *mem_, void *work_,
                             const char *field, void *grad_p);
+
+
+void ocp_nlp_sqp_eval_solution_sens_adj_p(void *config_, void *dims_,
+                        void *opts_, void *mem_, void *work_, void *sens_nlp_out,
+                        const char *field, int stage, void *grad_p);
+
 //
 void ocp_nlp_sqp_get(void *config_, void *dims_, void *mem_, const char *field, void *return_value_);
 //

--- a/examples/acados_python/chain_mass/solution_sensitivity_example.py
+++ b/examples/acados_python/chain_mass/solution_sensitivity_example.py
@@ -453,7 +453,7 @@ def main_parametric(qp_solver_ric_alg: int = 0, chain_params_: dict = get_chain_
         seed_x = np.ones((nx, 1))
         seed_u = np.ones((nu, 1))
 
-        sens_adj = sensitivity_solver.eval_adjoint_solution_sensitivity(seed_x=seed_x, seed_u=seed_u, stages=0)
+        sens_adj = sensitivity_solver.eval_adjoint_solution_sensitivity(seed_x=[(0, seed_x)], seed_u=[(0, seed_u)])
         timings_solve_params_adj[i] = sensitivity_solver.get_stats("time_solution_sens_solve")
 
         sens_adj_ref = seed_u.T @ sens_u_ + seed_x.T @ sens_x_

--- a/examples/acados_python/pendulum_on_cart/solution_sensitivities/forw_vs_adj_param_sens.py
+++ b/examples/acados_python/pendulum_on_cart/solution_sensitivities/forw_vs_adj_param_sens.py
@@ -1,0 +1,128 @@
+# -*- coding: future_fstrings -*-
+#
+# Copyright (c) The acados authors.
+#
+# This file is part of acados.
+#
+# The 2-Clause BSD License
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.;
+#
+import numpy as np
+from acados_template import AcadosOcpSolver
+from sensitivity_utils import export_parametric_ocp
+
+def main(qp_solver_ric_alg: int, use_cython=False, generate_solvers=True):
+    """
+    Evaluate policy and calculate its gradient for the pendulum on a cart with a parametric model.
+    """
+    p_nominal = 1.0
+    x0 = np.array([0.0, np.pi / 2, 0.0, 0.0])
+    p_test = p_nominal - 0.2
+
+    nx = len(x0)
+    nu = 1
+
+    N_horizon = 50
+    T_horizon = 2.0
+    Fmax = 80.0
+
+    cost_scale_as_param = True # test with 2 parameters
+
+    ocp = export_parametric_ocp(x0=x0, N_horizon=N_horizon, T_horizon=T_horizon, Fmax=Fmax, qp_solver_ric_alg=1, cost_scale_as_param=cost_scale_as_param)
+    if use_cython:
+        raise NotImplementedError()
+        AcadosOcpSolver.generate(ocp, json_file="parameter_augmented_acados_ocp.json")
+        AcadosOcpSolver.build(ocp.code_export_directory, with_cython=True)
+        acados_ocp_solver = AcadosOcpSolver.create_cython_solver("parameter_augmented_acados_ocp.json")
+    else:
+        acados_ocp_solver = AcadosOcpSolver(ocp, json_file="parameter_augmented_acados_ocp.json", generate=generate_solvers, build=generate_solvers)
+
+    # create sensitivity solver
+    ocp = export_parametric_ocp(x0=x0, N_horizon=N_horizon, T_horizon=T_horizon, Fmax=Fmax, hessian_approx='EXACT', qp_solver_ric_alg=qp_solver_ric_alg, cost_scale_as_param=cost_scale_as_param)
+    ocp.model.name = 'sensitivity_solver'
+    ocp.code_export_directory = f'c_generated_code_{ocp.model.name}'
+    if use_cython:
+        AcadosOcpSolver.generate(ocp, json_file=f"{ocp.model.name}.json")
+        AcadosOcpSolver.build(ocp.code_export_directory, with_cython=True)
+        sensitivity_solver = AcadosOcpSolver.create_cython_solver(f"{ocp.model.name}.json")
+    else:
+        sensitivity_solver = AcadosOcpSolver(ocp, json_file=f"{ocp.model.name}.json", generate=generate_solvers, build=generate_solvers)
+
+    p_val = np.array([p_test, 1.0])
+
+    acados_ocp_solver.set_p_global_and_precompute_dependencies(p_val)
+    sensitivity_solver.set_p_global_and_precompute_dependencies(p_val)
+
+    u_opt = acados_ocp_solver.solve_for_x0(x0)[0]
+    acados_ocp_solver.store_iterate(filename='iterate.json', overwrite=True, verbose=False)
+
+    sensitivity_solver.load_iterate(filename='iterate.json', verbose=False)
+    sensitivity_solver.solve_for_x0(x0, fail_on_nonzero_status=False, print_stats_on_failure=False)
+
+    if sensitivity_solver.get_status() not in [0, 2]:
+        breakpoint()
+
+    # adjoint direction for one stage
+    seed_xstage = np.ones((1, nx))
+    seed_xstage[0, 0] = -8
+    seed_ustage = np.ones((1, nu))
+    seed_ustage[0, 0] = 42
+
+    # test different settings forward vs. adjoint
+    for stages, seed_x, seed_u in [
+        ([0, 1], [seed_xstage, seed_xstage], [seed_ustage, seed_ustage]),
+        ([0, 3], [seed_xstage, seed_xstage], [seed_ustage, seed_ustage]),
+        ([0], [seed_xstage], [seed_ustage]),
+        ([5], [seed_xstage], [seed_ustage]),
+    ]:
+        # Calculate the policy gradient
+        sens_x_forw, sens_u_forw = sensitivity_solver.eval_solution_sensitivity(stages, "params_global")
+
+        adj_p_ref = sum([seed_x[k] @ sens_x_forw[k] + seed_u[k] @ sens_u_forw[k] for k in range(len(stages))])
+
+        # compute adjoint solution sensitivity
+        adj_p = sensitivity_solver.eval_adjoint_solution_sensitivity(stages=stages,
+                                                    seed_x=seed_x,
+                                                    seed_u=seed_u)
+
+        print(f"{adj_p=} {adj_p_ref=}")
+        if not np.allclose(adj_p, adj_p_ref, atol=1e-7):
+            raise Exception("adj_p and adj_p_ref should match.")
+        else:
+            print("Success: adj_p and adj_p_ref match!")
+
+    # test with list vs. single stage API
+    adj_p_ref = sensitivity_solver.eval_adjoint_solution_sensitivity(stages=[0],
+                                            seed_x=[seed_xstage],
+                                            seed_u=[seed_ustage])
+    adj_p = sensitivity_solver.eval_adjoint_solution_sensitivity(stages=0,
+                                            seed_x=seed_xstage,
+                                            seed_u=seed_ustage)
+    if not np.allclose(adj_p, adj_p_ref, atol=1e-7):
+        raise Exception("adj_p and adj_p_ref should match.")
+    else:
+        print("Success: adj_p and adj_p_ref match!")
+
+if __name__ == "__main__":
+    main(qp_solver_ric_alg=0, use_cython=False, generate_solvers=True)

--- a/examples/acados_python/pendulum_on_cart/solution_sensitivities/forw_vs_adj_param_sens.py
+++ b/examples/acados_python/pendulum_on_cart/solution_sensitivities/forw_vs_adj_param_sens.py
@@ -124,5 +124,24 @@ def main(qp_solver_ric_alg: int, use_cython=False, generate_solvers=True):
     else:
         print("Success: adj_p and adj_p_ref match!")
 
+    # test multiple adjoint seeds at once
+    adj_p_mat = sensitivity_solver.eval_adjoint_solution_sensitivity(stages=1,
+                                            seed_x=np.eye(nx),
+                                            seed_u=np.zeros((nx, nu)))
+    print(f"{adj_p_mat=}")
+
+    for i in range(nx):
+        seed_x = np.zeros((1, nx))
+        seed_x[0, i] = 1.0
+        adj_p_vec = sensitivity_solver.eval_adjoint_solution_sensitivity(stages=1,
+                                            seed_x=seed_x,
+                                            seed_u=np.zeros((1, nu)))
+        print(f"{adj_p_vec=} {adj_p_mat[i, :]=}")
+        if not np.allclose(adj_p_vec, adj_p_mat[i, :], atol=1e-7):
+            raise Exception(f"adj_p_vec and adj_p_mat[{i}, :] should match.")
+        else:
+            print(f"Success: adj_p_vec and adj_p_mat[{i}, :] match!")
+
+
 if __name__ == "__main__":
     main(qp_solver_ric_alg=0, use_cython=False, generate_solvers=True)

--- a/examples/acados_python/pendulum_on_cart/solution_sensitivities/sensitivity_utils.py
+++ b/examples/acados_python/pendulum_on_cart/solution_sensitivities/sensitivity_utils.py
@@ -101,7 +101,7 @@ def export_parametric_ocp(
         # add nonlinear dependency in cost
         cost_scale_factor = ca.exp(cost_scale_param)
     else:
-        cost_scale_factor = ca.exp(ocp.model.p_global)
+        cost_scale_factor = 1.0
 
     # NOTE here we make the cost parametric
     ocp.model.cost_expr_ext_cost = cost_scale_factor * ocp.model.x.T @ Q_mat @ ocp.model.x + ocp.model.u.T @ R_mat @ ocp.model.u

--- a/examples/acados_python/pendulum_on_cart/solution_sensitivities/sensitivity_utils.py
+++ b/examples/acados_python/pendulum_on_cart/solution_sensitivities/sensitivity_utils.py
@@ -74,7 +74,8 @@ def export_pendulum_ode_model_with_mass_as_p_global(dt) -> AcadosModel:
 
 def export_parametric_ocp(
     x0=np.array([0.0, np.pi / 6, 0.0, 0.0]), N_horizon=50, T_horizon=2.0, Fmax=80.0,
-    hessian_approx = "GAUSS_NEWTON", qp_solver_ric_alg=1
+    hessian_approx = "GAUSS_NEWTON", qp_solver_ric_alg=1,
+    cost_scale_as_param=False
 ) -> AcadosOcp:
 
     ocp = AcadosOcp()
@@ -83,24 +84,34 @@ def export_parametric_ocp(
 
     ocp.solver_options.N_horizon = N_horizon
 
+    # set mass to one
+    ocp.p_global_values = np.ones((1,))
+
     Q_mat = 2 * np.diag([1e3, 1e3, 1e-2, 1e-2])
     R_mat = 2 * np.diag([1e-1])
 
     ocp.cost.cost_type = "EXTERNAL"
     ocp.cost.cost_type_e = "EXTERNAL"
 
+    if cost_scale_as_param:
+        # add parameter to model
+        cost_scale_param = ca.SX.sym('cost_scale_param')
+        ocp.model.p_global = ca.vertcat(ocp.model.p_global, cost_scale_param)
+        ocp.p_global_values = np.concatenate((ocp.p_global_values, np.ones((1,))))
+        # add nonlinear dependency in cost
+        cost_scale_factor = ca.exp(cost_scale_param)
+    else:
+        cost_scale_factor = ca.exp(ocp.model.p_global)
+
     # NOTE here we make the cost parametric
-    ocp.model.cost_expr_ext_cost = ca.exp(ocp.model.p_global) * ocp.model.x.T @ Q_mat @ ocp.model.x + ocp.model.u.T @ R_mat @ ocp.model.u
-    ocp.model.cost_expr_ext_cost_e = ca.exp(ocp.model.p_global) * ocp.model.x.T @ Q_mat @ ocp.model.x
+    ocp.model.cost_expr_ext_cost = cost_scale_factor * ocp.model.x.T @ Q_mat @ ocp.model.x + ocp.model.u.T @ R_mat @ ocp.model.u
+    ocp.model.cost_expr_ext_cost_e = cost_scale_factor * ocp.model.x.T @ Q_mat @ ocp.model.x
 
     ocp.constraints.lbu = np.array([-Fmax])
     ocp.constraints.ubu = np.array([+Fmax])
     ocp.constraints.idxbu = np.array([0])
 
     ocp.constraints.x0 = x0
-
-    # set mass to one
-    ocp.p_global_values = np.ones((1,))
 
     ocp.solver_options.qp_solver = "PARTIAL_CONDENSING_HPIPM"
     ocp.solver_options.integrator_type = "DISCRETE"

--- a/interfaces/acados_c/ocp_nlp_interface.c
+++ b/interfaces/acados_c/ocp_nlp_interface.c
@@ -1261,6 +1261,11 @@ void ocp_nlp_eval_params_jac(ocp_nlp_solver *solver, ocp_nlp_in *nlp_in, ocp_nlp
 }
 
 
+void ocp_nlp_eval_solution_sens_adj_p(ocp_nlp_solver *solver, ocp_nlp_in *nlp_in, ocp_nlp_out *sens_nlp_out, const char *field, int stage, double *out)
+{
+    solver->config->eval_solution_sens_adj_p(solver->config, solver->dims, solver->opts, solver->mem, solver->work, sens_nlp_out, field, stage, out);
+}
+
 
 void ocp_nlp_get(ocp_nlp_solver *solver, const char *field, void *return_value_)
 {

--- a/interfaces/acados_c/ocp_nlp_interface.c
+++ b/interfaces/acados_c/ocp_nlp_interface.c
@@ -657,6 +657,18 @@ void ocp_nlp_out_set(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_out *ou
 }
 
 
+void ocp_nlp_out_set_values_to_zero(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_out *out)
+{
+    int N = dims->N;
+    for (int i = 0; i<=N; i++)
+    {
+        blasfeo_dvecse(dims->nv[i], 0.0, &out->ux[i], 0);
+        blasfeo_dvecse(dims->nz[i], 0.0, &out->z[i], 0);
+        blasfeo_dvecse(dims->nx[i+1], 0.0, &out->pi[i], 0);
+        blasfeo_dvecse(2*dims->ni[i], 0.0, &out->lam[i], 0);
+    }
+}
+
 
 void ocp_nlp_out_get(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_out *out,
         int stage, const char *field, void *value)

--- a/interfaces/acados_c/ocp_nlp_interface.h
+++ b/interfaces/acados_c/ocp_nlp_interface.h
@@ -419,6 +419,9 @@ ACADOS_SYMBOL_EXPORT void ocp_nlp_eval_param_sens(ocp_nlp_solver *solver, char *
 // Computes the gradient of the Lagrange function wrt parameters
 ACADOS_SYMBOL_EXPORT void ocp_nlp_eval_lagrange_grad_p(ocp_nlp_solver *solver, ocp_nlp_in *nlp_in, const char *field, double *out);
 
+
+void ocp_nlp_eval_solution_sens_adj_p(ocp_nlp_solver *solver, ocp_nlp_in *nlp_in, ocp_nlp_out *sens_nlp_out, const char *field, int stage, double *out);
+
 /* get */
 /// \param solver The solver struct.
 /// \param field Supports "sqp_iter", "status", "nlp_res", "time_tot", ...

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -719,7 +719,7 @@ class AcadosOcpSolver:
 
             return grad_p
         else:
-            raise NotImplementedError("")
+            raise NotImplementedError(f"with_respect_to {with_respect_to} not implemented.")
 
 
 

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -673,6 +673,56 @@ class AcadosOcpSolver:
         return sens_x, sens_u
 
 
+    def eval_adjoint_solution_sensitivity(self,
+                                          seed_x: Union[np.ndarray, List[np.ndarray]],
+                                          seed_u: Union[np.ndarray, List[np.ndarray]],
+                                          stages: Union[int, List[int]] = 0,
+                                          with_respect_to: str = "p_global") -> np.ndarray:
+
+        self.sanity_check_parametric_sensitivities()
+
+        stages_is_list = isinstance(stages, list)
+        stages_ = stages if stages_is_list else [stages]
+
+        N_horizon = self.acados_ocp.solver_options.N_horizon
+
+        for s in stages_:
+            if not isinstance(s, int) or s < 0 or s > N_horizon:
+                raise Exception(f"AcadosOcpSolver.eval_solution_sensitivity(): stages need to be int or list[int] and in [0, N], got stages = {stages_}.")
+
+        t0 = time.time()
+        self.__acados_lib.ocp_nlp_eval_params_jac(self.nlp_solver, self.nlp_in, self.nlp_out)
+        self.time_solution_sens_lin = time.time() - t0
+
+        # set seed:
+        if not stages_is_list:
+            seed_x = [seed_x]
+            seed_u = [seed_u]
+
+        self.reset_sens_out()
+        for stage, x_seed, u_seed in zip(stages_, seed_x, seed_u):
+            self.set(stage, 'sens_x', x_seed.flatten())
+            self.set(stage, 'sens_u', u_seed.flatten())
+
+        if with_respect_to == "p_global":
+            field = "p_global".encode('utf-8')
+
+            nparam = self.__acados_lib.ocp_nlp_dims_get_from_attr(self.nlp_config, self.nlp_dims, self.nlp_out, 0, field)
+
+            grad = np.zeros((nparam,))
+            grad_p = np.ascontiguousarray(grad, dtype=np.float64)
+            c_grad_p = cast(grad_p.ctypes.data, POINTER(c_double))
+
+            self.time_solution_sens_solve = 0.0
+            self.__acados_lib.ocp_nlp_eval_solution_sens_adj_p(self.nlp_solver, self.nlp_in, self.sens_out, field, 0, c_grad_p)
+            self.time_solution_sens_solve += self.get_stats("time_solution_sensitivities")
+
+            return grad_p
+        else:
+            raise NotImplementedError("")
+
+
+
     def eval_param_sens(self, index: int, stage: int=0, field="ex"):
         """
         Calculate the sensitivity of the current solution with respect to the initial state component of index.
@@ -1311,6 +1361,7 @@ class AcadosOcpSolver:
         self.__acados_lib.ocp_nlp_out_set_values_to_zero.argtypes = \
                     [c_void_p, c_void_p, c_void_p]
         self.__acados_lib.ocp_nlp_out_set_values_to_zero(self.nlp_config, self.nlp_dims, self.sens_out)
+
 
     def cost_set(self, stage_: int, field_: str, value_, api='warn'):
         """

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -620,7 +620,7 @@ class AcadosOcpSolver:
 
         for s in stages_:
             if not isinstance(s, int) or s < 0 or s > N:
-                raise Exception("AcadosOcpSolver.eval_solution_sensitivity(): stages need to be int or [int] and in [0, N].")
+                raise Exception(f"AcadosOcpSolver.eval_solution_sensitivity(): stages need to be int or list[int] and in [0, N], got stages = {stages_}.")
 
         if with_respect_to == "initial_state":
             nx = self.__acados_lib.ocp_nlp_dims_get_from_attr(self.nlp_config, self.nlp_dims, self.nlp_out, 0, "x".encode('utf-8'))

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -275,6 +275,9 @@ class AcadosOcpSolver:
         self.__acados_lib.ocp_nlp_eval_param_sens.argtypes = [c_void_p, c_char_p, c_int, c_int, c_void_p]
         self.__acados_lib.ocp_nlp_eval_param_sens.restype = None
 
+        self.__acados_lib.ocp_nlp_eval_solution_sens_adj_p.argtypes = [c_void_p, c_void_p, c_void_p, c_char_p, c_int, c_void_p]
+        self.__acados_lib.ocp_nlp_eval_solution_sens_adj_p.restype = None
+
         self.__acados_lib.ocp_nlp_solver_opts_set.argtypes = [c_void_p, c_void_p, c_char_p, c_void_p]
         self.__acados_lib.ocp_nlp_get.argtypes = [c_void_p, c_char_p, c_void_p]
 

--- a/interfaces/acados_template/acados_template/casadi_function_generation.py
+++ b/interfaces/acados_template/acados_template/casadi_function_generation.py
@@ -32,7 +32,7 @@ from typing import Union, List, Optional
 
 import os
 import casadi as ca
-from .utils import is_empty, casadi_length, check_casadi_version_supports_p_global
+from .utils import is_empty, casadi_length, check_casadi_version_supports_p_global, print_casadi_expression
 from .acados_model import AcadosModel
 from .acados_ocp_constraints import AcadosOcpConstraints
 
@@ -162,6 +162,8 @@ class GenerateContext:
         fun_name = f'{self.problem_name}_p_global_precompute_fun'
         self.add_function_definition(fun_name, [self.p_global], [self.global_data_expr], output_dir)
 
+        # self.print_global_data_summary()
+
         assert casadi_length(self.global_data_expr) == casadi_length(self.global_data_sym), f"Length mismatch: {casadi_length(self.global_data_expr)} != {casadi_length(self.global_data_sym)}"
 
     def finalize(self):
@@ -183,6 +185,13 @@ class GenerateContext:
                 continue
             out.append(f"{rel_fun_dir}/{fun_name}.c")
         return out
+
+    def print_global_data_summary(self) -> None:
+        if casadi_length(self.global_data_expr) == 0:
+            print("\nGenerateContext: detected empty global_data_expr.")
+        else:
+            print("\nGenerateContext: detected global_data_expr:\n")
+            print_casadi_expression(self.global_data_expr)
 
 ################
 # Dynamics
@@ -718,7 +727,6 @@ def generate_c_code_constraint(context: GenerateContext, model: AcadosModel, con
 
             context.add_function_definition(fun_name, [x, u, lam_h, z, p], \
                     [con_h_expr, jac_ux_t, hess_ux, jac_z_t, hess_z], constraints_dir)
-
 
         if stage_type == 'terminal':
             fun_name = model.name + '_constr_h_e_fun'

--- a/interfaces/acados_template/acados_template/utils.py
+++ b/interfaces/acados_template/acados_template/utils.py
@@ -29,6 +29,7 @@
 # POSSIBILITY OF SUCH DAMAGE.;
 #
 
+from typing import Union
 import json
 import os
 import shutil
@@ -505,7 +506,7 @@ def idx_perm_to_ipiv(idx_perm):
     return ipiv
 
 
-def print_casadi_expression(f):
+def print_casadi_expression(f: Union[MX, SX, DM]):
     for ii in range(casadi_length(f)):
         print(f[ii,:])
 


### PR DESCRIPTION
- can be used from Python via `AcadosOcpSolver.eval_adjoint_solution_sensitivity()`
```
Evaluate the adjoint sensitivity of the solution with respect to the parameters.
    :param seed_x : np.ndarray or list of np.ndarrays - seed for the states at stage `stages`
    :param seed_u : np.ndarray or list of np.ndarrays - seed for the controls at stage `stages`
    :param stages_seed_x : int or list of int - stages corresponding to the seeds_x
    :param stages_seed_u : int or list of int - stages corresponding to the seeds_u
    :param with_respect_to : string in ["p_global"]
    :param sanity_checks : bool - whether to perform sanity checks, turn off for minimal overhead, default: True
 ```
- chain-mass example `solution_sensitivity_example.py`: fix wrt global parameters, extend to also evaluate an adjoint sensitivity and compare timings of forward vs adjoint solution sensitivities.
- Python: gather solution sensitivity specific tests in function `sanity_check_parametric_sensitivities()`
- add test / example: `examples/acados_python/pendulum_on_cart/solution_sensitivities/forw_vs_adj_param_sens.py`