### PR TITLE
Implement getter and setter for values of the whole horizon

### DIFF
--- a/examples/acados_python/chain_mass/plot_utils.py
+++ b/examples/acados_python/chain_mass/plot_utils.py
@@ -42,7 +42,7 @@ def plot_timings(results_list, keys, labels, figure_filename=None):
         raise ValueError("Number of labels and result files do not match")
 
     width = 0.8
-    fig, ax = plt.subplots()
+    fig, ax = plt.subplots(figsize=(7.5, 6))
     bottom = np.zeros(num_entries)
 
     for i, k in enumerate(keys):

--- a/examples/acados_python/chain_mass/solution_sensitivity_example.py
+++ b/examples/acados_python/chain_mass/solution_sensitivity_example.py
@@ -439,8 +439,12 @@ def main_parametric(qp_solver_ric_alg: int = 0, chain_params_: dict = get_chain_
         # sensitivity_solver.load_iterate(filename="iterate.json", verbose=False)
 
         # using AcadosOcpIterate
-        iterate = ocp_solver.store_iterate_to_obj()
-        sensitivity_solver.load_iterate_from_obj(iterate)
+        # iterate = ocp_solver.store_iterate_to_obj()
+        # sensitivity_solver.load_iterate_from_obj(iterate)
+
+        # using AcadosOcpFlatIterate
+        iterate = ocp_solver.store_iterate_to_flat_obj()
+        sensitivity_solver.load_iterate_from_flat_obj(iterate)
 
         timings_store_load[i] = time.time() - t_start
 

--- a/interfaces/acados_c/ocp_nlp_interface.c
+++ b/interfaces/acados_c/ocp_nlp_interface.c
@@ -723,6 +723,65 @@ void ocp_nlp_out_get(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_out *ou
 }
 
 
+int ocp_nlp_dims_get_total_from_attr(ocp_nlp_config *config, ocp_nlp_dims *dims, const char *field)
+{
+    int N = dims->N;
+
+    int size = 0;
+    int stage;
+    if (!strcmp(field, "x"))
+    {
+        for (stage = 0; stage < N+1; stage++)
+        {
+            size += dims->nx[stage];
+        }
+    }
+    else if (!strcmp(field, "u"))
+    {
+        for (stage = 0; stage < N; stage++)
+        {
+            size += dims->nu[stage];
+        }
+    }
+    else if (!strcmp(field, "sl") || !strcmp(field, "su"))
+    {
+        for (stage = 0; stage < N+1; stage++)
+        {
+            size += dims->ns[stage];
+        }
+    }
+    else if (!strcmp(field, "s"))
+    {
+        for (stage = 0; stage < N+1; stage++)
+        {
+            size += 2*dims->ns[stage];
+        }
+    }
+    else if (!strcmp(field, "z"))
+    {
+        for (stage = 0; stage < N+1; stage++)
+        {
+            size += dims->nz[stage];
+        }
+    }
+    else if (!strcmp(field, "pi"))
+    {
+        for (stage = 0; stage < N; stage++)
+        {
+            size += dims->nx[stage+1];
+        }
+    }
+    else if (!strcmp(field, "lam"))
+    {
+        for (stage = 0; stage < N+1; stage++)
+        {
+            size += 2*dims->ni[stage];
+        }
+    }
+    return size;
+}
+
+
 
 int ocp_nlp_dims_get_from_attr(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_out *out,
         int stage, const char *field)
@@ -1466,6 +1525,7 @@ void ocp_nlp_get_from_iterate(ocp_nlp_solver *solver, int iter, int stage, const
     }
     ocp_nlp_out_get(config, dims, nlp_mem->iterates[iter], stage, field, value);
 }
+
 
 
 void ocp_nlp_get_all(ocp_nlp_solver *solver, ocp_nlp_in *in, ocp_nlp_out *out, const char *field, void *value)

--- a/interfaces/acados_c/ocp_nlp_interface.c
+++ b/interfaces/acados_c/ocp_nlp_interface.c
@@ -1470,18 +1470,16 @@ void ocp_nlp_get_from_iterate(ocp_nlp_solver *solver, int iter, int stage, const
 
 void ocp_nlp_get_all(ocp_nlp_solver *solver, ocp_nlp_in *in, ocp_nlp_out *out, const char *field, void *value)
 {
-    ocp_nlp_config *config = solver->config;
-    ocp_nlp_memory *nlp_mem;
     ocp_nlp_dims *dims = solver->dims;
 
     double *double_values = value;
     int tmp_offset = 0;
     int N = dims->N;
-    int tmp_int;
+    int tmp_int, stage;
 
     if (!strcmp(field, "x"))
     {
-        for (int stage = 0; stage < N+1; stage++)
+        for (stage = 0; stage < N+1; stage++)
         {
             tmp_int = dims->nx[stage];
             blasfeo_unpack_dvec(tmp_int, &out->ux[stage], dims->nu[stage], (double_values + tmp_offset), 1);
@@ -1490,7 +1488,7 @@ void ocp_nlp_get_all(ocp_nlp_solver *solver, ocp_nlp_in *in, ocp_nlp_out *out, c
     }
     else if (!strcmp(field, "u"))
     {
-        for (int stage = 0; stage < N; stage++)
+        for (stage = 0; stage < N; stage++)
         {
             tmp_int = dims->nu[stage];
             blasfeo_unpack_dvec(tmp_int, &out->ux[stage], 0, (double_values + tmp_offset), 1);
@@ -1499,7 +1497,7 @@ void ocp_nlp_get_all(ocp_nlp_solver *solver, ocp_nlp_in *in, ocp_nlp_out *out, c
     }
     else if (!strcmp(field, "sl"))
     {
-        for (int stage = 0; stage < N+1; stage++)
+        for (stage = 0; stage < N+1; stage++)
         {
             tmp_int = dims->ns[stage];
             blasfeo_unpack_dvec(tmp_int, &out->ux[stage], dims->nu[stage] + dims->nx[stage], (double_values + tmp_offset), 1);
@@ -1508,7 +1506,7 @@ void ocp_nlp_get_all(ocp_nlp_solver *solver, ocp_nlp_in *in, ocp_nlp_out *out, c
     }
     else if (!strcmp(field, "su"))
     {
-        for (int stage = 0; stage < N+1; stage++)
+        for (stage = 0; stage < N+1; stage++)
         {
             tmp_int = dims->ns[stage];
             blasfeo_unpack_dvec(tmp_int, &out->ux[stage], dims->nu[stage] + dims->nx[stage] + dims->ns[stage],
@@ -1518,7 +1516,7 @@ void ocp_nlp_get_all(ocp_nlp_solver *solver, ocp_nlp_in *in, ocp_nlp_out *out, c
     }
     else if (!strcmp(field, "s"))
     {
-        for (int stage = 0; stage < N+1; stage++)
+        for (stage = 0; stage < N+1; stage++)
         {
             tmp_int = 2*dims->ns[stage];
             blasfeo_unpack_dvec(tmp_int, &out->ux[stage], dims->nu[stage] + dims->nx[stage],
@@ -1528,7 +1526,7 @@ void ocp_nlp_get_all(ocp_nlp_solver *solver, ocp_nlp_in *in, ocp_nlp_out *out, c
     }
     else if (!strcmp(field, "z"))
     {
-        for (int stage = 0; stage < N+1; stage++)
+        for (stage = 0; stage < N; stage++)
         {
             tmp_int = dims->nz[stage];
             blasfeo_unpack_dvec(tmp_int, &out->z[stage], 0, (double_values + tmp_offset), 1);
@@ -1537,7 +1535,7 @@ void ocp_nlp_get_all(ocp_nlp_solver *solver, ocp_nlp_in *in, ocp_nlp_out *out, c
     }
     else if (!strcmp(field, "pi"))
     {
-        for (int stage = 0; stage < N; stage++)
+        for (stage = 0; stage < N; stage++)
         {
             tmp_int = dims->nx[stage+1];
             blasfeo_unpack_dvec(tmp_int, &out->pi[stage], 0, (double_values + tmp_offset), 1);
@@ -1546,7 +1544,7 @@ void ocp_nlp_get_all(ocp_nlp_solver *solver, ocp_nlp_in *in, ocp_nlp_out *out, c
     }
     else if (!strcmp(field, "lam"))
     {
-        for (int stage = 0; stage < N+1; stage++)
+        for (stage = 0; stage < N+1; stage++)
         {
             tmp_int = 2*dims->ni[stage];
             blasfeo_unpack_dvec(tmp_int, &out->lam[stage], 0, (double_values + tmp_offset), 1);

--- a/interfaces/acados_c/ocp_nlp_interface.c
+++ b/interfaces/acados_c/ocp_nlp_interface.c
@@ -1467,6 +1467,90 @@ void ocp_nlp_get_from_iterate(ocp_nlp_solver *solver, int iter, int stage, const
     ocp_nlp_out_get(config, dims, nlp_mem->iterates[iter], stage, field, value);
 }
 
+
+void ocp_nlp_get_all(ocp_nlp_solver *solver, ocp_nlp_in *in, ocp_nlp_out *out, const char *field, void *value)
+{
+    ocp_nlp_config *config = solver->config;
+    ocp_nlp_memory *nlp_mem;
+    ocp_nlp_dims *dims = solver->dims;
+
+    double *double_values = value;
+    int tmp_offset = 0;
+    int N = dims->N;
+    int tmp_int;
+
+    if (!strcmp(field, "x"))
+    {
+        for (int stage = 0; stage < N+1; stage++)
+        {
+            tmp_int = dims->nx[stage];
+            blasfeo_unpack_dvec(tmp_int, &out->ux[stage], dims->nu[stage], (double_values + tmp_offset), 1);
+            tmp_offset += tmp_int;
+        }
+    }
+    else if (!strcmp(field, "u"))
+    {
+        for (int stage = 0; stage < N; stage++)
+        {
+            tmp_int = dims->nu[stage];
+            blasfeo_unpack_dvec(tmp_int, &out->ux[stage], 0, (double_values + tmp_offset), 1);
+            tmp_offset += tmp_int;
+        }
+    }
+    else if (!strcmp(field, "sl"))
+    {
+        for (int stage = 0; stage < N+1; stage++)
+        {
+            tmp_int = dims->ns[stage];
+            blasfeo_unpack_dvec(tmp_int, &out->ux[stage], dims->nu[stage] + dims->nx[stage], (double_values + tmp_offset), 1);
+            tmp_offset += tmp_int;
+        }
+    }
+    else if (!strcmp(field, "su"))
+    {
+        for (int stage = 0; stage < N+1; stage++)
+        {
+            tmp_int = dims->ns[stage];
+            blasfeo_unpack_dvec(tmp_int, &out->ux[stage], dims->nu[stage] + dims->nx[stage] + dims->ns[stage],
+                                (double_values + tmp_offset), 1);
+            tmp_offset += tmp_int;
+        }
+    }
+    else if (!strcmp(field, "z"))
+    {
+        for (int stage = 0; stage < N+1; stage++)
+        {
+            tmp_int = dims->nz[stage];
+            blasfeo_unpack_dvec(tmp_int, &out->z[stage], 0, (double_values + tmp_offset), 1);
+            tmp_offset += tmp_int;
+        }
+    }
+    else if (!strcmp(field, "pi"))
+    {
+        for (int stage = 0; stage < N; stage++)
+        {
+            tmp_int = dims->nx[stage+1];
+            blasfeo_unpack_dvec(tmp_int, &out->pi[stage], 0, (double_values + tmp_offset), 1);
+            tmp_offset += tmp_int;
+        }
+    }
+    else if (!strcmp(field, "lam"))
+    {
+        for (int stage = 0; stage < N+1; stage++)
+        {
+            tmp_int = 2*dims->ni[stage];
+            blasfeo_unpack_dvec(tmp_int, &out->lam[stage], 0, (double_values + tmp_offset), 1);
+            tmp_offset += tmp_int;
+        }
+    }
+    else
+    {
+        printf("\nerror: ocp_nlp_get_all: field %s not available\n", field);
+        exit(1);
+    }
+}
+
+
 void ocp_nlp_set(ocp_nlp_solver *solver, int stage, const char *field, void *value)
 {
     ocp_nlp_memory *mem;

--- a/interfaces/acados_c/ocp_nlp_interface.c
+++ b/interfaces/acados_c/ocp_nlp_interface.c
@@ -612,41 +612,35 @@ void ocp_nlp_out_destroy(void *out_)
 void ocp_nlp_out_set(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_out *out,
         int stage, const char *field, void *value)
 {
+    double *double_values = value;
     if (!strcmp(field, "x"))
     {
-        double *double_values = value;
         blasfeo_pack_dvec(dims->nx[stage], double_values, 1, &out->ux[stage], dims->nu[stage]);
     }
     else if (!strcmp(field, "u"))
     {
-        double *double_values = value;
         blasfeo_pack_dvec(dims->nu[stage], double_values, 1, &out->ux[stage], 0);
     }
     else if (!strcmp(field, "sl"))
     {
-        double *double_values = value;
         blasfeo_pack_dvec(dims->ns[stage], double_values, 1, &out->ux[stage],
                             dims->nu[stage] + dims->nx[stage]);
     }
     else if (!strcmp(field, "su"))
     {
-        double *double_values = value;
         blasfeo_pack_dvec(dims->ns[stage], double_values, 1, &out->ux[stage],
                             dims->nu[stage] + dims->nx[stage] + dims->ns[stage]);
     }
     else if (!strcmp(field, "pi"))
     {
-        double *double_values = value;
         blasfeo_pack_dvec(dims->nx[stage+1], double_values, 1, &out->pi[stage], 0);
     }
     else if (!strcmp(field, "lam"))
     {
-        double *double_values = value;
         blasfeo_pack_dvec(2*dims->ni[stage], double_values, 1, &out->lam[stage], 0);
     }
     else if (!strcmp(field, "z"))
     {
-        double *double_values = value;
         blasfeo_pack_dvec(dims->nz[stage], double_values, 1, &out->z[stage], 0);
     }
     else

--- a/interfaces/acados_c/ocp_nlp_interface.c
+++ b/interfaces/acados_c/ocp_nlp_interface.c
@@ -1516,6 +1516,16 @@ void ocp_nlp_get_all(ocp_nlp_solver *solver, ocp_nlp_in *in, ocp_nlp_out *out, c
             tmp_offset += tmp_int;
         }
     }
+    else if (!strcmp(field, "s"))
+    {
+        for (int stage = 0; stage < N+1; stage++)
+        {
+            tmp_int = 2*dims->ns[stage];
+            blasfeo_unpack_dvec(tmp_int, &out->ux[stage], dims->nu[stage] + dims->nx[stage],
+                                (double_values + tmp_offset), 1);
+            tmp_offset += tmp_int;
+        }
+    }
     else if (!strcmp(field, "z"))
     {
         for (int stage = 0; stage < N+1; stage++)

--- a/interfaces/acados_c/ocp_nlp_interface.c
+++ b/interfaces/acados_c/ocp_nlp_interface.c
@@ -1613,6 +1613,95 @@ void ocp_nlp_get_all(ocp_nlp_solver *solver, ocp_nlp_in *in, ocp_nlp_out *out, c
 }
 
 
+void ocp_nlp_set_all(ocp_nlp_solver *solver, ocp_nlp_in *in, ocp_nlp_out *out, const char *field, void *value)
+{
+    ocp_nlp_dims *dims = solver->dims;
+
+    double *double_values = value;
+    int tmp_offset = 0;
+    int N = dims->N;
+    int tmp_int, stage;
+
+    if (!strcmp(field, "x"))
+    {
+        for (stage = 0; stage < N+1; stage++)
+        {
+            tmp_int = dims->nx[stage];
+            blasfeo_pack_dvec(tmp_int, double_values + tmp_offset, 1, &out->ux[stage], dims->nu[stage]);
+            tmp_offset += tmp_int;
+        }
+    }
+    else if (!strcmp(field, "u"))
+    {
+        for (stage = 0; stage < N; stage++)
+        {
+            tmp_int = dims->nu[stage];
+            blasfeo_pack_dvec(tmp_int, double_values + tmp_offset, 1, &out->ux[stage], 0);
+            tmp_offset += tmp_int;
+        }
+    }
+    else if (!strcmp(field, "sl"))
+    {
+        for (stage = 0; stage < N+1; stage++)
+        {
+            tmp_int = dims->ns[stage];
+            blasfeo_pack_dvec(tmp_int, double_values + tmp_offset, 1, &out->ux[stage], dims->nx[stage] + dims->nu[stage]);
+            tmp_offset += tmp_int;
+        }
+    }
+    else if (!strcmp(field, "su"))
+    {
+        for (stage = 0; stage < N+1; stage++)
+        {
+            tmp_int = dims->ns[stage];
+            blasfeo_pack_dvec(tmp_int, double_values + tmp_offset, 1, &out->ux[stage], dims->nx[stage] + dims->nu[stage] + dims->ns[stage]);
+            tmp_offset += tmp_int;
+        }
+    }
+    else if (!strcmp(field, "s"))
+    {
+        for (stage = 0; stage < N+1; stage++)
+        {
+            tmp_int = 2*dims->ns[stage];
+            blasfeo_pack_dvec(tmp_int, double_values + tmp_offset, 1, &out->ux[stage], dims->nx[stage] + dims->nu[stage]);
+            tmp_offset += tmp_int;
+        }
+    }
+    else if (!strcmp(field, "z"))
+    {
+        for (stage = 0; stage < N; stage++)
+        {
+            tmp_int = dims->nz[stage];
+            blasfeo_pack_dvec(tmp_int, double_values + tmp_offset, 1, &out->z[stage], 0);
+            tmp_offset += tmp_int;
+        }
+    }
+    else if (!strcmp(field, "pi"))
+    {
+        for (stage = 0; stage < N; stage++)
+        {
+            tmp_int = dims->nx[stage+1];
+            blasfeo_pack_dvec(tmp_int, double_values + tmp_offset, 1, &out->pi[stage], 0);
+            tmp_offset += tmp_int;
+        }
+    }
+    else if (!strcmp(field, "lam"))
+    {
+        for (stage = 0; stage < N+1; stage++)
+        {
+            tmp_int = 2*dims->ni[stage];
+            blasfeo_pack_dvec(tmp_int, double_values + tmp_offset, 1, &out->lam[stage], 0);
+            tmp_offset += tmp_int;
+        }
+    }
+    else
+    {
+        printf("\nerror: ocp_nlp_set_all: field %s not available\n", field);
+        exit(1);
+    }
+}
+
+
 void ocp_nlp_set(ocp_nlp_solver *solver, int stage, const char *field, void *value)
 {
     ocp_nlp_memory *mem;

--- a/interfaces/acados_c/ocp_nlp_interface.h
+++ b/interfaces/acados_c/ocp_nlp_interface.h
@@ -310,6 +310,9 @@ ACADOS_SYMBOL_EXPORT void ocp_nlp_get_from_iterate(ocp_nlp_solver *solver, int i
 ACADOS_SYMBOL_EXPORT void ocp_nlp_get_all(ocp_nlp_solver *solver, ocp_nlp_in *in, ocp_nlp_out *out, const char *field, void *value);
 
 
+ACADOS_SYMBOL_EXPORT void ocp_nlp_set_all(ocp_nlp_solver *solver, ocp_nlp_in *in, ocp_nlp_out *out, const char *field, void *value);
+
+
 // TODO(andrea): remove this once/if the MATLAB interface uses the new setters below?
 ACADOS_SYMBOL_EXPORT int ocp_nlp_dims_get_from_attr(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_out *out,
         int stage, const char *field);

--- a/interfaces/acados_c/ocp_nlp_interface.h
+++ b/interfaces/acados_c/ocp_nlp_interface.h
@@ -323,6 +323,8 @@ ACADOS_SYMBOL_EXPORT void ocp_nlp_cost_dims_get_from_attr(ocp_nlp_config *config
 ACADOS_SYMBOL_EXPORT void ocp_nlp_qp_dims_get_from_attr(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_out *out,
         int stage, const char *field, int *dims_out);
 
+int ocp_nlp_dims_get_total_from_attr(ocp_nlp_config *config, ocp_nlp_dims *dims, const char *field);
+
 /* opts */
 
 /// Creates an options struct for the non-linear program.

--- a/interfaces/acados_c/ocp_nlp_interface.h
+++ b/interfaces/acados_c/ocp_nlp_interface.h
@@ -306,6 +306,10 @@ ACADOS_SYMBOL_EXPORT void ocp_nlp_get_at_stage(ocp_nlp_solver *solver, int stage
 
 ACADOS_SYMBOL_EXPORT void ocp_nlp_get_from_iterate(ocp_nlp_solver *solver, int iter, int stage, const char *field, void *value);
 
+
+ACADOS_SYMBOL_EXPORT void ocp_nlp_get_all(ocp_nlp_solver *solver, ocp_nlp_in *in, ocp_nlp_out *out, const char *field, void *value);
+
+
 // TODO(andrea): remove this once/if the MATLAB interface uses the new setters below?
 ACADOS_SYMBOL_EXPORT int ocp_nlp_dims_get_from_attr(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_out *out,
         int stage, const char *field);

--- a/interfaces/acados_template/acados_template/acados_ocp_iterate.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_iterate.py
@@ -68,3 +68,13 @@ class AcadosOcpIterates:
             raise Exception(f"Stage-wise dimensions are not the same for {field} trajectory.")
 
         return traj
+
+@dataclass
+class AcadosOcpFlattenedIterate:
+    x: np.ndarray
+    u: np.ndarray
+    z: np.ndarray
+    sl: np.ndarray
+    su: np.ndarray
+    pi: np.ndarray
+    lam: np.ndarray

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -56,7 +56,7 @@ from .gnsf.detect_gnsf_structure import detect_gnsf_structure
 from .utils import (get_shared_lib_ext, get_shared_lib_prefix, get_shared_lib_dir, get_shared_lib,
                     make_object_json_dumpable, set_up_imported_gnsf_model, verbose_system_call,
                     acados_lib_is_compiled_with_openmp)
-from .acados_ocp_iterate import AcadosOcpIterate, AcadosOcpIterates
+from .acados_ocp_iterate import AcadosOcpIterate, AcadosOcpIterates, AcadosOcpFlattenedIterate
 
 
 class AcadosOcpSolver:
@@ -1126,6 +1126,32 @@ class AcadosOcpSolver:
 
             for n, val in enumerate(traj):
                 self.set(n, field, val)
+
+
+    def store_iterate_to_flat_obj(self) -> AcadosOcpFlattenedIterate:
+        """
+        Returns the current iterate of the OCP solver as an AcadosOcpFlattenedIterate.
+        """
+        return AcadosOcpFlattenedIterate(x = self.get_flat("x"),
+                                        u = self.get_flat("u"),
+                                        z = self.get_flat("z"),
+                                        sl = self.get_flat("sl"),
+                                        su = self.get_flat("su"),
+                                        pi = self.get_flat("pi"),
+                                        lam = self.get_flat("lam"))
+
+    def load_iterate_from_flat_obj(self, iterate: AcadosOcpFlattenedIterate) -> None:
+        """
+        Loads the provided iterate into the OCP solver.
+        Note: The iterate object does not contain the the parameters.
+        """
+        self.set_flat("x", iterate.x)
+        self.set_flat("u", iterate.u)
+        self.set_flat("z", iterate.z)
+        self.set_flat("sl", iterate.sl)
+        self.set_flat("su", iterate.su)
+        self.set_flat("pi", iterate.pi)
+        self.set_flat("lam", iterate.lam)
 
 
     def get_status(self) -> int:

--- a/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_solver_sfun.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_solver_sfun.in.c
@@ -678,6 +678,7 @@ static void mdlOutputs(SimStruct *S, int_T tid)
     ocp_nlp_dims *nlp_dims = {{ name }}_acados_get_nlp_dims(capsule);
     ocp_nlp_in *nlp_in = {{ name }}_acados_get_nlp_in(capsule);
     ocp_nlp_out *nlp_out = {{ name }}_acados_get_nlp_out(capsule);
+    ocp_nlp_solver *nlp_solver = {{ name }}_acados_get_nlp_solver(capsule);
 
     InputRealPtrsType in_sign;
 
@@ -1199,7 +1200,7 @@ static void mdlOutputs(SimStruct *S, int_T tid)
   {%- if custom_update_filename == "" and not simulink_opts.inputs.rti_phase %}
     int acados_status = {{ name }}_acados_solve(capsule);
     // get time
-    ocp_nlp_get(capsule->nlp_solver, "time_tot", (void *) buffer);
+    ocp_nlp_get(nlp_solver, "time_tot", (void *) buffer);
     tmp_double = buffer[0];
 
   {%- elif simulink_opts.inputs.rti_phase %}{# SPLIT RTI PHASE#}
@@ -1211,7 +1212,7 @@ static void mdlOutputs(SimStruct *S, int_T tid)
     ocp_nlp_solver_opts_set(nlp_config, capsule->nlp_opts, "rti_phase", &rti_phase);
     int acados_status = {{ name }}_acados_solve(capsule);
     // get time
-    ocp_nlp_get(capsule->nlp_solver, "time_tot", (void *) buffer);
+    ocp_nlp_get(nlp_solver, "time_tot", (void *) buffer);
     tmp_double = buffer[0];
     {%- endif %}
   {%- elif solver_options.nlp_solver_type == "SQP_RTI" %}{# if custom_update_filename != "" #}
@@ -1221,7 +1222,7 @@ static void mdlOutputs(SimStruct *S, int_T tid)
     int acados_status = {{ name }}_acados_solve(capsule);
 
     // preparation time
-    ocp_nlp_get(capsule->nlp_solver, "time_tot", (void *) buffer);
+    ocp_nlp_get(nlp_solver, "time_tot", (void *) buffer);
     tmp_double = buffer[0];
 
     // call custom update function
@@ -1234,7 +1235,7 @@ static void mdlOutputs(SimStruct *S, int_T tid)
     ocp_nlp_solver_opts_set(nlp_config, capsule->nlp_opts, "rti_phase", &rti_phase);
     acados_status = {{ name }}_acados_solve(capsule);
     // feedback time
-    ocp_nlp_get(capsule->nlp_solver, "time_tot", (void *) buffer);
+    ocp_nlp_get(nlp_solver, "time_tot", (void *) buffer);
     tmp_double += buffer[0];
   {%- else -%}
     Simulink block with custom solver template only works with SQP_RTI!
@@ -1320,8 +1321,8 @@ static void mdlOutputs(SimStruct *S, int_T tid)
   {%- if simulink_opts.outputs.cost_value == 1 %}
     {%- set i_output = i_output + 1 %}
     out_ptr = ssGetOutputPortRealSignal(S, {{ i_output }});
-    ocp_nlp_eval_cost(capsule->nlp_solver, nlp_in, nlp_out);
-    ocp_nlp_get(capsule->nlp_solver, "cost_value", (void *) out_ptr);
+    ocp_nlp_eval_cost(nlp_solver, nlp_in, nlp_out);
+    ocp_nlp_get(nlp_solver, "cost_value", (void *) out_ptr);
   {%- endif %}
 
   {%- if simulink_opts.outputs.KKT_residual == 1 %}
@@ -1335,12 +1336,12 @@ static void mdlOutputs(SimStruct *S, int_T tid)
     out_ptr = ssGetOutputPortRealSignal(S, {{ i_output }});
 
     {%- if solver_options.nlp_solver_type == "SQP_RTI" %}
-    ocp_nlp_eval_residuals(capsule->nlp_solver, nlp_in, nlp_out);
+    ocp_nlp_eval_residuals(nlp_solver, nlp_in, nlp_out);
     {%- endif %}
-    ocp_nlp_get(capsule->nlp_solver, "res_stat", (void *) &out_ptr[0]);
-    ocp_nlp_get(capsule->nlp_solver, "res_eq", (void *) &out_ptr[1]);
-    ocp_nlp_get(capsule->nlp_solver, "res_ineq", (void *) &out_ptr[2]);
-    ocp_nlp_get(capsule->nlp_solver, "res_comp", (void *) &out_ptr[3]);
+    ocp_nlp_get(nlp_solver, "res_stat", (void *) &out_ptr[0]);
+    ocp_nlp_get(nlp_solver, "res_eq", (void *) &out_ptr[1]);
+    ocp_nlp_get(nlp_solver, "res_ineq", (void *) &out_ptr[2]);
+    ocp_nlp_get(nlp_solver, "res_comp", (void *) &out_ptr[3]);
   {%- endif %}
 
   {%- if solver_options.N_horizon > 0 and simulink_opts.outputs.x1 == 1 %}
@@ -1358,26 +1359,26 @@ static void mdlOutputs(SimStruct *S, int_T tid)
   {%- if simulink_opts.outputs.CPU_time_sim == 1 %}
     {%- set i_output = i_output + 1 %}
     out_ptr = ssGetOutputPortRealSignal(S, {{ i_output }});
-    ocp_nlp_get(capsule->nlp_solver, "time_sim", (void *) out_ptr);
+    ocp_nlp_get(nlp_solver, "time_sim", (void *) out_ptr);
   {%- endif -%}
 
   {%- if simulink_opts.outputs.CPU_time_qp == 1 %}
     {%- set i_output = i_output + 1 %}
     out_ptr = ssGetOutputPortRealSignal(S, {{ i_output }});
-    ocp_nlp_get(capsule->nlp_solver, "time_qp", (void *) out_ptr);
+    ocp_nlp_get(nlp_solver, "time_qp", (void *) out_ptr);
   {%- endif -%}
 
   {%- if simulink_opts.outputs.CPU_time_lin == 1 %}
     {%- set i_output = i_output + 1 %}
     out_ptr = ssGetOutputPortRealSignal(S, {{ i_output }});
-    ocp_nlp_get(capsule->nlp_solver, "time_lin", (void *) out_ptr);
+    ocp_nlp_get(nlp_solver, "time_lin", (void *) out_ptr);
   {%- endif -%}
 
   {%- if simulink_opts.outputs.sqp_iter == 1 %}
     {%- set i_output = i_output + 1 %}
     out_ptr = ssGetOutputPortRealSignal(S, {{ i_output }});
     // get sqp iter
-    ocp_nlp_get(capsule->nlp_solver, "sqp_iter", (void *) &tmp_int);
+    ocp_nlp_get(nlp_solver, "sqp_iter", (void *) &tmp_int);
     *out_ptr = (double) tmp_int;
   {%- endif %}
 

--- a/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_solver_sfun.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_solver_sfun.in.c
@@ -1253,63 +1253,31 @@ static void mdlOutputs(SimStruct *S, int_T tid)
   {%- if simulink_opts.outputs.utraj == 1 %}
     {%- set i_output = i_output + 1 %}
     out_ptr = ssGetOutputPortRealSignal(S, {{ i_output }});
-    tmp_offset = 0;
-    for (int stage = 0; stage < N; stage++)
-    {
-        tmp_int = ocp_nlp_dims_get_from_attr(nlp_config, nlp_dims, nlp_out, stage, "u");
-        ocp_nlp_out_get(nlp_config, nlp_dims, nlp_out, stage, "u", (void *) (out_ptr + tmp_offset));
-        tmp_offset += tmp_int;
-    }
+    ocp_nlp_get_all(nlp_solver, nlp_in, nlp_out, "u", out_ptr);
   {%- endif %}
 
   {% if simulink_opts.outputs.xtraj == 1 %}
     {%- set i_output = i_output + 1 %}
     out_ptr = ssGetOutputPortRealSignal(S, {{ i_output }});
-    tmp_offset = 0;
-    for (int stage = 0; stage < {{ solver_options.N_horizon + 1 }}; stage++)
-    {
-        tmp_int = ocp_nlp_dims_get_from_attr(nlp_config, nlp_dims, nlp_out, stage, "x");
-        ocp_nlp_out_get(nlp_config, nlp_dims, nlp_out, stage, "x", (void *) (out_ptr + tmp_offset));
-        tmp_offset += tmp_int;
-    }
+    ocp_nlp_get_all(nlp_solver, nlp_in, nlp_out, "x", out_ptr);
   {%- endif %}
 
   {% if simulink_opts.outputs.ztraj == 1 %}
     {%- set i_output = i_output + 1 %}
     out_ptr = ssGetOutputPortRealSignal(S, {{ i_output }});
-    tmp_offset = 0;
-    for (int stage = 0; stage < N; stage++)
-    {
-        tmp_int = ocp_nlp_dims_get_from_attr(nlp_config, nlp_dims, nlp_out, stage, "z");
-        ocp_nlp_out_get(nlp_config, nlp_dims, nlp_out, stage, "z", (void *) (out_ptr + tmp_offset));
-        tmp_offset += tmp_int;
-    }
+    ocp_nlp_get_all(nlp_solver, nlp_in, nlp_out, "z", out_ptr);
   {%- endif %}
 
   {% if simulink_opts.outputs.pi_all == 1 %}
     {%- set i_output = i_output + 1 %}
     out_ptr = ssGetOutputPortRealSignal(S, {{ i_output }});
-    tmp_offset = 0;
-    for (int stage = 0; stage < N; stage++)
-    {
-        tmp_int = ocp_nlp_dims_get_from_attr(nlp_config, nlp_dims, nlp_out, stage, "pi");
-        ocp_nlp_out_get(nlp_config, nlp_dims, nlp_out, stage, "pi", (void *) (out_ptr + tmp_offset));
-        tmp_offset += tmp_int;
-    }
+    ocp_nlp_get_all(nlp_solver, nlp_in, nlp_out, "pi", out_ptr);
   {%- endif %}
 
   {% if simulink_opts.outputs.slack_values == 1 %}
     {%- set i_output = i_output + 1 %}
     out_ptr = ssGetOutputPortRealSignal(S, {{ i_output }});
-    tmp_offset = 0;
-    for (int stage = 0; stage <= N; stage++)
-    {
-        tmp_int = ocp_nlp_dims_get_from_attr(nlp_config, nlp_dims, nlp_out, stage, "sl");
-        ocp_nlp_out_get(nlp_config, nlp_dims, nlp_out, stage, "sl", (void *) (out_ptr + tmp_offset));
-        tmp_offset += tmp_int;
-        ocp_nlp_out_get(nlp_config, nlp_dims, nlp_out, stage, "su", (void *) (out_ptr + tmp_offset));
-        tmp_offset += tmp_int;
-    }
+    ocp_nlp_get_all(nlp_solver, nlp_in, nlp_out, "s", out_ptr);
   {%- endif %}
 
   {%- if simulink_opts.outputs.solver_status == 1 %}

--- a/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_solver_sfun.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_solver_sfun.in.c
@@ -718,6 +718,8 @@ static void mdlOutputs(SimStruct *S, int_T tid)
     double buffer[{{ buffer_size }}];
     double tmp_double;
     int tmp_offset, tmp_int;
+    {#- TODO: probably the whole buffer stuff can be avoided! #}
+    {#- TODO: use something like ocp_nlp_set_all(nlp_solver, nlp_in, nlp_out, "x", in_sign); for initializing #}
 
     /* go through inputs */
     {%- set i_input = -1 %}


### PR DESCRIPTION
- C: implement new functions `ocp_nlp_dims_get_total_from_attr`,  `ocp_nlp_get_all`, `ocp_nlp_set_all`
- Python: implement `AcadosOcpFlattenedIterate`, `AcadosOcpSolver.store_iterate_to_flat_obj`, `AcadosOcpSolver.load_iterate_from_flat_obj`
- Simulink: simplify logic using the new functions in the C interface.

The flat iterates are now used in the chain sensitivity example and show significant speedup.
Timings before with `AcadosOcpIterate` object:
![no_flat_iterates](https://github.com/user-attachments/assets/39af22a7-d542-471b-bff3-49b288b734ed)


Timings now with `AcadosOcpFlattenedIterate` object:
![flat_iterates](https://github.com/user-attachments/assets/939a0ee6-f965-47df-9b18-67e2d8dc3d7e)
