### PR TITLE
CI: codeql use upload-artifact@v4

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -115,7 +115,7 @@ jobs:
 
     - name: Upload CodeQL results as an artifact
       if: success() || failure()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: codeql-results
         path: ${{ steps.step1.outputs.sarif-output }}


### PR DESCRIPTION
v3 will be deprecated soon, see
https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/