### PR TITLE
Solution sensitivities refactoring

### DIFF
--- a/acados/ocp_nlp/ocp_nlp_common.c
+++ b/acados/ocp_nlp/ocp_nlp_common.c
@@ -3185,6 +3185,10 @@ void ocp_nlp_cost_compute(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in
 
 void ocp_nlp_params_jac_compute(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in, ocp_nlp_opts *opts, ocp_nlp_memory *mem, ocp_nlp_workspace *work)
 {
+    // This function sets up: jac_lag_stat_p_global, jac_ineq_p_global, jac_dyn_p_global
+    // - jac_dyn_p_global is computed in dynamics module
+    // - jac_ineq_p_global is computed in constraints module (TODO!)
+    // - jac_lag_stat_p_global: first dynamics writes its contribution, then cost and constraints modules add their contribution.
     int N = dims->N;
     int np_global = dims->np_global;
     int i;
@@ -3198,11 +3202,6 @@ void ocp_nlp_params_jac_compute(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_
     struct blasfeo_dmat *jac_lag_stat_p_global = mem->jac_lag_stat_p_global;
     struct blasfeo_dmat *jac_ineq_p_global = mem->jac_ineq_p_global;
     // struct blasfeo_dmat *jac_dyn_p_global = mem->jac_dyn_p_global;
-
-    // NOTE: this sets up: jac_lag_stat_p_global, jac_ineq_p_global, jac_dyn_p_global
-    // - jac_dyn_p_global is computed in dynamics module
-    // - jac_ineq_p_global is computed in constraints module (TODO!)
-    // - jac_lag_stat_p_global: first dynamics writes its contribution, then cost and constraints modules add their contribution.
 
 #if defined(ACADOS_WITH_OPENMP)
     #pragma omp parallel for

--- a/acados/ocp_nlp/ocp_nlp_common.c
+++ b/acados/ocp_nlp/ocp_nlp_common.c
@@ -1486,16 +1486,16 @@ acados_size_t ocp_nlp_memory_calculate_size(ocp_nlp_config *config, ocp_nlp_dims
 
     if (opts->with_solution_sens_wrt_params)
     {
-        size += 2*(N+1)*sizeof(struct blasfeo_dmat); // jac_lag_stat_p_global, tmp_2ni_x_np_global
-        size += N * sizeof(struct blasfeo_dmat);  // tmp_nxnext_x_np_global
+        size += 2*(N+1)*sizeof(struct blasfeo_dmat); // jac_lag_stat_p_global, jac_ineq_p_global
+        size += N * sizeof(struct blasfeo_dmat);  // jac_dyn_p_global
         for (int i = 0; i <= N; i++)
         {
             size += blasfeo_memsize_dmat(nv[i], np_global);  // jac_lag_stat_p_global
-            size += blasfeo_memsize_dmat(2*ni[i], np_global);  // tmp_2ni_x_np_global
+            size += blasfeo_memsize_dmat(2*ni[i], np_global);  // jac_ineq_p_global
         }
         for (int i = 0; i < N; i++)
         {
-            size += blasfeo_memsize_dmat(nx[i+1], np_global);  // tmp_nxnext_x_np_global
+            size += blasfeo_memsize_dmat(nx[i+1], np_global);  // jac_dyn_p_global
         }
     }
 
@@ -1669,8 +1669,8 @@ ocp_nlp_memory *ocp_nlp_memory_assign(ocp_nlp_config *config, ocp_nlp_dims *dims
     if (opts->with_solution_sens_wrt_params)
     {
         assign_and_advance_blasfeo_dmat_structs(N + 1, &mem->jac_lag_stat_p_global, &c_ptr);
-        assign_and_advance_blasfeo_dmat_structs(N + 1, &mem->tmp_2ni_x_np_global, &c_ptr);
-        assign_and_advance_blasfeo_dmat_structs(N, &mem->tmp_nxnext_x_np_global, &c_ptr);
+        assign_and_advance_blasfeo_dmat_structs(N + 1, &mem->jac_ineq_p_global, &c_ptr);
+        assign_and_advance_blasfeo_dmat_structs(N, &mem->jac_dyn_p_global, &c_ptr);
     }
 
     // dzduxt
@@ -1707,11 +1707,11 @@ ocp_nlp_memory *ocp_nlp_memory_assign(ocp_nlp_config *config, ocp_nlp_dims *dims
         for (int i = 0; i <= N; i++)
         {
             assign_and_advance_blasfeo_dmat_mem(nv[i], np_global, mem->jac_lag_stat_p_global+i, &c_ptr);
-            assign_and_advance_blasfeo_dmat_mem(2*ni[i], np_global, mem->tmp_2ni_x_np_global+i, &c_ptr);
+            assign_and_advance_blasfeo_dmat_mem(2*ni[i], np_global, mem->jac_ineq_p_global+i, &c_ptr);
         }
         for (int i = 0; i < N; i++)
         {
-            assign_and_advance_blasfeo_dmat_mem(nx[i+1], np_global, mem->tmp_nxnext_x_np_global+i, &c_ptr);
+            assign_and_advance_blasfeo_dmat_mem(nx[i+1], np_global, mem->jac_dyn_p_global+i, &c_ptr);
         }
     }
 
@@ -2372,7 +2372,7 @@ void ocp_nlp_alias_memory_to_submodules(ocp_nlp_config *config, ocp_nlp_dims *di
 
         if (opts->with_solution_sens_wrt_params)
         {
-            config->dynamics[i]->memory_set_dyn_jac_p_global_ptr(nlp_mem->tmp_nxnext_x_np_global+i, nlp_mem->dynamics[i]);
+            config->dynamics[i]->memory_set_dyn_jac_p_global_ptr(nlp_mem->jac_dyn_p_global+i, nlp_mem->dynamics[i]);
             config->dynamics[i]->memory_set_jac_lag_stat_p_global_ptr(nlp_mem->jac_lag_stat_p_global+i, nlp_mem->dynamics[i]);
         }
 
@@ -3191,18 +3191,26 @@ void ocp_nlp_params_jac_compute(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_
 
     int *nv = dims->nv;
     int *ni = dims->ni;
+    int *nx = dims->nx;
+    int *nu = dims->nu;
+    int *ns = dims->ns;
 
     struct blasfeo_dmat *jac_lag_stat_p_global = mem->jac_lag_stat_p_global;
-    struct blasfeo_dmat *tmp_2ni_x_np_global = mem->tmp_2ni_x_np_global;
-    // struct blasfeo_dmat *tmp_nxnext_x_np_global = mem->tmp_nxnext_x_np_global;
+    struct blasfeo_dmat *jac_ineq_p_global = mem->jac_ineq_p_global;
+    // struct blasfeo_dmat *jac_dyn_p_global = mem->jac_dyn_p_global;
+
+    // NOTE: this sets up: jac_lag_stat_p_global, jac_ineq_p_global, jac_dyn_p_global
+    // - jac_dyn_p_global is computed in dynamics module
+    // - jac_ineq_p_global is computed in constraints module (TODO!)
+    // - jac_lag_stat_p_global: first dynamics writes its contribution, then cost and constraints modules add their contribution.
 
 #if defined(ACADOS_WITH_OPENMP)
     #pragma omp parallel for
 #endif
     for (i = 0; i < N; i++)
     {
-        blasfeo_dgese(nv[i], np_global, 0., &jac_lag_stat_p_global[i], 0, 0);
-        blasfeo_dgese(2*ni[i], np_global, 0., &tmp_2ni_x_np_global[i], 0, 0);
+        blasfeo_dgese(2*ns[i], np_global, 0., &jac_lag_stat_p_global[i], nx[i]+nu[i], 0);  // first nx+nu rows are overwritten by dynamics anyway
+        blasfeo_dgese(2*ni[i], np_global, 0., &jac_ineq_p_global[i], 0, 0);
         config->dynamics[i]->compute_jac_hess_p(config->dynamics[i], dims->dynamics[i], in->dynamics[i],
                     opts->dynamics[i], mem->dynamics[i], work->dynamics[i]);
         config->cost[i]->compute_jac_p(config->cost[i], dims->cost[i], in->cost[i], opts->cost[i], mem->cost[i], work->cost[i]);
@@ -3210,8 +3218,8 @@ void ocp_nlp_params_jac_compute(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_
 
     // terminal
     i = N;
-    blasfeo_dgese(nv[i], np_global, 0., &jac_lag_stat_p_global[i], 0, 0);
-    blasfeo_dgese(2*ni[i], np_global, 0., &tmp_2ni_x_np_global[i], 0, 0);
+    blasfeo_dgese(nv[i], np_global, 0., &jac_lag_stat_p_global[i], 0, 0);  // only needed here, as dynamics dont contribute
+    blasfeo_dgese(2*ni[i], np_global, 0., &jac_ineq_p_global[i], 0, 0);
     config->cost[i]->compute_jac_p(config->cost[i], dims->cost[i], in->cost[i], opts->cost[i], mem->cost[i], work->cost[i]);
 }
 
@@ -3228,8 +3236,8 @@ void ocp_nlp_common_eval_param_sens(ocp_nlp_config *config, ocp_nlp_dims *dims,
     int *nx = dims->nx;
 
     struct blasfeo_dmat *jac_lag_stat_p_global = mem->jac_lag_stat_p_global;
-    // struct blasfeo_dmat *tmp_2ni_x_np_global = mem->tmp_2ni_x_np_global;
-    struct blasfeo_dmat *tmp_nxnext_x_np_global = mem->tmp_nxnext_x_np_global;
+    // struct blasfeo_dmat *jac_ineq_p_global = mem->jac_ineq_p_global;
+    struct blasfeo_dmat *jac_dyn_p_global = mem->jac_dyn_p_global;
 
     ocp_qp_in *tmp_qp_in = work->tmp_qp_in;
     ocp_qp_out *tmp_qp_out = work->tmp_qp_out;
@@ -3246,7 +3254,7 @@ void ocp_nlp_common_eval_param_sens(ocp_nlp_config *config, ocp_nlp_dims *dims,
     {
         for (i = 0; i < N; i++)
         {
-            blasfeo_dcolex(nx[i+1], &tmp_nxnext_x_np_global[i], 0, index, &tmp_qp_in->b[i], 0);
+            blasfeo_dcolex(nx[i+1], &jac_dyn_p_global[i], 0, index, &tmp_qp_in->b[i], 0);
             blasfeo_dcolex(nv[i], &jac_lag_stat_p_global[i], 0, index, &tmp_qp_in->rqz[i], 0);
         }
 
@@ -3290,8 +3298,8 @@ void ocp_nlp_common_eval_solution_sens_adj_p(ocp_nlp_config *config, ocp_nlp_dim
     int *nx = dims->nx;
 
     struct blasfeo_dmat *jac_lag_stat_p_global = mem->jac_lag_stat_p_global;
-    struct blasfeo_dmat *tmp_2ni_x_np_global = mem->tmp_2ni_x_np_global;
-    struct blasfeo_dmat *tmp_nxnext_x_np_global = mem->tmp_nxnext_x_np_global;
+    struct blasfeo_dmat *jac_ineq_p_global = mem->jac_ineq_p_global;
+    struct blasfeo_dmat *jac_dyn_p_global = mem->jac_dyn_p_global;
 
     ocp_qp_in *tmp_qp_in = work->tmp_qp_in;
     ocp_qp_out *tmp_qp_out = work->tmp_qp_out;
@@ -3320,15 +3328,15 @@ void ocp_nlp_common_eval_solution_sens_adj_p(ocp_nlp_config *config, ocp_nlp_dim
         {
             // multiply J.T with result of backsolve and add to in mem->out_np_global
             blasfeo_dgemv_t(nv[i], np_global, 1.0, &jac_lag_stat_p_global[i], 0, 0, tmp_qp_out->ux+i, 0, 1.0, &mem->out_np_global, 0, &mem->out_np_global, 0);
-            blasfeo_dgemv_t(ni[i], np_global, 1.0, &tmp_2ni_x_np_global[i], 0, 0, tmp_qp_out->lam+i, 0, 1.0, &mem->out_np_global, 0, &mem->out_np_global, 0);
-            blasfeo_dgemv_t(nx[i+1], np_global, 1.0, &tmp_nxnext_x_np_global[i], 0, 0, tmp_qp_out->pi+i, 0, 1.0, &mem->out_np_global, 0, &mem->out_np_global, 0);
+            blasfeo_dgemv_t(ni[i], np_global, 1.0, &jac_ineq_p_global[i], 0, 0, tmp_qp_out->lam+i, 0, 1.0, &mem->out_np_global, 0, &mem->out_np_global, 0);
+            blasfeo_dgemv_t(nx[i+1], np_global, 1.0, &jac_dyn_p_global[i], 0, 0, tmp_qp_out->pi+i, 0, 1.0, &mem->out_np_global, 0, &mem->out_np_global, 0);
         }
 
         // terminal
         i = N;
         // multiply J.T with result of backsolve and add to in mem->out_np_global
         blasfeo_dgemv_t(nv[i], np_global, 1.0, &jac_lag_stat_p_global[i], 0, 0, tmp_qp_out->ux+i, 0, 1.0, &mem->out_np_global, 0, &mem->out_np_global, 0);
-        blasfeo_dgemv_t(ni[i], np_global, 1.0, &tmp_2ni_x_np_global[i], 0, 0, tmp_qp_out->lam+i, 0, 1.0, &mem->out_np_global, 0, &mem->out_np_global, 0);
+        blasfeo_dgemv_t(ni[i], np_global, 1.0, &jac_ineq_p_global[i], 0, 0, tmp_qp_out->lam+i, 0, 1.0, &mem->out_np_global, 0, &mem->out_np_global, 0);
 
         // unpack
         blasfeo_unpack_dvec(np_global, &mem->out_np_global, 0, grad_p, 1);

--- a/acados/ocp_nlp/ocp_nlp_common.c
+++ b/acados/ocp_nlp/ocp_nlp_common.c
@@ -2370,7 +2370,6 @@ void ocp_nlp_alias_memory_to_submodules(ocp_nlp_config *config, ocp_nlp_dims *di
         // NOTE: no z at terminal stage, since dynamics modules dont compute it.
         config->dynamics[i]->memory_set_z_alg_ptr(nlp_mem->z_alg+i, nlp_mem->dynamics[i]);
 
-        printf("memory_set_dyn_jac_p_global_ptr %d\n", i);
         if (opts->with_solution_sens_wrt_params)
         {
             config->dynamics[i]->memory_set_dyn_jac_p_global_ptr(nlp_mem->tmp_nxnext_x_np_global+i, nlp_mem->dynamics[i]);

--- a/acados/ocp_nlp/ocp_nlp_common.c
+++ b/acados/ocp_nlp/ocp_nlp_common.c
@@ -2373,6 +2373,7 @@ void ocp_nlp_alias_memory_to_submodules(ocp_nlp_config *config, ocp_nlp_dims *di
         if (opts->with_solution_sens_wrt_params)
         {
             config->dynamics[i]->memory_set_dyn_jac_p_global_ptr(nlp_mem->tmp_nxnext_x_np_global+i, nlp_mem->dynamics[i]);
+            config->dynamics[i]->memory_set_jac_lag_stat_p_global_ptr(nlp_mem->tmp_nv_x_np_global+i, nlp_mem->dynamics[i]);
         }
 
         int cost_integration;
@@ -2403,6 +2404,10 @@ void ocp_nlp_alias_memory_to_submodules(ocp_nlp_config *config, ocp_nlp_dims *di
 #endif
     for (int i = 0; i <= N; i++)
     {
+        if (opts->with_solution_sens_wrt_params)
+        {
+            config->cost[i]->memory_set_jac_lag_stat_p_global_ptr(nlp_mem->tmp_nv_x_np_global+i, nlp_mem->cost[i]);
+        }
         config->cost[i]->memory_set_ux_ptr(nlp_out->ux+i, nlp_mem->cost[i]);
         config->cost[i]->memory_set_z_alg_ptr(nlp_mem->z_alg+i, nlp_mem->cost[i]);
         config->cost[i]->memory_set_dzdux_tran_ptr(nlp_mem->dzduxt+i, nlp_mem->cost[i]);
@@ -3182,12 +3187,11 @@ void ocp_nlp_params_jac_compute(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_
 {
     int N = dims->N;
     int np_global = dims->np_global;
-    int i, k;
+    int i;
 
     int *nv = dims->nv;
     int *ni = dims->ni;
 
-    ocp_qp_in *tmp_qp_in = work->tmp_qp_in;
     struct blasfeo_dmat *tmp_nv_x_np_global = mem->tmp_nv_x_np_global;
     struct blasfeo_dmat *tmp_2ni_x_np_global = mem->tmp_2ni_x_np_global;
     // struct blasfeo_dmat *tmp_nxnext_x_np_global = mem->tmp_nxnext_x_np_global;
@@ -3197,37 +3201,18 @@ void ocp_nlp_params_jac_compute(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_
 #endif
     for (i = 0; i < N; i++)
     {
+        blasfeo_dgese(nv[i], np_global, 0., &tmp_nv_x_np_global[i], 0, 0);
+        blasfeo_dgese(2*ni[i], np_global, 0., &tmp_2ni_x_np_global[i], 0, 0);
         config->dynamics[i]->compute_jac_hess_p(config->dynamics[i], dims->dynamics[i], in->dynamics[i],
                     opts->dynamics[i], mem->dynamics[i], work->dynamics[i]);
         config->cost[i]->compute_jac_p(config->cost[i], dims->cost[i], in->cost[i], opts->cost[i], mem->cost[i], work->cost[i]);
-
-        // copy gradients to column in jacobian
-        blasfeo_dgese(nv[i], np_global, 0., &tmp_nv_x_np_global[i], 0, 0);
-        blasfeo_dgese(2*ni[i], np_global, 0., &tmp_2ni_x_np_global[i], 0, 0);
-        for (k = 0; k < np_global; k++)
-        {
-            config->dynamics[i]->memory_get_params_lag_grad(config->dynamics[i], dims->dynamics[i], opts,
-                        mem->dynamics[i], k, &tmp_qp_in->rqz[i], 0);
-            config->cost[i]->memory_get_params_grad(config->cost[i], dims->cost[i], opts,
-                        mem->cost[i], k, &work->tmp_nv, 0);
-            blasfeo_dvecad(nv[i], 1., &work->tmp_nv, 0, &tmp_qp_in->rqz[i], 0);
-            // copy gradient to column in jacobian
-            blasfeo_dcolad(nv[i], 1.0, &tmp_qp_in->rqz[i], 0, &tmp_nv_x_np_global[i], 0, k);
-        }
     }
 
     // terminal
     i = N;
-    config->cost[i]->compute_jac_p(config->cost[i], dims->cost[i], in->cost[i], opts->cost[i], mem->cost[i], work->cost[i]);
-
     blasfeo_dgese(nv[i], np_global, 0., &tmp_nv_x_np_global[i], 0, 0);
     blasfeo_dgese(2*ni[i], np_global, 0., &tmp_2ni_x_np_global[i], 0, 0);
-    for (k = 0; k < np_global; k++)
-    {
-        config->cost[i]->memory_get_params_grad(config->cost[i], dims->cost[i], opts,
-                        mem->cost[i], k, &tmp_qp_in->rqz[i], 0);
-        blasfeo_dcolad(nv[i], 1., &tmp_qp_in->rqz[i], 0, &tmp_nv_x_np_global[i], 0, k);
-    }
+    config->cost[i]->compute_jac_p(config->cost[i], dims->cost[i], in->cost[i], opts->cost[i], mem->cost[i], work->cost[i]);
 }
 
 

--- a/acados/ocp_nlp/ocp_nlp_common.h
+++ b/acados/ocp_nlp/ocp_nlp_common.h
@@ -464,7 +464,9 @@ typedef struct ocp_nlp_workspace
     struct blasfeo_dvec dxnext_dy;
 
     // optimal value gradient wrt params
-    struct blasfeo_dmat *tmp_nvninx_np_global;
+    struct blasfeo_dmat *tmp_nv_x_np_global;
+    struct blasfeo_dmat *tmp_2ni_x_np_global;
+    struct blasfeo_dmat *tmp_nxnext_x_np_global;
     struct blasfeo_dvec tmp_np_global;
     // AS-RTI
     double *tmp_nv_double;

--- a/acados/ocp_nlp/ocp_nlp_common.h
+++ b/acados/ocp_nlp/ocp_nlp_common.h
@@ -410,7 +410,7 @@ typedef struct ocp_nlp_memory
     struct blasfeo_dvec *dyn_adj;
 
     // optimal value gradient wrt params
-    struct blasfeo_dmat *tmp_nv_x_np_global;
+    struct blasfeo_dmat *jac_lag_stat_p_global;
     struct blasfeo_dmat *tmp_2ni_x_np_global;
     struct blasfeo_dmat *tmp_nxnext_x_np_global;
     struct blasfeo_dvec out_np_global;

--- a/acados/ocp_nlp/ocp_nlp_common.h
+++ b/acados/ocp_nlp/ocp_nlp_common.h
@@ -410,6 +410,9 @@ typedef struct ocp_nlp_memory
     struct blasfeo_dvec *dyn_adj;
 
     // optimal value gradient wrt params
+    struct blasfeo_dmat *tmp_nv_x_np_global;
+    struct blasfeo_dmat *tmp_2ni_x_np_global;
+    struct blasfeo_dmat *tmp_nxnext_x_np_global;
     struct blasfeo_dvec out_np_global;
 
     double cost_value;
@@ -464,9 +467,6 @@ typedef struct ocp_nlp_workspace
     struct blasfeo_dvec dxnext_dy;
 
     // optimal value gradient wrt params
-    struct blasfeo_dmat *tmp_nv_x_np_global;
-    struct blasfeo_dmat *tmp_2ni_x_np_global;
-    struct blasfeo_dmat *tmp_nxnext_x_np_global;
     struct blasfeo_dvec tmp_np_global;
     // AS-RTI
     double *tmp_nv_double;

--- a/acados/ocp_nlp/ocp_nlp_common.h
+++ b/acados/ocp_nlp/ocp_nlp_common.h
@@ -410,9 +410,9 @@ typedef struct ocp_nlp_memory
     struct blasfeo_dvec *dyn_adj;
 
     // optimal value gradient wrt params
-    struct blasfeo_dmat *jac_lag_stat_p_global;
-    struct blasfeo_dmat *tmp_2ni_x_np_global;
-    struct blasfeo_dmat *tmp_nxnext_x_np_global;
+    struct blasfeo_dmat *jac_lag_stat_p_global;  // jacobian of stationarity condition wrt p_global (nv, np_global)
+    struct blasfeo_dmat *jac_ineq_p_global;  // jacobian of inequalities wrt p_global (2*ni, np_global)
+    struct blasfeo_dmat *jac_dyn_p_global;  // jacobian of dynamics wrt p_global (nx_next, np_global)
     struct blasfeo_dvec out_np_global;
 
     double cost_value;

--- a/acados/ocp_nlp/ocp_nlp_cost_common.h
+++ b/acados/ocp_nlp/ocp_nlp_cost_common.h
@@ -81,7 +81,7 @@ typedef struct
     void (*memory_set_dzdux_tran_ptr)(struct blasfeo_dmat *dzdux, void *memory);
     void (*memory_set_RSQrq_ptr)(struct blasfeo_dmat *RSQrq, void *memory);
     void (*memory_set_Z_ptr)(struct blasfeo_dvec *Z, void *memory);
-    void (*memory_get_params_grad)(void *config, void *dims, void *opts, void *memory, int index, struct blasfeo_dvec *out, int offset);
+    void (*memory_set_jac_lag_stat_p_global_ptr)(struct blasfeo_dmat *jac_lag_stat_p_global, void *memory);
     void *(*memory_assign)(void *config, void *dims, void *opts, void *raw_memory);
     acados_size_t (*workspace_calculate_size)(void *config, void *dims, void *opts);
     acados_size_t (*get_external_fun_workspace_requirement)(void *config, void *dims, void *opts_, void *in);

--- a/acados/ocp_nlp/ocp_nlp_cost_external.c
+++ b/acados/ocp_nlp/ocp_nlp_cost_external.c
@@ -376,22 +376,15 @@ acados_size_t ocp_nlp_cost_external_memory_calculate_size(void *config_, void *d
 {
     // ocp_nlp_cost_config *config = config_;
     ocp_nlp_cost_external_dims *dims = dims_;
-    ocp_nlp_cost_external_opts *opts = opts_;
 
     int nx = dims->nx;
     int nu = dims->nu;
     int ns = dims->ns;
-    int np_global = dims->np_global;
-    int nz = dims->nz;
 
     acados_size_t size = 0;
 
     size += sizeof(ocp_nlp_cost_external_memory);
 
-    if (opts->with_solution_sens_wrt_params)
-    {
-        size += 1 * blasfeo_memsize_dmat(nu + nx + nz, np_global);  // cost_grad_params_jac
-    }
     size += 1 * blasfeo_memsize_dvec(nu + nx + 2 * ns);  // grad
 
     size += 64;  // blasfeo_mem align
@@ -405,7 +398,6 @@ void *ocp_nlp_cost_external_memory_assign(void *config_, void *dims_, void *opts
 {
     // ocp_nlp_cost_config *config = config_;
     ocp_nlp_cost_external_dims *dims = dims_;
-    ocp_nlp_cost_external_opts *opts = opts_;
 
     char *c_ptr = (char *) raw_memory;
 
@@ -413,7 +405,6 @@ void *ocp_nlp_cost_external_memory_assign(void *config_, void *dims_, void *opts
     int nx = dims->nx;
     int nu = dims->nu;
     int ns = dims->ns;
-    int np_global = dims->np_global;
 
     // struct
     ocp_nlp_cost_external_memory *memory = (ocp_nlp_cost_external_memory *) c_ptr;
@@ -422,10 +413,6 @@ void *ocp_nlp_cost_external_memory_assign(void *config_, void *dims_, void *opts
     // blasfeo_mem align
     align_char_to(64, &c_ptr);
 
-    if (opts->with_solution_sens_wrt_params)
-    {
-        assign_and_advance_blasfeo_dmat_mem(nu + nx, np_global, &memory->cost_grad_params_jac, &c_ptr);
-    }
     // grad
     assign_and_advance_blasfeo_dvec_mem(nu + nx + 2 * ns, &memory->grad, &c_ptr);
 
@@ -503,15 +490,12 @@ void ocp_nlp_cost_external_memory_set_dzdux_tran_ptr(struct blasfeo_dmat *dzdux_
 }
 
 
-void ocp_nlp_cost_external_memory_get_params_grad(void *config, void *dims_, void *opts, void *memory_, int index, struct blasfeo_dvec *out, int offset)
+
+void ocp_nlp_cost_external_memory_set_jac_lag_stat_p_global_ptr(struct blasfeo_dmat *jac_lag_stat_p_global, void *memory_)
 {
-    ocp_nlp_cost_external_dims *dims = dims_;
     ocp_nlp_cost_external_memory *memory = memory_;
 
-    int nx = dims->nx;
-    int nu = dims->nu;
-
-    blasfeo_dcolex(nx + nu, &memory->cost_grad_params_jac, 0, index, out, offset);
+    memory->jac_lag_stat_p_global = jac_lag_stat_p_global;
 }
 
 
@@ -522,17 +506,23 @@ void ocp_nlp_cost_external_memory_get_params_grad(void *config, void *dims_, voi
 acados_size_t ocp_nlp_cost_external_workspace_calculate_size(void *config_, void *dims_, void *opts_)
 {
     ocp_nlp_cost_external_dims *dims = dims_;
+    ocp_nlp_cost_external_opts *opts = opts_;
 
     // extract dims
     int nx = dims->nx;
     int nz = dims->nz;
     int nu = dims->nu;
     int ns = dims->ns;
+    int np_global = dims->np_global;
 
     acados_size_t size = 0;
 
     size += sizeof(ocp_nlp_cost_external_workspace);
 
+    if (opts->with_solution_sens_wrt_params)
+    {
+        size += 1 * blasfeo_memsize_dmat(nu + nx, np_global);  // cost_grad_params_jac
+    }
     size += 1 * blasfeo_memsize_dmat(nu+nx, nu+nx);  // tmp_nunx_nunx
     size += 1 * blasfeo_memsize_dmat(nz, nz);  // tmp_nz_nz
     size += 1 * blasfeo_memsize_dmat(nz, nu+nx);  // tmp_nz_nunx
@@ -552,18 +542,26 @@ static void ocp_nlp_cost_external_cast_workspace(void *config_, void *dims_, voi
 {
     ocp_nlp_cost_external_dims *dims = dims_;
     ocp_nlp_cost_external_workspace *work = work_;
+    ocp_nlp_cost_external_opts *opts = opts_;
 
     // extract dims
     int nx = dims->nx;
     int nz = dims->nz;
     int nu = dims->nu;
     int ns = dims->ns;
+    int np_global = dims->np_global;
 
     char *c_ptr = (char *) work_;
     c_ptr += sizeof(ocp_nlp_cost_external_workspace);
 
     // blasfeo_mem align
     align_char_to(64, &c_ptr);
+
+
+    if (opts->with_solution_sens_wrt_params)
+    {
+        assign_and_advance_blasfeo_dmat_mem(nu + nx, np_global, &work->cost_grad_params_jac, &c_ptr);
+    }
 
     // tmp_nunx_nunx
     assign_and_advance_blasfeo_dmat_mem(nu + nx, nu + nx, &work->tmp_nunx_nunx, &c_ptr);
@@ -882,6 +880,7 @@ void ocp_nlp_cost_external_compute_jac_p(void *config_, void *dims_, void *model
     ocp_nlp_cost_external_dims *dims = dims_;
     ocp_nlp_cost_external_model *model = model_;
     ocp_nlp_cost_external_memory *memory = memory_;
+    ocp_nlp_cost_external_workspace *work = work_;
 
     ocp_nlp_cost_external_cast_workspace(config_, dims, opts_, work_);
 
@@ -889,7 +888,7 @@ void ocp_nlp_cost_external_compute_jac_p(void *config_, void *dims_, void *model
 
     int nu = dims->nu;
     int nx = dims->nx;
-    int nz = dims->nz;
+    // int nz = dims->nz;
     int np_global = dims->np_global;
 
     /* specify input types and pointers for external cost function */
@@ -916,7 +915,7 @@ void ocp_nlp_cost_external_compute_jac_p(void *config_, void *dims_, void *model
 
     // OUTPUT
     ext_fun_type_out[0] = BLASFEO_DMAT;
-    ext_fun_out[0] = &memory->cost_grad_params_jac;
+    ext_fun_out[0] = &work->cost_grad_params_jac;
 
     // evaluate external function
     if (model->ext_cost_hess_xu_p == 0)
@@ -927,11 +926,9 @@ void ocp_nlp_cost_external_compute_jac_p(void *config_, void *dims_, void *model
     model->ext_cost_hess_xu_p->evaluate(model->ext_cost_hess_xu_p, ext_fun_type_in, ext_fun_in,
                                   ext_fun_type_out, ext_fun_out);
 
-    // scale
-    if(model->scaling != 1.0)
-    {
-        blasfeo_dgesc(nu + nx + nz, np_global, model->scaling, &memory->cost_grad_params_jac, 0, 0);
-    }
+    // add contribution to stationarity jacobian:
+    // jac_lag_stat_p_global += scaling * cost_grad_params_jac
+    blasfeo_dgead(nu+nx, np_global, model->scaling, &work->cost_grad_params_jac, 0, 0, memory->jac_lag_stat_p_global, 0, 0);
 
     return;
 }
@@ -1052,7 +1049,7 @@ void ocp_nlp_cost_external_config_initialize_default(void *config_, int stage)
     config->memory_set_dzdux_tran_ptr = &ocp_nlp_cost_external_memory_set_dzdux_tran_ptr;
     config->memory_set_RSQrq_ptr = &ocp_nlp_cost_external_memory_set_RSQrq_ptr;
     config->memory_set_Z_ptr = &ocp_nlp_cost_external_memory_set_Z_ptr;
-    config->memory_get_params_grad = &ocp_nlp_cost_external_memory_get_params_grad;
+    config->memory_set_jac_lag_stat_p_global_ptr = &ocp_nlp_cost_external_memory_set_jac_lag_stat_p_global_ptr;
     config->workspace_calculate_size = &ocp_nlp_cost_external_workspace_calculate_size;
     config->get_external_fun_workspace_requirement = &ocp_nlp_cost_external_get_external_fun_workspace_requirement;
     config->set_external_fun_workspaces = &ocp_nlp_cost_external_set_external_fun_workspaces;

--- a/acados/ocp_nlp/ocp_nlp_cost_external.h
+++ b/acados/ocp_nlp/ocp_nlp_cost_external.h
@@ -119,7 +119,7 @@ void ocp_nlp_cost_external_opts_set(void *config, void *opts, const char *field,
 
 typedef struct
 {
-    struct blasfeo_dmat cost_grad_params_jac;    // jacobian of gradient of cost function wrt parameters
+    struct blasfeo_dmat *jac_lag_stat_p_global;    // pointer to jacobian of stationarity condition wrt parameters
     struct blasfeo_dvec grad;    // gradient of cost function
     struct blasfeo_dvec *ux;     // pointer to ux in nlp_out
     struct blasfeo_dmat *RSQrq;  // pointer to RSQrq in qp_in
@@ -148,8 +148,7 @@ void ocp_nlp_cost_external_memory_set_z_alg_ptr(struct blasfeo_dvec *z_alg, void
 //
 void ocp_nlp_cost_external_memory_set_dzdux_tran_ptr(struct blasfeo_dmat *dzdux_tran, void *memory_);
 //
-void ocp_nlp_cost_external_memory_get_params_grad(void *config, void *dims, void *opts, void *memory, int index, struct blasfeo_dvec *out, int offset);
-
+void ocp_nlp_cost_external_memory_set_jac_lag_stat_p_global_ptr(struct blasfeo_dmat *jac_lag_stat_p_global, void *memory_);
 
 /************************************************
  * workspace
@@ -157,6 +156,7 @@ void ocp_nlp_cost_external_memory_get_params_grad(void *config, void *dims, void
 
 typedef struct
 {
+    struct blasfeo_dmat cost_grad_params_jac;  // jacobian of gradient of cost function wrt parameters
     struct blasfeo_dmat tmp_nunx_nunx;
     struct blasfeo_dmat tmp_nz_nz;
     struct blasfeo_dmat tmp_nz_nunx;

--- a/acados/ocp_nlp/ocp_nlp_dynamics_common.h
+++ b/acados/ocp_nlp/ocp_nlp_dynamics_common.h
@@ -93,9 +93,9 @@ typedef struct
     void (*memory_set_sim_guess_ptr)(struct blasfeo_dvec *vec, bool *bool_ptr, void *memory_);
     void (*memory_set_z_alg_ptr)(struct blasfeo_dvec *vec, void *memory_);
     void (*memory_set_dyn_jac_p_global_ptr)(struct blasfeo_dmat *dyn_jac_p_global, void *memory);
+    void (*memory_set_jac_lag_stat_p_global_ptr)(struct blasfeo_dmat *jac_lag_stat_p_global, void *memory);
     void (*memory_get)(void *config, void *dims, void *mem, const char *field, void* value);
     void (*memory_set)(void *config, void *dims, void *mem, const char *field, void* value);
-    void (*memory_get_params_lag_grad)(void *config, void *dims, void *opts, void *memory, int index, struct blasfeo_dvec *out, int offset);
     /* workspace */
     acados_size_t (*workspace_calculate_size)(void *config, void *dims, void *opts);
     void (*initialize)(void *config_, void *dims, void *model_, void *opts_, void *mem_, void *work_);

--- a/acados/ocp_nlp/ocp_nlp_dynamics_common.h
+++ b/acados/ocp_nlp/ocp_nlp_dynamics_common.h
@@ -92,6 +92,7 @@ typedef struct
     void (*memory_set_dzduxt_ptr)(struct blasfeo_dmat *mat, void *memory_);
     void (*memory_set_sim_guess_ptr)(struct blasfeo_dvec *vec, bool *bool_ptr, void *memory_);
     void (*memory_set_z_alg_ptr)(struct blasfeo_dvec *vec, void *memory_);
+    void (*memory_set_dyn_jac_p_global_ptr)(struct blasfeo_dmat *mat, void *memory_);
     void (*memory_get)(void *config, void *dims, void *mem, const char *field, void* value);
     void (*memory_set)(void *config, void *dims, void *mem, const char *field, void* value);
     void (*memory_get_params_grad)(void *config, void *dims, void *opts, void *memory, int index, struct blasfeo_dvec *out, int offset);

--- a/acados/ocp_nlp/ocp_nlp_dynamics_common.h
+++ b/acados/ocp_nlp/ocp_nlp_dynamics_common.h
@@ -92,10 +92,9 @@ typedef struct
     void (*memory_set_dzduxt_ptr)(struct blasfeo_dmat *mat, void *memory_);
     void (*memory_set_sim_guess_ptr)(struct blasfeo_dvec *vec, bool *bool_ptr, void *memory_);
     void (*memory_set_z_alg_ptr)(struct blasfeo_dvec *vec, void *memory_);
-    void (*memory_set_dyn_jac_p_global_ptr)(struct blasfeo_dmat *mat, void *memory_);
+    void (*memory_set_dyn_jac_p_global_ptr)(struct blasfeo_dmat *dyn_jac_p_global, void *memory);
     void (*memory_get)(void *config, void *dims, void *mem, const char *field, void* value);
     void (*memory_set)(void *config, void *dims, void *mem, const char *field, void* value);
-    void (*memory_get_params_grad)(void *config, void *dims, void *opts, void *memory, int index, struct blasfeo_dvec *out, int offset);
     void (*memory_get_params_lag_grad)(void *config, void *dims, void *opts, void *memory, int index, struct blasfeo_dvec *out, int offset);
     /* workspace */
     acados_size_t (*workspace_calculate_size)(void *config, void *dims, void *opts);

--- a/acados/ocp_nlp/ocp_nlp_dynamics_cont.c
+++ b/acados/ocp_nlp/ocp_nlp_dynamics_cont.c
@@ -577,10 +577,15 @@ void ocp_nlp_dynamics_cont_memory_get(void *config_, void *dims_, void *mem_, co
 }
 
 
-void ocp_nlp_dynamics_cont_memory_get_params_grad(void *config, void *dims, void *opts, void *memory, int index, struct blasfeo_dvec *out, int offset)
+void ocp_nlp_dynamics_cont_memory_set_dyn_jac_p_global_ptr(struct blasfeo_dmat *dyn_jac_p_global, void *memory_)
 {
-    printf("\nerror: ocp_nlp_dynamics_cont_memory_params_grad: not implemented\n");
+    printf("\nerror: ocp_nlp_dynamics_cont_memory_set_dyn_jac_p_global_ptr: not implemented\n");
     exit(1);
+    // ocp_nlp_dynamics_cont_memory *memory = memory_;
+
+    // memory->dyn_jac_p_global = dyn_jac_p_global;
+
+    return;
 }
 
 
@@ -1131,8 +1136,8 @@ void ocp_nlp_dynamics_cont_config_initialize_default(void *config_, int stage)
     config->memory_set_dzduxt_ptr = &ocp_nlp_dynamics_cont_memory_set_dzduxt_ptr;
     config->memory_set_sim_guess_ptr = &ocp_nlp_dynamics_cont_memory_set_sim_guess_ptr;
     config->memory_set_z_alg_ptr = &ocp_nlp_dynamics_cont_memory_set_z_alg_ptr;
+    config->memory_set_dyn_jac_p_global_ptr = &ocp_nlp_dynamics_cont_memory_set_dyn_jac_p_global_ptr;
     config->memory_get = &ocp_nlp_dynamics_cont_memory_get;
-    config->memory_get_params_grad = &ocp_nlp_dynamics_cont_memory_get_params_grad;
     config->memory_get_params_lag_grad = &ocp_nlp_dynamics_cont_memory_get_params_lag_grad;
     config->workspace_calculate_size = &ocp_nlp_dynamics_cont_workspace_calculate_size;
     config->get_external_fun_workspace_requirement = &ocp_nlp_dynamics_cont_get_external_fun_workspace_requirement;

--- a/acados/ocp_nlp/ocp_nlp_dynamics_cont.c
+++ b/acados/ocp_nlp/ocp_nlp_dynamics_cont.c
@@ -579,21 +579,16 @@ void ocp_nlp_dynamics_cont_memory_get(void *config_, void *dims_, void *mem_, co
 
 void ocp_nlp_dynamics_cont_memory_set_dyn_jac_p_global_ptr(struct blasfeo_dmat *dyn_jac_p_global, void *memory_)
 {
-    printf("\nerror: ocp_nlp_dynamics_cont_memory_set_dyn_jac_p_global_ptr: not implemented\n");
-    exit(1);
     // ocp_nlp_dynamics_cont_memory *memory = memory_;
-
     // memory->dyn_jac_p_global = dyn_jac_p_global;
-
-    return;
 }
 
-
-void ocp_nlp_dynamics_cont_memory_get_params_lag_grad(void *config, void *dims, void *opts, void *memory, int index, struct blasfeo_dvec *out, int offset)
+void ocp_nlp_dynamics_cont_memory_set_jac_lag_stat_p_global_ptr(struct blasfeo_dmat *jac_lag_stat_p_global, void *memory_)
 {
-    printf("\nerror: ocp_nlp_dynamics_cont_memory_params_lag_grad: not implemented\n");
-    exit(1);
+    // ocp_nlp_dynamics_cont_memory *memory = memory_;
+    // memory->jac_lag_stat_p_global = jac_lag_stat_p_global;
 }
+
 
 
 /************************************************
@@ -1136,9 +1131,9 @@ void ocp_nlp_dynamics_cont_config_initialize_default(void *config_, int stage)
     config->memory_set_dzduxt_ptr = &ocp_nlp_dynamics_cont_memory_set_dzduxt_ptr;
     config->memory_set_sim_guess_ptr = &ocp_nlp_dynamics_cont_memory_set_sim_guess_ptr;
     config->memory_set_z_alg_ptr = &ocp_nlp_dynamics_cont_memory_set_z_alg_ptr;
+    config->memory_set_jac_lag_stat_p_global_ptr = &ocp_nlp_dynamics_cont_memory_set_jac_lag_stat_p_global_ptr;
     config->memory_set_dyn_jac_p_global_ptr = &ocp_nlp_dynamics_cont_memory_set_dyn_jac_p_global_ptr;
     config->memory_get = &ocp_nlp_dynamics_cont_memory_get;
-    config->memory_get_params_lag_grad = &ocp_nlp_dynamics_cont_memory_get_params_lag_grad;
     config->workspace_calculate_size = &ocp_nlp_dynamics_cont_workspace_calculate_size;
     config->get_external_fun_workspace_requirement = &ocp_nlp_dynamics_cont_get_external_fun_workspace_requirement;
     config->set_external_fun_workspaces = &ocp_nlp_dynamics_cont_set_external_fun_workspaces;

--- a/acados/ocp_nlp/ocp_nlp_dynamics_cont.h
+++ b/acados/ocp_nlp/ocp_nlp_dynamics_cont.h
@@ -140,8 +140,6 @@ void ocp_nlp_dynamics_cont_memory_set_pi_ptr(struct blasfeo_dvec *pi, void *memo
 //
 void ocp_nlp_dynamics_cont_memory_set_BAbt_ptr(struct blasfeo_dmat *BAbt, void *memory);
 //
-void ocp_nlp_dynamics_cont_memory_get_params_grad(void *config, void *dims, void *opts, void *memory, int index, struct blasfeo_dvec *out, int offset);
-//
 void ocp_nlp_dynamics_cont_memory_get_params_lag_grad(void *config, void *dims, void *opts, void *memory, int index, struct blasfeo_dvec *out, int offset);
 
 

--- a/acados/ocp_nlp/ocp_nlp_dynamics_disc.h
+++ b/acados/ocp_nlp/ocp_nlp_dynamics_disc.h
@@ -103,7 +103,7 @@ int ocp_nlp_dynamics_disc_precompute(void *config_, void *dims, void *model_, vo
 
 typedef struct
 {
-    struct blasfeo_dmat params_jac;  // jacobian of the dynamics wrt the parameters
+    struct blasfeo_dmat *dyn_jac_p_global;  // jacobian of the dynamics wrt the parameters
     struct blasfeo_dmat params_lag_jac;  // jacobian of the lagrange gradient contribution of the dynamics wrt the parameters
     struct blasfeo_dvec fun;
     struct blasfeo_dvec adj;

--- a/acados/ocp_nlp/ocp_nlp_dynamics_disc.h
+++ b/acados/ocp_nlp/ocp_nlp_dynamics_disc.h
@@ -103,8 +103,8 @@ int ocp_nlp_dynamics_disc_precompute(void *config_, void *dims, void *model_, vo
 
 typedef struct
 {
-    struct blasfeo_dmat *dyn_jac_p_global;  // jacobian of the dynamics wrt the parameters
-    struct blasfeo_dmat params_lag_jac;  // jacobian of the lagrange gradient contribution of the dynamics wrt the parameters
+    struct blasfeo_dmat *dyn_jac_p_global;  // pointer to jacobian of the dynamics wrt the parameters
+    struct blasfeo_dmat *jac_lag_stat_p_global;    // pointer to jacobian of stationarity condition wrt parameters
     struct blasfeo_dvec fun;
     struct blasfeo_dvec adj;
     struct blasfeo_dvec *ux;     // pointer to ux in nlp_out at current stage
@@ -131,9 +131,9 @@ void ocp_nlp_dynamics_disc_memory_set_pi_ptr(struct blasfeo_dvec *pi, void *memo
 //
 void ocp_nlp_dynamics_disc_memory_set_BAbt_ptr(struct blasfeo_dmat *BAbt, void *memory);
 //
-void ocp_nlp_dynamics_disc_memory_get_params_grad(void *config, void *dims, void *opts, void *memory, int index, struct blasfeo_dvec *out, int offset);
-//
-void ocp_nlp_dynamics_disc_memory_get_params_lag_grad(void *config, void *dims, void *opts, void *memory, int index, struct blasfeo_dvec *out, int offset);
+void ocp_nlp_dynamics_disc_memory_set_jac_lag_stat_p_global_ptr(struct blasfeo_dmat *jac_lag_stat_p_global, void *memory_);
+
+void ocp_nlp_dynamics_disc_memory_set_dyn_jac_p_global_ptr(struct blasfeo_dmat *dyn_jac_p_global, void *memory_);
 
 
 /************************************************

--- a/examples/acados_python/chain_mass/solution_sensitivity_example.py
+++ b/examples/acados_python/chain_mass/solution_sensitivity_example.py
@@ -491,9 +491,8 @@ def main_parametric(qp_solver_ric_alg: int = 0, chain_params_: dict = get_chain_
         "parameter update": timings_parameter_update * 1e3,
     }
 
-    print("\nMedian timings [ms]")
-    for key, value in timing_results_forward.items():
-        print(f"{key}: {1000*np.median(value):.3f}")
+    print_timings(timing_results_forward, metric="median")
+    print_timings(timing_results_forward, metric="min")
 
     u_opt = np.vstack(u_opt)
     sens_u = np.vstack(sens_u)
@@ -534,6 +533,20 @@ def main_parametric(qp_solver_ric_alg: int = 0, chain_params_: dict = get_chain_
 
     plt.show()
 
+
+def print_timings(timing_results: dict, metric: str = "median"):
+    if metric == "median":
+        timing_func = np.median
+    elif metric == "mean":
+        timing_func = np.mean
+    elif metric == "min":
+        timing_func = np.min
+    else:
+        raise ValueError(f"Unknown metric {metric}")
+
+    print(f"\n{metric} timings [ms]")
+    for key, value in timing_results.items():
+        print(f"{key}: {1e3*timing_func(value):.3f} ms")
 
 if __name__ == "__main__":
     chain_params = get_chain_params()

--- a/interfaces/acados_template/acados_template/casadi_function_generation.py
+++ b/interfaces/acados_template/acados_template/casadi_function_generation.py
@@ -482,7 +482,10 @@ def generate_c_code_external_cost(context: GenerateContext, model: AcadosModel, 
     context.add_function_definition(fun_name_jac, [x, u, z, p], [ext_cost, grad_uxz], cost_dir)
 
     if opts["with_solution_sens_wrt_params"]:
-        hess_xu_p = ca.jacobian(grad_uxz, p_global)
+        if casadi_length(z) > 0:
+            raise Exception("acados: solution sensitivities wrt parameters not supported with algebraic variables.")
+        grad_ux = ca.jacobian(ext_cost, ca.vertcat(u, x))
+        hess_xu_p = ca.jacobian(grad_ux, p_global)
         context.add_function_definition(fun_name_param, [x, u, z, p], [hess_xu_p], cost_dir)
 
     if opts["with_value_sens_wrt_params"]:


### PR DESCRIPTION
refactor functionality in `ocp_nlp_params_jac_compute`.
New description of this function:
```
this function sets up: jac_lag_stat_p_global, jac_ineq_p_global, jac_dyn_p_global
    - jac_dyn_p_global is computed in dynamics module
    - jac_ineq_p_global is computed in constraints module (TODO!)
    - jac_lag_stat_p_global: first dynamics writes its contribution, then cost and constraints modules add their contribution.
```
Detailed:
- split `tmp_nvninx_np_global` into matrices `jac_lag_stat_p_global`, `jac_ineq_p_global`, `jac_dyn_p_global`
- fix shape of inequality part `jac_ineq_p_global`, should be 2*ni
- directly set up those matrices in the cost and dynamics modules instead of taking out columns in `ocp_nlp_common`
- avoid copying

This resulted in significant speed-up in the chain benchmark example:
Minimum time for `eval rhs` on my machine
Before the changes:  775 ms
After the changes: 527 ms
