### PR TITLE
Fix `get_residuals`

### DIFF
--- a/acados/ocp_nlp/ocp_nlp_common.h
+++ b/acados/ocp_nlp/ocp_nlp_common.h
@@ -87,6 +87,7 @@ typedef struct ocp_nlp_config
     void (*opts_set_at_stage)(void *config_, void *opts_, size_t stage, const char *field, void* value);
     // evaluate solver // TODO rename into solve
     int (*evaluate)(void *config, void *dims, void *nlp_in, void *nlp_out, void *opts_, void *mem, void *work);
+    void (*eval_kkt_residual)(void *config, void *dims, void *nlp_in, void *nlp_out, void *opts_, void *mem, void *work);
     void (*eval_param_sens)(void *config, void *dims, void *opts_, void *mem, void *work,
                             char *field, int stage, int index, void *sens_nlp_out);
     void (*eval_lagr_grad_p)(void *config, void *dims, void *nlp_in, void *opts_, void *mem, void *work,

--- a/acados/ocp_nlp/ocp_nlp_ddp.c
+++ b/acados/ocp_nlp/ocp_nlp_ddp.c
@@ -868,6 +868,27 @@ int ocp_nlp_ddp(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
     return mem->nlp_mem->status;
 }
 
+
+void ocp_nlp_ddp_eval_kkt_residual(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
+                void *opts_, void *mem_, void *work_)
+{
+    ocp_nlp_dims *dims = dims_;
+    ocp_nlp_config *config = config_;
+    ocp_nlp_ddp_opts *opts = opts_;
+    ocp_nlp_opts *nlp_opts = opts->nlp_opts;
+    ocp_nlp_ddp_memory *mem = mem_;
+    ocp_nlp_in *nlp_in = nlp_in_;
+    ocp_nlp_out *nlp_out = nlp_out_;
+    ocp_nlp_memory *nlp_mem = mem->nlp_mem;
+    ocp_nlp_ddp_workspace *work = work_;
+    ocp_nlp_workspace *nlp_work = work->nlp_work;
+
+    ocp_nlp_initialize_submodules(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work);
+    ocp_nlp_approximate_qp_matrices(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work);
+    ocp_nlp_approximate_qp_vectors_sqp(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work);
+}
+
+
 void ocp_nlp_ddp_memory_reset_qp_solver(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
     void *opts_, void *mem_, void *work_)
 {
@@ -1106,6 +1127,7 @@ void ocp_nlp_ddp_config_initialize_default(void *config_)
     config->terminate = &ocp_nlp_ddp_terminate;
     config->step_update = &ocp_nlp_ddp_compute_trial_iterate;
     config->is_real_time_algorithm = &ocp_nlp_ddp_is_real_time_algorithm;
+    config->eval_kkt_residual = &ocp_nlp_ddp_eval_kkt_residual;
 
     return;
 }

--- a/acados/ocp_nlp/ocp_nlp_ddp.c
+++ b/acados/ocp_nlp/ocp_nlp_ddp.c
@@ -886,6 +886,7 @@ void ocp_nlp_ddp_eval_kkt_residual(void *config_, void *dims_, void *nlp_in_, vo
     ocp_nlp_initialize_submodules(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work);
     ocp_nlp_approximate_qp_matrices(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work);
     ocp_nlp_approximate_qp_vectors_sqp(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work);
+    ocp_nlp_res_compute(dims, nlp_in, nlp_out, nlp_mem->nlp_res, nlp_mem);
 }
 
 

--- a/acados/ocp_nlp/ocp_nlp_sqp.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp.c
@@ -864,6 +864,27 @@ int ocp_nlp_sqp(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
     return mem->nlp_mem->status;
 }
 
+
+void ocp_nlp_sqp_eval_kkt_residual(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
+                void *opts_, void *mem_, void *work_)
+{
+    ocp_nlp_dims *dims = dims_;
+    ocp_nlp_config *config = config_;
+    ocp_nlp_sqp_opts *opts = opts_;
+    ocp_nlp_opts *nlp_opts = opts->nlp_opts;
+    ocp_nlp_sqp_memory *mem = mem_;
+    ocp_nlp_in *nlp_in = nlp_in_;
+    ocp_nlp_out *nlp_out = nlp_out_;
+    ocp_nlp_memory *nlp_mem = mem->nlp_mem;
+    ocp_nlp_sqp_workspace *work = work_;
+    ocp_nlp_workspace *nlp_work = work->nlp_work;
+
+    ocp_nlp_initialize_submodules(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work);
+    ocp_nlp_approximate_qp_matrices(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work);
+    ocp_nlp_approximate_qp_vectors_sqp(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work);
+}
+
+
 void ocp_nlp_sqp_memory_reset_qp_solver(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
     void *opts_, void *mem_, void *work_)
 {
@@ -1078,6 +1099,7 @@ void ocp_nlp_sqp_config_initialize_default(void *config_)
     config->terminate = &ocp_nlp_sqp_terminate;
     config->step_update = &ocp_nlp_update_variables_sqp;
     config->is_real_time_algorithm = &ocp_nlp_sqp_is_real_time_algorithm;
+    config->eval_kkt_residual = &ocp_nlp_sqp_eval_kkt_residual;
 
     return;
 }

--- a/acados/ocp_nlp/ocp_nlp_sqp.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp.c
@@ -882,6 +882,7 @@ void ocp_nlp_sqp_eval_kkt_residual(void *config_, void *dims_, void *nlp_in_, vo
     ocp_nlp_initialize_submodules(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work);
     ocp_nlp_approximate_qp_matrices(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work);
     ocp_nlp_approximate_qp_vectors_sqp(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work);
+    ocp_nlp_res_compute(dims, nlp_in, nlp_out, nlp_mem->nlp_res, nlp_mem);
 }
 
 

--- a/acados/ocp_nlp/ocp_nlp_sqp_rti.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp_rti.c
@@ -1185,6 +1185,26 @@ int ocp_nlp_sqp_rti(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
 }
 
 
+void ocp_nlp_sqp_rti_eval_kkt_residual(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
+                void *opts_, void *mem_, void *work_)
+{
+    ocp_nlp_dims *dims = dims_;
+    ocp_nlp_config *config = config_;
+    ocp_nlp_sqp_rti_opts *opts = opts_;
+    ocp_nlp_opts *nlp_opts = opts->nlp_opts;
+    ocp_nlp_sqp_rti_memory *mem = mem_;
+    ocp_nlp_in *nlp_in = nlp_in_;
+    ocp_nlp_out *nlp_out = nlp_out_;
+    ocp_nlp_memory *nlp_mem = mem->nlp_mem;
+    ocp_nlp_sqp_rti_workspace *work = work_;
+    ocp_nlp_workspace *nlp_work = work->nlp_work;
+
+    ocp_nlp_initialize_submodules(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work);
+    ocp_nlp_approximate_qp_matrices(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work);
+    ocp_nlp_approximate_qp_vectors_sqp(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work);
+}
+
+
 void ocp_nlp_sqp_rti_memory_reset_qp_solver(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
     void *opts_, void *mem_, void *work_)
 {
@@ -1406,6 +1426,7 @@ void ocp_nlp_sqp_rti_config_initialize_default(void *config_)
     config->terminate = &ocp_nlp_sqp_rti_terminate;
     config->step_update = &ocp_nlp_update_variables_sqp;
     config->is_real_time_algorithm = &ocp_nlp_sqp_rti_is_real_time_algorithm;
+    config->eval_kkt_residual = &ocp_nlp_sqp_rti_eval_kkt_residual;
 
     return;
 }

--- a/acados/ocp_nlp/ocp_nlp_sqp_rti.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp_rti.c
@@ -1202,6 +1202,7 @@ void ocp_nlp_sqp_rti_eval_kkt_residual(void *config_, void *dims_, void *nlp_in_
     ocp_nlp_initialize_submodules(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work);
     ocp_nlp_approximate_qp_matrices(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work);
     ocp_nlp_approximate_qp_vectors_sqp(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work);
+    ocp_nlp_res_compute(dims, nlp_in, nlp_out, nlp_mem->nlp_res, nlp_mem);
 }
 
 

--- a/examples/acados_python/tests/test_rti_sqp_residuals.py
+++ b/examples/acados_python/tests/test_rti_sqp_residuals.py
@@ -141,10 +141,21 @@ def main(nlp_solver_type="SQP"):
             #
             # quick way to get all residuals
             res_all = solver.get_initial_residuals()
+            print(f"res_all: {res_all}")
+
             assert res_all[0] == res_stat_all[-1]
             assert res_all[1] == res_eq_all[-1]
             assert res_all[2] == res_ineq_all[-1]
             assert res_all[3] == res_comp_all[-1]
+            if nlp_iter > 0:
+                # veryfiy that the residuals were "predicted" correctly
+                assert res_next[0] == res_stat_all[-1]
+                assert res_next[1] == res_eq_all[-1]
+                assert res_next[2] == res_ineq_all[-1]
+                assert res_next[3] == res_comp_all[-1]
+            # overwrite res_next
+            res_next = solver.get_residuals()
+            print(f"res_next: {res_next}")
 
             if max([res_stat_all[-1], res_eq_all[-1], res_ineq_all[-1], res_comp_all[-1]]) < TOL:
                 break

--- a/examples/acados_python/tests/test_rti_sqp_residuals.py
+++ b/examples/acados_python/tests/test_rti_sqp_residuals.py
@@ -117,6 +117,14 @@ def main(nlp_solver_type="SQP"):
         res_ineq_all = solver.get_stats("res_ineq_all")
         res_comp_all = solver.get_stats("res_comp_all")
         nlp_iter = solver.get_stats('nlp_iter')
+
+        res_init = solver.get_initial_residuals()
+        print(f"residuals: {res_init}")
+        assert res_init[0] == res_stat_all[0]
+        assert res_init[1] == res_eq_all[0]
+        assert res_init[2] == res_ineq_all[0]
+        assert res_init[3] == res_comp_all[0]
+
     elif nlp_solver_type == "SQP_RTI":
         TOL = 1e-6
         res_stat_all = []
@@ -132,7 +140,11 @@ def main(nlp_solver_type="SQP"):
             res_comp_all.append(solver.get_stats("res_comp_all")[0])
             #
             # quick way to get all residuals
-            # res_all = solver.get_stats('statistics')[3:,0]
+            res_all = solver.get_initial_residuals()
+            assert res_all[0] == res_stat_all[-1]
+            assert res_all[1] == res_eq_all[-1]
+            assert res_all[2] == res_ineq_all[-1]
+            assert res_all[3] == res_comp_all[-1]
 
             if max([res_stat_all[-1], res_eq_all[-1], res_ineq_all[-1], res_comp_all[-1]]) < TOL:
                 break

--- a/interfaces/acados_c/ocp_nlp_interface.c
+++ b/interfaces/acados_c/ocp_nlp_interface.c
@@ -1283,8 +1283,9 @@ void ocp_nlp_eval_residuals(ocp_nlp_solver *solver, ocp_nlp_in *nlp_in, ocp_nlp_
 {
     ocp_nlp_config *config = solver->config;
     ocp_nlp_memory *nlp_mem;
-    config->get(config, solver->dims, solver->mem, "nlp_mem", &nlp_mem);
+    config->eval_kkt_residual(config, solver->dims, nlp_in, nlp_out, solver->opts, solver->mem, solver->work);
 
+    config->get(config, solver->dims, solver->mem, "nlp_mem", &nlp_mem);
     ocp_nlp_res_compute(solver->dims, nlp_in, nlp_out, nlp_mem->nlp_res, nlp_mem);
 }
 

--- a/interfaces/acados_c/ocp_nlp_interface.c
+++ b/interfaces/acados_c/ocp_nlp_interface.c
@@ -1284,9 +1284,6 @@ void ocp_nlp_eval_residuals(ocp_nlp_solver *solver, ocp_nlp_in *nlp_in, ocp_nlp_
     ocp_nlp_config *config = solver->config;
     ocp_nlp_memory *nlp_mem;
     config->eval_kkt_residual(config, solver->dims, nlp_in, nlp_out, solver->opts, solver->mem, solver->work);
-
-    config->get(config, solver->dims, solver->mem, "nlp_mem", &nlp_mem);
-    ocp_nlp_res_compute(solver->dims, nlp_in, nlp_out, nlp_mem->nlp_res, nlp_mem);
 }
 
 

--- a/interfaces/acados_matlab_octave/AcadosOcp.m
+++ b/interfaces/acados_matlab_octave/AcadosOcp.m
@@ -1037,6 +1037,9 @@ classdef AcadosOcp < handle
                 if self.simulink_opts.inputs.rti_phase && self.solver_options.nlp_solver_type ~= 'SQP_RTI'
                     error('rti_phase is only supported for SQP_RTI');
                 end
+                if self.simulink_opts.outputs.KKT_residuals && self.solver_options.nlp_solver_type == 'SQP_RTI'
+                    warning('KKT_residuals now computes the residuals of the output iterate in SQP_RTI, this leads to increased computation time, turn off this port if it is not needed. See https://github.com/acados/acados/pull/1346.');
+                end
             else
                 disp("Not rendering Simulink-related templates, as simulink_opts are not specified.")
             end

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -1310,7 +1310,7 @@ class AcadosOcpSolver:
             - statistics: table with info about last iteration
             - stat_m: number of rows in statistics matrix
             - stat_n: number of columns in statistics matrix
-            - residuals: residuals of last iterate
+            - residuals: residuals of current iterate
             - alpha: step sizes of SQP iterations
         """
 
@@ -1475,7 +1475,7 @@ class AcadosOcpSolver:
     def get_residuals(self, recompute=False):
         """
         Returns an array of the form [res_stat, res_eq, res_ineq, res_comp].
-        This residual has to be computed for SQP_RTI solver, since it is not available by default.
+        The residuals has to be computed for SQP_RTI solver, since it is not available by default.
 
         - res_stat: stationarity residual
         - res_eq: residual wrt equality constraints (dynamics)
@@ -1507,6 +1507,22 @@ class AcadosOcpSolver:
         self.__acados_lib.ocp_nlp_get(self.nlp_solver, field, out_data)
         return out.flatten()
 
+
+    def get_initial_residuals(self) -> np.ndarray:
+        """
+        Returns an array of the form [res_stat, res_eq, res_ineq, res_comp].
+        Residuals: residuals of initial iterate in previous solver call
+        """
+        full_stats = self.get_stats('statistics')
+        if self.__solver_options['nlp_solver_type'] == 'SQP':
+            return full_stats[1:5, 0]
+        elif self.__solver_options['nlp_solver_type'] == 'SQP_RTI':
+            if self.__solver_options['rti_log_residuals'] == 1:
+                return full_stats[3:7, 0]
+            else:
+                raise Exception("initial_residuals is not available for SQP_RTI if rti_log_residuals is not enabled.")
+        else:
+            raise Exception(f"initial_residuals is not available for nlp_solver_type {self.__solver_options['nlp_solver_type']}.")
 
     # Note: this function should not be used anymore, better use cost_set, constraints_set
     def set(self, stage_: int, field_: str, value_: np.ndarray):

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -1520,7 +1520,7 @@ class AcadosOcpSolver:
             if self.__solver_options['rti_log_residuals'] == 1:
                 return full_stats[3:7, 0]
             else:
-                raise Exception("initial_residuals is not available for SQP_RTI if rti_log_residuals is not enabled.")
+                raise Exception("initial_residuals is only available for SQP_RTI if rti_log_residuals is enabled, for efficiency the rti_log_only_available_residuals option is recommended.")
         else:
             raise Exception(f"initial_residuals is not available for nlp_solver_type {self.__solver_options['nlp_solver_type']}.")
 


### PR DESCRIPTION
- Python: implement convenience function `get_initial_residuals ` which are the residuals that always come for free in RTI, in the sense that they don't require additional external function evaluations
- C: call `eval_kkt_residual` in `eval_residuals`
- Python: when solver is RTI or `recompute` is True, `get_residuals` computes the correct residuals when updating parameters or other problem data.
- implement `eval_kkt_residual` for all NLP solvers.
- test correct behavior

- Simulink output port `KKT_residuals` now also computes the residuals correctly in case of RTI. This can significantly increase the turnaround time of the Simulink block when the output port is activated!