### PR TITLE
Fix value function sensitivities, add example varying parameters in certain direction on linear OCP

### DIFF
--- a/.github/workflows/full_build.yml
+++ b/.github/workflows/full_build.yml
@@ -172,6 +172,7 @@ jobs:
         source ${{runner.workspace}}/acados/acadosenv/bin/activate
         cd ${{runner.workspace}}/acados/examples/acados_python/pendulum_on_cart/solution_sensitivities
         python value_gradient_example.py
+        python value_gradient_example_linear.py
         python policy_gradient_example.py
         python test_solution_sens_and_exact_hess.py
         python forw_vs_adj_param_sens.py

--- a/acados/ocp_nlp/ocp_nlp_common.c
+++ b/acados/ocp_nlp/ocp_nlp_common.c
@@ -3400,12 +3400,12 @@ void ocp_nlp_common_eval_lagr_grad_p(ocp_nlp_config *config, ocp_nlp_dims *dims,
         for (i = 0; i < N; i++)
         {
             // dynamics contribution
-            config->dynamics[i]->compute_adj_p(config->dynamics[i], dims->dynamics[i], in->dynamics[i], opts,
+            config->dynamics[i]->compute_adj_p(config->dynamics[i], dims->dynamics[i], in->dynamics[i], opts->dynamics[i],
                                     mem->dynamics[i], &work->tmp_np_global);
             blasfeo_dvecad(np_global, 1., &work->tmp_np_global, 0, &mem->out_np_global, 0);
 
             // cost contribution
-            config->cost[i]->eval_grad_p(config->cost[i], dims->cost[i], in->cost[i], opts,
+            config->cost[i]->eval_grad_p(config->cost[i], dims->cost[i], in->cost[i], opts->cost[i],
                                     mem->cost[i], work->cost[i], &work->tmp_np_global);
             blasfeo_dvecad(np_global, 1., &work->tmp_np_global, 0, &mem->out_np_global, 0);
 
@@ -3417,7 +3417,7 @@ void ocp_nlp_common_eval_lagr_grad_p(ocp_nlp_config *config, ocp_nlp_dims *dims,
         }
 
         // terminal cost contribution
-        config->cost[N]->eval_grad_p(config->cost[N], dims->cost[N], in->cost[N], opts,
+        config->cost[N]->eval_grad_p(config->cost[N], dims->cost[N], in->cost[N], opts->cost[N],
                                     mem->cost[N], work->cost[N], &work->tmp_np_global);
         blasfeo_dvecad(np_global, 1., &work->tmp_np_global, 0, &mem->out_np_global, 0);
 

--- a/acados/ocp_nlp/ocp_nlp_constraints_bgh.c
+++ b/acados/ocp_nlp/ocp_nlp_constraints_bgh.c
@@ -1606,6 +1606,7 @@ void ocp_nlp_constraints_bgh_compute_adj_p(void* config_, void *dims_, void *mod
     int nh = dims->nh;
     int nb = dims->nb;
     int ng = dims->ng;
+    int np_global = dims->np_global;
 
     if (nh > 0)
     {
@@ -1647,6 +1648,11 @@ void ocp_nlp_constraints_bgh_compute_adj_p(void* config_, void *dims_, void *mod
         }
         model->nl_constr_h_adj_p->evaluate(model->nl_constr_h_adj_p,
                     ext_fun_type_in, ext_fun_in, ext_fun_type_out, ext_fun_out);
+    }
+    else
+    {
+        // set output to zero - no contribution.
+        blasfeo_dvecse(np_global, 0.0, out, 0);
     }
 }
 

--- a/acados/utils/external_function_generic.c
+++ b/acados/utils/external_function_generic.c
@@ -430,12 +430,15 @@ static void d_cvt_dmat_to_casadi(struct blasfeo_dmat *in, double *out, int *spar
 
 
 
-// column vector: assume sparsity_in[1] = 1 !!! or empty vector;
 static void d_cvt_casadi_to_dvec(double *in, int *sparsity_in, struct blasfeo_dvec *out, int is_dense)
 {
     int idx;
 
-    assert((sparsity_in[1] == 1) | (sparsity_in[0] == 0) | (sparsity_in[1] == 0));
+    if (!((sparsity_in[1] == 1) | (sparsity_in[0] == 0) | (sparsity_in[1] == 0)))
+    {
+        printf("\nd_cvt_casadi_to_dvec: expected column vector or empty vector. Exiting.\n\n");
+        exit(1);
+    }
 
     int n = sparsity_in[0];
 
@@ -466,13 +469,15 @@ static void d_cvt_casadi_to_dvec(double *in, int *sparsity_in, struct blasfeo_dv
 
 
 
-// column vector: assume sparsity_in[1] = 1 !!! or empty vector;
 static void d_cvt_dvec_to_casadi(struct blasfeo_dvec *in, double *out, int *sparsity_out, int is_dense)
 {
     int idx;
 
-    assert((sparsity_out[1] == 1) | (sparsity_out[0] == 0) | (sparsity_out[1] == 0));
-
+    if (!((sparsity_out[1] == 1) | (sparsity_out[0] == 0) | (sparsity_out[1] == 0)))
+    {
+        printf("\nd_cvt_dvec_to_casadi: expected column vector or empty vector. Exiting.\n\n");
+        exit(1);
+    }
     int n = sparsity_out[0];
 
     if (n<=0)
@@ -661,12 +666,15 @@ static void d_cvt_dmat_args_to_casadi(struct blasfeo_dmat_args *in, double *out,
 
 
 
-// column vector: assume sparsity_in[1] = 1 !!! or empty vector;
 static void d_cvt_casadi_to_dvec_args(double *in, int *sparsity_in, struct blasfeo_dvec_args *out, int is_dense)
 {
     int idx;
 
-    assert((sparsity_in[1] == 1) | (sparsity_in[0] == 0) | (sparsity_in[1] == 0));
+    if (!((sparsity_in[1] == 1) | (sparsity_in[0] == 0) | (sparsity_in[1] == 0)))
+    {
+        printf("\nd_cvt_casadi_to_dvec_args: expected column vector or empty vector. Exiting.\n\n");
+        exit(1);
+    }
 
     int n = sparsity_in[0];
 
@@ -700,13 +708,15 @@ static void d_cvt_casadi_to_dvec_args(double *in, int *sparsity_in, struct blasf
 
 
 
-// column vector: assume sparsity_in[1] = 1 !!! or empty vector;
 static void d_cvt_dvec_args_to_casadi(struct blasfeo_dvec_args *in, double *out, int *sparsity_out, int is_dense)
 {
     int idx;
 
-    assert((sparsity_out[1] == 1) | (sparsity_out[0] == 0) | (sparsity_out[1] == 0));
-
+    if (!((sparsity_out[1] == 1) | (sparsity_out[0] == 0) | (sparsity_out[1] == 0)))
+    {
+        printf("\nd_cvt_dvec_args_to_casadi: expected column vector or empty vector. Exiting.\n\n");
+        exit(1);
+    }
     int n = sparsity_out[0];
 
     if (n<=0)

--- a/examples/acados_python/pendulum_on_cart/solution_sensitivities/sensitivity_utils.py
+++ b/examples/acados_python/pendulum_on_cart/solution_sensitivities/sensitivity_utils.py
@@ -198,7 +198,7 @@ def plot_cost_gradient_results(p_test, cost_values, acados_cost_grad, np_cost_gr
     # plot differences
     isub = 2
     ax[isub].plot(p_test, np.abs(acados_cost_grad - np_cost_grad), "--", label='acados vs. finite diff')
-    ax[isub].set_ylabel(r"difference $\partial_p V^*$")
+    ax[isub].set_ylabel(r"abs diff $\partial_p V^*$")
 
     if y_scale_log:
         ax[isub].set_yscale("log")

--- a/examples/acados_python/pendulum_on_cart/solution_sensitivities/sensitivity_utils.py
+++ b/examples/acados_python/pendulum_on_cart/solution_sensitivities/sensitivity_utils.py
@@ -177,15 +177,19 @@ def export_parametric_ocp(
 
     return ocp
 
-def plot_cost_gradient_results(p_test, cost_values, acados_cost_grad, np_cost_grad, cost_reconstructed_np_grad, y_scale_log=True):
+def plot_cost_gradient_results(p_test, cost_values, acados_cost_grad, np_cost_grad,
+                               cost_reconstructed_np_grad, cost_reconstructed_acados=None,
+                               y_scale_log=True, xlabel=None, title=None):
     _, ax = plt.subplots(nrows=4, ncols=1, sharex=True, figsize=(9,9))
 
     ax[0].plot(p_test, cost_values, label='cost acados', color='k')
     ax[0].plot(p_test, cost_reconstructed_np_grad, "--", label='reconstructed from finite diff')
+    if cost_reconstructed_acados is not None:
+        ax[0].plot(p_test, cost_reconstructed_acados, ":", label='reconstructed from acados derivatives')
     ax[0].set_ylabel(r"cost")
 
     ax[1].plot(p_test, np.abs(np_cost_grad), "--", label='finite diff')
-    ax[1].plot(p_test, np.abs(acados_cost_grad), "--", label='acados')
+    ax[1].plot(p_test, np.abs(acados_cost_grad), ":", label='acados')
     ax[1].set_ylabel(r"$|\partial_p V^*|$")
 
     if y_scale_log:
@@ -210,7 +214,11 @@ def plot_cost_gradient_results(p_test, cost_values, acados_cost_grad, np_cost_gr
         ax[i].grid()
         ax[i].legend()
 
-    ax[-1].set_xlabel(f"mass")
+    if xlabel is not None:
+        ax[-1].set_xlabel(xlabel)
+
+    if title is not None:
+        ax[0].set_title(title)
     ax[-1].set_xlim([p_test[0], p_test[-1]])
 
     fig_filename = f"cost_gradient.pdf"

--- a/examples/acados_python/pendulum_on_cart/solution_sensitivities/sensitivity_utils.py
+++ b/examples/acados_python/pendulum_on_cart/solution_sensitivities/sensitivity_utils.py
@@ -177,28 +177,34 @@ def export_parametric_ocp(
 
     return ocp
 
-def plot_cost_gradient_results(p_test, cost_values, acados_cost_grad, np_cost_grad, cost_reconstructed_np_grad):
+def plot_cost_gradient_results(p_test, cost_values, acados_cost_grad, np_cost_grad, cost_reconstructed_np_grad, y_scale_log=True):
     _, ax = plt.subplots(nrows=4, ncols=1, sharex=True, figsize=(9,9))
 
     ax[0].plot(p_test, cost_values, label='cost acados', color='k')
     ax[0].plot(p_test, cost_reconstructed_np_grad, "--", label='reconstructed from finite diff')
     ax[0].set_ylabel(r"cost")
 
-    ax[1].plot(p_test, np_cost_grad, "--", label='finite diff')
-    ax[1].plot(p_test, acados_cost_grad, "--", label='acados')
-    ax[1].set_ylabel(r"$\partial_p V^*$")
-    ax[1].set_yscale("log")
+    ax[1].plot(p_test, np.abs(np_cost_grad), "--", label='finite diff')
+    ax[1].plot(p_test, np.abs(acados_cost_grad), "--", label='acados')
+    ax[1].set_ylabel(r"$|\partial_p V^*|$")
+
+    if y_scale_log:
+        ax[1].set_yscale("log")
 
     # plot differences
     isub = 2
     ax[isub].plot(p_test, np.abs(acados_cost_grad - np_cost_grad), "--", label='acados vs. finite diff')
     ax[isub].set_ylabel(r"difference $\partial_p V^*$")
-    ax[isub].set_yscale("log")
+
+    if y_scale_log:
+        ax[isub].set_yscale("log")
 
     isub += 1
     ax[isub].plot(p_test, np.abs(acados_cost_grad - np_cost_grad) / np.abs(np_cost_grad), "--", label='acados vs. finite diff')
     ax[isub].set_ylabel(r"rel. diff. $\partial_p V^*$")
-    ax[isub].set_yscale("log")
+
+    if y_scale_log:
+        ax[isub].set_yscale("log")
 
     for i in range(isub+1):
         ax[i].grid()

--- a/examples/acados_python/pendulum_on_cart/solution_sensitivities/value_gradient_example_linear.py
+++ b/examples/acados_python/pendulum_on_cart/solution_sensitivities/value_gradient_example_linear.py
@@ -1,0 +1,273 @@
+# -*- coding: future_fstrings -*-
+#
+# Copyright (c) The acados authors.
+#
+# This file is part of acados.
+#
+# The 2-Clause BSD License
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.;
+#
+
+import numpy as np
+from sensitivity_utils import plot_cost_gradient_results
+from acados_template import AcadosModel, AcadosOcp, AcadosOcpSolver
+from casadi.tools import entry, struct_symSX
+import casadi as cs
+
+
+# taken from seal example
+params = {
+    "A": np.array([[1.0, 0.25], [0.0, 1.0]]),
+    "B": np.array([[0.03125], [0.25]]),
+    "Q": np.identity(2),
+    "R": np.identity(1),
+    "b": np.array([[0.0], [0.0]]),
+    "f": np.array([[0.0], [0.0], [0.0]]),
+    "V_0": np.array([1e-3]),
+}
+
+
+def find_param_in_p_or_p_global(param_name: list[str], model: AcadosModel) -> list:
+    if model.p == []:
+        return {key: model.p_global[key] for key in param_name}  # type:ignore
+    elif model.p_global is None:
+        return {key: model.p[key] for key in param_name}  # type:ignore
+    else:
+        return {
+            key: (model.p[key] if key in model.p.keys() else model.p_global[key])  # type:ignore
+            for key in param_name
+        }
+
+
+def disc_dyn_expr(model: AcadosModel):
+    """
+    Define the discrete dynamics function expression.
+    """
+    x = model.x
+    u = model.u
+
+    param = find_param_in_p_or_p_global(["A", "B", "b"], model)
+
+    return param["A"] @ x + param["B"] @ u + param["b"]
+
+
+def cost_expr_ext_cost(model: AcadosModel):
+    """
+    Define the external cost function expression.
+    """
+    x = model.x
+    u = model.u
+    param = find_param_in_p_or_p_global(["Q", "R", "f"], model)
+
+    return 0.5 * (
+        cs.transpose(x) @ param["Q"] @ x
+        + cs.transpose(u) @ param["R"] @ u
+        + cs.transpose(param["f"]) @ cs.vertcat(x, u)
+    )
+
+
+def cost_expr_ext_cost_0(model: AcadosModel):
+    """
+    Define the external cost function expression at stage 0.
+    """
+    param = find_param_in_p_or_p_global(["V_0"], model)
+
+    return param["V_0"] + cost_expr_ext_cost(model)
+
+
+def cost_expr_ext_cost_e(model: AcadosModel, param: dict[str, np.ndarray]):
+    """
+    Define the external cost function expression at the terminal stage as the solution of the discrete-time algebraic Riccati
+    equation.
+    """
+
+    x = model.x
+
+    return 0.5 * cs.mtimes(
+        [
+            cs.transpose(x),
+            param["Q"],
+            x,
+        ]
+    )
+
+
+def export_parametric_ocp(
+    param: dict[str, np.ndarray],
+    cost_type="EXTERNAL",
+    name: str = "lti",
+    learnable_params: list[str] = [],
+) -> AcadosOcp:
+    """
+    Export a parametric optimal control problem (OCP) for a discrete-time linear time-invariant (LTI) system.
+
+    Parameters:
+    -----------
+    param : dict
+        Dictionary containing the parameters of the system. Keys should include "A", "B", "b", "V_0", and "f".
+    cost_type : str, optional
+        Type of cost function to use. Options are "LINEAR_LS" or "EXTERNAL".
+    name : str, optional
+        Name of the model.
+
+    Returns:
+    --------
+    AcadosOcp
+        An instance of the AcadosOcp class representing the optimal control problem.
+    """
+    ocp = AcadosOcp()
+
+    ocp.model.name = name
+
+    ocp.dims.nx = 2
+    ocp.dims.nu = 1
+
+    ocp.model.x = cs.SX.sym("x", ocp.dims.nx)  # type:ignore
+    ocp.model.u = cs.SX.sym("u", ocp.dims.nu)  # type:ignore
+
+    ocp.solver_options.N_horizon = 40
+    ocp.solver_options.tf = 800
+    ocp.solver_options.integrator_type = 'DISCRETE'
+
+    # Add learnable parameters to p_global
+    if len(learnable_params) != 0:
+        ocp.model.p_global = struct_symSX(
+            [entry(key, shape=param[key].shape) for key in learnable_params]
+        )
+        ocp.p_global_values = np.concatenate(
+            [param[key].T.reshape(-1, 1) for key in learnable_params]
+        ).flatten()
+
+    # Add non_learnable parameters to p (stage-wise parameters)
+    non_learnable_params = [key for key in param.keys() if key not in learnable_params]
+    if len(non_learnable_params) != 0:
+        ocp.model.p = struct_symSX(
+            [entry(key, shape=param[key].shape) for key in non_learnable_params]
+        )
+        ocp.parameter_values = np.concatenate(
+            [param[key].T.reshape(-1, 1) for key in non_learnable_params]
+        ).flatten()
+
+    print("learnable_params", learnable_params)
+    print("non_learnable_params", non_learnable_params)
+
+    ocp.model.disc_dyn_expr = disc_dyn_expr(ocp.model)
+
+    ocp.cost.cost_type_0 = "EXTERNAL"
+    ocp.model.cost_expr_ext_cost_0 = cost_expr_ext_cost_0(ocp.model)
+
+    ocp.cost.cost_type = "EXTERNAL"
+    ocp.model.cost_expr_ext_cost = cost_expr_ext_cost(ocp.model)
+
+    ocp.cost.cost_type_e = "EXTERNAL"
+    ocp.model.cost_expr_ext_cost_e = cost_expr_ext_cost_e(ocp.model, param)
+
+    ocp.constraints.idxbx_0 = np.array([0, 1])
+    ocp.constraints.lbx_0 = np.array([-1.0, -1.0])
+    ocp.constraints.ubx_0 = np.array([1.0, 1.0])
+
+    ocp.constraints.idxbx = np.array([0, 1])
+    ocp.constraints.lbx = np.array([-0.0, -1.0])
+    ocp.constraints.ubx = np.array([+1.0, +1.0])
+
+    ocp.constraints.idxsbx = np.array([0])
+    ocp.cost.zl = np.array([1e2])
+    ocp.cost.zu = np.array([1e2])
+    ocp.cost.Zl = np.diag([0])
+    ocp.cost.Zu = np.diag([0])
+
+    ocp.constraints.idxbu = np.array([0])
+    ocp.constraints.lbu = np.array([-1.0])
+    ocp.constraints.ubu = np.array([+1.0])
+
+    # TODO: Make a PR to acados to allow struct_symSX | struct_symMX in acados_template and then concatenate there
+    if isinstance(ocp.model.p, struct_symSX):
+        ocp.model.p = ocp.model.p.cat if ocp.model.p is not None else []
+    if isinstance(ocp.model.p_global, struct_symSX):
+        ocp.model.p_global = (
+            ocp.model.p_global.cat if ocp.model.p_global is not None else None
+        )
+
+    return ocp
+
+
+
+def main():
+    """
+    Evaluate policy and calculate its gradient for the pendulum on a cart with a parametric model.
+    """
+
+    p_nominal = 1.0
+    x0 = np.array([0.0, 0.0])
+    delta_p = 0.002
+    p_test = np.arange(p_nominal - 0.5, p_nominal + 0.5, delta_p)
+
+    np_test = p_test.shape[0]
+
+    idx = 1
+    learnable_param = "f"
+    p_dim_ones = np.zeros(params[learnable_param].shape).reshape((-1,))
+    p_dim_ones[idx] = 1.
+    ocp = export_parametric_ocp(params, learnable_params = [learnable_param])
+    ocp.solver_options.with_value_sens_wrt_params = True
+    acados_ocp_solver = AcadosOcpSolver(ocp)
+
+    np_global = p_dim_ones.shape[0]
+    optimal_value_grad = np.zeros((np_test, np_global))
+    optimal_value = np.zeros((np_test,))
+
+    pi = np.zeros(np_test)
+    for i, p in enumerate(p_test):
+
+        p_val = p * p_dim_ones
+        acados_ocp_solver.set_p_global_and_precompute_dependencies(p_val)
+        pi[i] = acados_ocp_solver.solve_for_x0(x0)[0]
+        optimal_value[i] = acados_ocp_solver.get_cost()
+        optimal_value_grad[i] = acados_ocp_solver.eval_and_get_optimal_value_gradient("p_global")
+
+        grad = 0
+        for n in range(ocp.solver_options.N_horizon):
+            x = acados_ocp_solver.get(n, 'x')
+            grad += x[idx]
+
+        grad = grad*0.5
+
+        print(f"acados {optimal_value_grad[i][idx]}, analytic {grad}, iterations {acados_ocp_solver.get_stats('qp_iter')}")
+
+    # evaluate cost gradient
+    optimal_value_grad_via_fd = np.gradient(optimal_value, delta_p)
+    cost_reconstructed_np_grad = np.cumsum(optimal_value_grad_via_fd) * delta_p + optimal_value[0]
+
+    plot_cost_gradient_results(p_test, optimal_value, optimal_value_grad[:, idx], optimal_value_grad_via_fd, cost_reconstructed_np_grad, y_scale_log=False)
+
+    # checks
+    test_tol = 1e-1
+    median_diff = np.median(np.abs(optimal_value_grad[:, idx] - optimal_value_grad_via_fd))
+    print(f"Median difference between value function gradient obtained by acados and via FD is {median_diff} should be < {test_tol}.")
+    assert median_diff <= test_tol
+
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/acados_python/pendulum_on_cart/solution_sensitivities/value_gradient_example_linear.py
+++ b/examples/acados_python/pendulum_on_cart/solution_sensitivities/value_gradient_example_linear.py
@@ -237,6 +237,8 @@ def main():
     optimal_value_grad = np.zeros((np_test, np_global))
     optimal_value = np.zeros((np_test,))
 
+    dt = ocp.solver_options.tf/ocp.solver_options.N_horizon
+
     pi = np.zeros(np_test)
     for i, p in enumerate(p_test):
 
@@ -251,15 +253,17 @@ def main():
             x = acados_ocp_solver.get(n, 'x')
             grad += x[idx]
 
-        grad = grad*0.5
+        grad = grad*0.5*dt
 
         print(f"acados {optimal_value_grad[i][idx]}, analytic {grad}, iterations {acados_ocp_solver.get_stats('qp_iter')}")
 
     # evaluate cost gradient
     optimal_value_grad_via_fd = np.gradient(optimal_value, delta_p)
     cost_reconstructed_np_grad = np.cumsum(optimal_value_grad_via_fd) * delta_p + optimal_value[0]
+    cost_reconstructed_acados = np.cumsum(optimal_value_grad[:, idx]) * delta_p + optimal_value[0]
 
     plot_cost_gradient_results(p_test, optimal_value, optimal_value_grad[:, idx], optimal_value_grad_via_fd, cost_reconstructed_np_grad, y_scale_log=False)
+    # plot_cost_gradient_results(p_test, optimal_value, optimal_value_grad[:, idx], optimal_value_grad_via_fd, cost_reconstructed_acados, y_scale_log=False)
 
     # checks
     test_tol = 1e-1

--- a/interfaces/acados_template/acados_template/casadi_function_generation.py
+++ b/interfaces/acados_template/acados_template/casadi_function_generation.py
@@ -489,7 +489,7 @@ def generate_c_code_external_cost(context: GenerateContext, model: AcadosModel, 
         context.add_function_definition(fun_name_param, [x, u, z, p], [hess_xu_p], cost_dir)
 
     if opts["with_value_sens_wrt_params"]:
-        grad_p = ca.jacobian(ext_cost, p_global)
+        grad_p = ca.jacobian(ext_cost, p_global).T
         context.add_function_definition(fun_name_value_sens, [x, u, z, p], [grad_p], cost_dir)
 
     return


### PR DESCRIPTION
- fixed external function generation: output should be column vector
- external functions: use `exit` instead of assert to also check when compiling with Release
- `ocp_nlp_common_eval_lagr_grad_p`: pass correct option pointers to submodules
- fix adj_p in constraint module with nh==0
- add new example and improved plot