### PR TITLE
Add option `cost_scaling` in template based interfaces

### DIFF
--- a/examples/acados_matlab_octave/mocp_transition_example/main_multiphase_ocp.m
+++ b/examples/acados_matlab_octave/mocp_transition_example/main_multiphase_ocp.m
@@ -57,12 +57,17 @@ ocp.mocp_opts.integrator_type = {'ERK', 'DISCRETE', 'ERK'};
 
 % set solver options, common for AcadosOcp and AcadosMultiphaseOcp
 ocp.solver_options.nlp_solver_type = 'SQP';
-ocp.solver_options.tf = settings.T_HORIZON + 1.0;
+ocp.solver_options.tf = settings.T_HORIZON;
 T_HORIZON_1 = 0.4 * settings.T_HORIZON;
 T_HORIZON_2 = settings.T_HORIZON - T_HORIZON_1;
 ocp.solver_options.time_steps = [T_HORIZON_1 / N_list(1) * ones(1, N_list(1)), ...
-                                1.0, ...  % transition stage
+                                0.0, ...  % transition stage
                                 T_HORIZON_2 / N_list(3) * ones(1, N_list(3))];
+
+ocp.solver_options.cost_scaling = [T_HORIZON_1 / N_list(1) * ones(1, N_list(1)), ...
+                                1.0, ...  % transition stage
+                                T_HORIZON_2 / N_list(3) * ones(1, N_list(3)), ...
+                                1.0];  % terminal cost
 
 ocp.solver_options.store_iterates = true;
 
@@ -119,12 +124,11 @@ end
 
 %% plot trajectories in subplots
 figure;
-t_grid_3_plot = t_grid_phases{3} - 1.0;
 
 subplot(3, 1, 1);
 hold on;
 plot(t_grid_phases{1}, p_traj_1(:, 1), '-');
-plot(t_grid_3_plot, p_traj_3(:, 1), '-');
+plot(t_grid_phases{3}, p_traj_3(:, 1), '-');
 legend('phase 0', 'phase 2')
 ylabel('position');
 xlim([0, settings.T_HORIZON]);
@@ -132,7 +136,7 @@ xlim([0, settings.T_HORIZON]);
 subplot(3, 1, 2);
 hold on;
 plot(t_grid_phases{1}, v_traj_1(:, 1), '-');
-stairs(t_grid_3_plot, [v_traj_3; v_traj_3(end)], '-');
+stairs(t_grid_phases{3}, [v_traj_3; v_traj_3(end)], '-');
 legend('phase 0', 'phase 2')
 ylabel('velocity');
 xlim([0, settings.T_HORIZON]);

--- a/examples/acados_python/mocp_transition_example/minimal_transition_example.py
+++ b/examples/acados_python/mocp_transition_example/minimal_transition_example.py
@@ -146,8 +146,13 @@ def main_multiphase_ocp():
     T_HORIZON_2 = T_HORIZON - T_HORIZON_1
     ocp.solver_options.time_steps = \
                 np.array(N_list[0] * [T_HORIZON_1 / N_list[0]]
-                         + [1.0] # transition stage
+                         + [0.0] # transition stage
                          + N_list[2] * [T_HORIZON_2 / N_list[2]])
+    ocp.solver_options.cost_scaling = \
+                np.array(N_list[0] * [T_HORIZON_1 / N_list[0]]
+                         + [1.0] # transition stage
+                         + N_list[2] * [T_HORIZON_2 / N_list[2]]
+                        + [1.0]) # terminal stage
 
     acados_ocp_solver = AcadosOcpSolver(ocp)
 
@@ -167,21 +172,19 @@ def main_multiphase_ocp():
         print("-----------------------------------")
 
     # plot solution
-    t_grid_2_plot = t_grid_phases[2] - 1.0
-
     fig, ax = plt.subplots(3, 1, sharex=True)
 
     p_traj_0 = [x[0] for x in x_traj_phases[0]]
     ax[0].plot(t_grid_phases[0], p_traj_0, color='C0', label='phase 1')
 
     p_traj_2 = [x[0] for x in x_traj_phases[2]]
-    ax[0].plot(t_grid_2_plot, p_traj_2, color='C1', label='phase 2')
+    ax[0].plot(t_grid_phases[2], p_traj_2, color='C1', label='phase 2')
 
     v_traj_0 = [x[1] for x in x_traj_phases[0]]
     ax[1].plot(t_grid_phases[0], v_traj_0, color='C0')
 
     v_traj_2 = [u_traj_phases[2][0][0]] + [x[0] for x in u_traj_phases[2]]
-    ax[1].step(t_grid_2_plot, v_traj_2, '-', color='C1')
+    ax[1].step(t_grid_phases[2], v_traj_2, '-', color='C1')
 
     a_traj = [u_traj_phases[0][0][0]] + [x[0] for x in u_traj_phases[0]]
     ax[2].step(t_grid_phases[0], a_traj, color='C0')

--- a/interfaces/acados_matlab_octave/AcadosOcp.m
+++ b/interfaces/acados_matlab_octave/AcadosOcp.m
@@ -582,6 +582,18 @@ classdef AcadosOcp < handle
                 error(['ocp discretization: time_steps between shooting nodes must all be > 0', ...
                     ' got: ' num2str(opts.time_steps)])
             end
+
+            % cost_scaling
+            if isempty(opts.cost_scaling)
+                opts.cost_scaling = [opts.time_steps(:); 1.0];
+            elseif length(opts.cost_scaling) ~= N+1
+                error(['cost_scaling must have length N+1 = ', num2str(N+1)]);
+            end
+
+            % set integrator time automatically
+            opts.Tsim = opts.time_steps(1);
+
+            % integrator: num_stages
             if ~isempty(opts.sim_method_num_stages)
                 if(strcmp(opts.integrator_type, "ERK"))
                     if (any(opts.sim_method_num_stages < 1) || any(opts.sim_method_num_stages > 4))
@@ -589,9 +601,6 @@ classdef AcadosOcp < handle
                     end
                 end
             end
-
-            % set integrator time automatically
-            opts.Tsim = opts.time_steps(1);
 
             % qpdunes
             if ~isempty(strfind(opts.qp_solver,'qpdunes'))

--- a/interfaces/acados_matlab_octave/AcadosOcpOptions.m
+++ b/interfaces/acados_matlab_octave/AcadosOcpOptions.m
@@ -56,6 +56,8 @@ classdef AcadosOcpOptions < handle
         sim_method_jac_reuse
         sim_method_detect_gnsf
         time_steps
+        shooting_nodes
+        cost_scaling
         Tsim
         qp_solver              %  qp solver to be used in the NLP solver
         qp_solver_tol_stat
@@ -75,7 +77,6 @@ classdef AcadosOcpOptions < handle
         cost_discretization
         regularize_method
         reg_epsilon
-        shooting_nodes
         exact_hess_cost
         exact_hess_dyn
         exact_hess_constr
@@ -161,6 +162,7 @@ classdef AcadosOcpOptions < handle
             obj.regularize_method = 'NO_REGULARIZE';
             obj.reg_epsilon = 1e-4;
             obj.shooting_nodes = [];
+            obj.cost_scaling = [];
             obj.exact_hess_cost = 1;
             obj.exact_hess_dyn = 1;
             obj.exact_hess_constr = 1;
@@ -220,7 +222,7 @@ classdef AcadosOcpOptions < handle
 
         function s = convert_to_struct_for_json_dump(self, N)
             s = self.struct();
-            s = prepare_struct_for_json_dump(s, {'time_steps', 'shooting_nodes', 'sim_method_num_stages', 'sim_method_num_steps', 'sim_method_jac_reuse', 'custom_templates'}, {});
+            s = prepare_struct_for_json_dump(s, {'time_steps', 'shooting_nodes', 'cost_scaling', 'sim_method_num_stages', 'sim_method_num_steps', 'sim_method_jac_reuse', 'custom_templates'}, {});
         end
     end
 end

--- a/interfaces/acados_template/acados_template/acados_ocp.py
+++ b/interfaces/acados_template/acados_template/acados_ocp.py
@@ -779,6 +779,12 @@ class AcadosOcp:
             raise Exception(f'Inconsistent discretization: {opts.tf}'\
                 f' = tf != sum(opts.time_steps) = {tf}.')
 
+        # cost scaling
+        if opts.cost_scaling is None:
+            opts.cost_scaling = np.append(opts.time_steps, 1.0)
+        if opts.cost_scaling.shape[0] != opts.N_horizon + 1:
+            raise Exception(f'cost_scaling should be of length N+1 = {opts.N_horizon+1}, got {opts.cost_scaling.shape[0]}.')
+
         # set integrator time automatically
         opts.Tsim = opts.time_steps[0]
 

--- a/interfaces/acados_template/acados_template/acados_ocp_options.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_options.py
@@ -908,8 +908,8 @@ class AcadosOcpOptions:
     @property
     def cost_scaling(self):
         """
-        Vector with cost scaling factors of length `N_horizon`.
-        If `None` set automatically to match [`time_steps`, 1.0].
+        Vector with cost scaling factors of length `N_horizon` + 1.
+        If `None` set automatically to [`time_steps`, 1.0].
         Default: :code:`None`
         """
         return self.__cost_scaling

--- a/interfaces/acados_template/acados_template/acados_ocp_options.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_options.py
@@ -65,6 +65,7 @@ class AcadosOcpOptions:
         self.__sim_method_jac_reuse = 0
         self.__shooting_nodes = None
         self.__time_steps = None
+        self.__cost_scaling = None
         self.__Tsim = None
         self.__qp_solver = 'PARTIAL_CONDENSING_HPIPM'
         self.__qp_solver_tol_stat = None
@@ -905,6 +906,15 @@ class AcadosOcpOptions:
         return self.__shooting_nodes
 
     @property
+    def cost_scaling(self):
+        """
+        Vector with cost scaling factors of length `N_horizon`.
+        If `None` set automatically to match [`time_steps`, 1.0].
+        Default: :code:`None`
+        """
+        return self.__cost_scaling
+
+    @property
     def tf(self):
         """
         Prediction horizon
@@ -1164,6 +1174,11 @@ class AcadosOcpOptions:
     def shooting_nodes(self, shooting_nodes):
         shooting_nodes = check_if_nparray_and_flatten(shooting_nodes, "shooting_nodes")
         self.__shooting_nodes = shooting_nodes
+
+    @cost_scaling.setter
+    def cost_scaling(self, cost_scaling):
+        cost_scaling = check_if_nparray_and_flatten(cost_scaling, "cost_scaling")
+        self.__cost_scaling = cost_scaling
 
     @Tsim.setter
     def Tsim(self, Tsim):

--- a/interfaces/acados_template/acados_template/acados_ocp_options.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_options.py
@@ -63,6 +63,7 @@ class AcadosOcpOptions:
         self.__sim_method_newton_iter = 3
         self.__sim_method_newton_tol = 0.0
         self.__sim_method_jac_reuse = 0
+        self.__shooting_nodes = None
         self.__time_steps = None
         self.__Tsim = None
         self.__qp_solver = 'PARTIAL_CONDENSING_HPIPM'
@@ -83,7 +84,6 @@ class AcadosOcpOptions:
         self.__cost_discretization = 'EULER'
         self.__regularize_method = 'NO_REGULARIZE'
         self.__reg_epsilon = 1e-4
-        self.__shooting_nodes = None
         self.__exact_hess_cost = 1
         self.__exact_hess_dyn = 1
         self.__exact_hess_constr = 1
@@ -887,7 +887,9 @@ class AcadosOcpOptions:
     @property
     def time_steps(self):
         """
-        Vector with time steps between the shooting nodes. Set automatically to uniform discretization if :py:attr:`N` and :py:attr:`tf` are provided.
+        Vector of length `N_horizon` containing the time steps between the shooting nodes.
+        If `None` set automatically to uniform discretization using :py:attr:`N_horizon` and :py:attr:`tf`.
+        For nonuniform discretization: Either provide shooting_nodes or time_steps.
         Default: :code:`None`
         """
         return self.__time_steps
@@ -895,7 +897,9 @@ class AcadosOcpOptions:
     @property
     def shooting_nodes(self):
         """
-        Vector with the shooting nodes, time_steps will be computed from it automatically.
+        Vector of length `N_horizon + 1` containing the shooting nodes.
+        If `None` set automatically to uniform discretization using :py:attr:`N_horizon` and :py:attr:`tf`.
+        For nonuniform discretization: Either provide shooting_nodes or time_steps.
         Default: :code:`None`
         """
         return self.__shooting_nodes

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -322,9 +322,6 @@ class AcadosOcpSolver:
         getattr(self.shared_lib, f"{self.name}_acados_custom_update").argtypes = [c_void_p, POINTER(c_double), c_int]
         getattr(self.shared_lib, f"{self.name}_acados_custom_update").restype = c_int
 
-        getattr(self.shared_lib, f"{self.name}_acados_update_time_steps").argtypes = [c_void_p, c_int, c_void_p]
-        getattr(self.shared_lib, f"{self.name}_acados_update_time_steps").restype = c_int
-
         getattr(self.shared_lib, f"{self.name}_acados_create_with_discretization").argtypes = [c_void_p, c_int, c_void_p]
         getattr(self.shared_lib, f"{self.name}_acados_create_with_discretization").restype = c_int
 
@@ -347,6 +344,9 @@ class AcadosOcpSolver:
         if isinstance(self.acados_ocp, AcadosOcp):
             getattr(self.shared_lib, f'{self.name}_acados_update_qp_solver_cond_N').argtypes = [c_void_p, c_int]
             getattr(self.shared_lib, f'{self.name}_acados_update_qp_solver_cond_N').restype = c_int
+            getattr(self.shared_lib, f"{self.name}_acados_update_time_steps").argtypes = [c_void_p, c_int, c_void_p]
+            getattr(self.shared_lib, f"{self.name}_acados_update_time_steps").restype = c_int
+
         return
 
     def __get_pointers_solver(self):
@@ -457,6 +457,8 @@ class AcadosOcpSolver:
                       the shooting nodes without changing the number, e.g., to reach a different final time. Both cases
                       do not require a new code export and compilation.
         """
+        if isinstance(self.acados_ocp, AcadosMultiphaseOcp):
+            raise Exception('This function can only be used for single phase OCPs!')
 
         # unlikely but still possible
         if not self.solver_created:

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.c
@@ -900,7 +900,7 @@ void {{ name }}_acados_create_setup_nlp_in({{ name }}_solver_capsule* capsule, i
 {%- endif %}
     // set cost scaling
     double* cost_scaling = malloc((N+1)*sizeof(double));
-    {%- for j in range(end=solver_options.N_horizon) %}
+    {%- for j in range(end=solver_options.N_horizon+1) %}
     cost_scaling[{{ j }}] = {{ solver_options.cost_scaling[j] }};
     {%- endfor %}
     for (int i = 0; i <= N; i++)

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -980,7 +980,7 @@ void {{ model.name }}_acados_setup_nlp_in({{ model.name }}_solver_capsule* capsu
     {%- endif %}
         // set cost scaling
         double* cost_scaling = malloc((N+1)*sizeof(double));
-      {%- for j in range(end=solver_options.N_horizon) %}
+      {%- for j in range(end=solver_options.N_horizon+1) %}
         cost_scaling[{{ j }}] = {{ solver_options.cost_scaling[j] }};
       {%- endfor %}
         for (int i = 0; i <= N; i++)

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -961,7 +961,7 @@ void {{ model.name }}_acados_setup_nlp_in({{ model.name }}_solver_capsule* capsu
     else
     {
         // set time_steps
-    {%- if all_equal == true -%}{# all time_steps are identical #}
+    {% if all_equal == true -%}{# all time_steps are identical #}
         double time_step = {{ solver_options.time_steps[0] }};
         for (int i = 0; i < N; i++)
         {

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -943,7 +943,7 @@ void {{ model.name }}_acados_setup_nlp_in({{ model.name }}_solver_capsule* capsu
 //    capsule->nlp_in = nlp_in;
     ocp_nlp_in * nlp_in = capsule->nlp_in;
 
-    // set up time_steps
+    // set up time_steps and cost_scaling
     {%- set all_equal = true -%}
     {%- set val = solver_options.time_steps[0] %}
     {%- for j in range(start=1, end=solver_options.N_horizon) %}
@@ -955,26 +955,41 @@ void {{ model.name }}_acados_setup_nlp_in({{ model.name }}_solver_capsule* capsu
 
     if (new_time_steps)
     {
+        // NOTE: this sets scaling and time_steps
         {{ model.name }}_acados_update_time_steps(capsule, N, new_time_steps);
     }
     else
     {
+        // set time_steps
     {%- if all_equal == true -%}{# all time_steps are identical #}
         double time_step = {{ solver_options.time_steps[0] }};
         for (int i = 0; i < N; i++)
         {
             ocp_nlp_in_set(nlp_config, nlp_dims, nlp_in, i, "Ts", &time_step);
-            ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, i, "scaling", &time_step);
         }
     {%- else -%}{# time_steps are varying #}
         double* time_steps = malloc(N*sizeof(double));
         {%- for j in range(end=solver_options.N_horizon) %}
         time_steps[{{ j }}] = {{ solver_options.time_steps[j] }};
         {%- endfor %}
-        {{ model.name }}_acados_update_time_steps(capsule, N, time_steps);
+        for (int i = 0; i < N; i++)
+        {
+            ocp_nlp_in_set(nlp_config, nlp_dims, nlp_in, i, "Ts", &time_steps[i]);
+        }
         free(time_steps);
     {%- endif %}
+        // set cost scaling
+        double* cost_scaling = malloc((N+1)*sizeof(double));
+      {%- for j in range(end=solver_options.N_horizon) %}
+        cost_scaling[{{ j }}] = {{ solver_options.cost_scaling[j] }};
+      {%- endfor %}
+        for (int i = 0; i <= N; i++)
+        {
+            ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, i, "scaling", &cost_scaling[i]);
+        }
+        free(cost_scaling);
     }
+
 
     /**** Dynamics ****/
     for (int i = 0; i < N; i++)


### PR DESCRIPTION
This allows to have `AcadosOcp.shooting_nodes` be "correct" when incorporating transition stages with costs.
Simplified transition examples accordingly.
```
cost_scaling: 
Vector with cost scaling factors of length N_horizon + 1.
If None set automatically to [`time_steps`, 1.0].
Default: None
```
Improved docstrings for `time_steps` and `shooting_nodes`
