### PR TITLE
C templates/python: Extend batch solver with load/store from/to flattenedd batch iterate

### DIFF
--- a/examples/acados_python/pendulum_on_cart/ocp/minimal_example_batch_ocp_solver.py
+++ b/examples/acados_python/pendulum_on_cart/ocp/minimal_example_batch_ocp_solver.py
@@ -144,10 +144,10 @@ def main_batch(Xinit, simU, tol, num_threads_in_batch_solve=1):
 
     print(f"main_batch: with {num_threads_in_batch_solve} threads, solve: {t_elapsed:.3f}ms")
 
-    for n in range(N_batch):
-        u = batch_solver.ocp_solvers[n].get(0, "u")
+    U_batch = batch_solver.get_flat("u")
 
-        if not np.linalg.norm(u-simU[n]) < tol*10:
+    for n in range(N_batch):
+        if not np.linalg.norm(U_batch[n, :ocp.dims.nu] -simU[n]) < tol*10:
             raise Exception(f"solution should match sequential call up to {tol*10} got error {np.linalg.norm(u-simU[n])} for {n}th batch solve")
 
 

--- a/interfaces/acados_c/ocp_nlp_interface.c
+++ b/interfaces/acados_c/ocp_nlp_interface.c
@@ -1525,7 +1525,6 @@ void ocp_nlp_get_from_iterate(ocp_nlp_solver *solver, int iter, int stage, const
 }
 
 
-
 void ocp_nlp_get_all(ocp_nlp_solver *solver, ocp_nlp_in *in, ocp_nlp_out *out, const char *field, void *value)
 {
     ocp_nlp_dims *dims = solver->dims;

--- a/interfaces/acados_template/acados_template/acados_ocp_batch_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_batch_solver.py
@@ -230,7 +230,7 @@ class AcadosOcpBatchSolver():
         Set concatenation solver initialization for all `N_batch` solvers.
 
             :param field_: string in ['x', 'u', 'z', 'pi', 'lam', 'sl', 'su', 'p']
-            :param value_: np.array of shape (N_batch, n_field)
+            :param value_: np.array of shape (N_batch, n_field_total)
         """
 
         field = field_.encode('utf-8')
@@ -256,6 +256,7 @@ class AcadosOcpBatchSolver():
         Get concatenation of all stages of last solution of the solver.
 
             :param field: string in ['x', 'u', 'z', 'pi', 'lam', 'sl', 'su', 'p']
+            :returns: numpy array of shape (N_batch, n_field_total)
         """
         if field_ not in ['x', 'u', 'z', 'pi', 'lam', 'sl', 'su', 'p']:
             raise Exception(f'AcadosOcpSolver.get_flat(field={field_}): \'{field_}\' is an invalid argument.')

--- a/interfaces/acados_template/acados_template/acados_ocp_batch_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_batch_solver.py
@@ -31,6 +31,7 @@
 
 from .acados_ocp_solver import AcadosOcpSolver
 from .acados_ocp import AcadosOcp
+from .acados_ocp_iterate import AcadosOcpFlattenedBatchIterate
 from typing import Optional, List, Tuple
 from collections.abc import Sequence
 from ctypes import (POINTER, c_int, c_void_p, cast, c_double, c_char_p)
@@ -73,6 +74,12 @@ class AcadosOcpBatchSolver():
 
         getattr(self.__shared_lib, f"{self.__name}_acados_batch_eval_solution_sens_adj_p").argtypes = [POINTER(c_void_p), c_char_p, c_int, POINTER(c_double), c_int, c_int]
         getattr(self.__shared_lib, f"{self.__name}_acados_batch_eval_solution_sens_adj_p").restype = c_void_p
+
+        getattr(self.__shared_lib, f"{self.__name}_acados_batch_set_flat").argtypes = [POINTER(c_void_p), c_char_p, POINTER(c_double), c_int, c_int]
+        getattr(self.__shared_lib, f"{self.__name}_acados_batch_set_flat").restype = c_void_p
+
+        getattr(self.__shared_lib, f"{self.__name}_acados_batch_get_flat").argtypes = [POINTER(c_void_p), c_char_p, POINTER(c_double), c_int, c_int]
+        getattr(self.__shared_lib, f"{self.__name}_acados_batch_get_flat").restype = c_void_p
 
         if self.ocp_solvers[0].acados_lib_uses_omp:
             msg = "Note: Please make sure that the acados shared library is compiled with the number of threads set to 1,\n"
@@ -240,7 +247,57 @@ class AcadosOcpBatchSolver():
 
         value_ = value_.astype(float)
         value_data = cast(value_.ctypes.data, POINTER(c_double))
-        value_data_p = cast((value_data), c_void_p)
 
-        getattr(self.__shared_lib, f"{self.__name}_acados_batch_set_flat")(self.__ocp_solvers_pointer, field, value_data_p, N_data, self.__N_batch)
+        getattr(self.__shared_lib, f"{self.__name}_acados_batch_set_flat")(self.__ocp_solvers_pointer, field, value_data, N_data, self.__N_batch)
 
+
+    def get_flat(self, field_: str) -> np.ndarray:
+        """
+        Get concatenation of all stages of last solution of the solver.
+
+            :param field: string in ['x', 'u', 'z', 'pi', 'lam', 'sl', 'su', 'p']
+        """
+        if field_ not in ['x', 'u', 'z', 'pi', 'lam', 'sl', 'su', 'p']:
+            raise Exception(f'AcadosOcpSolver.get_flat(field={field_}): \'{field_}\' is an invalid argument.')
+
+        field = field_.encode('utf-8')
+
+        dim = self.ocp_solvers[0].get_dim_flat(field_)
+
+        out = np.ascontiguousarray(np.zeros((self.N_batch, dim,)), dtype=np.float64)
+        out_data = cast(out.ctypes.data, POINTER(c_double))
+
+        getattr(self.__shared_lib, f"{self.__name}_acados_batch_get_flat")(self.__ocp_solvers_pointer, field, out_data, self.N_batch*dim, self.__N_batch)
+
+        return out
+
+
+    def store_iterate_to_flat_obj(self) -> AcadosOcpFlattenedBatchIterate:
+        """
+        Returns the current iterate of the OCP solvers as an AcadosOcpFlattenedBatchIterate.
+        """
+        return AcadosOcpFlattenedBatchIterate(x = self.get_flat("x"),
+                                              u = self.get_flat("u"),
+                                              z = self.get_flat("z"),
+                                              sl = self.get_flat("sl"),
+                                              su = self.get_flat("su"),
+                                              pi = self.get_flat("pi"),
+                                              lam = self.get_flat("lam"),
+                                              N_batch=self.N_batch)
+
+    def load_iterate_from_flat_obj(self, iterate: AcadosOcpFlattenedBatchIterate) -> None:
+        """
+        Loads the provided iterate into the OCP solvers.
+        Note: The iterate object does not contain the the parameters.
+        """
+
+        if self.N_batch != iterate.N_batch:
+            raise Exception(f"Wrong batch dimension. Expected {self.N_batch}, got {iterate.N_batch}")
+
+        self.set_flat("x", iterate.x)
+        self.set_flat("u", iterate.u)
+        self.set_flat("z", iterate.z)
+        self.set_flat("sl", iterate.sl)
+        self.set_flat("su", iterate.su)
+        self.set_flat("pi", iterate.pi)
+        self.set_flat("lam", iterate.lam)

--- a/interfaces/acados_template/acados_template/acados_ocp_iterate.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_iterate.py
@@ -46,6 +46,18 @@ class AcadosOcpFlattenedIterate:
 
 
 @dataclass
+class AcadosOcpFlattenedBatchIterate:
+    x: np.ndarray
+    u: np.ndarray
+    z: np.ndarray
+    sl: np.ndarray
+    su: np.ndarray
+    pi: np.ndarray
+    lam: np.ndarray
+    N_batch: int
+
+
+@dataclass
 class AcadosOcpIterate:
 
     x_traj: List[np.ndarray]

--- a/interfaces/acados_template/acados_template/acados_ocp_iterate.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_iterate.py
@@ -47,8 +47,8 @@ class AcadosOcpFlattenedIterate:
 
 @dataclass
 class AcadosOcpFlattenedBatchIterate:
-    x: np.ndarray
-    u: np.ndarray
+    x: np.ndarray # shape (N_batch, nx_total)
+    u: np.ndarray # shape (N_batch, nu_total)
     z: np.ndarray
     sl: np.ndarray
     su: np.ndarray

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.h
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.h
@@ -295,7 +295,10 @@ ACADOS_SYMBOL_EXPORT int {{ name }}_acados_set_p_global_and_precompute_dependenc
 ACADOS_SYMBOL_EXPORT int {{ model.name }}_acados_solve({{ model.name }}_solver_capsule * capsule);
 
 ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_solve({{ model.name }}_solver_capsule ** capsules, int N_batch);
-ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_set_flat({{ model.name }}_solver_capsule ** capsules, const char *field, void *value, int N_data, int N_batch);
+
+ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_set_flat({{ model.name }}_solver_capsule ** capsules, const char *field, double *data, int N_data, int N_batch);
+ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_get_flat({{ model.name }}_solver_capsule ** capsules, const char *field, double *data, int N_data, int N_batch);
+
 ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_eval_solution_sens_adj_p({{ model.name }}_solver_capsule ** capsules, const char *field, int stage, double *out, int offset, int N_batch);
 ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_eval_params_jac({{ model.name }}_solver_capsule ** capsules, int N_batch);
 


### PR DESCRIPTION
This PR extends the solver `AcadosOcpBatchSolver` with 
- `get_flat` to get the flattened iterate from all solvers in the batch
- `store_iterate_to_flat_obj` and `load_iterate_from_flat_obj` which allow to load/store a batch iterate