### PR TITLE
Python: fix type import

### DIFF
--- a/interfaces/acados_template/acados_template/acados_ocp_batch_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_batch_solver.py
@@ -32,8 +32,7 @@
 from .acados_ocp_solver import AcadosOcpSolver
 from .acados_ocp import AcadosOcp
 from .acados_ocp_iterate import AcadosOcpFlattenedBatchIterate
-from typing import Optional, List, Tuple
-from collections.abc import Sequence
+from typing import Optional, List, Tuple, Sequence
 from ctypes import (POINTER, c_int, c_void_p, cast, c_double, c_char_p)
 import numpy as np
 import time

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -44,8 +44,7 @@ if os.name == 'nt':
 else:
     from ctypes import CDLL as DllLoader
 from datetime import datetime
-from typing import Union, Optional, List, Tuple
-from collections.abc import Sequence
+from typing import Union, Optional, List, Tuple, Sequence
 
 import numpy as np
 import scipy.linalg


### PR DESCRIPTION
Import `Sequence` type from `typing` (not `collections`) to be compatible with python 3.8, cf. https://mypy.readthedocs.io/en/latest/builtin_types.html