### PR TITLE
MATLAB/python: QP diagnostic with consistent names

### DIFF
--- a/examples/acados_matlab_octave/getting_started/extensive_example_ocp.m
+++ b/examples/acados_matlab_octave/getting_started/extensive_example_ocp.m
@@ -284,16 +284,16 @@ disp('QP diagnostics of last QP before condensing')
 result = ocp_solver.qp_diagnostics(false);
 disp(['min eigenvalues of blocks are in [', num2str(min(result.min_eigv_stage)), ', ', num2str(max(result.min_eigv_stage)), ']'])
 disp(['max eigenvalues of blocks are in [', num2str(min(result.max_eigv_stage)), ', ', num2str(max(result.max_eigv_stage)), ']'])
-disp(['condition_number_blockwise: '])
-disp(result.condition_number_blockwise)
+disp(['condition_number_stage: '])
+disp(result.condition_number_stage)
 disp(['condition_number_global: ', num2str(result.condition_number_global)])
 
 disp('QP diagnostics of last QP after partial condensing')
 result = ocp_solver.qp_diagnostics(true);
 disp(['min eigenvalues of blocks are in [', num2str(min(result.min_eigv_stage)), ', ', num2str(max(result.min_eigv_stage)), ']'])
 disp(['max eigenvalues of blocks are in [', num2str(min(result.max_eigv_stage)), ', ', num2str(max(result.max_eigv_stage)), ']'])
-disp(['condition_number_blockwise: '])
-disp(result.condition_number_blockwise)
+disp(['condition_number_stage: '])
+disp(result.condition_number_stage)
 disp(['condition_number_global: ', num2str(result.condition_number_global)])
 
 % get second SQP iterate

--- a/examples/acados_matlab_octave/getting_started/extensive_example_ocp.m
+++ b/examples/acados_matlab_octave/getting_started/extensive_example_ocp.m
@@ -282,16 +282,16 @@ cond_H = ocp_solver.get('qp_solver_cond_H');
 
 disp('QP diagnostics of last QP before condensing')
 result = ocp_solver.qp_diagnostics(false);
-disp(['min eigenvalues of blocks are in [', num2str(min(result.min_ev)), ', ', num2str(max(result.min_ev)), ']'])
-disp(['max eigenvalues of blocks are in [', num2str(min(result.max_ev)), ', ', num2str(max(result.max_ev)), ']'])
+disp(['min eigenvalues of blocks are in [', num2str(min(result.min_eigv_stage)), ', ', num2str(max(result.min_eigv_stage)), ']'])
+disp(['max eigenvalues of blocks are in [', num2str(min(result.max_eigv_stage)), ', ', num2str(max(result.max_eigv_stage)), ']'])
 disp(['condition_number_blockwise: '])
 disp(result.condition_number_blockwise)
 disp(['condition_number_global: ', num2str(result.condition_number_global)])
 
 disp('QP diagnostics of last QP after partial condensing')
 result = ocp_solver.qp_diagnostics(true);
-disp(['min eigenvalues of blocks are in [', num2str(min(result.min_ev)), ', ', num2str(max(result.min_ev)), ']'])
-disp(['max eigenvalues of blocks are in [', num2str(min(result.max_ev)), ', ', num2str(max(result.max_ev)), ']'])
+disp(['min eigenvalues of blocks are in [', num2str(min(result.min_eigv_stage)), ', ', num2str(max(result.min_eigv_stage)), ']'])
+disp(['max eigenvalues of blocks are in [', num2str(min(result.max_eigv_stage)), ', ', num2str(max(result.max_eigv_stage)), ']'])
 disp(['condition_number_blockwise: '])
 disp(result.condition_number_blockwise)
 disp(['condition_number_global: ', num2str(result.condition_number_global)])

--- a/examples/acados_matlab_octave/legacy_interface/getting_started/extensive_example_ocp.m
+++ b/examples/acados_matlab_octave/legacy_interface/getting_started/extensive_example_ocp.m
@@ -323,16 +323,16 @@ cond_H = ocp_solver.get('qp_solver_cond_H');
 
 disp('QP diagnostics of last QP before condensing')
 result = ocp_solver.qp_diagnostics(false);
-disp(['min eigenvalues of blocks are in [', num2str(min(result.min_ev)), ', ', num2str(max(result.min_ev)), ']'])
-disp(['max eigenvalues of blocks are in [', num2str(min(result.max_ev)), ', ', num2str(max(result.max_ev)), ']'])
+disp(['min eigenvalues of blocks are in [', num2str(min(result.min_eigv_stage)), ', ', num2str(max(result.min_eigv_stage)), ']'])
+disp(['max eigenvalues of blocks are in [', num2str(min(result.max_eigv_stage)), ', ', num2str(max(result.max_eigv_stage)), ']'])
 disp(['condition_number_blockwise: '])
 disp(result.condition_number_blockwise)
 disp(['condition_number_global: ', num2str(result.condition_number_global)])
 
 disp('QP diagnostics of last QP after partial condensing')
 result = ocp_solver.qp_diagnostics(true);
-disp(['min eigenvalues of blocks are in [', num2str(min(result.min_ev)), ', ', num2str(max(result.min_ev)), ']'])
-disp(['max eigenvalues of blocks are in [', num2str(min(result.max_ev)), ', ', num2str(max(result.max_ev)), ']'])
+disp(['min eigenvalues of blocks are in [', num2str(min(result.min_eigv_stage)), ', ', num2str(max(result.min_eigv_stage)), ']'])
+disp(['max eigenvalues of blocks are in [', num2str(min(result.max_eigv_stage)), ', ', num2str(max(result.max_eigv_stage)), ']'])
 disp(['condition_number_blockwise: '])
 disp(result.condition_number_blockwise)
 disp(['condition_number_global: ', num2str(result.condition_number_global)])

--- a/examples/acados_matlab_octave/legacy_interface/getting_started/extensive_example_ocp.m
+++ b/examples/acados_matlab_octave/legacy_interface/getting_started/extensive_example_ocp.m
@@ -325,16 +325,16 @@ disp('QP diagnostics of last QP before condensing')
 result = ocp_solver.qp_diagnostics(false);
 disp(['min eigenvalues of blocks are in [', num2str(min(result.min_eigv_stage)), ', ', num2str(max(result.min_eigv_stage)), ']'])
 disp(['max eigenvalues of blocks are in [', num2str(min(result.max_eigv_stage)), ', ', num2str(max(result.max_eigv_stage)), ']'])
-disp(['condition_number_blockwise: '])
-disp(result.condition_number_blockwise)
+disp(['condition_number_stage: '])
+disp(result.condition_number_stage)
 disp(['condition_number_global: ', num2str(result.condition_number_global)])
 
 disp('QP diagnostics of last QP after partial condensing')
 result = ocp_solver.qp_diagnostics(true);
 disp(['min eigenvalues of blocks are in [', num2str(min(result.min_eigv_stage)), ', ', num2str(max(result.min_eigv_stage)), ']'])
 disp(['max eigenvalues of blocks are in [', num2str(min(result.max_eigv_stage)), ', ', num2str(max(result.max_eigv_stage)), ']'])
-disp(['condition_number_blockwise: '])
-disp(result.condition_number_blockwise)
+disp(['condition_number_stage: '])
+disp(result.condition_number_stage)
 disp(['condition_number_global: ', num2str(result.condition_number_global)])
 
 %% Plot trajectories

--- a/examples/acados_matlab_octave/pendulum_on_cart_model/example_ocp.m
+++ b/examples/acados_matlab_octave/pendulum_on_cart_model/example_ocp.m
@@ -231,14 +231,14 @@ if (strcmp(sim_method, 'irk_gnsf'))
 end
 
 %% create acados OCP solver
-solver_creation = 'transcribe_explicit'
+solver_creation = 'transcribe_explicit';
 
 if strcmp(solver_creation, 'legacy')
     % legacy interface
     ocp_solver = acados_ocp(ocp_model, ocp_opts);
 elseif strcmp(solver_creation, 'transcribe_explicit')
     % test translation to new OCP formulation object
-    ocp = setup_AcadosOcp_from_legacy_ocp_description(ocp_model, ocp_opts)
+    ocp = setup_AcadosOcp_from_legacy_ocp_description(ocp_model, ocp_opts);
     ocp_solver = AcadosOcpSolver(ocp);
 end
 

--- a/examples/acados_python/pendulum_on_cart/solution_sensitivities/policy_gradient_example.py
+++ b/examples/acados_python/pendulum_on_cart/solution_sensitivities/policy_gradient_example.py
@@ -114,10 +114,10 @@ def main_parametric(qp_solver_ric_alg: int, eigen_analysis=True, use_cython=Fals
         if eigen_analysis:
             full_hessian_diagnostics = sensitivity_solver.qp_diagnostics("FULL_HESSIAN")
             projected_hessian_diagnostics = sensitivity_solver.qp_diagnostics("PROJECTED_HESSIAN")
-            min_eig_full[i] = full_hessian_diagnostics['min_eigv_total']
-            min_abs_eig_full[i] = full_hessian_diagnostics['min_abs_eigv_total']
-            min_abs_eig_proj_hess[i]= projected_hessian_diagnostics['min_abs_eigv_total']
-            min_eig_proj_hess[i] = projected_hessian_diagnostics['min_eigv_total']
+            min_eig_full[i] = full_hessian_diagnostics['min_eigv_global']
+            min_abs_eig_full[i] = full_hessian_diagnostics['min_abs_eigv_global']
+            min_abs_eig_proj_hess[i]= projected_hessian_diagnostics['min_abs_eigv_global']
+            min_eig_proj_hess[i] = projected_hessian_diagnostics['min_eigv_global']
             min_eig_P[i] = projected_hessian_diagnostics['min_eig_P']
             min_abs_eig_P[i] = projected_hessian_diagnostics['min_abs_eig_P']
 

--- a/examples/acados_python/pendulum_on_cart/solution_sensitivities/policy_gradient_example.py
+++ b/examples/acados_python/pendulum_on_cart/solution_sensitivities/policy_gradient_example.py
@@ -118,8 +118,8 @@ def main_parametric(qp_solver_ric_alg: int, eigen_analysis=True, use_cython=Fals
             min_abs_eig_full[i] = full_hessian_diagnostics['min_abs_eigv_global']
             min_abs_eig_proj_hess[i]= projected_hessian_diagnostics['min_abs_eigv_global']
             min_eig_proj_hess[i] = projected_hessian_diagnostics['min_eigv_global']
-            min_eig_P[i] = projected_hessian_diagnostics['min_eig_P']
-            min_abs_eig_P[i] = projected_hessian_diagnostics['min_abs_eig_P']
+            min_eig_P[i] = projected_hessian_diagnostics['min_eigv_P_global']
+            min_abs_eig_P[i] = projected_hessian_diagnostics['min_abs_eigv_P_global']
 
         if ocp_solver.get_status() not in [0]:
             print(f"OCP solver returned status {ocp_solver.get_status()}.")

--- a/examples/acados_python/pendulum_on_cart/solution_sensitivities/state_augementation_policy_gradient.py
+++ b/examples/acados_python/pendulum_on_cart/solution_sensitivities/state_augementation_policy_gradient.py
@@ -250,10 +250,10 @@ def main_augmented(param_M_as_state: bool, idxp: int, qp_solver_ric_alg: int, ei
         if eigen_analysis:
             full_hessian_diagnostics = sensitivity_solver.qp_diagnostics("FULL_HESSIAN")
             projected_hessian_diagnostics = sensitivity_solver.qp_diagnostics("PROJECTED_HESSIAN")
-            min_eig_full[i] = full_hessian_diagnostics['min_eigv_total']
-            min_abs_eig_full[i] = full_hessian_diagnostics['min_abs_eigv_total']
-            min_abs_eig_proj_hess[i]= projected_hessian_diagnostics['min_abs_eigv_total']
-            min_eig_proj_hess[i] = projected_hessian_diagnostics['min_eigv_total']
+            min_eig_full[i] = full_hessian_diagnostics['min_eigv_global']
+            min_abs_eig_full[i] = full_hessian_diagnostics['min_abs_eigv_global']
+            min_abs_eig_proj_hess[i]= projected_hessian_diagnostics['min_abs_eigv_global']
+            min_eig_proj_hess[i] = projected_hessian_diagnostics['min_eigv_global']
             min_eig_P[i] = projected_hessian_diagnostics['min_eig_P']
             min_abs_eig_P[i] = projected_hessian_diagnostics['min_abs_eig_P']
 

--- a/examples/acados_python/pendulum_on_cart/solution_sensitivities/state_augementation_policy_gradient.py
+++ b/examples/acados_python/pendulum_on_cart/solution_sensitivities/state_augementation_policy_gradient.py
@@ -254,8 +254,8 @@ def main_augmented(param_M_as_state: bool, idxp: int, qp_solver_ric_alg: int, ei
             min_abs_eig_full[i] = full_hessian_diagnostics['min_abs_eigv_global']
             min_abs_eig_proj_hess[i]= projected_hessian_diagnostics['min_abs_eigv_global']
             min_eig_proj_hess[i] = projected_hessian_diagnostics['min_eigv_global']
-            min_eig_P[i] = projected_hessian_diagnostics['min_eig_P']
-            min_abs_eig_P[i] = projected_hessian_diagnostics['min_abs_eig_P']
+            min_eig_P[i] = projected_hessian_diagnostics['min_eigv_P_global']
+            min_abs_eig_P[i] = projected_hessian_diagnostics['min_abs_eigv_P_global']
 
         # Calculate the policy gradient
         _, sens_u_ = sensitivity_solver.eval_solution_sensitivity(0, "initial_state")

--- a/interfaces/acados_matlab_octave/AcadosOcpSolver.m
+++ b/interfaces/acados_matlab_octave/AcadosOcpSolver.m
@@ -245,13 +245,14 @@ classdef AcadosOcpSolver < handle
             % result = ocp_solver.qp_diagnostics([partially_condensed_qp=false])
 
             % returns a struct with the following fields:
-            % - min_eigv_stage: dict with minimum eigenvalue for each Hessian block.
-            % - max_eigv_stage: dict with maximum eigenvalue for each Hessian block.
-            % - condition_number_stage: dict with condition number for each Hessian block.
-            % - condition_number_global: condition number for the full Hessian.
+            % - min_eigv_stage: array with minimum eigenvalue for each Hessian block.
+            % - max_eigv_stage: array with maximum eigenvalue for each Hessian block.
+            % - condition_number_stage: array with condition number for each Hessian block.
             % - min_eigv_global: minimum eigenvalue for the full Hessian.
             % - min_abs_eigv_global: minimum absolute eigenvalue for the full Hessian.
             % - max_eigv_global: maximum eigenvalue for the full Hessian.
+            % - max_abs_eigv_global: maximum absolute eigenvalue for the full Hessian.
+            % - condition_number_global: condition number for the full Hessian.
 
             if length(varargin) > 0
                 partially_condensed_qp = varargin{1};

--- a/interfaces/acados_matlab_octave/AcadosOcpSolver.m
+++ b/interfaces/acados_matlab_octave/AcadosOcpSolver.m
@@ -245,10 +245,13 @@ classdef AcadosOcpSolver < handle
             % result = ocp_solver.qp_diagnostics([partially_condensed_qp=false])
 
             % returns a struct with the following fields:
-            % - min_ev: minimum eigenvalue for each Hessian block.
-            % - max_ev: maximum eigenvalue for each Hessian block.
-            % - condition_number: condition number for each Hessian block.
+            % - min_eigv_stage: dict with minimum eigenvalue for each Hessian block.
+            % - max_eigv_stage: dict with maximum eigenvalue for each Hessian block.
+            % - condition_number_stage: dict with condition number for each Hessian block.
             % - condition_number_global: condition number for the full Hessian.
+            % - min_eigv_global: minimum eigenvalue for the full Hessian.
+            % - min_abs_eigv_global: minimum absolute eigenvalue for the full Hessian.
+            % - max_eigv_global: maximum eigenvalue for the full Hessian.
 
             if length(varargin) > 0
                 partially_condensed_qp = varargin{1};
@@ -262,9 +265,9 @@ classdef AcadosOcpSolver < handle
                 num_blocks = obj.ocp.dims.N + 1;
             end
             result = struct();
-            result.min_ev = zeros(num_blocks, 1);
-            result.max_ev = zeros(num_blocks, 1);
-            result.condition_number = zeros(num_blocks, 1);
+            result.min_eigv_stage = zeros(num_blocks, 1);
+            result.max_eigv_stage = zeros(num_blocks, 1);
+            result.condition_number_stage = zeros(num_blocks, 1);
             min_abs_val = inf;
             max_abs_val = -inf;
             max_ev = -inf;
@@ -277,19 +280,19 @@ classdef AcadosOcpSolver < handle
                     hess_block = obj.get('hess_block', n-1);
                 end
                 eigvals = eig(hess_block);
-                result.min_ev(n) = min(eigvals);
                 max_ev = max(max_ev, max(eigvals));
                 max_abs_val = max(max_abs_val, max(abs(eigvals)));
                 min_ev = min(min_ev, min(eigvals));
                 min_abs_val = min(min_abs_val, min(abs(eigvals)));
-                result.max_ev(n) = max(eigvals);
-                result.condition_number_blockwise(n) = max(eigvals) / min(eigvals);
+                result.min_eigv_stage(n) = min(eigvals);
+                result.max_eigv_stage(n) = max(eigvals);
+                result.condition_number_stage(n) = max(eigvals) / min(eigvals);
             end
             result.condition_number_global = max_abs_val / min_abs_val;
-            result.max_ev_global = max_ev;
-            result.max_abs_ev_global = max_abs_val;
-            result.min_ev_global = min_ev;
-            result.min_abs_ev_global = min_abs_val;
+            result.max_eigv_global = max_ev;
+            result.max_abs_eigv_global = max_abs_val;
+            result.min_eigv_global = min_ev;
+            result.min_abs_eigv_global = min_abs_val;
         end
 
 

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -1076,11 +1076,11 @@ class AcadosOcpSolver:
             returns a dictionary with the following fields:
             - min_eigv_stage: dict with minimum eigenvalue for each Hessian block.
             - max_eigv_stage: dict with maximum eigenvalue for each Hessian block.
-            - condition_number: dict with condition number for each Hessian block.
-            - condition_number_total: condition number for the full Hessian.
-            - min_eigv_total: minimum eigenvalue for the full Hessian.
-            - min_abs_eigv_total: minimum absolute eigenvalue for the full Hessian.
-            - max_eigv_total: maximum eigenvalue for the full Hessian.
+            - condition_number_stage: dict with condition number for each Hessian block.
+            - condition_number_global: condition number for the full Hessian.
+            - min_eigv_global: minimum eigenvalue for the full Hessian.
+            - min_abs_eigv_global: minimum absolute eigenvalue for the full Hessian.
+            - max_eigv_global: maximum eigenvalue for the full Hessian.
 
             for the 'PROJECTED_HESSIAN' it also includes
             - min_eig_P: minimum eigenvalue of P matrices
@@ -1091,8 +1091,8 @@ class AcadosOcpSolver:
             qp_diagnostic = {}
             N_horizon = self.N
             offset = 0
-            min_eigv_total = np.inf
-            max_eigv_total = -np.inf
+            min_eigv_global = np.inf
+            max_eigv_global = -np.inf
             min_abs_eigv = np.inf
             max_abs_eigv = -np.inf
             max_eigv_stage = {}
@@ -1109,8 +1109,8 @@ class AcadosOcpSolver:
                     min_eigv = np.min(eigv)
                     max_eigv = np.max(eigv)
 
-                    min_eigv_total = min(min_eigv, min_eigv_total)
-                    max_eigv_total = max(max_eigv, max_eigv_total)
+                    min_eigv_global = min(min_eigv, min_eigv_global)
+                    max_eigv_global = max(max_eigv, max_eigv_global)
                     min_abs_eigv = min(min_abs_eigv, np.min(np.abs(eigv)))
                     max_abs_eigv = max(max_abs_eigv, np.max(np.abs(eigv)))
 
@@ -1118,12 +1118,12 @@ class AcadosOcpSolver:
                     min_eigv_stage[str(i)] = min_eigv
                     condition_number_stage[str(i)] = np.max(np.abs(eigv))/np.min(np.abs(eigv))
 
-                condition_number_total = max_abs_eigv/min_abs_eigv
+                condition_number_global = max_abs_eigv/min_abs_eigv
 
-                qp_diagnostic['max_eigv_total'] = max_eigv_total
-                qp_diagnostic['min_eigv_total'] = min_eigv_total
-                qp_diagnostic['min_abs_eigv_total'] = min_abs_eigv
-                qp_diagnostic['condition_number_total'] = condition_number_total
+                qp_diagnostic['max_eigv_global'] = max_eigv_global
+                qp_diagnostic['min_eigv_global'] = min_eigv_global
+                qp_diagnostic['min_abs_eigv_global'] = min_abs_eigv
+                qp_diagnostic['condition_number_global'] = condition_number_global
                 qp_diagnostic['max_eigv_stage'] = max_eigv_stage
                 qp_diagnostic['min_eigv_stage'] = min_eigv_stage
                 qp_diagnostic['condition_number_stage'] = condition_number_stage
@@ -1158,12 +1158,12 @@ class AcadosOcpSolver:
                     eigv = np.linalg.eigvals(P_mat)
                     min_eig_P = min(min_eig_P, np.min(eigv))
                     min_abs_eig_P = min(min_abs_eig_P, np.min(np.abs(eigv)))
-                condition_number_total = max_abs_eigv/min_abs_eigv
+                condition_number_global = max_abs_eigv/min_abs_eigv
 
-                qp_diagnostic['max_eigv_total'] = max_eig_proj_hess
-                qp_diagnostic['min_eigv_total'] = min_eig_proj_hess
-                qp_diagnostic['min_abs_eigv_total'] = min_abs_eigv
-                qp_diagnostic['condition_number_total'] = condition_number_total
+                qp_diagnostic['max_eigv_global'] = max_eig_proj_hess
+                qp_diagnostic['min_eigv_global'] = min_eig_proj_hess
+                qp_diagnostic['min_abs_eigv_global'] = min_abs_eigv
+                qp_diagnostic['condition_number_global'] = condition_number_global
                 qp_diagnostic['max_eigv_stage'] = max_eigv_stage
                 qp_diagnostic['min_eigv_stage'] = min_eigv_stage
                 qp_diagnostic['min_eig_P'] = min_eig_P

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -1067,7 +1067,7 @@ class AcadosOcpSolver:
             print("stored current iterate in ", os.path.join(os.getcwd(), filename))
 
 
-    def qp_diagnostics(self, hessian_type: str='FULL_HESSIAN'):
+    def qp_diagnostics(self, hessian_type: str = 'FULL_HESSIAN'):
             """
             Compute some diagnostic values for the last QP.
             result = ocp_solver.qp_diagnostics(hessian_type). Possible values are
@@ -1083,95 +1083,73 @@ class AcadosOcpSolver:
             - max_eigv_global: maximum eigenvalue for the full Hessian.
 
             for the 'PROJECTED_HESSIAN' it also includes
-            - min_eig_P: minimum eigenvalue of P matrices
-            - min_abs_eig_P: minimum absolute eigenvalue of P matrices
+            - min_eigv_P_global: minimum eigenvalue of P matrices
+            - min_abs_eigv_P_global: minimum absolute eigenvalue of P matrices
             """
-            if type(hessian_type) != str:
-                raise TypeError("Input should be string with value FULL_HESSIAN, REDUCED_HESSIAN")
+            if hessian_type not in ['FULL_HESSIAN', 'PROJECTED_HESSIAN']:
+                raise TypeError("Input should be string with value FULL_HESSIAN, PROJECTED_HESSIAN")
+
             qp_diagnostic = {}
             N_horizon = self.N
-            offset = 0
+
             min_eigv_global = np.inf
             max_eigv_global = -np.inf
             min_abs_eigv = np.inf
             max_abs_eigv = -np.inf
-            max_eigv_stage = {}
-            min_eigv_stage = {}
-            condition_number_stage = {}
 
-            if hessian_type == "FULL_HESSIAN":
-                for i in range(N_horizon+1):
-                    hess_block_acados = self.get_hessian_block(i)
-                    nv = hess_block_acados.shape[0]
-                    offset += nv
+            min_eig_P_global = np.inf
+            min_abs_eig_P_global = np.inf
 
-                    eigv = np.linalg.eigvals(hess_block_acados)
-                    min_eigv = np.min(eigv)
-                    max_eigv = np.max(eigv)
+            max_eigv_stage = []
+            min_eigv_stage = []
+            condition_number_stage = []
 
-                    min_eigv_global = min(min_eigv, min_eigv_global)
-                    max_eigv_global = max(max_eigv, max_eigv_global)
-                    min_abs_eigv = min(min_abs_eigv, np.min(np.abs(eigv)))
-                    max_abs_eigv = max(max_abs_eigv, np.max(np.abs(eigv)))
+            for i in range(N_horizon+1):
+                if hessian_type == "FULL_HESSIAN":
+                    hess_block = self.get_hessian_block(i)
 
-                    max_eigv_stage[str(i)] = max_eigv
-                    min_eigv_stage[str(i)] = min_eigv
-                    condition_number_stage[str(i)] = np.max(np.abs(eigv))/np.min(np.abs(eigv))
-
-                condition_number_global = max_abs_eigv/min_abs_eigv
-
-                qp_diagnostic['max_eigv_global'] = max_eigv_global
-                qp_diagnostic['min_eigv_global'] = min_eigv_global
-                qp_diagnostic['min_abs_eigv_global'] = min_abs_eigv
-                qp_diagnostic['condition_number_global'] = condition_number_global
-                qp_diagnostic['max_eigv_stage'] = max_eigv_stage
-                qp_diagnostic['min_eigv_stage'] = min_eigv_stage
-                qp_diagnostic['condition_number_stage'] = condition_number_stage
-
-            elif hessian_type == "PROJECTED_HESSIAN":
-                # check projected Hessian
-                min_eig_proj_hess = np.inf
-                max_eig_proj_hess = -np.inf
-                min_eig_P = np.inf
-                min_abs_eig_P = np.inf
-                for i in range(1, N_horizon):
+                elif hessian_type == "PROJECTED_HESSIAN":
                     P_mat = self.get_from_qp_in(i, 'P')
                     B_mat = self.get_from_qp_in(i-1, 'B')
                     # Lr: lower triangular decomposition of R within Riccati != R in qp_in!
                     Lr = self.get_from_qp_in(i-1, 'Lr')
                     R_ric = Lr @ Lr.T
-                    proj_hess_block = R_ric + B_mat.T @ P_mat @ B_mat
+                    hess_block = R_ric + B_mat.T @ P_mat @ B_mat
 
-                    eigv = np.linalg.eigvals(proj_hess_block)
-                    min_eigv = np.min(eigv)
-                    max_eigv = np.max(eigv)
-
-                    min_eig_proj_hess = min(min_eigv, min_eig_proj_hess)
-                    max_eig_proj_hess = max(max_eigv, max_eig_proj_hess)
-                    min_abs_eigv = min(min_abs_eigv, np.min(np.abs(eigv)))
-                    max_abs_eigv = max(max_abs_eigv, np.max(np.abs(eigv)))
-
-                    max_eigv_stage[str(i)] = max_eigv
-                    min_eigv_stage[str(i)] = min_eigv
-                    condition_number_stage[str(i)] = np.max(np.abs(eigv))/np.min(np.abs(eigv))
                     # P
                     eigv = np.linalg.eigvals(P_mat)
-                    min_eig_P = min(min_eig_P, np.min(eigv))
-                    min_abs_eig_P = min(min_abs_eig_P, np.min(np.abs(eigv)))
-                condition_number_global = max_abs_eigv/min_abs_eigv
+                    min_eig_P_global = min(min_eig_P_global, np.min(eigv))
+                    min_abs_eig_P_global = min(min_abs_eig_P_global, np.min(np.abs(eigv)))
 
-                qp_diagnostic['max_eigv_global'] = max_eig_proj_hess
-                qp_diagnostic['min_eigv_global'] = min_eig_proj_hess
-                qp_diagnostic['min_abs_eigv_global'] = min_abs_eigv
-                qp_diagnostic['condition_number_global'] = condition_number_global
-                qp_diagnostic['max_eigv_stage'] = max_eigv_stage
-                qp_diagnostic['min_eigv_stage'] = min_eigv_stage
-                qp_diagnostic['min_eig_P'] = min_eig_P
-                qp_diagnostic['min_abs_eig_P'] = min_abs_eig_P
-                qp_diagnostic['condition_number_stage'] = condition_number_stage
-            else:
-                raise ValueError("Wrong input given to function! Possible inputs\
-                                 are FULL_HESSIAN, REDUCED_HESSIAN")
+                else:
+                    raise ValueError("Wrong input given to function! Possible inputs are FULL_HESSIAN, PROJECTED_HESSIAN")
+
+                eigv = np.linalg.eigvals(hess_block)
+                min_eigv = np.min(eigv)
+                max_eigv = np.max(eigv)
+
+                min_eigv_global = min(min_eigv, min_eigv_global)
+                max_eigv_global = max(max_eigv, max_eigv_global)
+                min_abs_eigv = min(min_abs_eigv, np.min(np.abs(eigv)))
+                max_abs_eigv = max(max_abs_eigv, np.max(np.abs(eigv)))
+
+                max_eigv_stage.append(max_eigv)
+                min_eigv_stage.append(min_eigv)
+                condition_number_stage.append(np.max(np.abs(eigv))/np.min(np.abs(eigv)))
+
+            condition_number_global = max_abs_eigv/min_abs_eigv
+
+            qp_diagnostic['max_eigv_global'] = max_eigv_global
+            qp_diagnostic['min_eigv_global'] = min_eigv_global
+            qp_diagnostic['min_abs_eigv_global'] = min_abs_eigv
+            qp_diagnostic['condition_number_global'] = condition_number_global
+            qp_diagnostic['max_eigv_stage'] = max_eigv_stage
+            qp_diagnostic['min_eigv_stage'] = min_eigv_stage
+            qp_diagnostic['condition_number_stage'] = condition_number_stage
+
+            if hessian_type == "PROJECTED_HESSIAN":
+                qp_diagnostic['min_eigv_P_global'] = min_eig_P_global
+                qp_diagnostic['min_abs_eigv_P_global'] = min_abs_eig_P_global
 
             return qp_diagnostic
 


### PR DESCRIPTION
The QP diagnostic function now returns a dict/struct with consistent names
- `min_eigv_stage`
- `max_eigv_stage`
- `condition_number_stage`
- `condition_number_global`
- `min_eigv_global`
- `min_abs_eigv_global`
 - `max_eigv_global`
 - `min_eigv_P_global` for projected Hessian only
 - `min_abs_eigv_P_global` for projected Hessian only

In addition:
- improve docstring
- python: return list instead of dict for stagewise values, reduce redundancy