### PR TITLE
Sensitivities with parametric constraints: follow-up to #1345

### DIFF
--- a/acados/ocp_nlp/ocp_nlp_common.c
+++ b/acados/ocp_nlp/ocp_nlp_common.c
@@ -3375,10 +3375,14 @@ void ocp_nlp_common_eval_solution_sens_adj_p(ocp_nlp_config *config, ocp_nlp_dim
         blasfeo_dvecse(np_global, 0., &mem->out_np_global, 0);
         for (i = 0; i <= N; i++)
         {
-            // multiply J.T with result of backsolve and add to in mem->out_np_global
+            /* multiply J.T with result of backsolve and add to in mem->out_np_global */
+            // stationarity
             blasfeo_dgemv_t(nv[i], np_global, 1.0, &jac_lag_stat_p_global[i], 0, 0, tmp_qp_out->ux+i, 0, 1.0, &mem->out_np_global, 0, &mem->out_np_global, 0);
+            // inequalities: upper
             blasfeo_dgemv_t(ni_nl[i], np_global, -1.0, &jac_ineq_p_global[i], 0, 0, tmp_qp_out->lam+i, nb[i]+ng[i], 1.0, &mem->out_np_global, 0, &mem->out_np_global, 0);
+            // inequalities: lower
             blasfeo_dgemv_t(ni_nl[i], np_global, 1.0, &jac_ineq_p_global[i], 0, 0, tmp_qp_out->lam+i, 2*(nb[i]+ng[i])+ni_nl[i], 1.0, &mem->out_np_global, 0, &mem->out_np_global, 0);
+            // dynamics
             if (i < N)
             {
                 blasfeo_dgemv_t(nx[i+1], np_global, 1.0, &jac_dyn_p_global[i], 0, 0, tmp_qp_out->pi+i, 0, 1.0, &mem->out_np_global, 0, &mem->out_np_global, 0);

--- a/examples/acados_python/pendulum_on_cart/solution_sensitivities/forw_vs_adj_param_sens.py
+++ b/examples/acados_python/pendulum_on_cart/solution_sensitivities/forw_vs_adj_param_sens.py
@@ -47,6 +47,13 @@ def main(qp_solver_ric_alg: int, use_cython=False, generate_solvers=True, plot_t
 
     N_horizon = 10
     T_horizon = 1.0
+
+    # TODO: look more into why the test fails with these settings:
+    # adjoint sensitivities of first parameter dont match with forward sensitivities
+    # only "small" difference: in 5th digit, might be due to numerical inaccuracies
+    # N_horizon = 50
+    # T_horizon = 2.0
+    # p_test = p_nominal + 0.3
     Fmax = 80.0
 
     cost_scale_as_param = True # test with 2 parameters

--- a/examples/acados_python/pendulum_on_cart/solution_sensitivities/forw_vs_adj_param_sens.py
+++ b/examples/acados_python/pendulum_on_cart/solution_sensitivities/forw_vs_adj_param_sens.py
@@ -81,9 +81,9 @@ def main(qp_solver_ric_alg: int, use_cython=False, generate_solvers=True, plot_t
     sensitivity_solver.set_p_global_and_precompute_dependencies(p_val)
 
     u_opt = ocp_solver.solve_for_x0(x0)[0]
-    ocp_solver.store_iterate(filename='iterate.json', overwrite=True, verbose=False)
+    iterate = ocp_solver.store_iterate_to_obj()
 
-    sensitivity_solver.load_iterate(filename='iterate.json', verbose=False)
+    sensitivity_solver.load_iterate_from_obj(iterate)
     sensitivity_solver.solve_for_x0(x0, fail_on_nonzero_status=False, print_stats_on_failure=False)
 
     if sensitivity_solver.get_status() not in [0, 2]:
@@ -156,7 +156,6 @@ def main(qp_solver_ric_alg: int, use_cython=False, generate_solvers=True, plot_t
             raise Exception(f"adj_p_vec and adj_p_mat[{i}, :] should match.")
         else:
             print(f"Success: adj_p_vec and adj_p_mat[{i}, :] match!")
-
 
     if plot_trajectory:
         nx = ocp.dims.nx

--- a/examples/acados_python/pendulum_on_cart/solution_sensitivities/forw_vs_adj_param_sens.py
+++ b/examples/acados_python/pendulum_on_cart/solution_sensitivities/forw_vs_adj_param_sens.py
@@ -50,8 +50,10 @@ def main(qp_solver_ric_alg: int, use_cython=False, generate_solvers=True, plot_t
     Fmax = 80.0
 
     cost_scale_as_param = True # test with 2 parameters
+    with_parametric_constraint = True
+    with_nonlinear_constraint = False
 
-    ocp = export_parametric_ocp(x0=x0, N_horizon=N_horizon, T_horizon=T_horizon, Fmax=Fmax, qp_solver_ric_alg=1, cost_scale_as_param=cost_scale_as_param)
+    ocp = export_parametric_ocp(x0=x0, N_horizon=N_horizon, T_horizon=T_horizon, Fmax=Fmax, qp_solver_ric_alg=1, cost_scale_as_param=cost_scale_as_param, with_parametric_constraint=with_parametric_constraint, with_nonlinear_constraint=with_nonlinear_constraint)
     if use_cython:
         raise NotImplementedError()
         AcadosOcpSolver.generate(ocp, json_file="parameter_augmented_acados_ocp.json")
@@ -61,7 +63,7 @@ def main(qp_solver_ric_alg: int, use_cython=False, generate_solvers=True, plot_t
         ocp_solver = AcadosOcpSolver(ocp, json_file="parameter_augmented_acados_ocp.json", generate=generate_solvers, build=generate_solvers)
 
     # create sensitivity solver
-    ocp = export_parametric_ocp(x0=x0, N_horizon=N_horizon, T_horizon=T_horizon, Fmax=Fmax, hessian_approx='EXACT', qp_solver_ric_alg=qp_solver_ric_alg, cost_scale_as_param=cost_scale_as_param)
+    ocp = export_parametric_ocp(x0=x0, N_horizon=N_horizon, T_horizon=T_horizon, Fmax=Fmax, hessian_approx='EXACT', qp_solver_ric_alg=qp_solver_ric_alg, cost_scale_as_param=cost_scale_as_param, with_parametric_constraint=with_parametric_constraint, with_nonlinear_constraint=with_nonlinear_constraint)
     ocp.model.name = 'sensitivity_solver'
     ocp.code_export_directory = f'c_generated_code_{ocp.model.name}'
     if use_cython:

--- a/examples/acados_python/pendulum_on_cart/solution_sensitivities/forw_vs_adj_param_sens.py
+++ b/examples/acados_python/pendulum_on_cart/solution_sensitivities/forw_vs_adj_param_sens.py
@@ -40,18 +40,18 @@ def main(qp_solver_ric_alg: int, use_cython=False, generate_solvers=True, plot_t
     """
     p_nominal = 1.0
     x0 = np.array([0.0, np.pi / 2, 0.0, 0.0])
-    p_test = p_nominal + 0.4
+    p_test = p_nominal + 0.2
 
     nx = len(x0)
     nu = 1
 
-    N_horizon = 50
-    T_horizon = 2.0
+    N_horizon = 10
+    T_horizon = 1.0
     Fmax = 80.0
 
     cost_scale_as_param = True # test with 2 parameters
     with_parametric_constraint = True
-    with_nonlinear_constraint = False
+    with_nonlinear_constraint = True
 
     ocp = export_parametric_ocp(x0=x0, N_horizon=N_horizon, T_horizon=T_horizon, Fmax=Fmax, qp_solver_ric_alg=1, cost_scale_as_param=cost_scale_as_param, with_parametric_constraint=with_parametric_constraint, with_nonlinear_constraint=with_nonlinear_constraint)
     if use_cython:

--- a/examples/acados_python/pendulum_on_cart/solution_sensitivities/forw_vs_adj_param_sens.py
+++ b/examples/acados_python/pendulum_on_cart/solution_sensitivities/forw_vs_adj_param_sens.py
@@ -85,6 +85,15 @@ def main(qp_solver_ric_alg: int, use_cython=False, generate_solvers=True, plot_t
     u_opt = ocp_solver.solve_for_x0(x0)[0]
     iterate = ocp_solver.store_iterate_to_obj()
 
+    if with_parametric_constraint:
+        lambdas = np.zeros((N_horizon-1, 2))
+        for i in range(1, N_horizon):
+            lam_ = ocp_solver.get(i, "lam")
+            lambdas[i-1] = np.array([lam_[1], lam_[3]])
+        print(f"lambdas of parametric constraints: {lambdas}\n")
+        max_lam = np.max(np.abs(lambdas))
+        print(f"max lambda of parametric constraints: {max_lam:.2f}\n")
+
     sensitivity_solver.load_iterate_from_obj(iterate)
     sensitivity_solver.solve_for_x0(x0, fail_on_nonzero_status=False, print_stats_on_failure=False)
 

--- a/examples/acados_python/pendulum_on_cart/solution_sensitivities/policy_gradient_example.py
+++ b/examples/acados_python/pendulum_on_cart/solution_sensitivities/policy_gradient_example.py
@@ -45,11 +45,11 @@ def main_parametric(qp_solver_ric_alg: int, eigen_analysis=True, use_cython=Fals
     p_nominal = 1.0
     x0 = np.array([0.0, np.pi / 2, 0.0, 0.0])
     delta_p = 0.001
-    p_test = np.arange(p_nominal, p_nominal + 0.2, delta_p)
+    p_test = np.arange(p_nominal - 0.5, p_nominal + 0.5, delta_p)
 
     np_test = p_test.shape[0]
-    N_horizon = 10
-    T_horizon = 1.0
+    N_horizon = 50
+    T_horizon = 2.0
     Fmax = 80.0
     with_parametric_constraint = True
     with_nonlinear_constraint = True

--- a/examples/acados_python/pendulum_on_cart/solution_sensitivities/policy_gradient_example.py
+++ b/examples/acados_python/pendulum_on_cart/solution_sensitivities/policy_gradient_example.py
@@ -45,11 +45,11 @@ def main_parametric(qp_solver_ric_alg: int, eigen_analysis=True, use_cython=Fals
     p_nominal = 1.0
     x0 = np.array([0.0, np.pi / 2, 0.0, 0.0])
     delta_p = 0.001
-    p_test = np.arange(p_nominal - 0.5, p_nominal + 0.5, delta_p)
+    p_test = np.arange(p_nominal, p_nominal + 0.2, delta_p)
 
     np_test = p_test.shape[0]
-    N_horizon = 50
-    T_horizon = 2.0
+    N_horizon = 10
+    T_horizon = 1.0
     Fmax = 80.0
     with_parametric_constraint = True
     with_nonlinear_constraint = True

--- a/examples/acados_python/pendulum_on_cart/solution_sensitivities/sensitivity_utils.py
+++ b/examples/acados_python/pendulum_on_cart/solution_sensitivities/sensitivity_utils.py
@@ -231,10 +231,11 @@ def plot_cost_gradient_results(p_test, cost_values, acados_cost_grad, np_cost_gr
     plt.show()
 
 
-def plot_results(p_test, pi, pi_reconstructed_acados, pi_reconstructed_np_grad, sens_u, np_grad,
+def plot_solution_sensitivities_results(p_test, pi, pi_reconstructed_acados, pi_reconstructed_np_grad, sens_u, np_grad,
                  min_eig_full=None, min_eig_proj_hess=None, min_eig_P=None,
                  min_abs_eig_full=None, min_abs_eig_proj_hess=None, min_abs_eig_P=None,
-                 eigen_analysis=False, qp_solver_ric_alg=1, parameter_name="", max_lam_parametric_constraint=None):
+                 eigen_analysis=False, title=None, parameter_name="",
+                 max_lam_parametric_constraint=None, sum_lam_parametric_constraint=None):
 
     nsub = 5 if eigen_analysis else 3
     if max_lam_parametric_constraint is not None:
@@ -244,10 +245,11 @@ def plot_results(p_test, pi, pi_reconstructed_acados, pi_reconstructed_np_grad, 
 
     isub = 0
     ax[isub].plot(p_test, pi, label='acados', color='k')
-    ax[isub].plot(p_test, pi_reconstructed_acados, "--", label='reconstructed from acados')
+    ax[isub].plot(p_test, pi_reconstructed_acados, "--", label='reconstructed from acados solution sensitivities')
     ax[isub].plot(p_test, pi_reconstructed_np_grad, "--", label='reconstructed from finite diff')
     ax[isub].set_ylabel(r"$u$")
-    ax[isub].set_title(f'qp_solver_ric_alg {qp_solver_ric_alg}')
+    if title is not None:
+        ax[isub].set_title(title)
 
     isub += 1
     ax[isub].plot(p_test, sens_u, label="acados")
@@ -264,7 +266,9 @@ def plot_results(p_test, pi, pi_reconstructed_acados, pi_reconstructed_np_grad, 
         isub += 1
         ax[isub].plot(p_test, max_lam_parametric_constraint, label=r'max $\lambda$ parametric constraint')
         # ax[isub].set_ylabel("max lam parametric constraint")
-        # ax[isub].set_yscale("log")
+        ax[isub].set_yscale("log")
+        if sum_lam_parametric_constraint is not None:
+            ax[isub].plot(p_test, sum_lam_parametric_constraint, label=r'sum $\lambda$ parametric constraint')
 
     if eigen_analysis:
         isub += 1
@@ -286,7 +290,7 @@ def plot_results(p_test, pi, pi_reconstructed_acados, pi_reconstructed_np_grad, 
 
     ax[-1].set_xlabel(f"{parameter_name}")
 
-    fig_filename = f"solution_sens_{qp_solver_ric_alg}.pdf"
+    fig_filename = f"solution_sens_{title}.pdf"
     plt.savefig(fig_filename)
     print(f"stored figure as {fig_filename}")
     plt.show()

--- a/examples/acados_python/pendulum_on_cart/solution_sensitivities/sensitivity_utils.py
+++ b/examples/acados_python/pendulum_on_cart/solution_sensitivities/sensitivity_utils.py
@@ -169,10 +169,11 @@ def export_parametric_ocp(
     ocp.solver_options.qp_solver_ric_alg = qp_solver_ric_alg
     ocp.solver_options.hessian_approx = hessian_approx
     if hessian_approx == 'EXACT':
-        ocp.solver_options.globalization_fixed_step_length = 0.0
+        # sensitivity solver settings!
+        ocp.solver_options.globalization_fixed_step_length = 0.0 # to not perfrom an SQP step update
         ocp.solver_options.nlp_solver_max_iter = 1
         ocp.solver_options.qp_solver_iter_max = 200
-        ocp.solver_options.tol = 1e-10
+        ocp.solver_options.tol = 1e-10  # to "force" a QP solve
         ocp.solver_options.with_solution_sens_wrt_params = True
         ocp.solver_options.with_value_sens_wrt_params = True
     else:

--- a/examples/acados_python/pendulum_on_cart/solution_sensitivities/state_augementation_policy_gradient.py
+++ b/examples/acados_python/pendulum_on_cart/solution_sensitivities/state_augementation_policy_gradient.py
@@ -36,7 +36,7 @@ from acados_template import AcadosOcp, AcadosOcpSolver, AcadosModel
 import casadi as ca
 import numpy as np
 import scipy.linalg as scipylinalg
-from sensitivity_utils import plot_results
+from sensitivity_utils import plot_solution_sensitivities_results
 
 """
     This example computes solution sensitivities with respect to parameters using state augmentation.
@@ -270,10 +270,10 @@ def main_augmented(param_M_as_state: bool, idxp: int, qp_solver_ric_alg: int, ei
     u_opt_reconstructed_acados = np.cumsum(sens_u) * delta_p + u_opt[0]
     u_opt_reconstructed_acados += u_opt[0] - u_opt_reconstructed_acados[0]
 
-    plot_results(p_test, u_opt, u_opt_reconstructed_acados, u_opt_reconstructed_np_grad, sens_u, np_grad,
+    plot_solution_sensitivities_results(p_test, u_opt, u_opt_reconstructed_acados, u_opt_reconstructed_np_grad, sens_u, np_grad,
                  min_eig_full, min_eig_proj_hess, min_eig_P,
                  min_abs_eig_full, min_abs_eig_proj_hess, min_abs_eig_P,
-                 eigen_analysis, qp_solver_ric_alg, parameter_name)
+                 eigen_analysis, title=None, parameter_name=parameter_name)
 
 
 if __name__ == "__main__":

--- a/examples/acados_python/pendulum_on_cart/solution_sensitivities/value_gradient_example.py
+++ b/examples/acados_python/pendulum_on_cart/solution_sensitivities/value_gradient_example.py
@@ -70,10 +70,10 @@ def main():
     plot_cost_gradient_results(p_test, optimal_value, optimal_value_grad, optimal_value_grad_via_fd, cost_reconstructed_np_grad)
 
     # checks
-    test_tol = 1e-1
-    median_diff = np.median(np.abs(optimal_value_grad - optimal_value_grad_via_fd))
-    print(f"Median difference between value function gradient obtained by acados and via FD is {median_diff} should be < {test_tol}.")
-    assert median_diff <= test_tol
+    test_tol = 1e-2
+    mean_rel_diff = np.mean(np.abs(optimal_value_grad - optimal_value_grad_via_fd) / np.abs(optimal_value_grad_via_fd))
+    print(f"Mean difference between value function gradient obtained by acados and via FD is {mean_rel_diff} should be < {test_tol}.")
+    assert mean_rel_diff <= test_tol
 
 
 

--- a/interfaces/acados_template/acados_template/acados_ocp.py
+++ b/interfaces/acados_template/acados_template/acados_ocp.py
@@ -868,9 +868,6 @@ class AcadosOcp:
             for horizon_type, constraint in bgp_type_constraint_pairs:
                 if constraint is not None and any(ca.which_depends(constraint, model.p_global)):
                     raise Exception(f"with_value_sens_wrt_params is not supported for BGP constraints that depend on p_global. Got dependency on p_global for {horizon_type} constraint.")
-            for horizon_type, constraint in bgh_type_constraint_pairs:
-                if constraint is not None and model.p_global is not None and not ca.is_linear(constraint, model.p_global):
-                    raise Exception(f"with_value_sens_wrt_params does not work for h constraint nonlinear in p_global yet. Got nonlinear dependency on p_global for {horizon_type} constraint.")
 
         if opts.qp_solver_cond_N is None:
             opts.qp_solver_cond_N = opts.N_horizon

--- a/interfaces/acados_template/acados_template/acados_ocp.py
+++ b/interfaces/acados_template/acados_template/acados_ocp.py
@@ -854,9 +854,6 @@ class AcadosOcp:
             for horizon_type, constraint in bgp_type_constraint_pairs:
                 if constraint is not None and any(ca.which_depends(constraint, model.p_global)):
                     raise Exception(f"with_solution_sens_wrt_params is not supported for BGP constraints that depend on p_global. Got dependency on p_global for {horizon_type} constraint.")
-            for horizon_type, constraint in bgh_type_constraint_pairs:
-                if constraint is not None and model.p_global is not None and not ca.is_linear(constraint, model.p_global):
-                    raise Exception(f"with_solution_sens_wrt_params does not work for h constraint nonlinear in p_global yet. Got nonlinear dependency on p_global for {horizon_type} constraint.")
 
         if opts.with_value_sens_wrt_params:
             if dims.np_global == 0:


### PR DESCRIPTION
- allow constraints that are nonlinear in `p_global`
- improved examples and tests
- difference in forward vs. adjoint on the problem when using longer horizon might be due to numerical errors. For smaller problem the sensitivities match, although constraint is active. But one might check more closely.