### PR TITLE
Python & Matlab: use SQP by default

### DIFF
--- a/interfaces/acados_matlab_octave/AcadosOcpOptions.m
+++ b/interfaces/acados_matlab_octave/AcadosOcpOptions.m
@@ -129,7 +129,7 @@ classdef AcadosOcpOptions < handle
             obj.integrator_type = 'ERK';
             obj.tf = [];
             obj.N_horizon = [];
-            obj.nlp_solver_type = 'SQP_RTI';
+            obj.nlp_solver_type = 'SQP';
             obj.globalization_fixed_step_length = 1.0;
             obj.nlp_solver_step_length = [];
             obj.nlp_solver_tol_stat = 1e-6;

--- a/interfaces/acados_template/acados_template/acados_ocp_options.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_options.py
@@ -46,7 +46,7 @@ class AcadosOcpOptions:
         self.__integrator_type = 'ERK'
         self.__tf = None
         self.__N_horizon = None
-        self.__nlp_solver_type = 'SQP_RTI'
+        self.__nlp_solver_type = 'SQP'
         self.__nlp_solver_tol_stat = 1e-6
         self.__nlp_solver_tol_eq = 1e-6
         self.__nlp_solver_tol_ineq = 1e-6
@@ -248,7 +248,7 @@ class AcadosOcpOptions:
     def nlp_solver_type(self):
         """NLP solver.
         String in ('SQP', 'SQP_RTI', 'DDP').
-        Default: 'SQP_RTI'.
+        Default: 'SQP'.
         """
         return self.__nlp_solver_type
 


### PR DESCRIPTION
BREAKING: changed default value for `nlp_solver_type` from "SQP_RTI" to "SQP".
This makes it more robust and is more expected behavior for people that start using acados, e.g. https://github.com/acados/acados/issues/1365