### PR TITLE
Python: allow getting sensitivities wrt. `pi`, `lam`, `sl`, `su`

### DIFF
--- a/examples/acados_python/chain_mass/solution_sensitivity_example.py
+++ b/examples/acados_python/chain_mass/solution_sensitivity_example.py
@@ -455,7 +455,9 @@ def main_parametric(qp_solver_ric_alg: int = 0, chain_params_: dict = get_chain_
         print(f"sensitivity_solver status {sensitivity_solver.status}")
 
         # Calculate the policy gradient
-        sens_x_, sens_u_ = sensitivity_solver.eval_solution_sensitivity(0, "p_global")
+        out_dict = sensitivity_solver.eval_solution_sensitivity(0, "p_global")
+        sens_x_ = out_dict['sens_x']
+        sens_u_ = out_dict['sens_u']
         timings_lin_params[i] = sensitivity_solver.get_stats("time_solution_sens_lin")
         timings_solve_params[i] = sensitivity_solver.get_stats("time_solution_sens_solve")
 

--- a/examples/acados_python/pendulum_on_cart/example_solution_sens_closed_loop.py
+++ b/examples/acados_python/pendulum_on_cart/example_solution_sens_closed_loop.py
@@ -163,7 +163,8 @@ def main():
             u_lin = simU[i,:]
             x_lin = xcurrent
 
-            _, sens_u = acados_ocp_solver.eval_solution_sensitivity(0, with_respect_to="initial_state")
+            out_dict = acados_ocp_solver.eval_solution_sensitivity(0, with_respect_to="initial_state", return_sens_u=True, return_sens_x=False)
+            sens_u = out_dict['sens_u']
 
         else:
             # use linear feedback

--- a/examples/acados_python/pendulum_on_cart/solution_sensitivities/forw_vs_adj_param_sens.py
+++ b/examples/acados_python/pendulum_on_cart/solution_sensitivities/forw_vs_adj_param_sens.py
@@ -121,7 +121,9 @@ def main(qp_solver_ric_alg: int, use_cython=False, generate_solvers=True, plot_t
         ([5], [seed_xstage], [seed_ustage]),
     ]:
         # Calculate the policy gradient
-        sens_x_forw, sens_u_forw = sensitivity_solver.eval_solution_sensitivity(stages, "p_global")
+        out_dict = sensitivity_solver.eval_solution_sensitivity(stages, "p_global")
+        sens_x_forw = out_dict['sens_x']
+        sens_u_forw = out_dict['sens_u']
 
         adj_p_ref = sum([seed_x_list[k].T @ sens_x_forw[k] + seed_u_list[k].T @ sens_u_forw[k] for k in range(len(stages))])
 

--- a/examples/acados_python/pendulum_on_cart/solution_sensitivities/policy_gradient_example.py
+++ b/examples/acados_python/pendulum_on_cart/solution_sensitivities/policy_gradient_example.py
@@ -128,8 +128,8 @@ def main_parametric(qp_solver_ric_alg: int, eigen_analysis=True, use_cython=Fals
             print(f"sensitivity solver returned status {sensitivity_solver.get_status()}.")
             # breakpoint()
         # Calculate the policy gradient
-        _, sens_u_ = sensitivity_solver.eval_solution_sensitivity(0, "p_global")
-        sens_u[i] = sens_u_.item()
+        out_dict = sensitivity_solver.eval_solution_sensitivity(0, "p_global", return_sens_x=False)
+        sens_u[i] = out_dict['sens_u'].item()
 
     # Compare to numerical gradients
     sens_u_fd = np.gradient(u_opt, delta_p)

--- a/examples/acados_python/pendulum_on_cart/solution_sensitivities/state_augementation_policy_gradient.py
+++ b/examples/acados_python/pendulum_on_cart/solution_sensitivities/state_augementation_policy_gradient.py
@@ -258,7 +258,8 @@ def main_augmented(param_M_as_state: bool, idxp: int, qp_solver_ric_alg: int, ei
             min_abs_eig_P[i] = projected_hessian_diagnostics['min_abs_eigv_P_global']
 
         # Calculate the policy gradient
-        _, sens_u_ = sensitivity_solver.eval_solution_sensitivity(0, "initial_state")
+        out_dict = sensitivity_solver.eval_solution_sensitivity(0, "initial_state", return_sens_x=False)
+        sens_u_ = out_dict['sens_u']
         sens_u[i] = sens_u_[:, idxp]
 
     # Compare to numerical gradients

--- a/examples/acados_python/pendulum_on_cart/solution_sensitivities/test_solution_sens_and_exact_hess.py
+++ b/examples/acados_python/pendulum_on_cart/solution_sensitivities/test_solution_sens_and_exact_hess.py
@@ -253,7 +253,8 @@ def sensitivity_experiment(linearized_dynamics=False, discrete=False, show=True)
         acados_ocp_solver_exact.set(0, 'u', u0+1e-7)
         acados_ocp_solver_exact.solve_for_x0(x0, fail_on_nonzero_status=False, print_stats_on_failure=False)
 
-        sens_x_, sens_u_ = acados_ocp_solver_exact.eval_solution_sensitivity(0, with_respect_to="initial_state")
+        out_dict = acados_ocp_solver_exact.eval_solution_sensitivity(0, with_respect_to="initial_state", return_sens_x=False)
+        sens_u_ = out_dict['sens_u']
         du0_dp_values[i] = sens_u_[0, idxp]
 
         exact_hessian_status[i] = acados_ocp_solver_exact.get_stats('qp_stat')[-1]

--- a/interfaces/acados_template/acados_template/acados_ocp_batch_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_batch_solver.py
@@ -171,7 +171,7 @@ class AcadosOcpBatchSolver():
             for seed, name, dim in [(seed_x, "seed_x", nx,), (seed_u, "seed_u", nu)]:
                 for stage, seed_stage in seed:
                     if not isinstance(stage, int) or stage < 0 or stage > N_horizon:
-                        raise Exception(f"AcadosOcpSolver.eval_solution_sensitivity(): stage {stage} for {name} is not valid.")
+                        raise Exception(f"AcadosOcpBatchSolver.eval_adjoint_solution_sensitivity(): stage {stage} for {name} is not valid.")
                     if not isinstance(seed_stage, np.ndarray):
                         raise Exception(f"{name} for stage {stage} should be np.ndarray, got {type(seed_stage)}")
                     if seed_stage.shape != (self.N_batch, dim, n_seeds):

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -889,7 +889,7 @@ class AcadosOcpSolver:
 
         out_fields = ['x', 'u', 'z', 'pi', 'lam', 'sl', 'su']
         in_fields = ['p']
-        sens_fields = ['sens_u', 'sens_x']
+        sens_fields = ['sens_u', 'sens_x', 'sens_pi', 'sens_lam', 'sens_sl', 'sens_su']
         all_fields = out_fields + in_fields + sens_fields
 
         if (field_ not in all_fields):

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -873,7 +873,7 @@ class AcadosOcpSolver:
         Get the last solution of the solver:
 
             :param stage: integer corresponding to shooting node
-            :param field: string in ['x', 'u', 'z', 'pi', 'lam', 'sl', 'su', 'p', 'sens_u', 'sens_x']
+            :param field: string in ['x', 'u', 'z', 'pi', 'lam', 'sl', 'su', 'p', 'sens_u', 'sens_pi', 'sens_x', 'sens_lam', 'sens_sl', 'sens_su']
 
             .. note:: regarding lam: \n
                     the inequalities are internally organized in the following order: \n

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -844,7 +844,7 @@ class AcadosOcpSolver:
             for seed, name, dim in [(seed_x, "seed_x", nx), (seed_u, "seed_u", nu)]:
                 for stage, seed_stage in seed:
                     if not isinstance(stage, int) or stage < 0 or stage > N_horizon:
-                        raise Exception(f"AcadosOcpSolver.eval_solution_sensitivity(): stage {stage} for {name} is not valid.")
+                        raise Exception(f"AcadosOcpSolver.eval_adjoint_solution_sensitivity(): stage {stage} for {name} is not valid.")
                     if not isinstance(seed_stage, np.ndarray):
                         raise Exception(f"{name} for stage {stage} should be np.ndarray, got {type(seed_stage)}")
                     if seed_stage.shape != (dim, n_seeds):


### PR DESCRIPTION
The additional, optional fields `return_sens_x`, `return_sens_u`, `return_sens_pi`, `return_sens_lam`, `return_sens_su`, `return_sens_sl` allow to specify which sensitivities should be returned.

Breaking: The return type of  `eval_solution_sensitivity` changes: We now return a dict with fields `sens_x`, `sens_u`, `sens_pi`, `sens_lam`, `sens_su`, `sens_sl` if the corresponding flag has been set.

