### PR TITLE
Python: use [] as default for CasADi expressions consistently

### DIFF
--- a/examples/acados_python/p_global_example/example_p_global.py
+++ b/examples/acados_python/p_global_example/example_p_global.py
@@ -189,7 +189,7 @@ def create_ocp_formulation_without_opts(p_global, m, l, C, lut=True, use_p_globa
 
     if not use_p_global:
         model.p = ca.vertcat(model.p, p_global)
-        model.p_global = None
+        model.p_global = MX.sym('p_global', 0, 1)
 
     return ocp
 

--- a/interfaces/acados_template/acados_template/acados_model.py
+++ b/interfaces/acados_template/acados_template/acados_model.py
@@ -52,12 +52,12 @@ class AcadosModel():
         ## common for OCP and Integrator
         self.name = None
         """The model name is used for code generation. Type: string. Default: :code:`None`"""
-        self.x = None
-        """CasADi variable describing the state of the system; Default: :code:`None`"""
-        self.xdot = None
-        """CasADi variable describing the derivative of the state wrt time; Default: :code:`None`"""
-        self.u = None
-        """CasADi variable describing the input of the system; Default: :code:`None`"""
+        self.x = []
+        """CasADi variable describing the state of the system; Default: :code:`[]`"""
+        self.xdot = []
+        """CasADi variable describing the derivative of the state wrt time; Default: :code:`[]`"""
+        self.u = []
+        """CasADi variable describing the input of the system; Default: :code:`[]`"""
         self.z = []
         """CasADi variable describing the algebraic variables of the DAE; Default: :code:`[]`"""
         self.p = []
@@ -71,34 +71,34 @@ class AcadosModel():
         The time dependency can be used within cost formulations and is relevant when cost integration is used.
         Start times of shooting intervals can be added using parameters.
         """
-        self.p_global = None
+        self.p_global = []
         """
         CasADi variable containing global parameters.
         This feature can be used to precompute expensive terms which only depend on these parameters, e.g. spline coefficients, when p_global are underlying data points.
         Only supported for OCP solvers.
         Updating these parameters can be done using :py:attr:`acados_template.acados_ocp_solver.AcadosOcpSolver.set_p_global_and_precompute_dependencies(values)`.
         NOTE: this is only supported with CasADi beta release https://github.com/casadi/casadi/releases/tag/nightly-se
-        Default: :code:`None`
+        Default: :code:`[]`
         """
 
         ## dynamics
-        self.f_impl_expr = None
+        self.f_impl_expr = []
         r"""
         CasADi expression for the implicit dynamics :math:`f_\text{impl}(\dot{x}, x, u, z, p) = 0`.
         Used if :py:attr:`acados_template.acados_ocp_options.AcadosOcpOptions.integrator_type` == 'IRK'.
-        Default: :code:`None`
+        Default: :code:`[]`
         """
-        self.f_expl_expr = None
+        self.f_expl_expr = []
         r"""
         CasADi expression for the explicit dynamics :math:`\dot{x} = f_\text{expl}(x, u, p)`.
         Used if :py:attr:`acados_template.acados_ocp_options.AcadosOcpOptions.integrator_type` == 'ERK'.
-        Default: :code:`None`
+        Default: :code:`[]`
         """
-        self.disc_dyn_expr = None
+        self.disc_dyn_expr = []
         r"""
         CasADi expression for the discrete dynamics :math:`x_{+} = f_\text{disc}(x, u, p)`.
         Used if :py:attr:`acados_template.acados_ocp_options.AcadosOcpOptions.integrator_type` == 'DISCRETE'.
-        Default: :code:`None`
+        Default: :code:`[]`
         """
 
         self.dyn_ext_fun_type = 'casadi'
@@ -130,106 +130,106 @@ class AcadosModel():
         # NOTE: These could be moved to cost / constraints
 
         # constraints at initial stage
-        self.con_h_expr_0 = None
-        """CasADi expression for the initial constraint :math:`h^0`; Default: :code:`None`"""
-        self.con_phi_expr_0 = None
-        r"""CasADi expression for the terminal constraint :math:`\phi_0`; Default: :code:`None`"""
-        self.con_r_expr_0 = None
+        self.con_h_expr_0 = []
+        """CasADi expression for the initial constraint :math:`h^0`; Default: :code:`[]`"""
+        self.con_phi_expr_0 = []
+        r"""CasADi expression for the terminal constraint :math:`\phi_0`; Default: :code:`[]`"""
+        self.con_r_expr_0 = []
         r"""CasADi expression for the terminal constraint :math:`\phi_0(r)`,
-        dummy input for outer function; Default: :code:`None`"""
-        self.con_r_in_phi_0 = None
-        r"""CasADi expression for the terminal constraint :math:`\phi_0(r)`, input for outer function; Default: :code:`None`"""
+        dummy input for outer function; Default: :code:`[]`"""
+        self.con_r_in_phi_0 = []
+        r"""CasADi expression for the terminal constraint :math:`\phi_0(r)`, input for outer function; Default: :code:`[]`"""
 
 
         # path constraints
         # BGH(default): lh <= h(x, u) <= uh
-        self.con_h_expr = None
-        """CasADi expression for the constraint :math:`h`; Default: :code:`None`"""
+        self.con_h_expr = []
+        """CasADi expression for the constraint :math:`h`; Default: :code:`[]`"""
         # BGP(convex over nonlinear): lphi <= phi(r(x, u)) <= uphi
-        self.con_phi_expr = None
-        """CasADi expression for the constraint phi; Default: :code:`None`"""
-        self.con_r_expr = None
+        self.con_phi_expr = []
+        """CasADi expression for the constraint phi; Default: :code:`[]`"""
+        self.con_r_expr = []
         """CasADi expression for the constraint phi(r),
-        dummy input for outer function; Default: :code:`None`"""
-        self.con_r_in_phi = None
+        dummy input for outer function; Default: :code:`[]`"""
+        self.con_r_in_phi = []
         r"""CasADi expression for the terminal constraint :math:`\phi(r)`,
-        input for outer function; Default: :code:`None`"""
+        input for outer function; Default: :code:`[]`"""
 
         # terminal
-        self.con_h_expr_e = None
-        """CasADi expression for the terminal constraint :math:`h^e`; Default: :code:`None`"""
-        self.con_phi_expr_e = None
-        r"""CasADi expression for the terminal constraint :math:`\phi_e`; Default: :code:`None`"""
-        self.con_r_expr_e = None
+        self.con_h_expr_e = []
+        """CasADi expression for the terminal constraint :math:`h^e`; Default: :code:`[]`"""
+        self.con_phi_expr_e = []
+        r"""CasADi expression for the terminal constraint :math:`\phi_e`; Default: :code:`[]`"""
+        self.con_r_expr_e = []
         r"""CasADi expression for the terminal constraint :math:`\phi_e(r)`,
-        dummy input for outer function; Default: :code:`None`"""
-        self.con_r_in_phi_e = None
-        r"""CasADi expression for the terminal constraint :math:`\phi_e(r)`, input for outer function; Default: :code:`None`"""
+        dummy input for outer function; Default: :code:`[]`"""
+        self.con_r_in_phi_e = []
+        r"""CasADi expression for the terminal constraint :math:`\phi_e(r)`, input for outer function; Default: :code:`[]`"""
 
         # cost
-        self.cost_y_expr = None
-        """CasADi expression for nonlinear least squares; Default: :code:`None`"""
-        self.cost_y_expr_e = None
-        """CasADi expression for nonlinear least squares, terminal; Default: :code:`None`"""
-        self.cost_y_expr_0 = None
-        """CasADi expression for nonlinear least squares, initial; Default: :code:`None`"""
-        self.cost_expr_ext_cost = None
-        """CasADi expression for external cost; Default: :code:`None`"""
-        self.cost_expr_ext_cost_e = None
-        """CasADi expression for external cost, terminal; Default: :code:`None`"""
-        self.cost_expr_ext_cost_0 = None
-        """CasADi expression for external cost, initial; Default: :code:`None`"""
-        self.cost_expr_ext_cost_custom_hess = None
-        """CasADi expression for custom hessian (only for external cost); Default: :code:`None`"""
-        self.cost_expr_ext_cost_custom_hess_e = None
-        """CasADi expression for custom hessian (only for external cost), terminal; Default: :code:`None`"""
-        self.cost_expr_ext_cost_custom_hess_0 = None
-        """CasADi expression for custom hessian (only for external cost), initial; Default: :code:`None`"""
+        self.cost_y_expr = []
+        """CasADi expression for nonlinear least squares; Default: :code:`[]`"""
+        self.cost_y_expr_e = []
+        """CasADi expression for nonlinear least squares, terminal; Default: :code:`[]`"""
+        self.cost_y_expr_0 = []
+        """CasADi expression for nonlinear least squares, initial; Default: :code:`[]`"""
+        self.cost_expr_ext_cost = []
+        """CasADi expression for external cost; Default: :code:`[]`"""
+        self.cost_expr_ext_cost_e = []
+        """CasADi expression for external cost, terminal; Default: :code:`[]`"""
+        self.cost_expr_ext_cost_0 = []
+        """CasADi expression for external cost, initial; Default: :code:`[]`"""
+        self.cost_expr_ext_cost_custom_hess = []
+        """CasADi expression for custom hessian (only for external cost); Default: :code:`[]`"""
+        self.cost_expr_ext_cost_custom_hess_e = []
+        """CasADi expression for custom hessian (only for external cost), terminal; Default: :code:`[]`"""
+        self.cost_expr_ext_cost_custom_hess_0 = []
+        """CasADi expression for custom hessian (only for external cost), initial; Default: :code:`[]`"""
 
         ## CONVEX_OVER_NONLINEAR convex-over-nonlinear cost: psi(y(x, u, p) - y_ref; p)
-        self.cost_psi_expr_0 = None
+        self.cost_psi_expr_0 = []
         r"""
-        CasADi expression for the outer loss function :math:`\psi(r - yref, t, p)`, initial; Default: :code:`None`
+        CasADi expression for the outer loss function :math:`\psi(r - yref, t, p)`, initial; Default: :code:`[]`
         Used if :py:attr:`acados_template.acados_ocp_options.AcadosOcpOptions.cost_type_0` is 'CONVEX_OVER_NONLINEAR'.
         """
-        self.cost_psi_expr = None
+        self.cost_psi_expr = []
         r"""
-        CasADi expression for the outer loss function :math:`\psi(r - yref, t, p)`; Default: :code:`None`
+        CasADi expression for the outer loss function :math:`\psi(r - yref, t, p)`; Default: :code:`[]`
         Used if :py:attr:`acados_template.acados_ocp_options.AcadosOcpOptions.cost_type` is 'CONVEX_OVER_NONLINEAR'.
         """
-        self.cost_psi_expr_e = None
+        self.cost_psi_expr_e = []
         r"""
-        CasADi expression for the outer loss function :math:`\psi(r - yref, p)`, terminal; Default: :code:`None`
+        CasADi expression for the outer loss function :math:`\psi(r - yref, p)`, terminal; Default: :code:`[]`
         Used if :py:attr:`acados_template.acados_ocp_options.AcadosOcpOptions.cost_type_e` is 'CONVEX_OVER_NONLINEAR'.
         """
-        self.cost_r_in_psi_expr_0 = None
+        self.cost_r_in_psi_expr_0 = []
         r"""
-        CasADi symbolic input variable for the argument :math:`r` to the outer loss function :math:`\psi(r, t, p)`, initial; Default: :code:`None`
+        CasADi symbolic input variable for the argument :math:`r` to the outer loss function :math:`\psi(r, t, p)`, initial; Default: :code:`[]`
         Used if :py:attr:`acados_template.acados_ocp_options.AcadosOcpOptions.cost_type_0` is 'CONVEX_OVER_NONLINEAR'.
         """
-        self.cost_r_in_psi_expr = None
+        self.cost_r_in_psi_expr = []
         r"""
-        CasADi symbolic input variable for the argument :math:`r` to the outer loss function :math:`\psi(r, t, p)`; Default: :code:`None`
+        CasADi symbolic input variable for the argument :math:`r` to the outer loss function :math:`\psi(r, t, p)`; Default: :code:`[]`
         Used if :py:attr:`acados_template.acados_ocp_options.AcadosOcpOptions.cost_type` is 'CONVEX_OVER_NONLINEAR'.
         """
-        self.cost_r_in_psi_expr_e = None
+        self.cost_r_in_psi_expr_e = []
         r"""
-        CasADi symbolic input variable for the argument :math:`r` to the outer loss function :math:`\psi(r, p)`, terminal; Default: :code:`None`
+        CasADi symbolic input variable for the argument :math:`r` to the outer loss function :math:`\psi(r, p)`, terminal; Default: :code:`[]`
         Used if :py:attr:`acados_template.acados_ocp_options.AcadosOcpOptions.cost_type_e` is 'CONVEX_OVER_NONLINEAR'.
         """
-        self.cost_conl_custom_outer_hess_0 = None
+        self.cost_conl_custom_outer_hess_0 = []
         """
-        CasADi expression for the custom hessian of the outer loss function (only for convex-over-nonlinear cost), initial; Default: :code:`None`
+        CasADi expression for the custom hessian of the outer loss function (only for convex-over-nonlinear cost), initial; Default: :code:`[]`
         Used if :py:attr:`acados_template.acados_ocp_options.AcadosOcpOptions.cost_type_0` is 'CONVEX_OVER_NONLINEAR'.
         """
-        self.cost_conl_custom_outer_hess = None
+        self.cost_conl_custom_outer_hess = []
         """
-        CasADi expression for the custom hessian of the outer loss function (only for convex-over-nonlinear cost); Default: :code:`None`
+        CasADi expression for the custom hessian of the outer loss function (only for convex-over-nonlinear cost); Default: :code:`[]`
         Used if :py:attr:`acados_template.acados_ocp_options.AcadosOcpOptions.cost_type` is 'CONVEX_OVER_NONLINEAR'.
         """
-        self.cost_conl_custom_outer_hess_e = None
+        self.cost_conl_custom_outer_hess_e = []
         """
-        CasADi expression for the custom hessian of the outer loss function (only for convex-over-nonlinear cost), terminal; Default: :code:`None`
+        CasADi expression for the custom hessian of the outer loss function (only for convex-over-nonlinear cost), terminal; Default: :code:`[]`
         Used if :py:attr:`acados_template.acados_ocp_options.AcadosOcpOptions.cost_type_e` is 'CONVEX_OVER_NONLINEAR'.
         """
         self.nu_original = None # TODO: remove? only used by benchmark

--- a/interfaces/acados_template/acados_template/acados_model.py
+++ b/interfaces/acados_template/acados_template/acados_model.py
@@ -336,7 +336,7 @@ class AcadosModel():
             dims.np_global = 0
             self.p_global = casadi_symbol('p_global', 0, 1)
         else:
-            dims.np = casadi_length(self.p)
+            dims.np_global = casadi_length(self.p_global)
 
         # sanity checks
         for symbol, name in [(self.x, 'x'), (self.xdot, 'xdot'), (self.u, 'u'), (self.z, 'z'), (self.p, 'p'), (self.p_global, 'p_global')]:

--- a/interfaces/acados_template/acados_template/acados_multiphase_ocp.py
+++ b/interfaces/acados_template/acados_template/acados_multiphase_ocp.py
@@ -43,7 +43,7 @@ from .acados_ocp_constraints import AcadosOcpConstraints
 from .acados_ocp_options import AcadosOcpOptions, INTEGRATOR_TYPES, COLLOCATION_TYPES, COST_DISCRETIZATION_TYPES
 from .acados_ocp import AcadosOcp
 from .casadi_function_generation import GenerateContext
-from .utils import make_object_json_dumpable, get_acados_path, format_class_dict, get_shared_lib_ext, render_template
+from .utils import make_object_json_dumpable, get_acados_path, format_class_dict, get_shared_lib_ext, render_template, is_empty
 
 
 def find_non_default_fields_of_obj(obj: Union[AcadosOcpCost, AcadosOcpConstraints, AcadosOcpOptions], stage_type='all') -> list:
@@ -269,9 +269,9 @@ class AcadosMultiphaseOcp:
         # p_global check:
         p_global = self.model[0].p_global
         for i in range(self.n_phases):
-            if p_global is None and self.model[i].p_global is not None:
-                raise Exception(f"p_global is None for phase 0, but not for phase {i}. Should be the same for all phases.")
-            if p_global is not None and not ca.is_equal(p_global, self.model[i].p_global):
+            if is_empty(p_global) and not is_empty(self.model[i].p_global):
+                raise Exception(f"p_global is empty for phase 0, but not for phase {i}. Should be the same for all phases.")
+            if not is_empty(p_global) and not ca.is_equal(p_global, self.model[i].p_global):
                 raise Exception(f"p_global is different for phase 0 and phase {i}. Should be the same for all phases.")
 
         # compute phase indices

--- a/interfaces/acados_template/acados_template/acados_multiphase_ocp.py
+++ b/interfaces/acados_template/acados_template/acados_multiphase_ocp.py
@@ -76,9 +76,13 @@ def find_non_default_fields_of_obj(obj: Union[AcadosOcpCost, AcadosOcpConstraint
     for field in all_fields:
         val = getattr(obj, field)
         default_val = getattr(dummy_obj, field)
-        if isinstance(val, np.ndarray):
+        if not isinstance(val, type(default_val)):
+            nondefault_fields.append(field)
+
+        elif isinstance(val, np.ndarray):
             if not np.array_equal(val, default_val):
                 nondefault_fields.append(field)
+
         elif val != default_val:
             nondefault_fields.append(field)
 

--- a/interfaces/acados_template/acados_template/acados_ocp.py
+++ b/interfaces/acados_template/acados_template/acados_ocp.py
@@ -239,9 +239,9 @@ class AcadosOcp:
                 "GAUSS_NEWTON or EXACT with 'exact_hess_cost' == False.\n")
 
         # GN check
-        gn_warning_0 = (cost.cost_type_0 == 'EXTERNAL' and opts.hessian_approx == 'GAUSS_NEWTON' and opts.ext_cost_num_hess == 0 and model.cost_expr_ext_cost_custom_hess_0 is None)
-        gn_warning_path = (cost.cost_type == 'EXTERNAL' and opts.hessian_approx == 'GAUSS_NEWTON' and opts.ext_cost_num_hess == 0 and model.cost_expr_ext_cost_custom_hess is None)
-        gn_warning_terminal = (opts.hessian_approx == 'GAUSS_NEWTON' and opts.ext_cost_num_hess == 0 and model.cost_expr_ext_cost_custom_hess_e is None)
+        gn_warning_0 = (cost.cost_type_0 == 'EXTERNAL' and opts.hessian_approx == 'GAUSS_NEWTON' and opts.ext_cost_num_hess == 0 and is_empty(model.cost_expr_ext_cost_custom_hess_0))
+        gn_warning_path = (cost.cost_type == 'EXTERNAL' and opts.hessian_approx == 'GAUSS_NEWTON' and opts.ext_cost_num_hess == 0 and is_empty(model.cost_expr_ext_cost_custom_hess))
+        gn_warning_terminal = (opts.hessian_approx == 'GAUSS_NEWTON' and opts.ext_cost_num_hess == 0 and is_empty(model.cost_expr_ext_cost_custom_hess_e))
         if any([gn_warning_0, gn_warning_path, gn_warning_terminal]):
             external_cost_types = []
             if gn_warning_0:
@@ -1462,7 +1462,7 @@ class AcadosOcp:
         if self.cost.cost_type != "CONVEX_OVER_NONLINEAR":
             raise Exception("Huber penalty is only supported for CONVEX_OVER_NONLINEAR cost type.")
 
-        if use_xgn and self.model.cost_conl_custom_outer_hess is None:
+        if use_xgn and is_empty(self.model.cost_conl_custom_outer_hess):
             # switch to XGN Hessian start with exact Hessian of previously defined cost
             exact_cost_hess = ca.hessian(self.model.cost_psi_expr, self.model.cost_r_in_psi_expr)[0]
             self.model.cost_conl_custom_outer_hess = exact_cost_hess
@@ -1500,7 +1500,7 @@ class AcadosOcp:
             zero_offdiag = casadi_zeros(self.model.cost_conl_custom_outer_hess.shape[0], penalty_hess_xgn.shape[1])
             self.model.cost_conl_custom_outer_hess = ca.blockcat(self.model.cost_conl_custom_outer_hess,
                                                                 zero_offdiag, zero_offdiag.T, penalty_hess_xgn)
-        elif self.model.cost_conl_custom_outer_hess is not None:
+        elif not is_empty(self.model.cost_conl_custom_outer_hess):
             zero_offdiag = casadi_zeros(self.model.cost_conl_custom_outer_hess.shape[0], penalty_hess_xgn.shape[1])
             # add penalty Hessian to existing Hessian
             self.model.cost_conl_custom_outer_hess = ca.blockcat(self.model.cost_conl_custom_outer_hess,

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -54,7 +54,7 @@ from .acados_multiphase_ocp import AcadosMultiphaseOcp
 from .gnsf.detect_gnsf_structure import detect_gnsf_structure
 from .utils import (get_shared_lib_ext, get_shared_lib_prefix, get_shared_lib_dir, get_shared_lib,
                     make_object_json_dumpable, set_up_imported_gnsf_model, verbose_system_call,
-                    acados_lib_is_compiled_with_openmp)
+                    acados_lib_is_compiled_with_openmp, is_empty)
 from .acados_ocp_iterate import AcadosOcpIterate, AcadosOcpIterates, AcadosOcpFlattenedIterate
 
 
@@ -620,9 +620,9 @@ class AcadosOcpSolver:
             self.acados_ocp.solver_options.exact_hess_cost == 1 and
             self.acados_ocp.solver_options.exact_hess_dyn == 1 and
             self.acados_ocp.solver_options.fixed_hess == 0 and
-            self.acados_ocp.model.cost_expr_ext_cost_custom_hess_0 is None and
-            self.acados_ocp.model.cost_expr_ext_cost_custom_hess is None and
-            self.acados_ocp.model.cost_expr_ext_cost_custom_hess_e is None
+            is_empty(self.acados_ocp.model.cost_expr_ext_cost_custom_hess_0) and
+            is_empty(self.acados_ocp.model.cost_expr_ext_cost_custom_hess) and
+            is_empty(self.acados_ocp.model.cost_expr_ext_cost_custom_hess_e)
         ):
             raise Exception("Parametric sensitivities are only correct if an exact Hessian is used!")
 

--- a/interfaces/acados_template/acados_template/casadi_function_generation.py
+++ b/interfaces/acados_template/acados_template/casadi_function_generation.py
@@ -54,7 +54,7 @@ def is_casadi_SX(x):
 class GenerateContext:
     def __init__(self, p_global: Optional[Union[ca.SX, ca.MX]], problem_name: str, opts=None):
         self.p_global = p_global
-        if p_global is not None:
+        if not is_empty(p_global):
             check_casadi_version_supports_p_global()
 
         self.problem_name = problem_name
@@ -167,7 +167,7 @@ class GenerateContext:
         assert casadi_length(self.global_data_expr) == casadi_length(self.global_data_sym), f"Length mismatch: {casadi_length(self.global_data_expr)} != {casadi_length(self.global_data_sym)}"
 
     def finalize(self):
-        if self.p_global is not None:
+        if not is_empty(self.p_global):
             self.__setup_p_global_precompute_fun()
 
         self.__generate_functions()

--- a/interfaces/acados_template/acados_template/casadi_function_generation.py
+++ b/interfaces/acados_template/acados_template/casadi_function_generation.py
@@ -472,7 +472,7 @@ def generate_c_code_external_cost(context: GenerateContext, model: AcadosModel, 
     hess_z = hess_uxz[nunx:, nunx:]
     hess_z_ux = hess_uxz[nunx:, :nunx]
 
-    if custom_hess is not None:
+    if not is_empty(custom_hess):
         hess_ux = custom_hess
 
     cost_dir = os.path.abspath(os.path.join(opts["code_export_directory"], f'{model.name}_cost'))
@@ -562,8 +562,7 @@ def generate_c_code_conl_cost(context: GenerateContext, model: AcadosModel, stag
     t = model.t
 
     symbol = get_casadi_symbol(x)
-    if p_global is None:
-        p_global = symbol('p_global', 0, 0)
+    p_global = symbol('p_global', 0, 0)
 
     if stage_type == 'terminal':
         u = symbol('u', 0, 0)
@@ -614,7 +613,7 @@ def generate_c_code_conl_cost(context: GenerateContext, model: AcadosModel, stag
 
     outer_loss_grad_fun = ca.Function('outer_loss_grad', [res_expr, t, p, p_global], [ca.jacobian(outer_expr, res_expr).T])
 
-    if custom_hess is None:
+    if is_empty(custom_hess):
         hess = ca.hessian(outer_loss_fun(res_expr, t, p, p_global), res_expr)[0]
     else:
         hess = custom_hess

--- a/interfaces/acados_template/acados_template/mpc_utils.py
+++ b/interfaces/acados_template/acados_template/mpc_utils.py
@@ -141,8 +141,7 @@ def detect_constraint_structure(model: AcadosModel, constraints: AcadosOcpConstr
     nx = x.shape[0]
     nu = u.shape[0]
 
-    if model.p_global is None:
-        p_global = []  # to have same structure of model.p
+    p_global = model.p_global
 
     casadi_var = model.get_casadi_symbol()
     casadi_dm_zeros = ca.DM.zeros
@@ -165,7 +164,7 @@ def detect_constraint_structure(model: AcadosModel, constraints: AcadosOcpConstr
     else:
         raise ValueError('Constraint detection: Wrong stage_type.')
 
-    if expr_constr is None:
+    if is_empty(expr_constr):
         expr_constr = casadi_var('con_h_expr', 0, 0)
 
     # Initialize

--- a/interfaces/acados_template/acados_template/utils.py
+++ b/interfaces/acados_template/acados_template/utils.py
@@ -189,6 +189,8 @@ def is_empty(x):
         return True
     elif isinstance(x, (set, list)):
         return True if len(x) == 0 else False
+    elif isinstance(x, (float, int)):
+        return False
     else:
         raise Exception("is_empty expects one of the following types: casadi.MX, casadi.SX, "
                         + "None, numpy array empty list, set. Got: " + str(type(x)))


### PR DESCRIPTION
Before, we inconsistently used `None` and `[]`.
For CasADi expressions `[]` is more suitable, since it is compatible with `casadi.vertcat`.
Breaking: default types of fields in `AcadosModel` that might be symbolic have changed to `[]`.