### PR TITLE
Python/Matlab: More efficient code generation for MOCP models

### DIFF
--- a/interfaces/acados_matlab_octave/AcadosMultiphaseOcp.m
+++ b/interfaces/acados_matlab_octave/AcadosMultiphaseOcp.m
@@ -321,10 +321,22 @@ classdef AcadosMultiphaseOcp < handle
 
             for i=1:self.n_phases
                 disp(['generating external functions for phase ', num2str(i)]);
+                if i ~= self.n_phases
+                    ignore_terminal = true;
+                else
+                    ignore_terminal = false;
+                end
+
+                if i ~= 1
+                    ignore_initial = true;
+                else
+                    ignore_initial = false;
+                end
+
                 % this is the only option that can vary and influence external functions to be generated
                 self.dummy_ocp_list{i}.solver_options.integrator_type = self.mocp_opts.integrator_type{i};
                 self.dummy_ocp_list{i}.code_export_directory = self.code_export_directory;
-                context = self.dummy_ocp_list{i}.setup_code_generation_context(context);
+                context = self.dummy_ocp_list{i}.setup_code_generation_context(context, ignore_initial, ignore_terminal);
             end
 
             context.finalize();

--- a/interfaces/acados_matlab_octave/AcadosOcp.m
+++ b/interfaces/acados_matlab_octave/AcadosOcp.m
@@ -900,13 +900,13 @@ classdef AcadosOcp < handle
             end
 
             if ignore_initial && ignore_terminal
-                idxs = [2];
+                stage_type_indices = [2];
             elseif ignore_terminal
-                idxs = [1, 2];
+                stage_type_indices = [1, 2];
             elseif ignore_initial
-                idxs = [2, 3];
+                stage_type_indices = [2, 3];
             else
-                idxs = [1, 2, 3]
+                stage_type_indices = [1, 2, 3]
             end
 
             stage_types = {'initial', 'path', 'terminal'};
@@ -916,9 +916,9 @@ classdef AcadosOcp < handle
             cost_ext_fun_types = {cost.cost_ext_fun_type_0, cost.cost_ext_fun_type, cost.cost_ext_fun_type_e};
             cost_dir = fullfile(pwd, ocp.code_export_directory, [ocp.name '_cost']);
 
-            for n = 1:length(idxs)
+            for n = 1:length(stage_type_indices)
 
-                i = idxs(n);
+                i = stage_type_indices(n);
                 if strcmp(cost_ext_fun_types{i}, 'generic')
                     if strcmp(cost_types{i}, 'EXTERNAL')
                         setup_generic_cost(context, cost, cost_dir, stage_types{i})
@@ -950,8 +950,8 @@ classdef AcadosOcp < handle
             constraints_dims = {dims.nh_0, dims.nh, dims.nh_e};
             constraints_dir = fullfile(pwd, ocp.code_export_directory, [ocp.name '_constraints']);
 
-            for n = 1:length(idxs)
-                i = idxs(n);
+            for n = 1:length(stage_type_indices)
+                i = stage_type_indices(n);
                 if strcmp(constraints_types{i}, 'BGH') && constraints_dims{i} > 0
                     generate_c_code_nonlinear_constr(context, ocp.model, constraints_dir, stage_types{i});
                 end

--- a/interfaces/acados_template/acados_template/acados_multiphase_ocp.py
+++ b/interfaces/acados_template/acados_template/acados_multiphase_ocp.py
@@ -86,6 +86,9 @@ def find_non_default_fields_of_obj(obj: Union[AcadosOcpCost, AcadosOcpConstraint
         elif val != default_val:
             nondefault_fields.append(field)
 
+            if isinstance(val, ca.MX) or isinstance(val, ca.SX):
+                setattr(obj, field, default_val)
+
     return nondefault_fields
 
 

--- a/interfaces/acados_template/acados_template/acados_multiphase_ocp.py
+++ b/interfaces/acados_template/acados_template/acados_multiphase_ocp.py
@@ -463,9 +463,11 @@ class AcadosMultiphaseOcp:
         context = GenerateContext(self.model[0].p_global, self.name, code_gen_opts)
 
         for i in range(self.n_phases):
+            ignore_initial = True if i != 0 else False
+            ignore_terminal = True if i != self.n_phases-1 else False
             # this is the only option that can vary and influence external functions to be generated
             self.dummy_ocp_list[i].solver_options.integrator_type = self.mocp_opts.integrator_type[i]
-            context = self.dummy_ocp_list[i]._setup_code_generation_context(context)
+            context = self.dummy_ocp_list[i]._setup_code_generation_context(context, ignore_initial, ignore_terminal)
             self.dummy_ocp_list[i].code_export_directory = self.code_export_directory
 
         context.finalize()

--- a/interfaces/acados_template/acados_template/acados_multiphase_ocp.py
+++ b/interfaces/acados_template/acados_template/acados_multiphase_ocp.py
@@ -86,9 +86,6 @@ def find_non_default_fields_of_obj(obj: Union[AcadosOcpCost, AcadosOcpConstraint
         elif val != default_val:
             nondefault_fields.append(field)
 
-            if isinstance(val, ca.MX) or isinstance(val, ca.SX):
-                setattr(obj, field, default_val)
-
     return nondefault_fields
 
 

--- a/interfaces/acados_template/acados_template/acados_ocp.py
+++ b/interfaces/acados_template/acados_template/acados_ocp.py
@@ -1089,16 +1089,16 @@ class AcadosOcp:
         else:
             idxs = [0, 1, 2]
 
-        stage_types = ['initial', 'path', 'terminal']
-        nhs = ['nh_0', 'nh', 'nh_e']
-        nphis = ['nphi_0', 'nphi', 'nphi_e']
-        cost_types = ['cost_type_0', 'cost_type', 'cost_type_e']
+        stage_types = [val for i, val in enumerate(['initial', 'path', 'terminal']) if i in idxs]
+        nhs = [val for i, val in enumerate(['nh_0', 'nh', 'nh_e']) if i in idxs]
+        nphis = [val for i, val in enumerate(['nphi_0', 'nphi', 'nphi_e']) if i in idxs]
+        cost_types = [val for i, val in enumerate(['cost_type_0', 'cost_type', 'cost_type_e']) if i in idxs]
 
-        for attr_nh, attr_nphi, stage_type in zip(nhs[idxs], nphis[idxs], stage_types[idxs]):
+        for attr_nh, attr_nphi, stage_type in zip(nhs, nphis, stage_types):
             if getattr(self.dims, attr_nh) > 0 or getattr(self.dims, attr_nphi) > 0:
                 generate_c_code_constraint(context, model, constraints, stage_type)
 
-        for attr, stage_type in zip(cost_types[idxs], stage_types[idxs]):
+        for attr, stage_type in zip(cost_types, stage_types):
             if getattr(self.cost, attr) == 'NONLINEAR_LS':
                 generate_c_code_nls_cost(context, model, stage_type)
             elif getattr(self.cost, attr) == 'CONVEX_OVER_NONLINEAR':

--- a/interfaces/acados_template/acados_template/acados_ocp.py
+++ b/interfaces/acados_template/acados_template/acados_ocp.py
@@ -1081,18 +1081,18 @@ class AcadosOcp:
             context.add_external_function_file(model.dyn_generic_source, target_dir)
 
         if ignore_initial and ignore_terminal:
-            idxs = [1]
+            stage_type_indices = [1]
         elif ignore_initial:
-            idxs = [1, 2]
+            stage_type_indices = [1, 2]
         elif ignore_terminal:
-            idxs = [0, 1]
+            stage_type_indices = [0, 1]
         else:
-            idxs = [0, 1, 2]
+            stage_type_indices = [0, 1, 2]
 
-        stage_types = [val for i, val in enumerate(['initial', 'path', 'terminal']) if i in idxs]
-        nhs = [val for i, val in enumerate(['nh_0', 'nh', 'nh_e']) if i in idxs]
-        nphis = [val for i, val in enumerate(['nphi_0', 'nphi', 'nphi_e']) if i in idxs]
-        cost_types = [val for i, val in enumerate(['cost_type_0', 'cost_type', 'cost_type_e']) if i in idxs]
+        stage_types = [val for i, val in enumerate(['initial', 'path', 'terminal']) if i in stage_type_indices]
+        nhs = [val for i, val in enumerate(['nh_0', 'nh', 'nh_e']) if i in stage_type_indices]
+        nphis = [val for i, val in enumerate(['nphi_0', 'nphi', 'nphi_e']) if i in stage_type_indices]
+        cost_types = [val for i, val in enumerate(['cost_type_0', 'cost_type', 'cost_type_e']) if i in stage_type_indices]
 
         for attr_nh, attr_nphi, stage_type in zip(nhs, nphis, stage_types):
             if getattr(self.dims, attr_nh) > 0 or getattr(self.dims, attr_nphi) > 0:


### PR DESCRIPTION
This PR ignores non-required stages in code generation for multi-phase OCPs. This way the code generation overhead is reduced. If global parameters are used, this might also avoid the computation of parametric expressions which are not needed.