### PR TITLE
MATLAB: fix getter for QP values at terminal stage

### DIFF
--- a/examples/acados_matlab_octave/getting_started/extensive_example_ocp.m
+++ b/examples/acados_matlab_octave/getting_started/extensive_example_ocp.m
@@ -272,9 +272,6 @@ stage = N;
 field = 'qp_Q';
 disp(strcat(field, " at stage ", num2str(stage), " = "));
 ocp_solver.get(field, stage)
-field = 'qp_R';
-disp(strcat(field, " at stage ", num2str(stage), " = "));
-ocp_solver.get(field, stage)
 
 ... or for all stages.
 qp_Q = ocp_solver.get('qp_Q');

--- a/examples/acados_matlab_octave/legacy_interface/getting_started/extensive_example_ocp.m
+++ b/examples/acados_matlab_octave/legacy_interface/getting_started/extensive_example_ocp.m
@@ -313,9 +313,7 @@ stage = N;
 field = 'qp_Q';
 disp(strcat(field, " at stage ", num2str(stage), " = "));
 ocp_solver.get(field, stage)
-field = 'qp_R';
-disp(strcat(field, " at stage ", num2str(stage), " = "));
-ocp_solver.get(field, stage)
+
 
 % or for all stages
 qp_Q = ocp_solver.get('qp_Q');

--- a/interfaces/acados_matlab_octave/AcadosOcpSolver.m
+++ b/interfaces/acados_matlab_octave/AcadosOcpSolver.m
@@ -120,14 +120,14 @@ classdef AcadosOcpSolver < handle
                     return;
                 else
                     value = cell(obj.ocp.solver_options.N_horizon, 1);
-                    for n=0:obj.ocp.solver_options.N_horizon
+                    for n=0:(obj.ocp.solver_options.N_horizon-1)
                         Q = obj.get('qp_Q', n);
                         R = obj.get('qp_R', n);
                         S = obj.get('qp_S', n);
 
                         value{n+1} = [R, S; S', Q];
-
                     end
+                    value{end+1} = obj.get('qp_Q', obj.ocp.solver_options.N_horizon);
                     return;
                 end
             elseif strcmp('pc_hess_block', field)
@@ -311,8 +311,17 @@ classdef AcadosOcpSolver < handle
                     val = obj.get(field, i);
                     qp_data = setfield(qp_data, key, val);
                 end
-
-                if strcmp(field, 'qp_Q') || strcmp(field, 'qp_q') || strcmp(field, 'qp_zl') || strcmp(field, 'qp_zu') || strcmp(field, 'qp_Zl') || strcmp(field, 'qp_Zu')
+                if strcmp(field, 'qp_Q') || ...
+                   strcmp(field, 'qp_q') || ...
+                   strcmp(field, 'qp_C') || ...
+                   strcmp(field, 'qp_lg') || ...
+                   strcmp(field, 'qp_ug') || ...
+                   strcmp(field, 'qp_lbx') || ...
+                   strcmp(field, 'qp_ubx') || ...
+                   strcmp(field, 'qp_zl') || ...
+                   strcmp(field, 'qp_zu') || ...
+                   strcmp(field, 'qp_Zl') || ...
+                   strcmp(field, 'qp_Zu')
                     s_indx = sprintf(strcat('%0', num2str(lN), 'd'), obj.ocp.solver_options.N_horizon);
                     key = strcat(field, '_', s_indx);
                     val = obj.get(field, obj.ocp.solver_options.N_horizon);

--- a/interfaces/acados_matlab_octave/AcadosOcpSolver.m
+++ b/interfaces/acados_matlab_octave/AcadosOcpSolver.m
@@ -112,11 +112,17 @@ classdef AcadosOcpSolver < handle
 
                 if length(varargin) > 0
                     n = varargin{1};
-                    Q = obj.get('qp_Q', n);
-                    R = obj.get('qp_R', n);
-                    S = obj.get('qp_S', n);
 
-                    value = [R, S; S', Q];
+                    if n < obj.ocp.solver_options.N_horizon
+                        Q = obj.get('qp_Q', n);
+                        R = obj.get('qp_R', n);
+                        S = obj.get('qp_S', n);
+
+                        value = [R, S; S', Q];
+                    else
+                        value = obj.get('qp_Q', n);
+                    end
+
                     return;
                 else
                     value = cell(obj.ocp.solver_options.N_horizon, 1);

--- a/interfaces/acados_matlab_octave/ocp_get.c
+++ b/interfaces/acados_matlab_octave/ocp_get.c
@@ -93,7 +93,23 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
             sprintf(buffer, "\nocp_get: invalid stage index, got %d\n", stage);
             mexErrMsgTxt(buffer);
         }
-        else if (stage == N && strcmp(field, "x") && strcmp(field, "lam") && strcmp(field, "p") && strcmp(field, "sens_x") && strcmp(field, "sl") && strcmp(field, "su") && strcmp(field, "qp_Q") && strcmp(field, "qp_R") && strcmp(field, "qp_S") && strcmp(field, "qp_q") && strcmp(field, "qp_lbx") && strcmp(field, "qp_ubx") && strcmp(field, "qp_zl") && strcmp(field, "qp_zu") && strcmp(field, "qp_Zl") && strcmp(field, "qp_Zu"))
+        else if (stage == N && strcmp(field, "x") &&
+                               strcmp(field, "lam") &&
+                               strcmp(field, "p") &&
+                               strcmp(field, "sens_x") &&
+                               strcmp(field, "sl") &&
+                               strcmp(field, "su") &&
+                               strcmp(field, "qp_Q") &&
+                               strcmp(field, "qp_q") &&
+                               strcmp(field, "qp_C") &&
+                               strcmp(field, "qp_lg") &&
+                               strcmp(field, "qp_ug") &&
+                               strcmp(field, "qp_lbx") &&
+                               strcmp(field, "qp_ubx") &&
+                               strcmp(field, "qp_zl") &&
+                               strcmp(field, "qp_zu") &&
+                               strcmp(field, "qp_Zl") &&
+                               strcmp(field, "qp_Zu"))
         {
             sprintf(buffer, "\nocp_get: invalid stage index, got stage = %d = N, field = %s, field not available at final shooting node\n", stage, field);
             mexErrMsgTxt(buffer);


### PR DESCRIPTION
- Fix getter for QP matrices and vectors at the terminal stage.
- Fix `dump_last_qp_to_json` to include constraint-related terms at terminal stage.
