### PR TITLE
MATLAB/Python: Add check whether `p_global` is defined, but `global_data` is empty

### DIFF
--- a/interfaces/acados_matlab_octave/GenerateContext.m
+++ b/interfaces/acados_matlab_octave/GenerateContext.m
@@ -185,6 +185,14 @@ classdef GenerateContext < handle
             global_data_expr_list = cellfun(@(pair) pair{2}, precompute_pairs, 'UniformOutput', false);
             self.global_data_expr = cse(vertcat(global_data_expr_list{:}));
 
+            % Assert length match
+            assert(length(self.global_data_expr) == length(self.global_data_sym), ...
+                   sprintf('Length mismatch: %d != %d', length(self.global_data_expr), length(self.global_data_sym)));
+
+            if length(self.global_data_expr) == 0
+                error("The model contains global parameters, but no CasADi function depends on them. This is currently not supported. Please remove p_global from the model definition.")
+            end
+
             % Add global data as input to all functions
             for i = 1:length(self.function_input_output_pairs)
                 self.function_input_output_pairs{i}{1}{end+1} = self.global_data_sym;
@@ -197,9 +205,6 @@ classdef GenerateContext < handle
             % Add function definition
             self.add_function_definition(fun_name, {self.p_global}, {self.global_data_expr}, output_dir);
 
-            % Assert length match
-            assert(length(self.global_data_expr) == length(self.global_data_sym), ...
-                   sprintf('Length mismatch: %d != %d', length(self.global_data_expr), length(self.global_data_sym)));
         end
 
 

--- a/interfaces/acados_template/acados_template/casadi_function_generation.py
+++ b/interfaces/acados_template/acados_template/casadi_function_generation.py
@@ -154,6 +154,11 @@ class GenerateContext:
         self.global_data_sym = ca.vertcat(*global_data_sym_list)
         self.global_data_expr = ca.cse(ca.vertcat(*[output for _, output in precompute_pairs]))
 
+        assert casadi_length(self.global_data_expr) == casadi_length(self.global_data_sym), f"Length mismatch: {casadi_length(self.global_data_expr)} != {casadi_length(self.global_data_sym)}"
+
+        if casadi_length(self.global_data_expr) == 0:
+            raise Exception("The model contains global parameters, but no CasADi function depends on them. This is currently not supported. Please remove p_global from the model definition.")
+
         # add global data as input to all functions
         for i in range(len(self.function_input_output_pairs)):
             self.function_input_output_pairs[i][0].append(self.global_data_sym)
@@ -164,7 +169,6 @@ class GenerateContext:
 
         # self.print_global_data_summary()
 
-        assert casadi_length(self.global_data_expr) == casadi_length(self.global_data_sym), f"Length mismatch: {casadi_length(self.global_data_expr)} != {casadi_length(self.global_data_sym)}"
 
     def finalize(self):
         if not is_empty(self.p_global):


### PR DESCRIPTION
We do not support the case where the model contains global parameters, but no CasADi function depends on them. This PR adds a corresponding check and raises a corresponding exception during code generation.