### PR TITLE
Python: Cleanup code generation, sim solver

### DIFF
--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -89,6 +89,7 @@ class AcadosOcpSolver:
         """`shared_lib` - solver shared library"""
         return self.__shared_lib
 
+    # TODO move this to AcadosOcp
     @classmethod
     def generate(cls, acados_ocp: Union[AcadosOcp, AcadosMultiphaseOcp], json_file: str, simulink_opts=None, cmake_builder: CMakeBuilder = None):
         """

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -1980,16 +1980,18 @@ class AcadosOcpSolver:
         """
         Set options of the solver.
 
-            :param field: string, e.g. 'print_level', 'rti_phase', 'globalization_fixed_step_length', 'globalization_alpha_min', 'globalization_alpha_reduction',
-                                        'qp_warm_start', 'globalization_line_search_use_sufficient_descent',
-                                        'globalization_full_step_dual', 'globalization_use_SOC', 'qp_tol_stat',
-                                        'qp_tol_eq', 'qp_tol_ineq', 'qp_tol_comp', 'qp_tau_min',
-                                        'qp_mu0', 'qp_print_level', 'globalization_funnel_init_increase_factor',
-                                        'globalization_funnel_init_upper_bound', 'globalization_funnel_sufficient_decrease_factor',
-                                        'globalization_funnel_kappa', 'globalization_funnel_fraction_switching_condition',
-                                        'globalization_funnel_initial_penalty_parameter', 'levenberg_marquardt',
-                                        'adaptive_levenberg_marquardt_lam', 'adaptive_levenberg_marquardt_mu_min',
-                                        'adaptive_levenberg_marquardt_mu0',
+            :param field: string, possible values are:
+                'print_level', 'rti_phase', 'nlp_solver_max_iter, 'as_rti_level',
+                'tol_eq', 'tol_stat', 'tol_ineq', 'tol_comp',
+                'qp_tol_stat', 'qp_tol_eq', 'qp_tol_ineq', 'qp_tol_comp', 'qp_tau_min',
+                'qp_warm_start', 'qp_mu0', 'qp_print_level', 'warm_start_first_qp',
+                'globalization_fixed_step_length', 'globalization_alpha_min', 'globalization_alpha_reduction',
+                'globalization_line_search_use_sufficient_descent', 'globalization_full_step_dual', 'globalization_use_SOC',
+                'globalization_funnel_init_upper_bound', 'globalization_funnel_sufficient_decrease_factor',
+                'globalization_funnel_kappa', 'globalization_funnel_fraction_switching_condition',
+                'globalization_funnel_initial_penalty_parameter', 'globalization_funnel_init_increase_factor',
+                'levenberg_marquardt',
+                'adaptive_levenberg_marquardt_lam', 'adaptive_levenberg_marquardt_mu_min', 'adaptive_levenberg_marquardt_mu0',
 
             :param value: of type int, float, string, bool
 
@@ -2010,6 +2012,7 @@ class AcadosOcpSolver:
                       'warm_start_first_qp',
                       'as_rti_level',
                       'max_iter',
+                      'nlp_solver_max_iter',
                       'qp_warm_start',
                       'qp_print_level']
         double_fields = ['globalization_fixed_step_length',
@@ -2066,7 +2069,7 @@ class AcadosOcpSolver:
                 f' Possible values are {fields}.')
 
 
-        if field_ == 'max_iter' and value_ > self.__solver_options['nlp_solver_max_iter']:
+        if (field_ == 'max_iter' or field_ == 'nlp_solver_max_iter') and value_ > self.__solver_options['nlp_solver_max_iter']:
             raise Exception('AcadosOcpSolver.options_set() cannot increase nlp_solver_max_iter' \
                     f' above initial value {self.__nlp_solver_max_iter} (you have {value_})')
             return

--- a/interfaces/acados_template/acados_template/acados_sim.py
+++ b/interfaces/acados_template/acados_template/acados_sim.py
@@ -321,13 +321,11 @@ class AcadosSim:
                             f'Expected numpy array, got {type(parameter_values)}.')
 
     def make_consistent(self):
-        dims = self.dims
-        model = self.model
-        model.make_consistent(dims)
+        self.model.make_consistent(self.dims)
 
-        if self.parameter_values.shape[0] != dims.np:
+        if self.parameter_values.shape[0] != self.dims.np:
             raise Exception('inconsistent dimension np, regarding model.p and parameter_values.' + \
-                f'\nGot np = {dims.np}, acados_sim.parameter_values.shape = {self.parameter_values.shape[0]}\n')
+                f'\nGot np = {self.dims.np}, acados_sim.parameter_values.shape = {self.parameter_values.shape[0]}\n')
 
         # check required arguments are given
         if self.solver_options.T is None:

--- a/interfaces/acados_template/acados_template/acados_sim.py
+++ b/interfaces/acados_template/acados_template/acados_sim.py
@@ -29,11 +29,12 @@
 # POSSIBILITY OF SUCH DAMAGE.;
 #
 
-import os
+import os, json
 import numpy as np
+from copy import deepcopy
 from .acados_model import AcadosModel
 from .acados_dims import AcadosSimDims
-from .utils import get_acados_path, get_shared_lib_ext
+from .utils import get_acados_path, get_shared_lib_ext, format_class_dict, make_object_json_dumpable
 
 class AcadosSimOptions:
     """
@@ -324,3 +325,21 @@ class AcadosSim:
         # check required arguments are given
         if self.solver_options.T is None:
             raise Exception('acados_sim.solver_options.T is None, should be provided.')
+
+
+    def to_dict(self) -> dict:
+        # Copy input sim object dictionary
+        sim_dict = dict(deepcopy(self).__dict__)
+
+        # convert acados classes to dicts
+        for key, v in sim_dict.items():
+            # skip non dict attributes
+            if isinstance(v, (AcadosSim, AcadosSimDims, AcadosSimOptions, AcadosModel)):
+                sim_dict[key]=dict(getattr(self, key).__dict__)
+
+        return format_class_dict(sim_dict)
+
+
+    def dump_to_json(self, json_file='acados_sim.json') -> None:
+        with open(json_file, 'w') as f:
+            json.dump(self.to_dict(), f, default=make_object_json_dumpable, indent=4, sort_keys=True)

--- a/interfaces/acados_template/acados_template/acados_sim.py
+++ b/interfaces/acados_template/acados_template/acados_sim.py
@@ -359,35 +359,25 @@ class AcadosSim:
         if not os.path.exists(json_path):
             raise Exception(f"{json_path} not found!")
 
-        # Render templates
-        in_file = 'acados_sim_solver.in.c'
-        out_file = f'acados_sim_solver_{self.model.name}.c'
-        render_template(in_file, out_file, self.code_export_dir, json_path)
-
-        in_file = 'acados_sim_solver.in.h'
-        out_file = f'acados_sim_solver_{self.model.name}.h'
-        render_template(in_file, out_file, self.code_export_dir, json_path)
-
-        in_file = 'acados_sim_solver.in.pxd'
-        out_file = f'acados_sim_solver.pxd'
-        render_template(in_file, out_file, self.code_export_dir, json_path)
+        template_list = [
+            ('acados_sim_solver.in.c', f'acados_sim_solver_{self.model.name}.c'),
+            ('acados_sim_solver.in.h', f'acados_sim_solver_{self.model.name}.h'),
+            ('acados_sim_solver.in.pxd', 'acados_sim_solver.pxd'),
+            ('main_sim.in.c', f'main_sim_{self.model.name}.c'),
+        ]
 
         # Builder
         if cmake_options is not None:
-            in_file = 'CMakeLists.in.txt'
-            out_file = 'CMakeLists.txt'
-            render_template(in_file, out_file, self.code_export_dir, json_path)
+            template_list.append(('CMakeLists.in.txt', 'CMakeLists.txt'))
         else:
-            in_file = 'Makefile.in'
-            out_file = 'Makefile'
-            render_template(in_file, out_file, self.code_export_dir, json_path)
+            template_list.append(('Makefile.in', 'Makefile'))
 
-        in_file = 'main_sim.in.c'
-        out_file = f'main_sim_{self.model.name}.c'
-        render_template(in_file, out_file, self.code_export_dir, json_path)
+        # Render templates
+        for (in_file, out_file) in template_list:
+            render_template(in_file, out_file, self.code_export_directory, json_path)
 
         # folder model
-        model_dir = os.path.join(self.code_export_dir, self.model.name + '_model')
+        model_dir = os.path.join(self.code_export_directory, self.model.name + '_model')
 
         in_file = 'model.in.h'
         out_file = f'{self.model.name}_model.h'

--- a/interfaces/acados_template/acados_template/acados_sim_solver.py
+++ b/interfaces/acados_template/acados_template/acados_sim_solver.py
@@ -147,7 +147,7 @@ class AcadosSimSolver:
         model_name = acados_sim.model.name
         self.model_name = model_name
 
-        # TODO move somewhere else? make a property in sim and move to setter?
+        # TODO this has to be done here, in build and in generate (to work with cython), fix somehow?
         acados_sim.code_export_directory = os.path.abspath(acados_sim.code_export_directory)
 
         # reuse existing json and casadi functions, when creating integrator from ocp

--- a/interfaces/acados_template/acados_template/acados_sim_solver.py
+++ b/interfaces/acados_template/acados_template/acados_sim_solver.py
@@ -86,11 +86,12 @@ class AcadosSimSolver:
 
     # TODO move this to AcadosSim
     @classmethod
-    def generate(cls, acados_sim: AcadosSim, json_file='acados_sim.json', cmake_builder: CMakeBuilder = None):
+    def generate(self, acados_sim: AcadosSim, json_file='acados_sim.json', cmake_builder: CMakeBuilder = None):
         """
         Generates the code for an acados sim solver, given the description in acados_sim
         """
 
+        acados_sim.code_export_directory = os.path.abspath(acados_sim.code_export_directory)
         acados_sim.make_consistent()
 
         # module dependent post processing
@@ -109,8 +110,9 @@ class AcadosSimSolver:
 
 
     @classmethod
-    def build(cls, code_export_dir, with_cython=False, cmake_builder: CMakeBuilder = None, verbose: bool = True):
+    def build(self, code_export_dir, with_cython=False, cmake_builder: CMakeBuilder = None, verbose: bool = True):
         # Compile solver
+        code_export_dir = os.path.abspath(code_export_dir)
         cwd = os.getcwd()
         os.chdir(code_export_dir)
         if with_cython:
@@ -125,7 +127,7 @@ class AcadosSimSolver:
 
 
     @classmethod
-    def create_cython_solver(cls, json_file):
+    def create_cython_solver(self, json_file):
         """
         """
         with open(json_file, 'r') as f:
@@ -145,7 +147,7 @@ class AcadosSimSolver:
         model_name = acados_sim.model.name
         self.model_name = model_name
 
-        # TODO move somewhere else?
+        # TODO move somewhere else? make a property in sim and move to setter?
         acados_sim.code_export_directory = os.path.abspath(acados_sim.code_export_directory)
 
         # reuse existing json and casadi functions, when creating integrator from ocp

--- a/interfaces/acados_template/acados_template/acados_sim_solver.py
+++ b/interfaces/acados_template/acados_template/acados_sim_solver.py
@@ -91,8 +91,6 @@ class AcadosSimSolver:
         Generates the code for an acados sim solver, given the description in acados_sim
         """
 
-        acados_sim.code_export_directory = os.path.abspath(acados_sim.code_export_directory)
-
         acados_sim.make_consistent()
 
         # module dependent post processing
@@ -147,7 +145,8 @@ class AcadosSimSolver:
         model_name = acados_sim.model.name
         self.model_name = model_name
 
-        code_export_dir = os.path.abspath(acados_sim.code_export_directory)
+        # TODO move somewhere else?
+        acados_sim.code_export_directory = os.path.abspath(acados_sim.code_export_directory)
 
         # reuse existing json and casadi functions, when creating integrator from ocp
         if generate and not isinstance(acados_sim, AcadosOcp):
@@ -164,7 +163,7 @@ class AcadosSimSolver:
         self.acados_sim = acados_sim # TODO make read-only property
 
         if build:
-            self.build(code_export_dir, cmake_builder=cmake_builder, verbose=verbose)
+            self.build(acados_sim.code_export_directory, cmake_builder=cmake_builder, verbose=verbose)
 
         # prepare library loading
         lib_ext = get_shared_lib_ext()
@@ -184,7 +183,7 @@ class AcadosSimSolver:
         self.__acados_lib_uses_omp = acados_lib_is_compiled_with_openmp(self.__acados_lib, verbose)
 
         libacados_sim_solver_name = f'{lib_prefix}acados_sim_solver_{self.model_name}{lib_ext}'
-        self.shared_lib_name = os.path.join(code_export_dir, libacados_sim_solver_name)
+        self.shared_lib_name = os.path.join(acados_sim.code_export_directory, libacados_sim_solver_name)
         self.shared_lib = get_shared_lib(self.shared_lib_name, winmode=self.winmode)
 
         # create capsule

--- a/interfaces/acados_template/acados_template/casadi_function_generation.py
+++ b/interfaces/acados_template/acados_template/casadi_function_generation.py
@@ -37,14 +37,6 @@ from .acados_model import AcadosModel
 from .acados_ocp_constraints import AcadosOcpConstraints
 
 
-def get_casadi_symbol(x):
-    if isinstance(x, ca.MX):
-        return ca.MX.sym
-    elif isinstance(x, ca.SX):
-        return ca.SX.sym
-    else:
-        raise TypeError("Expected casadi SX or MX.")
-
 def is_casadi_SX(x):
     if isinstance(x, ca.SX):
         return True
@@ -212,7 +204,7 @@ def generate_c_code_discrete_dynamics(context: GenerateContext, model: AcadosMod
     phi = model.disc_dyn_expr
     model_name = model.name
 
-    symbol = get_casadi_symbol(x)
+    symbol = model.get_casadi_symbol()
     nx1 = casadi_length(phi)
 
     lam = symbol('lam', nx1, 1)
@@ -265,7 +257,7 @@ def generate_c_code_explicit_ode(context: GenerateContext, model: AcadosModel, m
     nx = x.size()[0]
     nu = u.size()[0]
 
-    symbol = get_casadi_symbol(x)
+    symbol = model.get_casadi_symbol()
 
     # set up expressions
     Sx = symbol('Sx', nx, nx)
@@ -342,7 +334,7 @@ def generate_c_code_implicit_ode(context: GenerateContext, model: AcadosModel, m
 
     if context.opts["generate_hess"]:
         x_xdot_z_u = ca.vertcat(x, xdot, z, u)
-        symbol = get_casadi_symbol(x)
+        symbol = model.get_casadi_symbol()
         multiplier = symbol('multiplier', nx + nz)
         ADJ = ca.jtimes(f_impl, x_xdot_z_u, multiplier, True)
         HESS = ca.jacobian(ADJ, x_xdot_z_u, {"symmetric": is_casadi_SX(x)})
@@ -370,7 +362,7 @@ def generate_c_code_gnsf(context: GenerateContext, model: AcadosModel, model_dir
     # the DAE can be exported as ca.SX -> detect GNSF in Matlab
     # -> evaluated ca.SX GNSF functions with ca.MX.
     u = model.u
-    symbol = get_casadi_symbol(u)
+    symbol = model.get_casadi_symbol()
 
     y = symbol("y", gnsf_ny, 1)
     uhat = symbol("uhat", gnsf_nuhat, 1)
@@ -428,7 +420,7 @@ def generate_c_code_external_cost(context: GenerateContext, model: AcadosModel, 
     u = model.u
     z = model.z
     p_global = model.p_global
-    symbol = get_casadi_symbol(x)
+    symbol = model.get_casadi_symbol()
 
     if stage_type == 'terminal':
         suffix_name = "_cost_ext_cost_e_fun"
@@ -508,7 +500,7 @@ def generate_c_code_nls_cost(context: GenerateContext, model: AcadosModel, stage
     u = model.u
     t = model.t
 
-    symbol = get_casadi_symbol(x)
+    symbol = model.get_casadi_symbol()
 
     if stage_type == 'terminal':
         middle_name = '_cost_y_e'
@@ -565,7 +557,7 @@ def generate_c_code_conl_cost(context: GenerateContext, model: AcadosModel, stag
     p_global = model.p_global
     t = model.t
 
-    symbol = get_casadi_symbol(x)
+    symbol = model.get_casadi_symbol()
     p_global = symbol('p_global', 0, 0)
 
     if stage_type == 'terminal':
@@ -662,7 +654,7 @@ def generate_c_code_constraint(context: GenerateContext, model: AcadosModel, con
     u = model.u
     z = model.z
 
-    symbol = get_casadi_symbol(x)
+    symbol = model.get_casadi_symbol()
 
     if stage_type == 'terminal':
         constr_type = constraints.constr_type_e


### PR DESCRIPTION
- use `get_casadi_symbol()` from `AcadosModel` in code generation
- move `generate`, `dump_to_json`, `render_templates` to `AcadosSim` (which is consistent with `AcadosOcpSolver`)
- improve docstring in `AcadosOcpSolver.options_set()`, allow `nlp_solver_max_iter`