### PR TITLE
Simulink: Fix `nh_total` dimension in sfunction

### DIFF
--- a/examples/acados_matlab_octave/mocp_transition_example/main_mocp_simulink.m
+++ b/examples/acados_matlab_octave/mocp_transition_example/main_mocp_simulink.m
@@ -51,9 +51,9 @@ ocp.set_phase(phase_2, 2);
 
 phase_3 = formulate_single_integrator_ocp(settings);
 % add dummy constraints to test Simulink
-phase_3.model.con_h_expr = phase_3.model.x;
-phase_3.constraints.lh = -100;
-phase_3.constraints.uh = 100;
+phase_3.model.con_h_expr = [phase_3.model.x; phase_3.model.x^2];
+phase_3.constraints.lh = [-100; -200];
+phase_3.constraints.uh = [100; 200];
 
 phase_3.constraints.idxbx = [0];
 phase_3.constraints.lbx = -200;

--- a/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_solver_sfun.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_solver_sfun.in.c
@@ -109,7 +109,7 @@
     {% set_global ns_total = ns_total + (end_idx[jj] - cost_start_idx[jj]) * phases_dims[jj].ns %}
     {% set_global nx_total = nx_total + (end_idx[jj] - start_idx[jj]) * phases_dims[jj].nx %}
     {% set_global nbx_total = nbx_total + (end_idx[jj] - cost_start_idx[jj]) * phases_dims[jj].nbx %}
-    {% set_global nh_total = nh_total + (end_idx[jj] - cost_start_idx[jj]) * phases_dims[jj].nbx %}
+    {% set_global nh_total = nh_total + (end_idx[jj] - cost_start_idx[jj]) * phases_dims[jj].nh %}
     {% set_global nu_total = nu_total + (end_idx[jj] - start_idx[jj]) * phases_dims[jj].nu %}
     {% set_global nbu_total = nbu_total + (end_idx[jj] - start_idx[jj]) * phases_dims[jj].nbu %}
     {% set_global nz_total = nz_total + (end_idx[jj] - start_idx[jj]) * phases_dims[jj].nz %}

--- a/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/make_sfun.in.m
+++ b/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/make_sfun.in.m
@@ -76,7 +76,7 @@
     {% set_global ns_total = ns_total + (end_idx[jj] - cost_start_idx[jj]) * phases_dims[jj].ns %}
     {% set_global nx_total = nx_total + (end_idx[jj] - start_idx[jj]) * phases_dims[jj].nx %}
     {% set_global nbx_total = nbx_total + (end_idx[jj] - cost_start_idx[jj]) * phases_dims[jj].nbx %}
-    {% set_global nh_total = nh_total + (end_idx[jj] - cost_start_idx[jj]) * phases_dims[jj].nbx %}
+    {% set_global nh_total = nh_total + (end_idx[jj] - cost_start_idx[jj]) * phases_dims[jj].nh %}
     {% set_global nu_total = nu_total + (end_idx[jj] - start_idx[jj]) * phases_dims[jj].nu %}
     {% set_global nbu_total = nbu_total + (end_idx[jj] - start_idx[jj]) * phases_dims[jj].nbu %}
     {% set_global nz_total = nz_total + (end_idx[jj] - start_idx[jj]) * phases_dims[jj].nz %}


### PR DESCRIPTION
This PR
* fixes the dimension `nh_total` in sfunction creation
* improves the MOCP simulink test by testing with `nbx != nh`