### PR TITLE
Python: `build` and `generate` flags for batch solvers

### DIFF
--- a/interfaces/acados_template/acados_template/acados_ocp_batch_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_batch_solver.py
@@ -43,19 +43,26 @@ class AcadosOcpBatchSolver():
 
         :param sim: type :py:class:`~acados_template.acados_sim.AcadosOcp`
         :param N_batch: batch size, positive integer
-        :param json_file: Default: 'acados_sim.json'
+        :param json_file: Default: 'acados_ocp.json'
+        :param build: Flag indicating whether solver should be (re)compiled. If False an attempt is made to load an already compiled shared library for the solver. Default: True
+        :param generate: Flag indicating whether problem functions should be code generated. Default: True
         :verbose: bool, default: True
     """
 
     __ocp_solvers : List[AcadosOcpSolver]
 
-    def __init__(self, ocp: AcadosOcp, N_batch: int, json_file: str = 'acados_ocp.json', verbose: bool=True):
+    def __init__(self, ocp: AcadosOcp, N_batch: int, json_file: str = 'acados_ocp.json',  build: bool = True, generate: bool = True, verbose: bool=True):
 
         if not isinstance(N_batch, int) or N_batch <= 0:
             raise Exception("AcadosOcpBatchSolver: argument N_batch should be a positive integer.")
 
         self.__N_batch = N_batch
-        self.__ocp_solvers = [AcadosOcpSolver(ocp, json_file=json_file, build=n==0, generate=n==0, verbose=verbose) for n in range(self.N_batch)]
+        self.__ocp_solvers = [AcadosOcpSolver(ocp,
+                                              json_file=json_file,
+                                              build=n==0 if build else False,
+                                              generate=n==0 if generate else False,
+                                              verbose=verbose)
+                               for n in range(self.N_batch)]
 
         self.__shared_lib = self.ocp_solvers[0].shared_lib
         self.__acados_lib = self.ocp_solvers[0].acados_lib

--- a/interfaces/acados_template/acados_template/acados_ocp_batch_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_batch_solver.py
@@ -39,9 +39,9 @@ import time
 
 class AcadosOcpBatchSolver():
     """
-    Batch Integrator for parallel integration.
+    Batch OCP solver for parallel solves.
 
-        :param sim: type :py:class:`~acados_template.acados_sim.AcadosOcp`
+        :param ocp: type :py:class:`~acados_template.acados_ocp.AcadosOcp`
         :param N_batch: batch size, positive integer
         :param json_file: Default: 'acados_ocp.json'
         :param build: Flag indicating whether solver should be (re)compiled. If False an attempt is made to load an already compiled shared library for the solver. Default: True

--- a/interfaces/acados_template/acados_template/acados_sim_batch_solver.py
+++ b/interfaces/acados_template/acados_template/acados_sim_batch_solver.py
@@ -42,18 +42,25 @@ class AcadosSimBatchSolver():
         :param sim: type :py:class:`~acados_template.acados_sim.AcadosSim`
         :param N_batch: batch size, positive integer
         :param json_file: Default: 'acados_sim.json'
+        :param build: Flag indicating whether solver should be (re)compiled. If False an attempt is made to load an already compiled shared library for the solver. Default: True
+        :param generate: Flag indicating whether problem functions should be code generated. Default: True
         :verbose: bool, default: True
     """
 
     __sim_solvers : List[AcadosSimSolver]
 
-    def __init__(self, sim: AcadosSim, N_batch: int, json_file: str = 'acados_sim.json', verbose: bool=True):
+    def __init__(self, sim: AcadosSim, N_batch: int, json_file: str = 'acados_sim.json', build: bool = True, generate: bool = True, verbose: bool=True):
 
         if not isinstance(N_batch, int) or N_batch <= 0:
             raise Exception("AcadosSimBatchSolver: argument N_batch should be a positive integer.")
 
         self.__N_batch = N_batch
-        self.__sim_solvers = [AcadosSimSolver(sim, json_file=json_file, build=n==0, generate=n==0, verbose=verbose) for n in range(self.N_batch)]
+        self.__sim_solvers = [AcadosSimSolver(sim,
+                                              json_file=json_file,
+                                              build=n==0 if build else False,
+                                              generate=n==0 if generate else False,
+                                              verbose=verbose)
+                              for n in range(self.N_batch)]
 
         self.__shared_lib = self.sim_solvers[0].shared_lib
         self.__model_name = self.sim_solvers[0].model_name


### PR DESCRIPTION
This PR adds the  `build` and `generate` flags to the batch OCP solver and batch sim solver indicating whether the solver should be (re)compiled and the problem functions should be (re)generated, respectively.