### PR TITLE
C/Python: Fix solver status in batch solve

### DIFF
--- a/interfaces/acados_c/ocp_nlp_interface.c
+++ b/interfaces/acados_c/ocp_nlp_interface.c
@@ -509,8 +509,6 @@ int ocp_nlp_cost_model_get(ocp_nlp_config *config, ocp_nlp_dims *dims,
         ocp_nlp_in *in, int stage, const char *field, void *value)
 {
     ocp_nlp_cost_config *cost_config = config->cost[stage];
-
-    printf("ocp_nlp_cost_model_get\n");
     return cost_config->model_get(cost_config, dims->cost[stage], in->cost[stage], field, value);
 
 }

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -1351,6 +1351,7 @@ class AcadosOcpSolver:
         self.set_flat("lam", iterate.lam)
 
 
+    # TODO this should be a property
     def get_status(self) -> int:
         """
         Returns the status of the last solver call.

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -2766,7 +2766,7 @@ int {{ model.name }}_acados_solve({{ model.name }}_solver_capsule* capsule)
 }
 
 
-void {{ model.name }}_acados_batch_solve({{ model.name }}_solver_capsule ** capsules, int N_batch)
+void {{ model.name }}_acados_batch_solve({{ model.name }}_solver_capsule ** capsules, int * status_out, int N_batch)
 {
 {% if solver_options.num_threads_in_batch_solve > 1 %}
     int num_threads_bkp = omp_get_num_threads();
@@ -2776,7 +2776,7 @@ void {{ model.name }}_acados_batch_solve({{ model.name }}_solver_capsule ** caps
 {%- endif %}
     for (int i = 0; i < N_batch; i++)
     {
-        ocp_nlp_solve(capsules[i]->nlp_solver, capsules[i]->nlp_in, capsules[i]->nlp_out);
+        status_out[i] = ocp_nlp_solve(capsules[i]->nlp_solver, capsules[i]->nlp_in, capsules[i]->nlp_out);
     }
 
 {% if solver_options.num_threads_in_batch_solve > 1 %}

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.h
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.h
@@ -294,7 +294,7 @@ ACADOS_SYMBOL_EXPORT int {{ name }}_acados_set_p_global_and_precompute_dependenc
 
 ACADOS_SYMBOL_EXPORT int {{ model.name }}_acados_solve({{ model.name }}_solver_capsule * capsule);
 
-ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_solve({{ model.name }}_solver_capsule ** capsules, int N_batch);
+ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_solve({{ model.name }}_solver_capsule ** capsules, int * status_out, int N_batch);
 
 ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_set_flat({{ model.name }}_solver_capsule ** capsules, const char *field, double *data, int N_data, int N_batch);
 ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_get_flat({{ model.name }}_solver_capsule ** capsules, const char *field, double *data, int N_data, int N_batch);


### PR DESCRIPTION
This PR fixes the solver status in batch solves. 

BREAKING: the templated function `{{ model.name }}_acados_batch_solve` now requires an additional input  `int * status_out`  for storing the solver status for each solve in the batch.