### PR TITLE
MATLAB: Use flat getters and setters

### DIFF
--- a/examples/acados_matlab_octave/test/param_test.m
+++ b/examples/acados_matlab_octave/test/param_test.m
@@ -48,7 +48,8 @@ ocp_opts.set('nlp_solver_max_iter', 0);
 ocp_solver = acados_ocp(ocp_model, ocp_opts, simulink_opts);
 
 %% test parameter setters and getters;
-ocp_solver.set('p', zeros(np, 1));
+ocp_solver.set('p', zeros(np, 1)); % TODO: this behaviour is only supported for p!
+ocp_solver.set('p', zeros(np, N+1));
 
 p_values = {ones(np, 1), (1:np)'};
 

--- a/examples/acados_matlab_octave/test/param_test.m
+++ b/examples/acados_matlab_octave/test/param_test.m
@@ -38,7 +38,7 @@ import casadi.*
 N = 20; % number of discretization steps
 nx = 3;
 nu = 3;
-np = 100;
+np = 10;
 [ocp_model, ocp_opts, simulink_opts, x0] = create_parametric_ocp_qp(N, np);
 % NOTE: here we don't perform iterations and just test initialization
 % functionality
@@ -49,16 +49,16 @@ ocp_solver = acados_ocp(ocp_model, ocp_opts, simulink_opts);
 
 %% test parameter setters and getters;
 ocp_solver.set('p', zeros(np, 1)); % TODO: this behaviour is only supported for p!
-ocp_solver.set('p', zeros(np, N+1));
 
-p_values = {ones(np, 1), (1:np)'};
+p_vals_different = eye(np, N+1);
+ocp_solver.set('p', p_vals_different);
 
-for i_p = 1: length(p_values);
-    p_val = p_values{i_p};
+for i_p = 1:length(N+1);
+    p_val = p_vals_different(:, i_p);
     ocp_solver.set('p', p_val, 0);
     p = ocp_solver.get('p', 0);
 
-    if any(p~=p_val)
+    if any(p ~= p_val)
         disp('simple parameter setter doesnt work properly');
         exit(1);
     end
@@ -66,7 +66,7 @@ end
 
 for stage = 1:N
     p = ocp_solver.get('p', stage);
-    if any(p)
+    if any(p ~= p_vals_different(:, stage+1))
         disp('simple parameter setter doesnt work properly, parameter values should not change after setting at another stage');
         exit(1);
     end

--- a/interfaces/acados_c/ocp_nlp_interface.h
+++ b/interfaces/acados_c/ocp_nlp_interface.h
@@ -292,6 +292,9 @@ ACADOS_SYMBOL_EXPORT void ocp_nlp_out_set(ocp_nlp_config *config, ocp_nlp_dims *
         int stage, const char *field, void *value);
 
 
+// TODO: document
+ACADOS_SYMBOL_EXPORT void ocp_nlp_out_set_values_to_zero(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_out *out);
+
 /// Gets values of fields in the output struct of an nlp solver.
 ///
 /// \param config The configuration struct.
@@ -328,7 +331,7 @@ ACADOS_SYMBOL_EXPORT void ocp_nlp_cost_dims_get_from_attr(ocp_nlp_config *config
 ACADOS_SYMBOL_EXPORT void ocp_nlp_qp_dims_get_from_attr(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_out *out,
         int stage, const char *field, int *dims_out);
 
-int ocp_nlp_dims_get_total_from_attr(ocp_nlp_config *config, ocp_nlp_dims *dims, const char *field);
+ACADOS_SYMBOL_EXPORT int ocp_nlp_dims_get_total_from_attr(ocp_nlp_config *config, ocp_nlp_dims *dims, const char *field);
 
 /* opts */
 

--- a/interfaces/acados_matlab_octave/ocp_get.c
+++ b/interfaces/acados_matlab_octave/ocp_get.c
@@ -144,8 +144,9 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
                     sprintf(buffer, "\nocp_get: cannot get multiple %s values at once due to varying dimension", field);
                     mexErrMsgTxt(buffer);
                 }
-                ocp_nlp_out_get(config, dims, out, ii, "x", x+ii*nx0);
             }
+            ocp_nlp_get_all(solver, in, out, "x", x);
+
         }
         else if (nrhs==3)
         {
@@ -183,8 +184,8 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
                     sprintf(buffer, "\nocp_get: cannot get multiple %s values at once due to varying dimension", field);
                     mexErrMsgTxt(buffer);
                 }
-                ocp_nlp_out_get(config, dims, out, ii, "u", u+ii*nu0);
             }
+            ocp_nlp_get_all(solver, in, out, "u", u);
         }
         else if (nrhs==3)
         {
@@ -249,8 +250,8 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
                     sprintf(buffer, "\nocp_get: cannot get multiple %s values at once due to varying dimension", field);
                     mexErrMsgTxt(buffer);
                 }
-                ocp_nlp_out_get(config, dims, out, ii, "z", z+ii*nz);
             }
+            ocp_nlp_get_all(solver, in, out, "z", z);
         }
         else if (nrhs==3)
         {
@@ -289,8 +290,8 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
                     sprintf(buffer, "\nocp_get: cannot get multiple %s values at once due to varying dimension", field);
                     mexErrMsgTxt(buffer);
                 }
-                ocp_nlp_out_get(config, dims, out, ii, "pi", pi+ii*npi);
             }
+            ocp_nlp_get_all(solver, in, out, "pi", pi);
         }
         else if (nrhs==3)
         {

--- a/interfaces/acados_template/acados_template/c_templates_tera/main.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/main.in.c
@@ -170,7 +170,7 @@ int main()
     ocp_nlp_eval_params_jac(nlp_solver, nlp_in, nlp_out);
     double tmp_p_global[NP_GLOBAL];
     ocp_nlp_eval_solution_sens_adj_p(nlp_solver, nlp_in, sens_out, "p_global", 0, tmp_p_global);
-    printf("Sucessfully evaluated adjoint solution sensitivities wrt p_global.")
+    printf("\nSucessfully evaluated adjoint solution sensitivities wrt p_global.\n");
 {%- endif %}
 
     // free solver

--- a/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_mex_set.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_mex_set.in.c
@@ -392,20 +392,9 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     {
         if (nrhs == min_nrhs)
         {
-            acados_size = 0;
-            for (int ii=0; ii<N; ii++)
-            {
-                tmp_int = ocp_nlp_dims_get_from_attr(config, dims, out, ii, "u");
-                acados_size += tmp_int;
-            }
+            acados_size = ocp_nlp_dims_get_total_from_attr(config, dims, "u");
             MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
-            offset = 0;
-            for (int ii=0; ii<N; ii++)
-            {
-                ocp_nlp_out_set(config, dims, out, ii, "u", value+offset);
-                tmp_int = ocp_nlp_dims_get_from_attr(config, dims, out, ii, "u");
-                offset += tmp_int;
-            }
+            ocp_nlp_set_all(solver, in, out, "u", value);
         }
         else // (nrhs == min_nrhs + 1)
         {
@@ -516,20 +505,9 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     {
         if (nrhs == min_nrhs)
         {
-            acados_size = 0;
-            for (int ii=0; ii<N; ii++)
-            {
-                tmp_int = ocp_nlp_dims_get_from_attr(config, dims, out, ii, "pi");
-                acados_size += tmp_int;
-            }
+            acados_size = ocp_nlp_dims_get_total_from_attr(config, dims, "pi");
             MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
-            offset = 0;
-            for (int ii=0; ii<N; ii++)
-            {
-                ocp_nlp_out_set(config, dims, out, ii, "pi", value+offset);
-                tmp_int = ocp_nlp_dims_get_from_attr(config, dims, out, ii, "pi");
-                offset += tmp_int;
-            }
+            ocp_nlp_set_all(solver, in, out, "pi", value);
         }
         else // (nrhs == min_nrhs + 1)
         {
@@ -542,7 +520,9 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     {
         if (nrhs == min_nrhs)
         {
-            MEX_SETTER_NO_ALL_STAGES_SUPPORT(fun_name, field)
+            acados_size = ocp_nlp_dims_get_total_from_attr(config, dims, "lam");
+            MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
+            ocp_nlp_set_all(solver, in, out, "lam", value);
         }
         else //(nrhs == min_nrhs+1)
         {
@@ -555,7 +535,9 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     {
         if (nrhs == min_nrhs)
         {
-            MEX_SETTER_NO_ALL_STAGES_SUPPORT(fun_name, field)
+            acados_size = ocp_nlp_dims_get_total_from_attr(config, dims, "sl");
+            MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
+            ocp_nlp_set_all(solver, in, out, "sl", value);
         }
         else //(nrhs == min_nrhs+1)
         {
@@ -568,7 +550,9 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     {
         if (nrhs == min_nrhs)
         {
-            MEX_SETTER_NO_ALL_STAGES_SUPPORT(fun_name, field)
+            acados_size = ocp_nlp_dims_get_total_from_attr(config, dims, "su");
+            MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
+            ocp_nlp_set_all(solver, in, out, "su", value);
         }
         else //(nrhs == min_nrhs+1)
         {
@@ -581,12 +565,9 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     {
         if (nrhs == min_nrhs) // all stages
         {
-            for (int ii=0; ii<=N; ii++)
-            {
-                acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, ii, "p");
-                MEX_DIM_CHECK_VEC_STAGE(fun_name, field, ii, matlab_size, acados_size)
-                {{ name }}_acados_update_params(capsule, ii, value, matlab_size);
-            }
+            acados_size = ocp_nlp_dims_get_total_from_attr(config, dims, "p");
+            MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
+            ocp_nlp_set_all(solver, in, out, "p", value);
         }
         else if (nrhs == min_nrhs+1) // one stage
         {

--- a/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_mex_set.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_mex_set.in.c
@@ -405,26 +405,19 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     }
     else if (!strcmp(field, "init_z")||!strcmp(field, "z"))
     {
-{% if problem_class == "MOCP" %}
-        MEX_FIELD_NOT_SUPPORTED(fun_name, field);
-{% else %}
         sim_solver_plan_t sim_plan = plan->sim_solver_plan[0];
         sim_solver_t type = sim_plan.sim_solver;
         if (type == IRK)
         {
-            int nz = ocp_nlp_dims_get_from_attr(config, dims, out, 0, "z");
             if (nrhs == min_nrhs)
             {
-                acados_size = N*nz;
+                acados_size = ocp_nlp_dims_get_total_from_attr(config, dims, "z");
                 MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
-                for (int ii=0; ii<N; ii++)
-                {
-                    ocp_nlp_set(solver, ii, "z_guess", value+ii*nz);
-                }
+                ocp_nlp_set_all(solver, in, out, "z", value);
             }
             else // (nrhs == min_nrhs+1)
             {
-                acados_size = nz;
+                acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, s0, "z");
                 MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
                 ocp_nlp_set(solver, s0, "z_guess", value);
             }
@@ -433,7 +426,6 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         {
             MEX_FIELD_ONLY_SUPPORTED_FOR_SOLVER(fun_name, "init_z", "irk")
         }
-{% endif %}
     }
     else if (!strcmp(field, "init_xdot")||!strcmp(field, "xdot"))
     {

--- a/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_mex_set.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_mex_set.in.c
@@ -565,9 +565,25 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     {
         if (nrhs == min_nrhs) // all stages
         {
-            acados_size = ocp_nlp_dims_get_total_from_attr(config, dims, "p");
-            MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
-            ocp_nlp_set_all(solver, in, out, "p", value);
+
+            acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, 0, "p");
+            // TODO: this behaviour (setting the same value for all stages) is only supported for parameters p!
+            if (acados_size == matlab_size)
+            {
+                for (int ii=0; ii<=N; ii++)
+                {
+                    acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, ii, "p");
+                    MEX_DIM_CHECK_VEC_STAGE(fun_name, field, ii, matlab_size, acados_size)
+                    {{ name }}_acados_update_params(capsule, ii, value, matlab_size);
+                }
+            }
+            else
+            {
+                acados_size = ocp_nlp_dims_get_total_from_attr(config, dims, "p");
+                MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
+                ocp_nlp_set_all(solver, in, out, "p", value);
+            }
+
         }
         else if (nrhs == min_nrhs+1) // one stage
         {

--- a/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_mex_set.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_mex_set.in.c
@@ -377,20 +377,9 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     {
         if (nrhs == min_nrhs)
         {
-            acados_size = 0;
-            for (int ii=0; ii<=N; ii++)
-            {
-                tmp_int = ocp_nlp_dims_get_from_attr(config, dims, out, ii, "x");
-                acados_size += tmp_int;
-            }
+            acados_size = ocp_nlp_dims_get_total_from_attr(config, dims, "x");
             MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
-            offset = 0;
-            for (int ii=0; ii<=N; ii++)
-            {
-                ocp_nlp_out_set(config, dims, out, ii, "x", value+offset);
-                tmp_int = ocp_nlp_dims_get_from_attr(config, dims, out, ii, "x");
-                offset += tmp_int;
-            }
+            ocp_nlp_set_all(solver, in, out, "x", value);
         }
         else // (nrhs == min_nrhs + 1)
         {


### PR DESCRIPTION
This PR uses flat getters and setters in the MATLAB interface. This makes existing full trajectory getters/setters more efficient and adds support for full trajectory setters for `lam`, `sl`, `su`, `z`.

NOTE: setting `solver.set('p', vals) ` allows to
* set the same `p` vector for every stage, i.e. `size(vals) = [np, 1]`,
* set the full `p` trajectory.

The first option is *only* available for `p` (and not for any of the other setters).

In addition:
* fix missing `;` in generated main