### PR TITLE
Add  ACADOS_WITH_SYSTEM_BLASFEO CMake option (by default OFF) to use an external blasfeo instead of building an internal copy of blasfeo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,8 @@ option(ACADOS_WITH_OSQP "OSQP solver" OFF)
 # Interfaces
 option(ACADOS_OCTAVE "Octave Interface tests" OFF)
 option(ACADOS_PYTHON "Python Interface tests" OFF)
+# Options to use libraries found via find_package
+option(ACADOS_WITH_SYSTEM_BLASFEO "If ON, use blasfeo found via find_package(blasfeo) instead of compiling it" OFF)
 
 
 # Set custom path

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,10 @@ option(ACADOS_OCTAVE "Octave Interface tests" OFF)
 option(ACADOS_PYTHON "Python Interface tests" OFF)
 # Options to use libraries found via find_package
 option(ACADOS_WITH_SYSTEM_BLASFEO "If ON, use blasfeo found via find_package(blasfeo) instead of compiling it" OFF)
-
+mark_as_advanced(ACADOS_WITH_SYSTEM_BLASFEO)
+if(ACADOS_WITH_SYSTEM_BLASFEO)
+    message(WARNING "The ACADOS_WITH_SYSTEM_BLASFEO option is enabled. ACADOS is tested by its developers only with ACADOS_WITH_SYSTEM_BLASFEO=OFF, when using an external blasfeo may sure that everything works as expected.")
+endif()
 
 # Set custom path
 set(EXTERNAL_SRC_DIR ${PROJECT_SOURCE_DIR}/external)

--- a/acados/CMakeLists.txt
+++ b/acados/CMakeLists.txt
@@ -76,6 +76,11 @@ target_include_directories(acados PUBLIC
         $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/interfaces>
         $<INSTALL_INTERFACE:include>)
 
+if(NOT ACADOS_WITH_SYSTEM_BLASFEO)
+    target_include_directories(acados PUBLIC
+        $<BUILD_INTERFACE:${EXTERNAL_SRC_DIR}/blasfeo/include>)
+endif()
+
 # OPENMP
 # find_package(OpenMP)
 if(ACADOS_WITH_OPENMP)

--- a/acados/dense_qp/dense_qp_common.c
+++ b/acados/dense_qp/dense_qp_common.c
@@ -45,9 +45,9 @@
 #include "hpipm/include/hpipm_d_dense_qp_dim.h"
 
 // blasfeo
-#include "blasfeo/include/blasfeo_d_aux.h"
-#include "blasfeo/include/blasfeo_d_aux_ext_dep.h"
-#include "blasfeo/include/blasfeo_d_blas.h"
+#include "blasfeo_d_aux.h"
+#include "blasfeo_d_aux_ext_dep.h"
+#include "blasfeo_d_blas.h"
 // acados
 #include "acados/dense_qp/dense_qp_common.h"
 #include "acados/utils/types.h"

--- a/acados/dense_qp/dense_qp_daqp.c
+++ b/acados/dense_qp/dense_qp_daqp.c
@@ -35,8 +35,8 @@
 #include <string.h>
 #include <stdio.h>
 // blasfeo
-#include "blasfeo/include/blasfeo_d_aux.h"
-#include "blasfeo/include/blasfeo_d_blas.h"
+#include "blasfeo_d_aux.h"
+#include "blasfeo_d_blas.h"
 
 // daqp
 #define SOFT_WEIGHTS

--- a/acados/dense_qp/dense_qp_daqp.h
+++ b/acados/dense_qp/dense_qp_daqp.h
@@ -37,7 +37,7 @@ extern "C" {
 #endif
 
 // blasfeo
-#include "blasfeo/include/blasfeo_common.h"
+#include "blasfeo_common.h"
 
 // daqp
 #include "daqp/include/types.h"

--- a/acados/dense_qp/dense_qp_ooqp.c
+++ b/acados/dense_qp/dense_qp_ooqp.c
@@ -38,8 +38,8 @@
 #include "ooqp/cQpGenDense.h"
 
 // blasfeo
-#include "blasfeo/include/blasfeo_d_aux.h"
-#include "blasfeo/include/blasfeo_d_aux_ext_dep.h"
+#include "blasfeo_d_aux.h"
+#include "blasfeo_d_aux_ext_dep.h"
 
 // acados
 #include "acados/dense_qp/dense_qp_ooqp.h"

--- a/acados/dense_qp/dense_qp_qore.c
+++ b/acados/dense_qp/dense_qp_qore.c
@@ -34,8 +34,8 @@
 #include <math.h>
 #include <string.h>
 // blasfeo
-#include "blasfeo/include/blasfeo_d_aux.h"
-#include "blasfeo/include/blasfeo_d_aux_ext_dep.h"
+#include "blasfeo_d_aux.h"
+#include "blasfeo_d_aux_ext_dep.h"
 // acados
 #include "acados/dense_qp/dense_qp_common.h"
 #include "acados/dense_qp/dense_qp_qore.h"

--- a/acados/dense_qp/dense_qp_qpoases.c
+++ b/acados/dense_qp/dense_qp_qpoases.c
@@ -34,8 +34,8 @@
 #include <assert.h>
 #include <string.h>
 // blasfeo
-#include "blasfeo/include/blasfeo_d_aux.h"
-#include "blasfeo/include/blasfeo_d_blas.h"
+#include "blasfeo_d_aux.h"
+#include "blasfeo_d_blas.h"
 
 /* Ignore compiler warnings from qpOASES */
 #if defined(__clang__)

--- a/acados/dense_qp/dense_qp_qpoases.h
+++ b/acados/dense_qp/dense_qp_qpoases.h
@@ -37,7 +37,7 @@ extern "C" {
 #endif
 
 // blasfeo
-#include "blasfeo/include/blasfeo_common.h"
+#include "blasfeo_common.h"
 
 // acados
 #include "acados/dense_qp/dense_qp_common.h"

--- a/acados/ocp_nlp/ocp_nlp_common.c
+++ b/acados/ocp_nlp/ocp_nlp_common.c
@@ -37,8 +37,8 @@
 #include <math.h>
 
 // blasfeo
-#include "blasfeo/include/blasfeo_common.h"
-#include "blasfeo/include/blasfeo_d_blas.h"
+#include "blasfeo_common.h"
+#include "blasfeo_d_blas.h"
 // hpipm
 #include "hpipm/include/hpipm_d_ocp_qp_dim.h"
 // acados

--- a/acados/ocp_nlp/ocp_nlp_constraints_bgh.c
+++ b/acados/ocp_nlp/ocp_nlp_constraints_bgh.c
@@ -36,8 +36,8 @@
 #include <string.h>
 
 // blasfeo
-#include "blasfeo/include/blasfeo_d_aux.h"
-#include "blasfeo/include/blasfeo_d_blas.h"
+#include "blasfeo_d_aux.h"
+#include "blasfeo_d_blas.h"
 // acados
 #include "acados/ocp_qp/ocp_qp_common.h"
 #include "acados/utils/mem.h"

--- a/acados/ocp_nlp/ocp_nlp_constraints_bgp.c
+++ b/acados/ocp_nlp/ocp_nlp_constraints_bgp.c
@@ -36,8 +36,8 @@
 #include <string.h>
 
 // blasfeo
-#include "blasfeo/include/blasfeo_d_aux.h"
-#include "blasfeo/include/blasfeo_d_blas.h"
+#include "blasfeo_d_aux.h"
+#include "blasfeo_d_blas.h"
 // acados
 #include "acados/ocp_qp/ocp_qp_common.h"
 #include "acados/utils/mem.h"

--- a/acados/ocp_nlp/ocp_nlp_constraints_common.c
+++ b/acados/ocp_nlp/ocp_nlp_constraints_common.c
@@ -36,8 +36,8 @@
 #include <string.h>
 
 // blasfeo
-#include "blasfeo/include/blasfeo_d_aux.h"
-#include "blasfeo/include/blasfeo_d_blas.h"
+#include "blasfeo_d_aux.h"
+#include "blasfeo_d_blas.h"
 // acados
 #include "acados/ocp_qp/ocp_qp_common.h"
 #include "acados/utils/mem.h"

--- a/acados/ocp_nlp/ocp_nlp_cost_common.c
+++ b/acados/ocp_nlp/ocp_nlp_cost_common.c
@@ -36,8 +36,8 @@
 #include <string.h>
 
 // blasfeo
-#include "blasfeo/include/blasfeo_d_aux.h"
-#include "blasfeo/include/blasfeo_d_blas.h"
+#include "blasfeo_d_aux.h"
+#include "blasfeo_d_blas.h"
 // acados
 #include "acados/utils/mem.h"
 

--- a/acados/ocp_nlp/ocp_nlp_cost_conl.c
+++ b/acados/ocp_nlp/ocp_nlp_cost_conl.c
@@ -38,9 +38,9 @@
 #include <math.h>
 
 // blasfeo
-#include "blasfeo/include/blasfeo_d_aux.h"
-#include "blasfeo/include/blasfeo_d_blas.h"
-#include "blasfeo/include/blasfeo_common.h"
+#include "blasfeo_d_aux.h"
+#include "blasfeo_d_blas.h"
+#include "blasfeo_common.h"
 // acados
 #include "acados/utils/mem.h"
 

--- a/acados/ocp_nlp/ocp_nlp_cost_conl.h
+++ b/acados/ocp_nlp/ocp_nlp_cost_conl.h
@@ -46,7 +46,7 @@ extern "C" {
 #endif
 
 // blasfeo
-#include "blasfeo/include/blasfeo_common.h"
+#include "blasfeo_common.h"
 
 // acados
 #include "acados/ocp_nlp/ocp_nlp_cost_common.h"

--- a/acados/ocp_nlp/ocp_nlp_cost_external.c
+++ b/acados/ocp_nlp/ocp_nlp_cost_external.c
@@ -37,8 +37,8 @@
 #include <string.h>
 
 // blasfeo
-#include "blasfeo/include/blasfeo_d_aux.h"
-#include "blasfeo/include/blasfeo_d_blas.h"
+#include "blasfeo_d_aux.h"
+#include "blasfeo_d_blas.h"
 // acados
 #include "acados/utils/mem.h"
 #include "acados/utils/print.h"

--- a/acados/ocp_nlp/ocp_nlp_cost_external.h
+++ b/acados/ocp_nlp/ocp_nlp_cost_external.h
@@ -37,7 +37,7 @@ extern "C" {
 #endif
 
 // blasfeo
-#include "blasfeo/include/blasfeo_common.h"
+#include "blasfeo_common.h"
 
 // acados
 #include "acados/ocp_nlp/ocp_nlp_cost_common.h"

--- a/acados/ocp_nlp/ocp_nlp_cost_ls.c
+++ b/acados/ocp_nlp/ocp_nlp_cost_ls.c
@@ -44,8 +44,8 @@
 #include <string.h>
 
 // blasfeo
-#include "blasfeo/include/blasfeo_d_aux.h"
-#include "blasfeo/include/blasfeo_d_blas.h"
+#include "blasfeo_d_aux.h"
+#include "blasfeo_d_blas.h"
 // acados
 #include "acados/utils/mem.h"
 

--- a/acados/ocp_nlp/ocp_nlp_cost_ls.h
+++ b/acados/ocp_nlp/ocp_nlp_cost_ls.h
@@ -50,7 +50,7 @@ extern "C" {
 #include <math.h>
 
 // blasfeo
-#include "blasfeo/include/blasfeo_common.h"
+#include "blasfeo_common.h"
 
 // acados
 #include "acados/ocp_nlp/ocp_nlp_cost_common.h"

--- a/acados/ocp_nlp/ocp_nlp_cost_nls.c
+++ b/acados/ocp_nlp/ocp_nlp_cost_nls.c
@@ -38,8 +38,8 @@
 #include <math.h>
 
 // blasfeo
-#include "blasfeo/include/blasfeo_d_aux.h"
-#include "blasfeo/include/blasfeo_d_blas.h"
+#include "blasfeo_d_aux.h"
+#include "blasfeo_d_blas.h"
 // acados
 #include "acados/utils/mem.h"
 

--- a/acados/ocp_nlp/ocp_nlp_cost_nls.h
+++ b/acados/ocp_nlp/ocp_nlp_cost_nls.h
@@ -45,7 +45,7 @@ extern "C" {
 #endif
 
 // blasfeo
-#include "blasfeo/include/blasfeo_common.h"
+#include "blasfeo_common.h"
 
 // acados
 #include "acados/ocp_nlp/ocp_nlp_cost_common.h"

--- a/acados/ocp_nlp/ocp_nlp_ddp.c
+++ b/acados/ocp_nlp/ocp_nlp_ddp.c
@@ -42,9 +42,9 @@
 #endif
 
 // blasfeo
-#include "blasfeo/include/blasfeo_d_aux.h"
-#include "blasfeo/include/blasfeo_d_aux_ext_dep.h"
-#include "blasfeo/include/blasfeo_d_blas.h"
+#include "blasfeo_d_aux.h"
+#include "blasfeo_d_aux_ext_dep.h"
+#include "blasfeo_d_blas.h"
 // acados
 #include "acados/ocp_nlp/ocp_nlp_common.h"
 #include "acados/ocp_nlp/ocp_nlp_dynamics_cont.h"

--- a/acados/ocp_nlp/ocp_nlp_dynamics_common.c
+++ b/acados/ocp_nlp/ocp_nlp_dynamics_common.c
@@ -36,8 +36,8 @@
 #include <string.h>
 
 // blasfeo
-#include "blasfeo/include/blasfeo_d_aux.h"
-#include "blasfeo/include/blasfeo_d_blas.h"
+#include "blasfeo_d_aux.h"
+#include "blasfeo_d_blas.h"
 // acados
 #include "acados/utils/mem.h"
 

--- a/acados/ocp_nlp/ocp_nlp_dynamics_common.h
+++ b/acados/ocp_nlp/ocp_nlp_dynamics_common.h
@@ -45,7 +45,7 @@ extern "C" {
 
 
 // blasfeo
-#include "blasfeo/include/blasfeo_common.h"
+#include "blasfeo_common.h"
 
 // acados
 #include "acados/sim/sim_common.h"

--- a/acados/ocp_nlp/ocp_nlp_dynamics_cont.c
+++ b/acados/ocp_nlp/ocp_nlp_dynamics_cont.c
@@ -37,8 +37,8 @@
 #include <string.h>
 
 // blasfeo
-#include "blasfeo/include/blasfeo_d_aux.h"
-#include "blasfeo/include/blasfeo_d_blas.h"
+#include "blasfeo_d_aux.h"
+#include "blasfeo_d_blas.h"
 // acados
 #include "acados/utils/mem.h"
 

--- a/acados/ocp_nlp/ocp_nlp_dynamics_cont.h
+++ b/acados/ocp_nlp/ocp_nlp_dynamics_cont.h
@@ -44,7 +44,7 @@ extern "C" {
 
 
 // blasfeo
-#include "blasfeo/include/blasfeo_common.h"
+#include "blasfeo_common.h"
 
 // acados
 #include "acados/ocp_nlp/ocp_nlp_dynamics_common.h"

--- a/acados/ocp_nlp/ocp_nlp_dynamics_disc.c
+++ b/acados/ocp_nlp/ocp_nlp_dynamics_disc.c
@@ -36,8 +36,8 @@
 #include <string.h>
 
 // blasfeo
-#include "blasfeo/include/blasfeo_d_aux.h"
-#include "blasfeo/include/blasfeo_d_blas.h"
+#include "blasfeo_d_aux.h"
+#include "blasfeo_d_blas.h"
 // acados
 #include "acados/utils/mem.h"
 

--- a/acados/ocp_nlp/ocp_nlp_dynamics_disc.h
+++ b/acados/ocp_nlp/ocp_nlp_dynamics_disc.h
@@ -42,7 +42,7 @@ extern "C" {
 #endif
 
 // blasfeo
-#include "blasfeo/include/blasfeo_common.h"
+#include "blasfeo_common.h"
 
 // acados
 #include "acados/ocp_nlp/ocp_nlp_dynamics_common.h"

--- a/acados/ocp_nlp/ocp_nlp_globalization_common.c
+++ b/acados/ocp_nlp/ocp_nlp_globalization_common.c
@@ -36,8 +36,8 @@
 #include <string.h>
 
 // blasfeo
-#include "blasfeo/include/blasfeo_d_aux.h"
-#include "blasfeo/include/blasfeo_d_blas.h"
+#include "blasfeo_d_aux.h"
+#include "blasfeo_d_blas.h"
 // acados
 #include "acados/utils/mem.h"
 

--- a/acados/ocp_nlp/ocp_nlp_globalization_fixed_step.c
+++ b/acados/ocp_nlp/ocp_nlp_globalization_fixed_step.c
@@ -39,8 +39,8 @@
 #endif
 
 // blasfeo
-#include "blasfeo/include/blasfeo_d_aux.h"
-#include "blasfeo/include/blasfeo_d_blas.h"
+#include "blasfeo_d_aux.h"
+#include "blasfeo_d_blas.h"
 // acados
 #include "acados/utils/mem.h"
 

--- a/acados/ocp_nlp/ocp_nlp_globalization_fixed_step.h
+++ b/acados/ocp_nlp/ocp_nlp_globalization_fixed_step.h
@@ -42,7 +42,7 @@ extern "C" {
 #endif
 
 // blasfeo
-#include "blasfeo/include/blasfeo_common.h"
+#include "blasfeo_common.h"
 
 // acados
 #include "acados/ocp_nlp/ocp_nlp_globalization_common.h"

--- a/acados/ocp_nlp/ocp_nlp_globalization_funnel.c
+++ b/acados/ocp_nlp/ocp_nlp_globalization_funnel.c
@@ -44,8 +44,8 @@
 #endif
 
 // blasfeo
-#include "blasfeo/include/blasfeo_d_aux.h"
-#include "blasfeo/include/blasfeo_d_blas.h"
+#include "blasfeo_d_aux.h"
+#include "blasfeo_d_blas.h"
 // acados
 #include "acados/utils/mem.h"
 

--- a/acados/ocp_nlp/ocp_nlp_globalization_funnel.h
+++ b/acados/ocp_nlp/ocp_nlp_globalization_funnel.h
@@ -42,7 +42,7 @@ extern "C" {
 #endif
 
 // blasfeo
-#include "blasfeo/include/blasfeo_common.h"
+#include "blasfeo_common.h"
 
 // acados
 #include "acados/ocp_nlp/ocp_nlp_globalization_common.h"

--- a/acados/ocp_nlp/ocp_nlp_globalization_merit_backtracking.c
+++ b/acados/ocp_nlp/ocp_nlp_globalization_merit_backtracking.c
@@ -46,8 +46,8 @@
 #include "acados/utils/mem.h"
 
 // blasfeo
-#include "blasfeo/include/blasfeo_d_aux.h"
-#include "blasfeo/include/blasfeo_d_blas.h"
+#include "blasfeo_d_aux.h"
+#include "blasfeo_d_blas.h"
 
 
 /************************************************

--- a/acados/ocp_nlp/ocp_nlp_globalization_merit_backtracking.h
+++ b/acados/ocp_nlp/ocp_nlp_globalization_merit_backtracking.h
@@ -42,7 +42,7 @@ extern "C" {
 #endif
 
 // blasfeo
-#include "blasfeo/include/blasfeo_common.h"
+#include "blasfeo_common.h"
 
 // acados
 #include "acados/ocp_nlp/ocp_nlp_globalization_common.h"

--- a/acados/ocp_nlp/ocp_nlp_reg_convexify.c
+++ b/acados/ocp_nlp/ocp_nlp_reg_convexify.c
@@ -40,8 +40,8 @@
 #include "acados/utils/math.h"
 #include "acados/utils/mem.h"
 
-#include "blasfeo/include/blasfeo_d_aux.h"
-#include "blasfeo/include/blasfeo_d_blas.h"
+#include "blasfeo_d_aux.h"
+#include "blasfeo_d_blas.h"
 
 
 

--- a/acados/ocp_nlp/ocp_nlp_reg_convexify.h
+++ b/acados/ocp_nlp/ocp_nlp_reg_convexify.h
@@ -44,7 +44,7 @@ extern "C" {
 
 
 // blasfeo
-#include "blasfeo/include/blasfeo_common.h"
+#include "blasfeo_common.h"
 
 // acados
 #include "acados/ocp_nlp/ocp_nlp_reg_common.h"

--- a/acados/ocp_nlp/ocp_nlp_reg_mirror.c
+++ b/acados/ocp_nlp/ocp_nlp_reg_mirror.c
@@ -39,8 +39,8 @@
 #include "acados/ocp_nlp/ocp_nlp_reg_common.h"
 #include "acados/utils/math.h"
 
-#include "blasfeo/include/blasfeo_d_aux.h"
-#include "blasfeo/include/blasfeo_d_blas.h"
+#include "blasfeo_d_aux.h"
+#include "blasfeo_d_blas.h"
 
 
 

--- a/acados/ocp_nlp/ocp_nlp_reg_mirror.h
+++ b/acados/ocp_nlp/ocp_nlp_reg_mirror.h
@@ -44,7 +44,7 @@ extern "C" {
 
 
 // blasfeo
-#include "blasfeo/include/blasfeo_common.h"
+#include "blasfeo_common.h"
 
 // acados
 #include "acados/ocp_nlp/ocp_nlp_reg_common.h"

--- a/acados/ocp_nlp/ocp_nlp_reg_noreg.c
+++ b/acados/ocp_nlp/ocp_nlp_reg_noreg.c
@@ -39,8 +39,8 @@
 #include "acados/ocp_nlp/ocp_nlp_reg_common.h"
 #include "acados/utils/math.h"
 
-#include "blasfeo/include/blasfeo_d_aux.h"
-#include "blasfeo/include/blasfeo_d_blas.h"
+#include "blasfeo_d_aux.h"
+#include "blasfeo_d_blas.h"
 
 
 

--- a/acados/ocp_nlp/ocp_nlp_reg_noreg.h
+++ b/acados/ocp_nlp/ocp_nlp_reg_noreg.h
@@ -44,7 +44,7 @@ extern "C" {
 
 
 // blasfeo
-#include "blasfeo/include/blasfeo_common.h"
+#include "blasfeo_common.h"
 
 // acados
 #include "acados/ocp_nlp/ocp_nlp_reg_common.h"

--- a/acados/ocp_nlp/ocp_nlp_reg_project.c
+++ b/acados/ocp_nlp/ocp_nlp_reg_project.c
@@ -39,8 +39,8 @@
 #include "acados/ocp_nlp/ocp_nlp_reg_common.h"
 #include "acados/utils/math.h"
 
-#include "blasfeo/include/blasfeo_d_aux.h"
-#include "blasfeo/include/blasfeo_d_blas.h"
+#include "blasfeo_d_aux.h"
+#include "blasfeo_d_blas.h"
 
 
 

--- a/acados/ocp_nlp/ocp_nlp_reg_project.h
+++ b/acados/ocp_nlp/ocp_nlp_reg_project.h
@@ -44,7 +44,7 @@ extern "C" {
 
 
 // blasfeo
-#include "blasfeo/include/blasfeo_common.h"
+#include "blasfeo_common.h"
 
 // acados
 #include "acados/ocp_nlp/ocp_nlp_reg_common.h"

--- a/acados/ocp_nlp/ocp_nlp_reg_project_reduc_hess.c
+++ b/acados/ocp_nlp/ocp_nlp_reg_project_reduc_hess.c
@@ -40,8 +40,8 @@
 #include "acados/utils/math.h"
 #include "acados/utils/mem.h"
 
-#include "blasfeo/include/blasfeo_d_aux.h"
-#include "blasfeo/include/blasfeo_d_blas.h"
+#include "blasfeo_d_aux.h"
+#include "blasfeo_d_blas.h"
 
 
 

--- a/acados/ocp_nlp/ocp_nlp_reg_project_reduc_hess.h
+++ b/acados/ocp_nlp/ocp_nlp_reg_project_reduc_hess.h
@@ -44,7 +44,7 @@ extern "C" {
 
 
 // blasfeo
-#include "blasfeo/include/blasfeo_common.h"
+#include "blasfeo_common.h"
 
 // acados
 #include "acados/ocp_nlp/ocp_nlp_reg_common.h"

--- a/acados/ocp_nlp/ocp_nlp_sqp.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp.c
@@ -42,9 +42,9 @@
 #endif
 
 // blasfeo
-#include "blasfeo/include/blasfeo_d_aux.h"
-#include "blasfeo/include/blasfeo_d_aux_ext_dep.h"
-#include "blasfeo/include/blasfeo_d_blas.h"
+#include "blasfeo_d_aux.h"
+#include "blasfeo_d_aux_ext_dep.h"
+#include "blasfeo_d_blas.h"
 // acados
 #include "acados/ocp_nlp/ocp_nlp_common.h"
 #include "acados/ocp_nlp/ocp_nlp_dynamics_cont.h"

--- a/acados/ocp_nlp/ocp_nlp_sqp_rti.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp_rti.c
@@ -42,9 +42,9 @@
 #endif
 
 // blasfeo
-#include "blasfeo/include/blasfeo_d_aux.h"
-#include "blasfeo/include/blasfeo_d_aux_ext_dep.h"
-#include "blasfeo/include/blasfeo_d_blas.h"
+#include "blasfeo_d_aux.h"
+#include "blasfeo_d_aux_ext_dep.h"
+#include "blasfeo_d_blas.h"
 // acados
 #include "acados/ocp_nlp/ocp_nlp_common.h"
 #include "acados/ocp_nlp/ocp_nlp_dynamics_cont.h"

--- a/acados/ocp_qp/ocp_qp_common.c
+++ b/acados/ocp_qp/ocp_qp_common.c
@@ -36,8 +36,8 @@
 #include <string.h>
 
 // blasfeo
-#include "blasfeo/include/blasfeo_d_aux.h"
-#include "blasfeo/include/blasfeo_d_blas.h"
+#include "blasfeo_d_aux.h"
+#include "blasfeo_d_blas.h"
 
 // hpipm
 #include "hpipm/include/hpipm_d_ocp_qp.h"

--- a/acados/ocp_qp/ocp_qp_common_frontend.c
+++ b/acados/ocp_qp/ocp_qp_common_frontend.c
@@ -35,7 +35,7 @@
 #include <string.h>
 
 // blasfeo
-#include "blasfeo/include/blasfeo_d_aux.h"
+#include "blasfeo_d_aux.h"
 
 // hpipm
 // #include "hpipm/include/hpipm_d_ocp_qp.h"

--- a/acados/ocp_qp/ocp_qp_hpmpc.c
+++ b/acados/ocp_qp/ocp_qp_hpmpc.c
@@ -36,9 +36,9 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "blasfeo/include/blasfeo_d_aux.h"
-#include "blasfeo/include/blasfeo_d_blas.h"
-#include "blasfeo/include/blasfeo_v_aux_ext_dep.h"
+#include "blasfeo_d_aux.h"
+#include "blasfeo_d_blas.h"
+#include "blasfeo_v_aux_ext_dep.h"
 
 #include "hpmpc/include/c_interface.h"
 #include "hpmpc/include/lqcp_solvers.h"

--- a/acados/ocp_qp/ocp_qp_ooqp.c
+++ b/acados/ocp_qp/ocp_qp_ooqp.c
@@ -36,8 +36,8 @@
 #include "ooqp/cQpGenSparse.h"
 
 // blasfeo
-#include "blasfeo/include/blasfeo_d_aux.h"
-#include "blasfeo/include/blasfeo_d_aux_ext_dep.h"
+#include "blasfeo_d_aux.h"
+#include "blasfeo_d_aux_ext_dep.h"
 
 // acados
 #include "acados/ocp_qp/ocp_qp_ooqp.h"

--- a/acados/ocp_qp/ocp_qp_osqp.c
+++ b/acados/ocp_qp/ocp_qp_osqp.c
@@ -32,7 +32,7 @@
 #include <assert.h>
 
 // blasfeo
-#include "blasfeo/include/blasfeo_d_blasfeo_api.h"
+#include "blasfeo_d_blasfeo_api.h"
 
 // acados
 #include "acados/ocp_qp/ocp_qp_common.h"

--- a/acados/ocp_qp/ocp_qp_qpdunes.c
+++ b/acados/ocp_qp/ocp_qp_qpdunes.c
@@ -40,8 +40,8 @@
 #include <string.h>
 
 // blasfeo
-#include "blasfeo/include/blasfeo_d_aux.h"
-#include "blasfeo/include/blasfeo_d_aux_ext_dep.h"
+#include "blasfeo_d_aux.h"
+#include "blasfeo_d_aux_ext_dep.h"
 
 // acados
 #include "acados/utils/mem.h"

--- a/acados/sim/sim_collocation_utils.c
+++ b/acados/sim/sim_collocation_utils.c
@@ -36,10 +36,10 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "blasfeo/include/blasfeo_d_aux_ext_dep.h"
-#include "blasfeo/include/blasfeo_d_blas.h"
-#include "blasfeo/include/blasfeo_d_kernel.h"
-#include "blasfeo/include/blasfeo_i_aux_ext_dep.h"
+#include "blasfeo_d_aux_ext_dep.h"
+#include "blasfeo_d_blas.h"
+#include "blasfeo_d_kernel.h"
+#include "blasfeo_i_aux_ext_dep.h"
 
 #include "acados/utils/print.h"
 #include "acados/utils/mem.h"

--- a/acados/sim/sim_gnsf.c
+++ b/acados/sim/sim_gnsf.c
@@ -46,10 +46,10 @@
 #include "acados/sim/sim_gnsf.h"
 
 // blasfeo
-#include "blasfeo/include/blasfeo_common.h"
-#include "blasfeo/include/blasfeo_d_aux.h"
-#include "blasfeo/include/blasfeo_d_blas.h"
-// #include "blasfeo/include/blasfeo_d_aux_ext_dep.h" // can be included for printing while
+#include "blasfeo_common.h"
+#include "blasfeo_d_aux.h"
+#include "blasfeo_d_blas.h"
+// #include "blasfeo_d_aux_ext_dep.h" // can be included for printing while
 // debugging
 
 

--- a/acados/sim/sim_gnsf.h
+++ b/acados/sim/sim_gnsf.h
@@ -42,7 +42,7 @@ extern "C" {
 #include "acados/utils/types.h"
 #include "acados/sim/sim_common.h"
 
-#include "blasfeo/include/blasfeo_common.h"
+#include "blasfeo_common.h"
 
 /*
 GNSF - Generalized Nonlinear Static Feedback Model

--- a/acados/sim/sim_irk_integrator.c
+++ b/acados/sim/sim_irk_integrator.c
@@ -45,9 +45,9 @@
 
 #include "acados/sim/sim_common.h"
 
-#include "blasfeo/include/blasfeo_d_aux.h"
-#include "blasfeo/include/blasfeo_d_blas.h"
-#include "blasfeo/include/blasfeo_common.h"
+#include "blasfeo_d_aux.h"
+#include "blasfeo_d_blas.h"
+#include "blasfeo_common.h"
 
 
 /************************************************

--- a/acados/sim/sim_irk_integrator.h
+++ b/acados/sim/sim_irk_integrator.h
@@ -39,7 +39,7 @@ extern "C" {
 #include "acados/sim/sim_common.h"
 #include "acados/utils/types.h"
 
-#include "blasfeo/include/blasfeo_common.h"
+#include "blasfeo_common.h"
 
 typedef struct
 {

--- a/acados/sim/sim_lifted_irk_integrator.c
+++ b/acados/sim/sim_lifted_irk_integrator.c
@@ -42,11 +42,11 @@
 
 #include "acados/sim/sim_common.h"
 
-#include "blasfeo/include/blasfeo_common.h"
-#include "blasfeo/include/blasfeo_d_aux.h"
-#include "blasfeo/include/blasfeo_d_aux_ext_dep.h"
-#include "blasfeo/include/blasfeo_d_blas.h"
-#include "blasfeo/include/blasfeo_v_aux_ext_dep.h"
+#include "blasfeo_common.h"
+#include "blasfeo_d_aux.h"
+#include "blasfeo_d_aux_ext_dep.h"
+#include "blasfeo_d_blas.h"
+#include "blasfeo_v_aux_ext_dep.h"
 
 
 /************************************************

--- a/acados/utils/mem.c
+++ b/acados/utils/mem.c
@@ -35,8 +35,8 @@
 #include <stdlib.h>
 
 // blasfeo
-#include "blasfeo/include/blasfeo_d_aux.h"
-#include "blasfeo/include/blasfeo_d_aux_ext_dep.h"
+#include "blasfeo_d_aux.h"
+#include "blasfeo_d_aux_ext_dep.h"
 // acados
 #include "acados/utils/mem.h"
 

--- a/acados/utils/mem.h
+++ b/acados/utils/mem.h
@@ -42,8 +42,8 @@ extern "C" {
 #include "types.h"
 
 // blasfeo
-#include "blasfeo/include/blasfeo_d_aux.h"
-#include "blasfeo/include/blasfeo_d_aux_ext_dep.h"
+#include "blasfeo_d_aux.h"
+#include "blasfeo_d_aux_ext_dep.h"
 
 // TODO(dimitris): probably does not belong here
 typedef struct

--- a/acados/utils/print.c
+++ b/acados/utils/print.c
@@ -44,9 +44,9 @@
 #include <string.h>
 
 // blasfeo
-#include "blasfeo/include/blasfeo_d_aux.h"
-#include "blasfeo/include/blasfeo_d_aux_ext_dep.h"
-#include "blasfeo/include/blasfeo_i_aux_ext_dep.h"
+#include "blasfeo_d_aux.h"
+#include "blasfeo_d_aux_ext_dep.h"
+#include "blasfeo_i_aux_ext_dep.h"
 
 // hpipm
 #include "hpipm/include/hpipm_d_ocp_qp.h"

--- a/examples/acados_python/pendulum_on_cart/custom_update/custom_update_function.c
+++ b/examples/acados_python/pendulum_on_cart/custom_update/custom_update_function.c
@@ -35,7 +35,7 @@
 #include "acados_c/ocp_nlp_interface.h"
 #include "acados/utils/mem.h"
 
-#include "blasfeo/include/blasfeo_d_aux_ext_dep.h"
+#include "blasfeo_d_aux_ext_dep.h"
 
 
 typedef struct custom_memory

--- a/examples/c/dense_qp.c
+++ b/examples/c/dense_qp.c
@@ -43,7 +43,7 @@
 // hpipm
 #include "hpipm/include/hpipm_d_dense_qp_kkt.h"
 
-#include "blasfeo/include/blasfeo_d_aux_ext_dep.h"
+#include "blasfeo_d_aux_ext_dep.h"
 
 // static dense_qp_res *dense_qp_res_create(dense_qp_dims *dims)
 // {

--- a/examples/c/engine_example.c
+++ b/examples/c/engine_example.c
@@ -32,8 +32,8 @@
 #include <stdlib.h>
 // #include <xmmintrin.h>
 
-#include "blasfeo/include/blasfeo_d_aux.h"
-#include "blasfeo/include/blasfeo_d_aux_ext_dep.h"
+#include "blasfeo_d_aux.h"
+#include "blasfeo_d_aux_ext_dep.h"
 
 // acados
 #include "acados/utils/print.h"

--- a/examples/c/engine_model/engine_nmpc.c
+++ b/examples/c/engine_model/engine_nmpc.c
@@ -49,9 +49,9 @@
 
 #include <stdlib.h>
 
-#include "blasfeo/include/blasfeo_d_aux.h"
-#include "blasfeo/include/blasfeo_d_aux_ext_dep.h"
-#include "blasfeo/include/blasfeo_d_blas.h"
+#include "blasfeo_d_aux.h"
+#include "blasfeo_d_aux_ext_dep.h"
+#include "blasfeo_d_blas.h"
 
 // acados
 #include "acados/ocp_nlp/ocp_nlp_cost_nls.h"

--- a/examples/c/no_interface_examples/mass_spring_fcond_split.c
+++ b/examples/c/no_interface_examples/mass_spring_fcond_split.c
@@ -44,7 +44,7 @@
 #include "acados/utils/timing.h"
 
 // blasfeo
-#include "blasfeo/include/blasfeo_d_aux_ext_dep.h"
+#include "blasfeo_d_aux_ext_dep.h"
 
 #define NREP 100
 #define ELIMINATE_X0

--- a/examples/c/no_interface_examples/mass_spring_model/mass_spring_qp.c
+++ b/examples/c/no_interface_examples/mass_spring_model/mass_spring_qp.c
@@ -35,8 +35,8 @@
 #include <stdlib.h>
 
 // blasfeo
-#include "blasfeo/include/blasfeo_d_aux_ext_dep.h"
-#include "blasfeo/include/blasfeo_i_aux_ext_dep.h"
+#include "blasfeo_d_aux_ext_dep.h"
+#include "blasfeo_i_aux_ext_dep.h"
 
 // hpipm
 #include "hpipm/include/hpipm_d_ocp_qp.h"

--- a/examples/c/no_interface_examples/mass_spring_nmpc_example.c
+++ b/examples/c/no_interface_examples/mass_spring_nmpc_example.c
@@ -36,9 +36,9 @@
 // #include <xmmintrin.h>
 #include "acados_c/ocp_nlp_interface.h"
 
-#include "blasfeo/include/blasfeo_d_aux_ext_dep.h"
-#include "blasfeo/include/blasfeo_d_blasfeo_api.h"
-#include "blasfeo/include/blasfeo_i_aux_ext_dep.h"
+#include "blasfeo_d_aux_ext_dep.h"
+#include "blasfeo_d_blasfeo_api.h"
+#include "blasfeo_i_aux_ext_dep.h"
 
 #include "acados/ocp_qp/ocp_qp_common.h"
 #include "acados/ocp_qp/ocp_qp_xcond_solver.h"

--- a/examples/c/no_interface_examples/mass_spring_offline_fcond_qpoases_split.c
+++ b/examples/c/no_interface_examples/mass_spring_offline_fcond_qpoases_split.c
@@ -46,9 +46,9 @@
 #include "acados/utils/timing.h"
 
 // blasfeo
-#include "blasfeo/include/blasfeo_d_aux.h"
-#include "blasfeo/include/blasfeo_d_aux_ext_dep.h"
-#include "blasfeo/include/blasfeo_d_blas.h"
+#include "blasfeo_d_aux.h"
+#include "blasfeo_d_aux_ext_dep.h"
+#include "blasfeo_d_blas.h"
 
 // NOTE(nielsvd): required to cast memory etc. should go.
 #include "acados/ocp_qp/ocp_qp_full_condensing_solver.h"

--- a/examples/c/no_interface_examples/mass_spring_pcond_split.c
+++ b/examples/c/no_interface_examples/mass_spring_pcond_split.c
@@ -45,7 +45,7 @@
 #include "acados/utils/timing.h"
 
 // blasfeo
-#include "blasfeo/include/blasfeo_d_aux_ext_dep.h"
+#include "blasfeo_d_aux_ext_dep.h"
 
 #define NREP 100
 #define ELIMINATE_X0

--- a/examples/c/no_interface_examples/nonlinear_chain_ocp_nlp_no_interface.c
+++ b/examples/c/no_interface_examples/nonlinear_chain_ocp_nlp_no_interface.c
@@ -33,8 +33,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include "blasfeo/include/blasfeo_d_aux_ext_dep.h"
-#include "blasfeo/include/blasfeo_i_aux_ext_dep.h"
+#include "blasfeo_d_aux_ext_dep.h"
+#include "blasfeo_i_aux_ext_dep.h"
 
 #include "acados/dense_qp/dense_qp_hpipm.h"
 #include "acados/ocp_qp/ocp_qp_common.h"

--- a/examples/c/nonlinear_chain_ocp_nlp.c
+++ b/examples/c/nonlinear_chain_ocp_nlp.c
@@ -36,8 +36,8 @@
 #include <stdlib.h>
 
 // blasfeo
-#include "blasfeo/include/blasfeo_d_aux_ext_dep.h"
-#include "blasfeo/include/blasfeo_i_aux_ext_dep.h"
+#include "blasfeo_d_aux_ext_dep.h"
+#include "blasfeo_i_aux_ext_dep.h"
 
 // acados
 #include "acados_c/external_function_interface.h"

--- a/examples/c/sim_crane_example.c
+++ b/examples/c/sim_crane_example.c
@@ -49,11 +49,11 @@
 #include "examples/c/crane_model/crane_model.h"
 
 // blasfeo
-#include "blasfeo/include/blasfeo_common.h"
-#include "blasfeo/include/blasfeo_d_aux.h"
-#include "blasfeo/include/blasfeo_d_aux_ext_dep.h"
-#include "blasfeo/include/blasfeo_d_blas.h"
-#include "blasfeo/include/blasfeo_v_aux_ext_dep.h"
+#include "blasfeo_common.h"
+#include "blasfeo_d_aux.h"
+#include "blasfeo_d_aux_ext_dep.h"
+#include "blasfeo_d_blas.h"
+#include "blasfeo_v_aux_ext_dep.h"
 
 
 

--- a/examples/c/sim_engine.cpp
+++ b/examples/c/sim_engine.cpp
@@ -33,9 +33,9 @@
 #include <vector>
 // #include <xmmintrin.h>
 
-#include "blasfeo/include/blasfeo_d_aux.h"
-#include "blasfeo/include/blasfeo_d_aux_ext_dep.h"
-#include "blasfeo/include/blasfeo_d_blas.h"
+#include "blasfeo_d_aux.h"
+#include "blasfeo_d_aux_ext_dep.h"
+#include "blasfeo_d_blas.h"
 
 // acados
 #include "acados/sim/sim_common.h"

--- a/examples/c/sim_gnsf_crane.c
+++ b/examples/c/sim_gnsf_crane.c
@@ -45,7 +45,7 @@
 #include "acados_c/external_function_interface.h"
 #include "acados_c/sim_interface.h"
 
-#include "blasfeo/include/blasfeo_d_aux_ext_dep.h" // for printing
+#include "blasfeo_d_aux_ext_dep.h" // for printing
 
 // model
 #include "examples/c/crane_nx9_model/crane_nx9_model.h"

--- a/examples/c/sim_pendulum_dae.c
+++ b/examples/c/sim_pendulum_dae.c
@@ -52,11 +52,11 @@
 #include "examples/c/pendulum_dae_model/pendulum_dae_model.h"
 
 // blasfeo
-#include "blasfeo/include/blasfeo_common.h"
-#include "blasfeo/include/blasfeo_d_aux.h"
-#include "blasfeo/include/blasfeo_d_aux_ext_dep.h"
-#include "blasfeo/include/blasfeo_d_blas.h"
-#include "blasfeo/include/blasfeo_v_aux_ext_dep.h"
+#include "blasfeo_common.h"
+#include "blasfeo_d_aux.h"
+#include "blasfeo_d_aux_ext_dep.h"
+#include "blasfeo_d_blas.h"
+#include "blasfeo_v_aux_ext_dep.h"
 
 
 int main()

--- a/examples/c/sim_wt_model_nx3.c
+++ b/examples/c/sim_wt_model_nx3.c
@@ -51,11 +51,11 @@
 #include "examples/c/wt_model_nx3/u_x0.c"
 
 // blasfeo
-#include "blasfeo/include/blasfeo_common.h"
-#include "blasfeo/include/blasfeo_d_aux.h"
-#include "blasfeo/include/blasfeo_d_aux_ext_dep.h"
-#include "blasfeo/include/blasfeo_d_blas.h"
-#include "blasfeo/include/blasfeo_v_aux_ext_dep.h"
+#include "blasfeo_common.h"
+#include "blasfeo_d_aux.h"
+#include "blasfeo_d_aux_ext_dep.h"
+#include "blasfeo_d_blas.h"
+#include "blasfeo_v_aux_ext_dep.h"
 
 
 int main()

--- a/examples/c/sim_wt_model_nx6.c
+++ b/examples/c/sim_wt_model_nx6.c
@@ -43,11 +43,11 @@
 #include "acados_c/sim_interface.h"
 
 // blasfeo
-#include "blasfeo/include/blasfeo_common.h"
-#include "blasfeo/include/blasfeo_d_aux.h"
-#include "blasfeo/include/blasfeo_d_aux_ext_dep.h"
-#include "blasfeo/include/blasfeo_d_blas.h"
-#include "blasfeo/include/blasfeo_v_aux_ext_dep.h"
+#include "blasfeo_common.h"
+#include "blasfeo_d_aux.h"
+#include "blasfeo_d_aux_ext_dep.h"
+#include "blasfeo_d_blas.h"
+#include "blasfeo_v_aux_ext_dep.h"
 
 // wt model
 #include "examples/c/wt_model_nx6/wt_model.h"

--- a/examples/c/simple_dae_example.c
+++ b/examples/c/simple_dae_example.c
@@ -44,7 +44,7 @@
 #include "acados_c/ocp_nlp_interface.h"
 #include "acados_c/external_function_interface.h"
 
-#include "blasfeo/include/blasfeo_d_aux.h"
+#include "blasfeo_d_aux.h"
 
 #include "simple_dae_model/simple_dae_model.h"
 #include "simple_dae_model/simple_dae_constr.h"

--- a/examples/c/wind_turbine_nmpc.c
+++ b/examples/c/wind_turbine_nmpc.c
@@ -36,8 +36,8 @@
 #include <stdlib.h>
 
 // blasfeo
-#include "blasfeo/include/blasfeo_d_aux_ext_dep.h"
-#include "blasfeo/include/blasfeo_i_aux_ext_dep.h"
+#include "blasfeo_d_aux_ext_dep.h"
+#include "blasfeo_i_aux_ext_dep.h"
 
 // acados
 #include "acados_c/external_function_interface.h"

--- a/examples/c/wind_turbine_nmpc_soft.c
+++ b/examples/c/wind_turbine_nmpc_soft.c
@@ -35,8 +35,8 @@
 #include <stdlib.h>
 
 // blasfeo
-#include "blasfeo/include/blasfeo_d_aux_ext_dep.h"
-#include "blasfeo/include/blasfeo_i_aux_ext_dep.h"
+#include "blasfeo_d_aux_ext_dep.h"
+#include "blasfeo_i_aux_ext_dep.h"
 
 // acados
 #include "interfaces/acados_c/external_function_interface.h"

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -37,16 +37,23 @@ if(CMAKE_SYSTEM_NAME MATCHES "dSpace")
 endif()
 
 # When BLASFEO is used as part of acados
-set(BLASFEO_HEADERS_INSTALLATION_DIRECTORY "include/blasfeo/include" CACHE STRING "")
+if(ACADOS_WITH_SYSTEM_BLASFEO)
+    find_package(blasfeo REQUIRED)
+else()
+    set(BLASFEO_HEADERS_INSTALLATION_DIRECTORY "include/blasfeo/include" CACHE STRING "")
 
-set(TARGET ${BLASFEO_TARGET} CACHE STRING "Set CPU architecture target" FORCE)
-set(MF "PANELMAJ" CACHE STRING "Matrix format" FORCE)
-set(BLAS_API OFF CACHE BOOL "Compile BLAS API" FORCE)
-add_subdirectory(blasfeo)
+    set(TARGET ${BLASFEO_TARGET} CACHE STRING "Set CPU architecture target" FORCE)
+    set(MF "PANELMAJ" CACHE STRING "Matrix format" FORCE)
+    set(BLAS_API OFF CACHE BOOL "Compile BLAS API" FORCE)
+    add_subdirectory(blasfeo)
+endif()
 
 # When HPIPM is used as part of acados
-set(HPIPM_BLASFEO_PATH ${BLASFEO_SRC_DIR} CACHE STRING "Set CPU architecture target" FORCE)
-
+if(ACADOS_WITH_SYSTEM_BLASFEO)
+    set(HPIPM_FIND_BLASFEO ON CACHE BOOL "" FORCE)
+else()
+    set(HPIPM_BLASFEO_PATH ${BLASFEO_SRC_DIR} CACHE STRING "Set CPU architecture target" FORCE)
+endif()
 set(HPIPM_BLASFEO_LIB OFF CACHE BOOL "Turn off BLASFEO from HPIPM" FORCE)
 set(HPIPM_HEADERS_INSTALLATION_DIRECTORY "include/hpipm/include" CACHE STRING "")
 set(TARGET ${HPIPM_TARGET} CACHE STRING "Set CPU architecture target" FORCE)

--- a/interfaces/acados_matlab_octave/ocp_get.c
+++ b/interfaces/acados_matlab_octave/ocp_get.c
@@ -35,7 +35,7 @@
 // acados
 #include "acados_c/ocp_nlp_interface.h"
 #include "acados/dense_qp/dense_qp_common.h"
-#include "blasfeo/include/blasfeo_d_aux.h"
+#include "blasfeo_d_aux.h"
 // mex
 #include "mex.h"
 #include "mex_macros.h"

--- a/interfaces/acados_template/acados_template/c_templates_tera/main.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/main.in.c
@@ -45,7 +45,7 @@
 #include "acados_solver_{{ name }}.h"
 
 // blasfeo
-#include "blasfeo/include/blasfeo_d_aux_ext_dep.h"
+#include "blasfeo_d_aux_ext_dep.h"
 
 #define NX     {{ name | upper }}_NX
 #define NP     {{ name | upper }}_NP

--- a/interfaces/acados_template/acados_template/c_templates_tera/main_multi.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/main_multi.in.c
@@ -45,7 +45,7 @@
 #include "acados_solver_{{ name }}.h"
 
 // blasfeo
-#include "blasfeo/include/blasfeo_d_aux_ext_dep.h"
+#include "blasfeo_d_aux_ext_dep.h"
 
 {%- set nx_values = [] -%}
 {%- for jj in range(end=n_phases) %}

--- a/interfaces/acados_template/acados_template/custom_update_templates/custom_update_function_zoro_template.in.c
+++ b/interfaces/acados_template/acados_template/custom_update_templates/custom_update_function_zoro_template.in.c
@@ -39,8 +39,8 @@
 #include "acados_c/ocp_nlp_interface.h"
 #include "acados/utils/mem.h"
 
-#include "blasfeo/include/blasfeo_d_aux_ext_dep.h"
-#include "blasfeo/include/blasfeo_d_blasfeo_api.h"
+#include "blasfeo_d_aux_ext_dep.h"
+#include "blasfeo_d_blasfeo_api.h"
 
 
 typedef struct custom_memory

--- a/test/ocp_nlp/test_chain.cpp
+++ b/test/ocp_nlp/test_chain.cpp
@@ -37,8 +37,8 @@
 #include "test/test_utils/eigen.h"
 #include "catch/include/catch.hpp"
 
-#include "blasfeo/include/blasfeo_d_aux_ext_dep.h"
-#include "blasfeo/include/blasfeo_i_aux_ext_dep.h"
+#include "blasfeo_d_aux_ext_dep.h"
+#include "blasfeo_i_aux_ext_dep.h"
 
 #include "acados_c/external_function_interface.h"
 #include "acados_c/ocp_qp_interface.h"

--- a/test/ocp_nlp/test_wind_turbine.cpp
+++ b/test/ocp_nlp/test_wind_turbine.cpp
@@ -42,8 +42,8 @@
 #include <stdlib.h>
 
 // blasfeo
-#include "blasfeo/include/blasfeo_d_aux_ext_dep.h"
-#include "blasfeo/include/blasfeo_i_aux_ext_dep.h"
+#include "blasfeo_d_aux_ext_dep.h"
+#include "blasfeo_i_aux_ext_dep.h"
 
 // acados
 #include "acados_c/external_function_interface.h"

--- a/test/ocp_qp/test_qpsolvers_old.cpp
+++ b/test/ocp_qp/test_qpsolvers_old.cpp
@@ -33,8 +33,8 @@
 #include <string>
 #include <vector>
 
-#include "blasfeo/include/blasfeo_target.h"
-#include "blasfeo/include/blasfeo_v_aux_ext_dep.h"
+#include "blasfeo_target.h"
+#include "blasfeo_v_aux_ext_dep.h"
 #include "catch/include/catch.hpp"
 
 #ifdef OOQP

--- a/test/sim/sim_test_dae.cpp
+++ b/test/sim/sim_test_dae.cpp
@@ -42,7 +42,7 @@
 
 #include "test/test_utils/eigen.h"
 #include "catch/include/catch.hpp"
-#include "blasfeo/include/blasfeo_d_aux_ext_dep.h"
+#include "blasfeo_d_aux_ext_dep.h"
 
 // acados
 #include "acados/sim/sim_common.h"

--- a/test/sim/sim_test_hessian.cpp
+++ b/test/sim/sim_test_hessian.cpp
@@ -47,8 +47,8 @@
 #include "acados_c/external_function_interface.h"
 #include "acados_c/sim_interface.h"
 
-#include "blasfeo/include/blasfeo_d_aux.h"
-#include "blasfeo/include/blasfeo_d_aux_ext_dep.h"
+#include "blasfeo_d_aux.h"
+#include "blasfeo_d_aux_ext_dep.h"
 
 // pendulum_model
 #include "examples/c/pendulum_model/pendulum_model.h"

--- a/test/test_utils/read_ocp_qp_in.c
+++ b/test/test_utils/read_ocp_qp_in.c
@@ -38,8 +38,8 @@
 
 #include "acados/ocp_qp/ocp_qp_common.h"
 
-#include "blasfeo/include/blasfeo_d_aux_ext_dep.h"
-#include "blasfeo/include/blasfeo_i_aux_ext_dep.h"
+#include "blasfeo_d_aux_ext_dep.h"
+#include "blasfeo_i_aux_ext_dep.h"
 
 static void transpose_matrix(real_t *mat, int m, int n)
 {


### PR DESCRIPTION
In cases in which one already has a `libblasfeo` in the environment, `acados` building its own can lead to conflicts (see https://github.com/acados/acados/issues/1237). 

To mitigate this problem, this PR adds a `ACADOS_WITH_SYSTEM_BLASFEO` CMake option (that by default is off) to permit advanced users to select an externally built blasfeo.

This option can also be useful if someone wanted to work on https://github.com/acados/acados/issues/606, probably after https://github.com/giaf/hpipm/issues/170 is solved.

I manually run the Makefile build system, and it seems to be working fine even after the change of include style for blasfeo headers.