### PR TITLE
MATLAB/Python: Cleanup examples

### DIFF
--- a/examples/acados_matlab_octave/mocp_transition_example/main_multiphase_ocp.m
+++ b/examples/acados_matlab_octave/mocp_transition_example/main_multiphase_ocp.m
@@ -42,6 +42,7 @@ ocp.set_phase(phase_1, 1);
 
 phase_2 = AcadosOcp();
 phase_2.model = get_transition_model();
+
 % define transition cost
 phase_2.cost.cost_type = 'NONLINEAR_LS';
 phase_2.model.cost_y_expr = phase_2.model.x;
@@ -73,8 +74,15 @@ ocp.solver_options.store_iterates = true;
 
 ocp_solver = AcadosOcpSolver(ocp);
 
+
+% initialize x trajectory using flattened format
+x0 = ocp.constraints{1}.x0;
+x_init = [repmat(x0, 1, N_list(1)+N_list(2)) repmat(x0(1), 1, N_list(3)+1)];
+
+ocp_solver.set('x', x_init);
+
 ocp_solver.solve();
-ocp_solver.print()
+ocp_solver.print();
 
 iterate = ocp_solver.get_iterate(ocp_solver.get('sqp_iter'));
 

--- a/examples/acados_python/pendulum_on_cart/mhe/closed_loop_mhe_ocp.py
+++ b/examples/acados_python/pendulum_on_cart/mhe/closed_loop_mhe_ocp.py
@@ -46,6 +46,9 @@ import numpy as np
 
 
 def main():
+
+    np.random.seed(42)
+
     Tf_ocp = 1.0
     N_ocp = 20
 
@@ -80,12 +83,12 @@ def main():
     # mhe model and solver
     model_mhe = export_mhe_ode_model()
 
-    # inverse covariances, R_mhe has to be scaled with time step
-    Q_mhe = np.diag(1/w_stds_mhe)
-    R_mhe = 1/Ts*np.diag(1/v_stds_mhe)
+    # inverse covariances
+    Q_mhe = np.diag(1/w_stds_mhe**2)
+    R_mhe = np.diag(1/v_stds_mhe**2)
 
     # arrival cost weighting
-    Q0_mhe = 0.01*Q_mhe
+    Q0_mhe = 0.005*Q_mhe
 
     acados_mhe_solver = export_mhe_solver(model_mhe, N_mhe, Ts, Q_mhe, Q0_mhe, R_mhe)
 

--- a/examples/acados_python/pendulum_on_cart/mhe/export_mhe_solver.py
+++ b/examples/acados_python/pendulum_on_cart/mhe/export_mhe_solver.py
@@ -48,10 +48,10 @@ def export_mhe_solver(model: AcadosModel, N: int, h, Q, Q0, R) -> AcadosOcpSolve
     nu = u.rows()
     nparam = model.p.rows()
 
-    ny_0 = 3*nx     # h(x), w and arrival cost
+    ny_0 = 3*nx   # h(x), w and arrival cost
     ny = 2*nx     # h(x), w
 
-    ocp_mhe.dims.N = N
+    ocp_mhe.solver_options.N_horizon = N
 
     ## set cost
     ocp_mhe.cost.cost_type_0 = 'NONLINEAR_LS' # 'LINEAR_LS'
@@ -89,6 +89,7 @@ def export_mhe_solver(model: AcadosModel, N: int, h, Q, Q0, R) -> AcadosOcpSolve
     ocp_mhe.solver_options.qp_solver = 'FULL_CONDENSING_QPOASES'
     ocp_mhe.solver_options.hessian_approx = 'GAUSS_NEWTON'
     ocp_mhe.solver_options.integrator_type = 'ERK'
+    ocp_mhe.solver_options.cost_scaling = np.ones((N+1,)) # we do not want to scale with the time step
 
     # set prediction horizon
     ocp_mhe.solver_options.tf = N*h

--- a/examples/acados_python/pendulum_on_cart/mhe/minimal_example_mhe_with_noisy_param.py
+++ b/examples/acados_python/pendulum_on_cart/mhe/minimal_example_mhe_with_noisy_param.py
@@ -50,6 +50,7 @@ Fmax = 80
 
 # NOTE: hard coded in export_pendulum_ode_model;
 l_true = 0.8
+v_stds = np.array([0.4, 0.2, 0.2, 0.2])
 
 # ocp model and solver
 model = export_pendulum_ode_model()
@@ -69,16 +70,13 @@ nx_augmented = model_mhe.x.rows()
 nw = model_mhe.u.rows()
 ny = nx
 
-Q0_mhe = np.diag([0.1, 0.1, 0.1, 0.1, 1])
+Q0_mhe = np.diag([0.01, 0.01, 0.01, 0.01, .01])
 Q_mhe  = 10.*np.diag([0.2, 0.2, 2, 2, 0.1])
-R_mhe  = 2*np.diag([0.1, 0.1, 0.1, 0.1])
+R_mhe  = np.diag(1/v_stds**2)
 
 acados_solver_mhe = export_mhe_solver_with_param(model_mhe, N, h, Q_mhe, Q0_mhe, R_mhe, use_cython=True)
 
 # simulation
-v_stds = [0.2, 0.5, 1, 1]
-v_stds = [0, 0, 0, 0]
-
 simX = np.zeros((N+1, nx))
 simU = np.zeros((N, nu))
 simY = np.zeros((N+1, nx))
@@ -88,8 +86,8 @@ simWest = np.zeros((N, nx_augmented))
 sim_l_est = np.zeros((N+1, 1))
 
 # arrival cost mean (with wrong guess for l)
-# x0_bar = np.array([0.0, np.pi, 0.0, 0.0, 1])
-x0_bar = np.array([0.0, 0, 0.0, 0.0, 0.2])
+x0_bar = np.array([0.0, np.pi, 0.0, 0.0, 1])
+# x0_bar = np.array([0.0, 0, 0.0, 0.0, 0.2])
 
 # solve ocp problem
 status = acados_solver_ocp.solve()

--- a/examples/acados_python/pendulum_on_cart/mhe/minimal_example_mhe_with_param.py
+++ b/examples/acados_python/pendulum_on_cart/mhe/minimal_example_mhe_with_param.py
@@ -50,6 +50,7 @@ Fmax = 80
 
 # NOTE: hard coded in export_pendulum_ode_model;
 l_true = 0.8
+v_stds = np.array([0.4, 0.2, 0.2, 0.2])
 
 # ocp model and solver
 model = export_pendulum_ode_model()
@@ -69,15 +70,14 @@ nx_augmented = model_mhe.x.rows()
 nw = model_mhe.u.rows()
 ny = nx
 
+
 Q0_mhe = np.diag([0.1, 0.01, 0.01, 0.01, 10])
 Q_mhe  = 10.*np.diag([0.1, 0.01, 0.01, 0.01])
-R_mhe  = 2*np.diag([0.1, 0.01, 0.01, 0.01])
+R_mhe  = 0.1*np.diag(1./v_stds**2)
 
 acados_solver_mhe = export_mhe_solver_with_param(model_mhe, N, h, Q_mhe, Q0_mhe, R_mhe)
 
 # simulation
-v_stds = [0.1, 0.1, 0.1, 0.1]
-v_stds = [0, 0, 0, 0]
 
 simX = np.zeros((N+1, nx))
 simU = np.zeros((N, nu))
@@ -88,7 +88,6 @@ simWest = np.zeros((N, nx))
 sim_l_est = np.zeros((N+1, 1))
 
 # arrival cost mean (with wrong guess for l)
-x0_bar = np.array([0.0, np.pi, 0.0, 0.0, 0.8])
 x0_bar = np.array([0.0, np.pi, 0.0, 0.0, 1])
 
 # solve ocp problem
@@ -151,15 +150,3 @@ print('difference |l_est - l_true|', np.abs(sim_l_est[0] - l_true))
 
 ts = np.linspace(0, Tf, N+1)
 plot_pendulum(ts, Fmax, simU, simX, simXest, simY, latexify=False)
-
-## plot estimated M over shooting nodes
-
-# import matplotlib.pyplot as plt
-# plt.figure()
-# plt.plot(ts, l_true*np.ones((N+1, 1)), '-')
-# plt.plot(ts, sim_l_est, '.-')
-# plt.grid()
-# plt.ylabel('M')
-# plt.xlabel('time')
-# plt.legend(['true M', 'estimated M'])
-# plt.show()


### PR DESCRIPTION
Minor changes to examples:

MATLAB: showcase initialization of MOCP solvers using flat format.
Python: Cleanup MHE examples.