### PR TITLE
MATLAB: no `quit()`

### DIFF
--- a/examples/acados_matlab_octave/mocp_transition_example/main_mocp_simulink.m
+++ b/examples/acados_matlab_octave/mocp_transition_example/main_mocp_simulink.m
@@ -208,49 +208,42 @@ for itest = 1:2
     kkt_signal = out_sim.logsout.getElement('KKT_residual');
     kkt_val = kkt_signal.Values.data;
     if any(kkt_val > 1e-6)
-        disp('failed');
-        quit(1);
+        error('failed');
     end
 
     sqp_iter_signal = out_sim.logsout.getElement('sqp_iter');
     sqp_iter_val = sqp_iter_signal.Values.Data;
     disp('checking sqp_iter_val, should be 1 because problem is a QP.')
     if any(sqp_iter_val ~= 1)
-        disp('failed');
-        quit(1);
+        error('failed');
     end
 
     status_signal = out_sim.logsout.getElement('status');
     status_val = status_signal.Values.Data;
     disp('checking status, should be 0 (success).')
     if any(status_val ~= 0)
-        disp('failed. got status values:');
-        disp(status_val);
-        quit(1);
+        error(['failed. got status values:' mat2str(status_val)]);
     end
 
     utraj_signal = out_sim.logsout.getElement('utraj');
     u_simulink = utraj_signal.Values.Data(1, :);
     disp('checking u values.')
     if norm(u_simulink(:) - u_traj(:)) > 1e-8
-        disp('failed');
-        quit(1);
+        error('failed');
     end
 
     xtraj_signal = out_sim.logsout.getElement('xtraj');
     x_simulink = xtraj_signal.Values.Data(1, :);
     disp('checking x values, should match solution in MATLAB.')
     if norm(x_simulink(:) - x_traj(:)) > 1e-8
-        disp('failed');
-        quit(1);
+        error('failed');
     end
     %
     pi_signal = out_sim.logsout.getElement('pi_all');
     pi_simulink = pi_signal.Values.Data(1, :);
     disp('checking pi values, should match solution in MATLAB.')
     if norm(pi_simulink(:) - pi_traj(:)) > 1e-8
-        disp('failed');
-        quit(1);
+        error('failed');
     end
 
     x1_signal = out_sim.logsout.getElement('x1');
@@ -258,8 +251,7 @@ for itest = 1:2
     x1_ref = ocp_solver.get('x', 1);
     disp('checking x1_value')
     if norm(x1_val(:) - x1_ref(:)) > 1e-8
-        disp('failed');
-        quit(1);
+        error('failed');
     end
 
     u0_signal = out_sim.logsout.getElement('u0');
@@ -267,8 +259,7 @@ for itest = 1:2
     u0_ref = ocp_solver.get('u', 0);
     disp('checking u0_value')
     if norm(u0_val(:) - u0_ref(:)) > 1e-8
-        disp('failed');
-        quit(1);
+        error('failed');
     end
 
 end

--- a/examples/acados_matlab_octave/p_global_example/simulink_test_p_global.m
+++ b/examples/acados_matlab_octave/p_global_example/simulink_test_p_global.m
@@ -99,11 +99,10 @@ xtraj_val = xtraj_signal.Values.Data(1, :);
 utraj_signal = out_sim.logsout.getElement('utraj');
 utraj_val = utraj_signal.Values.Data(1, :);
 if norm(xtraj_val - xtraj) > 1e-8
-    disp('error: xtraj values in SIMULINK and MATLAB should match.')
-    quit(1);
+    error('xtraj values in SIMULINK and MATLAB should match.')
 end
 if norm(utraj_val - utraj) > 1e-8
-    disp('error: utraj values in SIMULINK and MATLAB should match.')
-    quit(1);
+    error('utraj values in SIMULINK and MATLAB should match.')
 end
+
 disp('Simulink p_global test: got matching trajectories in Matlab and Simulink!')

--- a/examples/acados_matlab_octave/test/exit_with_error.m
+++ b/examples/acados_matlab_octave/test/exit_with_error.m
@@ -35,5 +35,5 @@ function exit_with_error(error)
     disp(error.message)
     fprintf(error.message);
     fprintf('\nRUN_TEST: FAIL -> exit\n');
-    quit(1);
+    error('')
 end

--- a/examples/acados_matlab_octave/test/simulink_init_test.m
+++ b/examples/acados_matlab_octave/test/simulink_init_test.m
@@ -131,46 +131,39 @@ for itest = [1, 2, 3, 4]
     disp('checking KKT residual, should be zero just because not evaluated')
     kkt_signal = out_sim.logsout.getElement('KKT_residual');
     if any(kkt_signal.Values.data > 1e-6)
-        disp('failed');
-        quit(1);
+        error('failed');
     end
 
     sqp_iter_signal = out_sim.logsout.getElement('sqp_iter');
     disp('checking SQP iter, we set max iter to 0, so expect 0.')
     if any(sqp_iter_signal.Values.Data ~= 0)
-        disp('failed');
-        quit(1);
+        error('failed');
     end
 
     status_signal = out_sim.logsout.getElement('status');
     disp('checking status, should be 2 (max iter).')
     if any(status_signal.Values.Data ~= 2)
-        disp('failed. got status values:');
-        disp(status_signal.Values.Data);
-        quit(1);
+        error(['failed. got status values:' mat2str(status_signal.Values.Data)]);
     end
 
     utraj_signal = out_sim.logsout.getElement('utraj');
     u_simulink = utraj_signal.Values.Data(1, :);
     disp('checking u values.')
     if any(abs(u_simulink(:) - u_expected(:)) > 1e-8)
-        disp('failed');
-        quit(1);
+        error('failed');
     end
 
     xtraj_signal = out_sim.logsout.getElement('xtraj');
     x_simulink = xtraj_signal.Values.Data(1, :);
     disp('checking x values, should match initialization.')
     if any(abs(x_simulink(:) - x_expected(:)) > 1e-8)
-        disp('failed');
-        quit(1);
+        error('failed');
     end
 
     pi_signal = out_sim.logsout.getElement('pi_all');
     pi_simulink = pi_signal.Values.Data(1, :);
     disp('checking pi values, should match initialization.')
     if any(abs(pi_simulink(:) - pi_expected(:)) > 1e-8)
-        disp('failed');
-        quit(1);
+        error('failed');
     end
 end

--- a/examples/acados_matlab_octave/test/simulink_param_test.m
+++ b/examples/acados_matlab_octave/test/simulink_param_test.m
@@ -78,16 +78,13 @@ out_sim = sim('parameter_test_simulink', 'SaveOutput', 'on');
 status_signal = out_sim.logsout.getElement('status');
 disp('checking status, should be 2 (max iter).')
 if any(status_signal.Values.Data ~= 2)
-    disp('failed. got status values:');
-    disp(status_signal.Values.Data);
-    quit(1);
+    errror(['failed. got status values:' mat2str(status_signal.Values.Data)]);
 end
 
 element_names = out_sim.logsout.getElementNames();
 parameter_traj_out_signal = out_sim.logsout.getElement('parameter_traj_out');
 if any(parameter_traj_out_signal.Values.Data(1,:) ~= p_values)
-    disp('Setting parameters in Simulink does NOT work as expected.');
-    quit(1);
+    error('Setting parameters in Simulink does NOT work as expected.');
 end
 disp('Setting parameters in Simulink works as expected.');
 

--- a/examples/acados_matlab_octave/test/simulink_qp_test.m
+++ b/examples/acados_matlab_octave/test/simulink_qp_test.m
@@ -99,40 +99,34 @@ for itest = [1, 2, 3]
     disp('checking KKT residual')
     kkt_signal = out_sim.logsout.getElement('KKT_residual');
     if any(kkt_signal.Values.data > 1e-6)
-        disp('failed');
-        quit(1);
+        error('failed');
     end
 
     sqp_iter_signal = out_sim.logsout.getElement('sqp_iter');
     sqp_iter_simulink = sqp_iter_signal.Values.Data;
     disp('checking SQP iter, QP should take 1 SQP iter.')
     if any(sqp_iter_simulink ~= 1)
-        disp('failed');
-        quit(1);
+        error('failed');
     end
 
     status_signal = out_sim.logsout.getElement('status');
     disp('checking status.')
     if any(status_signal.Values.Data)
-        disp('failed. got status values:');
-        disp(status_signal.Values.Data);
-        % quit(1);
+        error(['failed. got status values:' mat2str(status_signal.Values.Data)]);
     end
 
     utraj_signal = out_sim.logsout.getElement('utraj');
     u_simulink = utraj_signal.Values.Data(1, :);
     disp('checking u values.')
     if any(abs(u_simulink(:) - utraj(:)) > 1e-8)
-        disp('failed');
-        quit(1);
+        error('failed');
     end
 
     xtraj_signal = out_sim.logsout.getElement('xtraj');
     x_simulink = xtraj_signal.Values.Data(1, :);
     disp('checking x values.')
     if any(abs(x_simulink(:) - xtraj(:)) > 1e-8)
-        disp('failed');
-        quit(1);
+        error('failed');
     end
 end
 %% Run with different initialization
@@ -146,16 +140,13 @@ sqp_iter_signal = out_sim.logsout.getElement('sqp_iter');
 sqp_iter_simulink = sqp_iter_signal.Values.Data;
 disp('checking SQP iter, QP should take 1 SQP iter.')
 if any(sqp_iter_simulink ~= 1)
-    disp('failed');
-    quit(1);
+    error('failed');
 end
 
 status_signal = out_sim.logsout.getElement('status');
 disp('checking status.')
 if any(status_signal.Values.Data)
-    disp('failed. got status values:');
-    disp(status_signal.Values.Data);
-    quit(1);
+    error(['failed. got status values:' mat2str(status_signal.Values.Data)]);
 end
 
 %% Run with different initialization
@@ -173,18 +164,15 @@ disp(sqp_iter_simulink)
 
 fprintf('should require one SQP iteration in first instance.\n')
 if sqp_iter_simulink(1) ~= 1
-    disp('failed');
-    quit(1);
+    error('failed');
 end
 fprintf('should require 0 SQP iterations if initialized at solution.\n')
 if any(sqp_iter_simulink(2:n_sim))
-    disp('failed');
-    quit(1);
+    error('failed');
 end
 
 status_signal = out_sim.logsout.getElement('status');
 disp('checking status.')
 if any(status_signal.Values.Data)
-    disp('failed');
-    quit(1);
+    error('failed');
 end

--- a/examples/acados_matlab_octave/test/simulink_slack_test.m
+++ b/examples/acados_matlab_octave/test/simulink_slack_test.m
@@ -83,23 +83,19 @@ element_names = out_sim.logsout.getElementNames();
 status_signal = out_sim.logsout.getElement('status');
 disp('checking status, should be 0.')
 if any(status_signal.Values.Data ~= 0)
-    disp('failed. got status values:');
-    disp(status_signal.Values.Data);
-    % quit(1);
+    error(['failed. got status values:' mat2str(status_signal.Values.Data)]);
 end
 
 utraj_signal = out_sim.logsout.getElement('utraj');
 u_simulink = utraj_signal.Values.Data(1, :);
 disp('checking u values.')
 if any(abs(u_simulink(:) - utraj(:)) > 1e-8)
-    disp('failed');
-    quit(1);
+    error('failed');
 end
 
 xtraj_signal = out_sim.logsout.getElement('xtraj');
 x_simulink = xtraj_signal.Values.Data(1, :);
 disp('checking x values.')
 if any(abs(x_simulink(:) - xtraj(:)) > 1e-8)
-    disp('failed');
-    quit(1);
+    error('failed');
 end

--- a/examples/acados_matlab_octave/test/simulink_sparse_param_test.m
+++ b/examples/acados_matlab_octave/test/simulink_sparse_param_test.m
@@ -93,8 +93,7 @@ p_ref([43, 44], :) = 8;
 p_ref([13], 3+1) = input_update_port_p12_stage3(end);
 
 if any(any(p_ref ~= p_matlab))
-    disp('Setting sparse parameters in Matlab does NOT work as expected.');
-    quit(1);
+    error('Setting sparse parameters in Matlab does NOT work as expected.');
 else
     disp('Setting sparse parameters in Matlab works as expected.');
 end
@@ -115,8 +114,7 @@ parameter_traj_out_signal = out_sim.logsout.getElement('parameter_traj_out');
 p_simulink = reshape(parameter_traj_out_signal.Values.Data(1, :), np, N+1);
 
 if any(any(p_simulink ~= p_matlab))
-    disp('Setting sparse parameters in Simulink does NOT work as expected.');
-    quit(1);
+    error('Setting sparse parameters in Simulink does NOT work as expected.');
 else
     disp('Setting sparse parameters in Simulink works as expected.');
 end

--- a/examples/acados_matlab_octave/test/simulink_test.m
+++ b/examples/acados_matlab_octave/test/simulink_test.m
@@ -70,7 +70,7 @@ disp(['Norm of control traj. wrt. reference solution is: ',...
     num2str(err_vs_ref, '%e'), ' test TOL = ', num2str(TOL)]);
 
 if err_vs_ref > TOL
-    quit(1)
+    error('Failed.')
 end
 
 % sanity check on cost values
@@ -78,8 +78,7 @@ cost_signal = out_sim.logsout.getElement('cost_val');
 cost_vals = cost_signal.Values.Data;
 
 if ~issorted(cost_vals,'strictdescend')
-    disp('cost_values should be monotonically decreasing for this example.');
-    quit(1)
+    error('cost_values should be monotonically decreasing for this example.');
 else
     disp('cost_values are monotonically decreasing.');
 end
@@ -88,8 +87,7 @@ end
 status_signal = out_sim.logsout.getElement('ocp_solver_status');
 status_vals = status_signal.Values.Data;
 if any(status_vals)
-    disp('OCP solver status should be always zero on this example');
-    quit(1)
+    error('OCP solver status should be always zero on this example');
 else
     disp('OCP solver status is always zero.');
 end

--- a/examples/acados_matlab_octave/test/test_ocp_OSQP.m
+++ b/examples/acados_matlab_octave/test/test_ocp_OSQP.m
@@ -128,7 +128,6 @@ ocp_solver.print('stat')
 if status == 0
     disp('test_ocp_OSQP: success!');
 else
-    disp(['test_ocp_OSQP: Failed with status ', num2str(status)]);
-    quit(1);
+    error(['test_ocp_OSQP: Failed with status ', num2str(status)]);
 end
 

--- a/examples/acados_matlab_octave/test/test_ocp_qpdunes.m
+++ b/examples/acados_matlab_octave/test/test_ocp_qpdunes.m
@@ -153,7 +153,6 @@ ocp_solver.print('stat')
 if status == 0
     disp('test_ocp_qpDUNES: success!');
 else
-    disp(['test_ocp_qpDUNES: Failed with status ', num2str(status)]);
-    quit(1);
+    error(['test_ocp_qpDUNES: Failed with status ', num2str(status)]);
 end
 


### PR DESCRIPTION
This PR replaces all calls to `quit()` in the examples and tests with `error()` as `quit()` closes MATLAB.