### PR TITLE
C: More  total dimension getters

### DIFF
--- a/interfaces/acados_c/ocp_nlp_interface.c
+++ b/interfaces/acados_c/ocp_nlp_interface.c
@@ -720,7 +720,7 @@ void ocp_nlp_out_get(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_out *ou
 }
 
 
-int ocp_nlp_dims_get_total_from_attr(ocp_nlp_config *config, ocp_nlp_dims *dims, const char *field)
+int ocp_nlp_dims_get_total_from_attr(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_out *out, const char *field)
 {
     int N = dims->N;
 
@@ -740,14 +740,16 @@ int ocp_nlp_dims_get_total_from_attr(ocp_nlp_config *config, ocp_nlp_dims *dims,
             size += dims->nu[stage];
         }
     }
-    else if (!strcmp(field, "sl") || !strcmp(field, "su"))
+    else if (!strcmp(field, "sl") || !strcmp(field, "su") ||
+             !strcmp(field, "zl") || !strcmp(field, "zu") ||
+             !strcmp(field, "Zl") || !strcmp(field, "Zu"))
     {
         for (stage = 0; stage < N+1; stage++)
         {
             size += dims->ns[stage];
         }
     }
-    else if (!strcmp(field, "s"))
+    else if (!strcmp(field, "s") || !strcmp(field, "cost_z") || !strcmp(field, "cost_Z"))
     {
         for (stage = 0; stage < N+1; stage++)
         {
@@ -782,6 +784,40 @@ int ocp_nlp_dims_get_total_from_attr(ocp_nlp_config *config, ocp_nlp_dims *dims,
             size += dims->np[stage];
         }
     }
+    else if (!strcmp(field, "lbx") || !strcmp(field, "ubx") || !strcmp(field, "nbx"))
+    {
+        for (stage = 0; stage < N+1; stage++)
+        {
+            size += ocp_nlp_dims_get_from_attr(config, dims, out, stage, "lbx");
+        }
+    }
+    else if (!strcmp(field, "lbu") || !strcmp(field, "ubu") || !strcmp(field, "nbu"))
+    {
+        for (stage = 0; stage < N; stage++)
+        {
+            size += ocp_nlp_dims_get_from_attr(config, dims, out, stage, "lbu");
+        }
+    }
+    else if (!strcmp(field, "lg") || !strcmp(field, "ug") || !strcmp(field, "ng"))
+    {
+        for (stage = 0; stage < N+1; stage++)
+        {
+            size += ocp_nlp_dims_get_from_attr(config, dims, out, stage, "lg");
+        }
+    }
+    else if (!strcmp(field, "lh") || !strcmp(field, "uh") || !strcmp(field, "nh"))
+    {
+        for (stage = 0; stage < N+1; stage++)
+        {
+            size += ocp_nlp_dims_get_from_attr(config, dims, out, stage, "lh");
+        }
+    }
+    else
+    {
+        printf("\nerror: ocp_nlp_dims_get_total_from_attr: field %s not available\n", field);
+        exit(1);
+    }
+
     return size;
 }
 
@@ -821,9 +857,13 @@ int ocp_nlp_dims_get_from_attr(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_n
     {
         return 2*dims->ni[stage];
     }
-    else if (!strcmp(field, "sl") || !strcmp(field, "su") || !strcmp(field, "s") ||
-             !strcmp(field, "zl") || !strcmp(field, "zu") || !strcmp(field, "cost_z") ||
-             !strcmp(field, "Zl") || !strcmp(field, "Zu") || !strcmp(field, "cost_Z"))
+    else if (!strcmp(field, "s") || !strcmp(field, "cost_z") || !strcmp(field, "cost_Z"))
+    {
+        return 2*dims->ns[stage];
+    }
+    else if (!strcmp(field, "sl") || !strcmp(field, "su") ||
+             !strcmp(field, "zl") || !strcmp(field, "zu") ||
+             !strcmp(field, "Zl") || !strcmp(field, "Zu"))
     {
         return dims->ns[stage];
     }

--- a/interfaces/acados_c/ocp_nlp_interface.h
+++ b/interfaces/acados_c/ocp_nlp_interface.h
@@ -331,7 +331,7 @@ ACADOS_SYMBOL_EXPORT void ocp_nlp_cost_dims_get_from_attr(ocp_nlp_config *config
 ACADOS_SYMBOL_EXPORT void ocp_nlp_qp_dims_get_from_attr(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_out *out,
         int stage, const char *field, int *dims_out);
 
-ACADOS_SYMBOL_EXPORT int ocp_nlp_dims_get_total_from_attr(ocp_nlp_config *config, ocp_nlp_dims *dims, const char *field);
+ACADOS_SYMBOL_EXPORT int ocp_nlp_dims_get_total_from_attr(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_out *out, const char *field);
 
 /* opts */
 

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -1021,7 +1021,6 @@ class AcadosOcpSolver:
 
         self.__acados_lib.ocp_nlp_get_all(self.nlp_solver, self.nlp_in, self.nlp_out, field, out_data)
 
-        print("done")
         return out
 
 

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -323,7 +323,7 @@ class AcadosOcpSolver:
         self.__acados_lib.ocp_nlp_get_from_iterate.argtypes = [c_void_p, c_int, c_int, c_char_p, c_void_p]
         self.__acados_lib.ocp_nlp_get_from_iterate.restypes = c_void_p
 
-        self.__acados_lib.ocp_nlp_dims_get_total_from_attr.argtypes = [c_void_p, c_void_p, c_char_p]
+        self.__acados_lib.ocp_nlp_dims_get_total_from_attr.argtypes = [c_void_p, c_void_p, c_void_p, c_char_p]
         self.__acados_lib.ocp_nlp_dims_get_total_from_attr.restype = c_int
 
         self.__acados_lib.ocp_nlp_get_all.argtypes = [c_void_p, c_void_p, c_void_p, c_char_p, c_void_p]
@@ -443,7 +443,7 @@ class AcadosOcpSolver:
         if field not in ['x', 'u', 'z', 'pi', 'lam', 'sl', 'su', 'p']:
             raise Exception(f'AcadosOcpSolver.get_dim_flat(field={field}): \'{field}\' is an invalid argument.')
 
-        return self.__acados_lib.ocp_nlp_dims_get_total_from_attr(self.nlp_config, self.nlp_dims, field.encode('utf-8'))
+        return self.__acados_lib.ocp_nlp_dims_get_total_from_attr(self.nlp_config, self.nlp_dims, self.nlp_out, field.encode('utf-8'))
 
 
     def custom_update(self, data_: np.ndarray):
@@ -1014,12 +1014,14 @@ class AcadosOcpSolver:
 
         field = field_.encode('utf-8')
 
-        dims = self.__acados_lib.ocp_nlp_dims_get_total_from_attr(self.nlp_config, self.nlp_dims, field)
+        dims = self.__acados_lib.ocp_nlp_dims_get_total_from_attr(self.nlp_config, self.nlp_dims, self.nlp_out, field)
 
         out = np.zeros((dims,), dtype=np.float64, order="C")
         out_data = cast(out.ctypes.data, POINTER(c_double))
 
         self.__acados_lib.ocp_nlp_get_all(self.nlp_solver, self.nlp_in, self.nlp_out, field, out_data)
+
+        print("done")
         return out
 
 
@@ -1032,7 +1034,7 @@ class AcadosOcpSolver:
         field = field_.encode('utf-8')
         if field_ not in ['x', 'u', 'z', 'pi', 'lam', 'sl', 'su', 'p']:
             raise Exception(f'AcadosOcpSolver.get_flat(field={field_}): \'{field_}\' is an invalid argument.')
-        dims = self.__acados_lib.ocp_nlp_dims_get_total_from_attr(self.nlp_config, self.nlp_dims, field)
+        dims = self.__acados_lib.ocp_nlp_dims_get_total_from_attr(self.nlp_config, self.nlp_dims, self.nlp_out, field)
 
         if len(value_) != dims:
             raise Exception(f'AcadosOcpSolver.set_flat(field={field_}, value): value has wrong length, expected {dims}, got {len(value_)}.')
@@ -1346,12 +1348,12 @@ class AcadosOcpSolver:
         Returns the current iterate of the OCP solver as an AcadosOcpFlattenedIterate.
         """
         return AcadosOcpFlattenedIterate(x = self.get_flat("x"),
-                                        u = self.get_flat("u"),
-                                        z = self.get_flat("z"),
-                                        sl = self.get_flat("sl"),
-                                        su = self.get_flat("su"),
-                                        pi = self.get_flat("pi"),
-                                        lam = self.get_flat("lam"))
+                                         u = self.get_flat("u"),
+                                         z = self.get_flat("z"),
+                                         sl = self.get_flat("sl"),
+                                         su = self.get_flat("su"),
+                                         pi = self.get_flat("pi"),
+                                         lam = self.get_flat("lam"))
 
     def load_iterate_from_flat_obj(self, iterate: AcadosOcpFlattenedIterate) -> None:
         """

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -2830,7 +2830,7 @@ void {{ model.name }}_acados_batch_eval_solution_sens_adj_p({{ model.name }}_sol
 
 void {{ model.name }}_acados_batch_set_flat({{ model.name }}_solver_capsule ** capsules, const char *field, double *data, int N_data, int N_batch)
 {
-    int offset = ocp_nlp_dims_get_total_from_attr(capsules[0]->nlp_solver->config, capsules[0]->nlp_solver->dims, field);
+    int offset = ocp_nlp_dims_get_total_from_attr(capsules[0]->nlp_solver->config, capsules[0]->nlp_solver->dims, capsules[0]->nlp_out, field);
 
     if (N_batch*offset != N_data)
     {
@@ -2859,7 +2859,7 @@ void {{ model.name }}_acados_batch_set_flat({{ model.name }}_solver_capsule ** c
 
 void {{ model.name }}_acados_batch_get_flat({{ model.name }}_solver_capsule ** capsules, const char *field, double *data, int N_data, int N_batch)
 {
-    int offset = ocp_nlp_dims_get_total_from_attr(capsules[0]->nlp_solver->config, capsules[0]->nlp_solver->dims, field);
+    int offset = ocp_nlp_dims_get_total_from_attr(capsules[0]->nlp_solver->config, capsules[0]->nlp_solver->dims, capsules[0]->nlp_out, field);
 
     if (N_batch*offset != N_data)
     {

--- a/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_mex_set.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_mex_set.in.c
@@ -377,7 +377,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     {
         if (nrhs == min_nrhs)
         {
-            acados_size = ocp_nlp_dims_get_total_from_attr(config, dims, "x");
+            acados_size = ocp_nlp_dims_get_total_from_attr(config, dims, out, "x");
             MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
             ocp_nlp_set_all(solver, in, out, "x", value);
         }
@@ -392,7 +392,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     {
         if (nrhs == min_nrhs)
         {
-            acados_size = ocp_nlp_dims_get_total_from_attr(config, dims, "u");
+            acados_size = ocp_nlp_dims_get_total_from_attr(config, dims, out, "u");
             MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
             ocp_nlp_set_all(solver, in, out, "u", value);
         }
@@ -411,7 +411,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         {
             if (nrhs == min_nrhs)
             {
-                acados_size = ocp_nlp_dims_get_total_from_attr(config, dims, "z");
+                acados_size = ocp_nlp_dims_get_total_from_attr(config, dims, out, "z");
                 MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
                 ocp_nlp_set_all(solver, in, out, "z", value);
             }
@@ -497,7 +497,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     {
         if (nrhs == min_nrhs)
         {
-            acados_size = ocp_nlp_dims_get_total_from_attr(config, dims, "pi");
+            acados_size = ocp_nlp_dims_get_total_from_attr(config, dims, out, "pi");
             MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
             ocp_nlp_set_all(solver, in, out, "pi", value);
         }
@@ -512,7 +512,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     {
         if (nrhs == min_nrhs)
         {
-            acados_size = ocp_nlp_dims_get_total_from_attr(config, dims, "lam");
+            acados_size = ocp_nlp_dims_get_total_from_attr(config, dims, out, "lam");
             MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
             ocp_nlp_set_all(solver, in, out, "lam", value);
         }
@@ -527,7 +527,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     {
         if (nrhs == min_nrhs)
         {
-            acados_size = ocp_nlp_dims_get_total_from_attr(config, dims, "sl");
+            acados_size = ocp_nlp_dims_get_total_from_attr(config, dims, out, "sl");
             MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
             ocp_nlp_set_all(solver, in, out, "sl", value);
         }
@@ -542,7 +542,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     {
         if (nrhs == min_nrhs)
         {
-            acados_size = ocp_nlp_dims_get_total_from_attr(config, dims, "su");
+            acados_size = ocp_nlp_dims_get_total_from_attr(config, dims, out, "su");
             MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
             ocp_nlp_set_all(solver, in, out, "su", value);
         }
@@ -571,7 +571,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
             }
             else
             {
-                acados_size = ocp_nlp_dims_get_total_from_attr(config, dims, "p");
+                acados_size = ocp_nlp_dims_get_total_from_attr(config, dims, out, "p");
                 MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
                 ocp_nlp_set_all(solver, in, out, "p", value);
             }

--- a/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_solver_sfun.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_solver_sfun.in.c
@@ -1096,7 +1096,7 @@ static void mdlOutputs(SimStruct *S, int_T tid)
         // x_init
         {%- set i_input = i_input + 1 %}
         in_sign = ssGetInputPortRealSignalPtrs(S, {{ i_input }});
-        tmp_int = ocp_nlp_dims_get_total_from_attr(nlp_config, nlp_dims, "x");
+        tmp_int = ocp_nlp_dims_get_total_from_attr(nlp_config, nlp_dims, nlp_out, "x");
         for (int jj = 0; jj < tmp_int; jj++)
             buffer[jj] = (double)(*in_sign[jj]);
         ocp_nlp_set_all(nlp_solver, nlp_in, nlp_out, "x", (void *) buffer);
@@ -1106,7 +1106,7 @@ static void mdlOutputs(SimStruct *S, int_T tid)
         // u_init
         {%- set i_input = i_input + 1 %}
         in_sign = ssGetInputPortRealSignalPtrs(S, {{ i_input }});
-        tmp_int = ocp_nlp_dims_get_total_from_attr(nlp_config, nlp_dims, "u");
+        tmp_int = ocp_nlp_dims_get_total_from_attr(nlp_config, nlp_dims, nlp_out, "u");
         for (int jj = 0; jj < tmp_int; jj++)
             buffer[jj] = (double)(*in_sign[jj]);
         ocp_nlp_set_all(nlp_solver, nlp_in, nlp_out, "u", (void *) buffer);
@@ -1116,7 +1116,7 @@ static void mdlOutputs(SimStruct *S, int_T tid)
         // pi_init
         {%- set i_input = i_input + 1 %}
         in_sign = ssGetInputPortRealSignalPtrs(S, {{ i_input }});
-        tmp_int = ocp_nlp_dims_get_total_from_attr(nlp_config, nlp_dims, "pi");
+        tmp_int = ocp_nlp_dims_get_total_from_attr(nlp_config, nlp_dims, nlp_out, "pi");
         for (int jj = 0; jj < tmp_int; jj++)
             buffer[jj] = (double)(*in_sign[jj]);
         ocp_nlp_set_all(nlp_solver, nlp_in, nlp_out, "pi", (void *) buffer);


### PR DESCRIPTION
The function `ocp_nlp_dims_get_total_from_attr` now additionally supports the fields:

- `zl`, `zu`, `Zl`, `Zu`
- `cost_z`, `cost_Z`
- `lbx`, `ubx`, `nbx`
- `lbu`, `ubu`, `nbu`
- `lg`, `ug`, `ng`
- `lh`, `uh`, `nh`

In addition, this fixes a bug in `ocp_nlp_dims_get_from_attr` which now correctly returns `2*ns` for `s`, `cost_z`, `cost_Z`.

BREAKING: The function `ocp_nlp_dims_get_total_from_attr` now requires the additional argument `ocp_nlp_out *out,`