### PR TITLE
MATLAB: flat setter example

### DIFF
--- a/examples/acados_matlab_octave/mocp_transition_example/formulate_double_integrator_ocp.m
+++ b/examples/acados_matlab_octave/mocp_transition_example/formulate_double_integrator_ocp.m
@@ -48,6 +48,10 @@ function ocp = formulate_double_integrator_ocp(settings)
     ocp.constraints.ubu = [u_max];
     ocp.constraints.idxbu = [0];
 
+    ocp.constraints.lbx = [-100, -10];
+    ocp.constraints.ubx = [100, 10];
+    ocp.constraints.idxbx = [0, 1];
+
     ocp.constraints.x0 = settings.X0;
 
 end

--- a/examples/acados_matlab_octave/mocp_transition_example/formulate_single_integrator_ocp.m
+++ b/examples/acados_matlab_octave/mocp_transition_example/formulate_single_integrator_ocp.m
@@ -48,6 +48,14 @@ function ocp = formulate_single_integrator_ocp(settings)
     ocp.constraints.ubu = [u_max];
     ocp.constraints.idxbu = [0];
 
+    ocp.constraints.lbx = [-100];
+    ocp.constraints.ubx = [100];
+    ocp.constraints.idxbx = [0];
+
+    ocp.constraints.lbx_e = [-100];
+    ocp.constraints.ubx_e = [100];
+    ocp.constraints.idxbx_e = [0];
+
     ocp.constraints.x0 = settings.X0(1);
 end
 

--- a/examples/acados_matlab_octave/mocp_transition_example/main_multiphase_ocp.m
+++ b/examples/acados_matlab_octave/mocp_transition_example/main_multiphase_ocp.m
@@ -74,12 +74,18 @@ ocp.solver_options.store_iterates = true;
 
 ocp_solver = AcadosOcpSolver(ocp);
 
+x0 = ocp.constraints{1}.x0;
 
 % initialize x trajectory using flattened format
-x0 = ocp.constraints{1}.x0;
 x_init = [repmat(x0, 1, N_list(1)+N_list(2)) repmat(x0(1), 1, N_list(3)+1)];
-
 ocp_solver.set('x', x_init);
+
+% update state bounds using flattened format
+lbx = [repmat([-10, -5], 1, N_list(1)) repmat([-10], 1, N_list(3)+1)];
+ocp_solver.set('constr_lbx', lbx);
+
+% need to set initial state after updating the bounds onx as this again overwrites lbx_0
+ocp_solver.set('constr_x0', x0);
 
 ocp_solver.solve();
 ocp_solver.print();


### PR DESCRIPTION
Extend MOCP transition example with bounds on `x` and showcase usage of flat format setters.