### PR TITLE
QP warm-start in first NLP solver iteration

### DIFF
--- a/acados/ocp_nlp/ocp_nlp_common.c
+++ b/acados/ocp_nlp/ocp_nlp_common.c
@@ -2903,6 +2903,28 @@ void ocp_nlp_update_variables_sqp(void *config_, void *dims_,
     }
 }
 
+void ocp_nlp_initialize_qp_from_nlp(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_qp_in *qp_in,
+            ocp_nlp_out *out, ocp_qp_out *qp_out)
+{
+    int N = dims->N;
+    int *nv = dims->nv;
+    int *nx = dims->nx;
+    int *ni = dims->ni;
+
+    for (int i = 0; i <= N; i++)
+    {
+        // set primal variables to zero
+        blasfeo_dvecse(nv[i], 0.0, qp_out->ux+i, 0);
+
+        // copy multipliers from ocp_nlp_out to ocp_qp_out
+        blasfeo_dveccp(2*ni[i], out->lam+i, 0, qp_out->lam+i, 0);
+        if (i < N)
+            blasfeo_dveccp(nx[i+1], out->pi+i, 0, qp_out->pi+i, 0);
+    }
+    // compute t
+    ocp_qp_compute_t(qp_in, qp_out);
+}
+
 
 int ocp_nlp_precompute_common(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in,
             ocp_nlp_out *out, ocp_nlp_opts *opts, ocp_nlp_memory *mem, ocp_nlp_workspace *work)

--- a/acados/ocp_nlp/ocp_nlp_common.h
+++ b/acados/ocp_nlp/ocp_nlp_common.h
@@ -519,6 +519,11 @@ void ocp_nlp_update_variables_sqp(void *config_, void *dims_,
 //
 int ocp_nlp_precompute_common(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *in,
             ocp_nlp_out *out, ocp_nlp_opts *opts, ocp_nlp_memory *mem, ocp_nlp_workspace *work);
+
+//
+void ocp_nlp_initialize_qp_from_nlp(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_qp_in *qp_in,
+            ocp_nlp_out *out, ocp_qp_out *qp_out);
+
 //
 void ocp_nlp_res_compute(ocp_nlp_dims *dims, ocp_nlp_in *in, ocp_nlp_out *out,
                          ocp_nlp_res *res, ocp_nlp_memory *mem);

--- a/acados/ocp_nlp/ocp_nlp_ddp.c
+++ b/acados/ocp_nlp/ocp_nlp_ddp.c
@@ -121,6 +121,7 @@ void ocp_nlp_ddp_opts_initialize_default(void *config_, void *dims_, void *opts_
 
     opts->qp_warm_start = 0;
     opts->warm_start_first_qp = false;
+    opts->warm_start_first_qp_from_nlp = false;
     opts->eval_residual_at_max_iter = false;
 
     // overwrite default submodules opts
@@ -210,6 +211,11 @@ void ocp_nlp_ddp_opts_set(void *config_, void *opts_, const char *field, void* v
         {
             bool* warm_start_first_qp = (bool *) value;
             opts->warm_start_first_qp = *warm_start_first_qp;
+        }
+        else if (!strcmp(field, "warm_start_first_qp_from_nlp"))
+        {
+            bool* warm_start_first_qp_from_nlp = (bool *) value;
+            opts->warm_start_first_qp_from_nlp = *warm_start_first_qp_from_nlp;
         }
         else if (!strcmp(field, "eval_residual_at_max_iter"))
         {
@@ -747,11 +753,19 @@ int ocp_nlp_ddp(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
         }
 
         /* solve QP */
-        // (typically) no warm start at first iteration
-        if (ddp_iter == 0 && !opts->warm_start_first_qp)
+        // warm start of first QP
+        if (ddp_iter == 0)
         {
-            int tmp_int = 0;
-            qp_solver->opts_set(qp_solver, nlp_opts->qp_solver_opts, "warm_start", &tmp_int);
+            if (!opts->warm_start_first_qp)
+            {
+                // (typically) no warm start at first iteration
+                int tmp_int = 0;
+                qp_solver->opts_set(qp_solver, nlp_opts->qp_solver_opts, "warm_start", &tmp_int);
+            }
+            else if (opts->warm_start_first_qp_from_nlp)
+            {
+                ocp_nlp_initialize_qp_from_nlp(config, dims, qp_in, nlp_out, qp_out);
+            }
         }
         // Show input to QP
         if (nlp_opts->print_level > 1)

--- a/acados/ocp_nlp/ocp_nlp_ddp.h
+++ b/acados/ocp_nlp/ocp_nlp_ddp.h
@@ -64,6 +64,7 @@ typedef struct
     int ext_qp_res;      // compute external QP residuals (i.e. at SQP level) at each SQP iteration (for debugging)
     int qp_warm_start;   // qp_warm_start in all but the first ddp iterations
     bool warm_start_first_qp; // to set qp_warm_start in first iteration
+    bool warm_start_first_qp_from_nlp;
     bool eval_residual_at_max_iter; // if convergence should be checked after last iterations or only throw max_iter reached
 } ocp_nlp_ddp_opts;
 

--- a/acados/ocp_nlp/ocp_nlp_sqp.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp.c
@@ -724,11 +724,19 @@ int ocp_nlp_sqp(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
 
 
         /* solve QP */
-        // (typically) no warm start at first iteration
-        if (sqp_iter == 0 && !opts->warm_start_first_qp)
+        // warm start of first QP
+        if (sqp_iter == 0)
         {
-            int tmp_int = 0;
-            qp_solver->opts_set(qp_solver, nlp_opts->qp_solver_opts, "warm_start", &tmp_int);
+            // (typically) no warm start at first iteration
+            if (!opts->warm_start_first_qp)
+            {
+                int tmp_int = 0;
+                qp_solver->opts_set(qp_solver, nlp_opts->qp_solver_opts, "warm_start", &tmp_int);
+            }
+            else
+            {
+                ocp_nlp_initialize_qp_from_nlp(config, dims, qp_in, nlp_out, qp_out);
+            }
         }
         // Show input to QP
         if (nlp_opts->print_level > 3)

--- a/acados/ocp_nlp/ocp_nlp_sqp.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp.c
@@ -216,6 +216,11 @@ void ocp_nlp_sqp_opts_set(void *config_, void *opts_, const char *field, void* v
             bool* warm_start_first_qp = (bool *) value;
             opts->warm_start_first_qp = *warm_start_first_qp;
         }
+        else if (!strcmp(field, "warm_start_first_qp_from_nlp"))
+        {
+            bool* warm_start_first_qp_from_nlp = (bool *) value;
+            opts->warm_start_first_qp_from_nlp = *warm_start_first_qp_from_nlp;
+        }
         else if (!strcmp(field, "eval_residual_at_max_iter"))
         {
             bool* eval_residual_at_max_iter = (bool *) value;
@@ -727,13 +732,13 @@ int ocp_nlp_sqp(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
         // warm start of first QP
         if (sqp_iter == 0)
         {
-            // (typically) no warm start at first iteration
             if (!opts->warm_start_first_qp)
             {
+                // (typically) no warm start at first iteration
                 int tmp_int = 0;
                 qp_solver->opts_set(qp_solver, nlp_opts->qp_solver_opts, "warm_start", &tmp_int);
             }
-            else
+            else if (opts->warm_start_first_qp_from_nlp)
             {
                 ocp_nlp_initialize_qp_from_nlp(config, dims, qp_in, nlp_out, qp_out);
             }

--- a/acados/ocp_nlp/ocp_nlp_sqp.h
+++ b/acados/ocp_nlp/ocp_nlp_sqp.h
@@ -66,6 +66,7 @@ typedef struct
     int log_primal_step_norm; // compute and log the max norm of the primal steps
     int qp_warm_start;   // qp_warm_start in all but the first sqp iterations
     bool warm_start_first_qp; // to set qp_warm_start in first iteration
+    bool warm_start_first_qp_from_nlp;  // if True first QP will be initialized using values from NLP iterate, otherwise from previous QP solution.
     bool eval_residual_at_max_iter; // if convergence should be checked after last iterations or only throw max_iter reached
     double timeout_max_time; // maximum time the solve may require before timeout is triggered. No timeout if 0.
     ocp_nlp_timeout_heuristic_t timeout_heuristic; // type of heuristic used to predict solve time of next QP

--- a/acados/ocp_nlp/ocp_nlp_sqp_rti.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp_rti.c
@@ -115,6 +115,7 @@ void ocp_nlp_sqp_rti_opts_initialize_default(void *config_,
     // SQP RTI opts
     opts->ext_qp_res = 0;
     opts->warm_start_first_qp = false;
+    opts->warm_start_first_qp_from_nlp = true;
     opts->rti_phase = 0;
     opts->as_rti_level = STANDARD_RTI;
     opts->as_rti_advancement_strategy = SIMULATE_ADVANCE;
@@ -595,11 +596,19 @@ static void ocp_nlp_sqp_rti_feedback_step(ocp_nlp_config *config, ocp_nlp_dims *
         print_ocp_qp_in(nlp_mem->qp_in);
     }
 
-    if (mem->is_first_call && !opts->warm_start_first_qp)
+    // set QP warm start
+    if (mem->is_first_call)
     {
-        int tmp_int = 0;
-        config->qp_solver->opts_set(config->qp_solver,
-            opts->nlp_opts->qp_solver_opts, "warm_start", &tmp_int);
+        if (!opts->warm_start_first_qp)
+        {
+            int tmp_int = 0;
+            config->qp_solver->opts_set(config->qp_solver,
+                opts->nlp_opts->qp_solver_opts, "warm_start", &tmp_int);
+        }
+        else if (opts->warm_start_first_qp_from_nlp)
+        {
+            ocp_nlp_initialize_qp_from_nlp(config, dims, nlp_mem->qp_in, nlp_out, nlp_mem->qp_out);
+        }
     }
 
     // solve QP

--- a/acados/ocp_nlp/ocp_nlp_sqp_rti.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp_rti.c
@@ -595,7 +595,7 @@ static void ocp_nlp_sqp_rti_feedback_step(ocp_nlp_config *config, ocp_nlp_dims *
         print_ocp_qp_in(nlp_mem->qp_in);
     }
 
-    if (!opts->warm_start_first_qp)
+    if (mem->is_first_call && !opts->warm_start_first_qp)
     {
         int tmp_int = 0;
         config->qp_solver->opts_set(config->qp_solver,
@@ -613,6 +613,12 @@ static void ocp_nlp_sqp_rti_feedback_step(ocp_nlp_config *config, ocp_nlp_dims *
     qp_info *qp_info_;
     ocp_qp_out_get(nlp_mem->qp_out, "qp_info", &qp_info_);
     qp_iter = qp_info_->num_iter;
+
+    // restore default warm start
+    if (mem->is_first_call)
+    {
+        config->qp_solver->opts_set(config->qp_solver, nlp_opts->qp_solver_opts, "warm_start", &opts->qp_warm_start);
+    }
 
     // compute external QP residuals (for debugging)
     if (opts->ext_qp_res)
@@ -658,6 +664,7 @@ static void ocp_nlp_sqp_rti_feedback_step(ocp_nlp_config *config, ocp_nlp_dims *
         }
     }
     mem->nlp_mem->status = ACADOS_SUCCESS;
+    mem->is_first_call = false;
 
     if (opts->rti_log_residuals && !opts->rti_log_only_available_residuals)
     {
@@ -1126,8 +1133,6 @@ static void ocp_nlp_sqp_rti_preparation_advanced_step(ocp_nlp_config *config, oc
         // tmp_nlp_out <- nlp_out
         copy_ocp_nlp_out(dims, nlp_out, tmp_nlp_out);
     }
-
-    mem->is_first_call = false;
 
     return;
 }

--- a/acados/ocp_nlp/ocp_nlp_sqp_rti.h
+++ b/acados/ocp_nlp/ocp_nlp_sqp_rti.h
@@ -83,6 +83,7 @@ typedef struct
     int ext_qp_res;           // compute external QP residuals (i.e. at SQP level) at each SQP iteration (for debugging)
     int qp_warm_start;        // NOTE: this is not actually setting the warm_start! Just for compatibility with sqp.
     bool warm_start_first_qp; // to set qp_warm_start in first iteration
+    bool warm_start_first_qp_from_nlp;
     rti_phase_t rti_phase;
     as_rti_level_t as_rti_level;
     as_rti_advancement_strategy_t as_rti_advancement_strategy;

--- a/interfaces/acados_matlab_octave/AcadosOcpOptions.m
+++ b/interfaces/acados_matlab_octave/AcadosOcpOptions.m
@@ -45,6 +45,7 @@ classdef AcadosOcpOptions < handle
         nlp_solver_max_iter
         nlp_solver_ext_qp_res
         nlp_solver_warm_start_first_qp
+        nlp_solver_warm_start_first_qp_from_nlp
         nlp_solver_tol_min_step_norm
         globalization
         levenberg_marquardt
@@ -141,6 +142,7 @@ classdef AcadosOcpOptions < handle
             obj.nlp_solver_max_iter = 100;
             obj.nlp_solver_ext_qp_res = 0;
             obj.nlp_solver_warm_start_first_qp = false;
+            obj.nlp_solver_warm_start_first_qp_from_nlp = false;
             obj.globalization = 'FIXED_STEP';
             obj.levenberg_marquardt = 0.0;
             obj.collocation_type = 'GAUSS_LEGENDRE';

--- a/interfaces/acados_template/acados_template/acados_ocp_options.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_options.py
@@ -321,8 +321,8 @@ class AcadosOcpOptions:
     def nlp_solver_warm_start_first_qp(self):
         """
         Flag indicating whether the first QP in an NLP solve should be warm started.
-        Type: int.
-        Default: 0.
+        Type: bool.
+        Default: False.
         """
         return self.__nlp_solver_warm_start_first_qp
 

--- a/interfaces/acados_template/acados_template/acados_ocp_options.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_options.py
@@ -54,6 +54,7 @@ class AcadosOcpOptions:
         self.__nlp_solver_max_iter = 100
         self.__nlp_solver_ext_qp_res = 0
         self.__nlp_solver_warm_start_first_qp = False
+        self.__nlp_solver_warm_start_first_qp_from_nlp = False
         self.__nlp_solver_tol_min_step_norm = None
         self.__globalization = 'FIXED_STEP'
         self.__levenberg_marquardt = 0.0
@@ -324,6 +325,16 @@ class AcadosOcpOptions:
         Default: 0.
         """
         return self.__nlp_solver_warm_start_first_qp
+
+    @property
+    def nlp_solver_warm_start_first_qp_from_nlp(self):
+        """
+        If True first QP will be initialized using values from NLP iterate, otherwise from previous QP solution, only relevant if `nlp_solver_warm_start_first_qp` is True.
+        Type: bool.
+        Default: False.
+        """
+        return self.__nlp_solver_warm_start_first_qp_from_nlp
+
 
     @property
     def levenberg_marquardt(self):
@@ -1399,6 +1410,12 @@ class AcadosOcpOptions:
             self.__nlp_solver_warm_start_first_qp = nlp_solver_warm_start_first_qp
         else:
             raise Exception('Invalid nlp_solver_warm_start_first_qp value. Expected bool.')
+
+    @nlp_solver_warm_start_first_qp_from_nlp.setter
+    def nlp_solver_warm_start_first_qp_from_nlp(self, nlp_solver_warm_start_first_qp_from_nlp):
+        if not isinstance(nlp_solver_warm_start_first_qp_from_nlp, bool):
+            raise Exception('Invalid nlp_solver_warm_start_first_qp_from_nlp value. Expected bool.')
+        self.__nlp_solver_warm_start_first_qp_from_nlp = nlp_solver_warm_start_first_qp_from_nlp
 
     @levenberg_marquardt.setter
     def levenberg_marquardt(self, levenberg_marquardt):

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.c
@@ -2227,9 +2227,14 @@ void {{ name }}_acados_create_set_opts({{ name }}_solver_capsule* capsule)
     int globalization_full_step_dual = {{ solver_options.globalization_full_step_dual }};
     ocp_nlp_solver_opts_set(nlp_config, capsule->nlp_opts, "globalization_full_step_dual", &globalization_full_step_dual);
 
-    {%- if solver_options.nlp_solver_warm_start_first_qp %}
+    {%- if solver_options.nlp_solver_warm_start_first_qp_from_nlp %}
     int nlp_solver_warm_start_first_qp = {{ solver_options.nlp_solver_warm_start_first_qp }};
     ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "warm_start_first_qp", &nlp_solver_warm_start_first_qp);
+    {%- endif %}
+
+    {%- if solver_options.nlp_solver_warm_start_first_qp_from_nlp %}
+    int nlp_solver_warm_start_first_qp_from_nlp = {{ solver_options.nlp_solver_warm_start_first_qp_from_nlp }};
+    ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "warm_start_first_qp", &nlp_solver_warm_start_first_qp_from_nlp);
     {%- endif %}
 
     double levenberg_marquardt = {{ solver_options.levenberg_marquardt }};

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -2349,6 +2349,11 @@ static void {{ model.name }}_acados_create_set_opts({{ model.name }}_solver_caps
     ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "warm_start_first_qp", &nlp_solver_warm_start_first_qp);
     {%- endif %}
 
+    {%- if solver_options.nlp_solver_warm_start_first_qp_from_nlp %}
+    int nlp_solver_warm_start_first_qp_from_nlp = {{ solver_options.nlp_solver_warm_start_first_qp_from_nlp }};
+    ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "warm_start_first_qp_from_nlp", &nlp_solver_warm_start_first_qp_from_nlp);
+    {%- endif %}
+
     double levenberg_marquardt = {{ solver_options.levenberg_marquardt }};
     ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "levenberg_marquardt", &levenberg_marquardt);
 


### PR DESCRIPTION
Implement option `nlp_solver_warm_start_first_qp_from_nlp`, if True first QP will be initialized using values from NLP iterate, otherwise from previous QP solution, only relevant if `nlp_solver_warm_start_first_qp` is True. Default: False.

The new initialization (with `nlp_solver_warm_start_first_qp = True`) is likely beneficial.
We might change the default behavior after more testing.

Fixed option `warm_start_first_qp` for SQP-RTI.