### PR TITLE
Github Actions: switch to ubuntu-22.04

### DIFF
--- a/.github/workflows/c_test_blasfeo_reference.yml
+++ b/.github/workflows/c_test_blasfeo_reference.yml
@@ -23,7 +23,7 @@ env:
 
 jobs:
   full_build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,7 @@ jobs:
     #   - https://gh.io/supported-runners-and-hardware-resources
     #   - https://gh.io/using-larger-runners
     # Consider using larger runners for possible analysis time improvements.
-    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-20.04' }}
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-22.04' }}
     timeout-minutes: ${{ (matrix.language == 'swift' && 120) || 360 }}
     permissions:
       actions: read

--- a/.github/workflows/ext_dep_off.yml
+++ b/.github/workflows/ext_dep_off.yml
@@ -23,7 +23,7 @@ env:
 
 jobs:
   ext_dep_off_test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Mail from Github:
The Ubuntu 20.04 runner image will be fully unsupported by April 1, 2025.