### PR TITLE
Update `print_iterations`

### DIFF
--- a/acados/ocp_nlp/ocp_nlp_common.c
+++ b/acados/ocp_nlp/ocp_nlp_common.c
@@ -3678,6 +3678,21 @@ void ocp_nlp_dump_qp_out_to_file(ocp_qp_out *qp_out, int sqp_iter, int soc)
 }
 
 
+void ocp_nlp_print_iteration_header()
+{
+    printf("%6s   %10s   %10s   %10s   %10s   ", "# it", "res_stat", "res_eq", "res_ineq", "res_comp");
+}
+
+void ocp_nlp_print_iteration(int iter_count, ocp_nlp_res *nlp_res)
+{
+    printf("%6i   %10.4e   %10.4e   %10.4e   %10.4e   ",
+        iter_count,
+        nlp_res->inf_norm_res_stat,
+        nlp_res->inf_norm_res_eq,
+        nlp_res->inf_norm_res_ineq,
+        nlp_res->inf_norm_res_comp);
+}
+
 void ocp_nlp_timings_get(ocp_nlp_config *config, ocp_nlp_timings *timings, const char *field, void *return_value_)
 {
     double *value = return_value_;

--- a/acados/ocp_nlp/ocp_nlp_common.c
+++ b/acados/ocp_nlp/ocp_nlp_common.c
@@ -3678,12 +3678,12 @@ void ocp_nlp_dump_qp_out_to_file(ocp_qp_out *qp_out, int sqp_iter, int soc)
 }
 
 
-void ocp_nlp_print_iteration_header()
+void ocp_nlp_common_print_iteration_header()
 {
     printf("%6s   %10s   %10s   %10s   %10s   ", "# it", "res_stat", "res_eq", "res_ineq", "res_comp");
 }
 
-void ocp_nlp_print_iteration(int iter_count, ocp_nlp_res *nlp_res)
+void ocp_nlp_common_print_iteration(int iter_count, ocp_nlp_res *nlp_res)
 {
     printf("%6i   %10.4e   %10.4e   %10.4e   %10.4e   ",
         iter_count,

--- a/acados/ocp_nlp/ocp_nlp_common.h
+++ b/acados/ocp_nlp/ocp_nlp_common.h
@@ -576,6 +576,8 @@ double ocp_nlp_compute_qp_objective_value(ocp_nlp_dims *dims, ocp_qp_in *qp_in, 
 // print / debug functionality
 void ocp_nlp_dump_qp_out_to_file(ocp_qp_out *qp_out, int sqp_iter, int soc);
 void ocp_nlp_dump_qp_in_to_file(ocp_qp_in *qp_in, int sqp_iter, int soc);
+void ocp_nlp_print_iteration_header();
+void ocp_nlp_print_iteration(int iter_count, ocp_nlp_res *nlp_res);
 
 
 #ifdef __cplusplus

--- a/acados/ocp_nlp/ocp_nlp_common.h
+++ b/acados/ocp_nlp/ocp_nlp_common.h
@@ -576,8 +576,8 @@ double ocp_nlp_compute_qp_objective_value(ocp_nlp_dims *dims, ocp_qp_in *qp_in, 
 // print / debug functionality
 void ocp_nlp_dump_qp_out_to_file(ocp_qp_out *qp_out, int sqp_iter, int soc);
 void ocp_nlp_dump_qp_in_to_file(ocp_qp_in *qp_in, int sqp_iter, int soc);
-void ocp_nlp_print_iteration_header();
-void ocp_nlp_print_iteration(int iter_count, ocp_nlp_res *nlp_res);
+void ocp_nlp_common_print_iteration_header();
+void ocp_nlp_common_print_iteration(int iter_count, ocp_nlp_res *nlp_res);
 
 
 #ifdef __cplusplus

--- a/acados/ocp_nlp/ocp_nlp_ddp.c
+++ b/acados/ocp_nlp/ocp_nlp_ddp.c
@@ -607,13 +607,13 @@ static void print_iteration(int iter, ocp_nlp_config *config, ocp_nlp_res *nlp_r
     if (iter % 10 == 0)
     {
         ocp_nlp_common_print_iteration_header();
-        printf("%10s   %10s  %7s   %7s   ", "step_norm", "lm_reg.", "qp_status", "qp_iter");
+        printf("%7s   %7s  %8s   %8s  ", "qp_status", "qp_iter", "step_norm", "lm_reg.");
         config->globalization->print_iteration_header();
         printf("\n");
     }
     // print iteration
     ocp_nlp_common_print_iteration(iter, nlp_res);
-    printf("%10.4e   %10.4e  %7d   %7d   ", mem->step_norm, prev_levenberg_marquardt, qp_status, qp_iter);
+    printf("%7d   %7d   %8.2e   %8.2e  ", qp_status, qp_iter, mem->step_norm, prev_levenberg_marquardt);
     config->globalization->print_iteration(nlp_mem->cost_value, nlp_opts->globalization, nlp_mem->globalization);
     printf("\n");
 }

--- a/acados/ocp_nlp/ocp_nlp_ddp.c
+++ b/acados/ocp_nlp/ocp_nlp_ddp.c
@@ -600,20 +600,20 @@ static bool check_termination(int ddp_iter, ocp_nlp_res *nlp_res, ocp_nlp_ddp_me
  * output
  ************************************************/
 static void print_iteration(int iter, ocp_nlp_config *config, ocp_nlp_res *nlp_res, ocp_nlp_ddp_memory *mem,
-    ocp_nlp_opts *nlp_opts, double prev_levenberg_marquardt)
+    ocp_nlp_opts *nlp_opts, double prev_levenberg_marquardt, int qp_status, int qp_iter)
 {
     ocp_nlp_memory *nlp_mem = mem->nlp_mem;
     // print iteration header
     if (iter % 10 == 0)
     {
-    ocp_nlp_print_iteration_header(); //print common stuff
-    printf("%10s   %10s   ", "step_norm", "LM_reg.");
-    config->globalization->print_iteration_header();
-    printf("\n");
+        ocp_nlp_print_iteration_header(); //print common stuff
+        printf("%10s   %10s   %9s   %7s   ", "step_norm", "lm_reg.", "qp_status", "qp_iter");
+        config->globalization->print_iteration_header();
+        printf("\n");
     }
     // print iteration
     ocp_nlp_print_iteration(iter, nlp_res);
-    printf("%10.4e   %10.4e   ", mem->step_norm, prev_levenberg_marquardt);
+    printf("%10.4e   %10.4e   %9d   %7d   ", mem->step_norm, prev_levenberg_marquardt, qp_status, qp_iter);
     config->globalization->print_iteration(nlp_mem->cost_value, nlp_opts->globalization, nlp_mem->globalization);
     printf("\n");
 }
@@ -747,7 +747,7 @@ int ocp_nlp_ddp(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
         // Output
         if (nlp_opts->print_level > 0)
         {
-            print_iteration(ddp_iter, config, nlp_res, mem, nlp_opts, reg_param_memory);
+            print_iteration(ddp_iter, config, nlp_res, mem, nlp_opts, reg_param_memory, qp_status, qp_iter);
         }
         reg_param_memory = nlp_opts->levenberg_marquardt;
 

--- a/acados/ocp_nlp/ocp_nlp_ddp.c
+++ b/acados/ocp_nlp/ocp_nlp_ddp.c
@@ -597,6 +597,28 @@ static bool check_termination(int ddp_iter, ocp_nlp_res *nlp_res, ocp_nlp_ddp_me
 
 
 /************************************************
+ * output
+ ************************************************/
+static void print_iteration(int iter, ocp_nlp_config *config, ocp_nlp_res *nlp_res, ocp_nlp_ddp_memory *mem,
+    ocp_nlp_opts *nlp_opts, double prev_levenberg_marquardt)
+{
+    ocp_nlp_memory *nlp_mem = mem->nlp_mem;
+    // print iteration header
+    if (iter % 10 == 0)
+    {
+    ocp_nlp_print_iteration_header(); //print common stuff
+    printf("%10s   %10s   ", "step_norm", "LM_reg.");
+    config->globalization->print_iteration_header();
+    printf("\n");
+    }
+    // print iteration
+    ocp_nlp_print_iteration(iter, nlp_res);
+    printf("%10.4e   %10.4e   ", mem->step_norm, prev_levenberg_marquardt);
+    config->globalization->print_iteration(nlp_mem->cost_value, nlp_opts->globalization, nlp_mem->globalization);
+    printf("\n");
+}
+
+/************************************************
  * functions
  ************************************************/
 
@@ -725,15 +747,7 @@ int ocp_nlp_ddp(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
         // Output
         if (nlp_opts->print_level > 0)
         {
-            config->globalization->print_iteration(nlp_mem->cost_value,
-                                                   ddp_iter,
-                                                   nlp_res,
-                                                   mem->step_norm,
-                                                   reg_param_memory,
-                                                   qp_status,
-                                                   qp_iter,
-                                                   nlp_opts,
-                                                   nlp_mem->globalization);
+            print_iteration(ddp_iter, config, nlp_res, mem, nlp_opts, reg_param_memory);
         }
         reg_param_memory = nlp_opts->levenberg_marquardt;
 

--- a/acados/ocp_nlp/ocp_nlp_ddp.c
+++ b/acados/ocp_nlp/ocp_nlp_ddp.c
@@ -607,13 +607,13 @@ static void print_iteration(int iter, ocp_nlp_config *config, ocp_nlp_res *nlp_r
     if (iter % 10 == 0)
     {
         ocp_nlp_common_print_iteration_header();
-        printf("%10s   %10s   %9s   %7s   ", "step_norm", "lm_reg.", "qp_status", "qp_iter");
+        printf("%10s   %10s  %7s   %7s   ", "step_norm", "lm_reg.", "qp_status", "qp_iter");
         config->globalization->print_iteration_header();
         printf("\n");
     }
     // print iteration
     ocp_nlp_common_print_iteration(iter, nlp_res);
-    printf("%10.4e   %10.4e   %9d   %7d   ", mem->step_norm, prev_levenberg_marquardt, qp_status, qp_iter);
+    printf("%10.4e   %10.4e  %7d   %7d   ", mem->step_norm, prev_levenberg_marquardt, qp_status, qp_iter);
     config->globalization->print_iteration(nlp_mem->cost_value, nlp_opts->globalization, nlp_mem->globalization);
     printf("\n");
 }

--- a/acados/ocp_nlp/ocp_nlp_ddp.c
+++ b/acados/ocp_nlp/ocp_nlp_ddp.c
@@ -606,13 +606,13 @@ static void print_iteration(int iter, ocp_nlp_config *config, ocp_nlp_res *nlp_r
     // print iteration header
     if (iter % 10 == 0)
     {
-        ocp_nlp_print_iteration_header(); //print common stuff
+        ocp_nlp_common_print_iteration_header();
         printf("%10s   %10s   %9s   %7s   ", "step_norm", "lm_reg.", "qp_status", "qp_iter");
         config->globalization->print_iteration_header();
         printf("\n");
     }
     // print iteration
-    ocp_nlp_print_iteration(iter, nlp_res);
+    ocp_nlp_common_print_iteration(iter, nlp_res);
     printf("%10.4e   %10.4e   %9d   %7d   ", mem->step_norm, prev_levenberg_marquardt, qp_status, qp_iter);
     config->globalization->print_iteration(nlp_mem->cost_value, nlp_opts->globalization, nlp_mem->globalization);
     printf("\n");

--- a/acados/ocp_nlp/ocp_nlp_globalization_common.h
+++ b/acados/ocp_nlp/ocp_nlp_globalization_common.h
@@ -65,12 +65,6 @@ typedef struct
     int (*find_acceptable_iterate)(void *nlp_config, void *nlp_dims, void *nlp_in, void *nlp_out, void *nlp_mem, void *solver_mem, void *nlp_work, void *nlp_opts, double *step_size);
     void (*print_iteration_header)();
     void (*print_iteration)(double objective_value,
-                            int iter_count,
-                            void* nlp_res_,
-                            double step_norm,
-                            double reg_param,
-                            int qp_status,
-                            int qp_iter,
                             void *globalization_opts,
                             void* globalization_mem);
     int (*needs_objective_value)();

--- a/acados/ocp_nlp/ocp_nlp_globalization_fixed_step.c
+++ b/acados/ocp_nlp/ocp_nlp_globalization_fixed_step.c
@@ -174,36 +174,15 @@ int ocp_nlp_globalization_fixed_step_find_acceptable_iterate(void *nlp_config_, 
 
 void ocp_nlp_globalization_fixed_step_print_iteration_header()
 {
-    printf("# it\tstat\t\teq\t\tineq\t\tcomp\t\tqp_stat\tqp_iter\talpha\n");
+    printf("%10s   ", "alpha");
 }
 
 void ocp_nlp_globalization_fixed_step_print_iteration(double objective_value,
-                                                int iter_count,
-                                                void* nlp_res_,
-                                                double step_norm,
-                                                double reg_param,
-                                                int qp_status,
-                                                int qp_iter,
                                                 void* nlp_opts_,
                                                 void* mem_)
 {
-    ocp_nlp_res *nlp_res = nlp_res_;
-    ocp_nlp_opts *nlp_opts = nlp_opts_;
-    ocp_nlp_globalization_fixed_step_opts *opts = nlp_opts->globalization;
-    // ocp_nlp_globalization_fixed_step_memory* mem = mem_;
-
-    if ((iter_count % 10 == 0)){
-        ocp_nlp_globalization_fixed_step_print_iteration_header();
-    }
-    printf("%i\t%e\t%e\t%e\t%e\t%d\t%d\t%e\n",
-        iter_count,
-        nlp_res->inf_norm_res_stat,
-        nlp_res->inf_norm_res_eq,
-        nlp_res->inf_norm_res_ineq,
-        nlp_res->inf_norm_res_comp,
-        qp_status,
-        qp_iter,
-        opts->step_length);
+    ocp_nlp_globalization_fixed_step_opts *opts = nlp_opts_;
+    printf("%10.4e    ", opts->step_length);
 }
 
 int ocp_nlp_globalization_fixed_step_needs_objective_value()

--- a/acados/ocp_nlp/ocp_nlp_globalization_fixed_step.c
+++ b/acados/ocp_nlp/ocp_nlp_globalization_fixed_step.c
@@ -174,7 +174,7 @@ int ocp_nlp_globalization_fixed_step_find_acceptable_iterate(void *nlp_config_, 
 
 void ocp_nlp_globalization_fixed_step_print_iteration_header()
 {
-    printf("%10s   ", "alpha");
+    printf("%8s   ", "alpha");
 }
 
 void ocp_nlp_globalization_fixed_step_print_iteration(double objective_value,
@@ -182,7 +182,7 @@ void ocp_nlp_globalization_fixed_step_print_iteration(double objective_value,
                                                 void* mem_)
 {
     ocp_nlp_globalization_fixed_step_opts *opts = nlp_opts_;
-    printf("%10.4e    ", opts->step_length);
+    printf("%8.2e    ", opts->step_length);
 }
 
 int ocp_nlp_globalization_fixed_step_needs_objective_value()

--- a/acados/ocp_nlp/ocp_nlp_globalization_fixed_step.h
+++ b/acados/ocp_nlp/ocp_nlp_globalization_fixed_step.h
@@ -90,14 +90,8 @@ int ocp_nlp_globalization_fixed_step_find_acceptable_iterate(void *nlp_config_, 
 void ocp_nlp_globalization_fixed_step_print_iteration_header();
 //
 void ocp_nlp_globalization_fixed_step_print_iteration(double objective_value,
-                                                int iter_count,
-                                                void* nlp_res_,
-                                                double step_norm,
-                                                double reg_param,
-                                                int qp_status,
-                                                int qp_iter,
-                                                void* nlp_opts_,
-                                                void* mem_);
+                                                    void* nlp_opts_,
+                                                    void* mem_);
 //
 int ocp_nlp_globalization_fixed_step_needs_objective_value();
 //

--- a/acados/ocp_nlp/ocp_nlp_globalization_funnel.c
+++ b/acados/ocp_nlp/ocp_nlp_globalization_funnel.c
@@ -571,13 +571,13 @@ Printing functions
 
 void ocp_nlp_globalization_funnel_print_iteration_header()
 {
-    printf("%10s   %10s   %10s   %10s   %7s   ", "obj", "alpha", "funnel_w", "penalty", "it_type");
+    printf("%10s   %8s   %10s   %10s   %7s   ", "obj", "alpha", "funnel_w", "penalty", "it_type");
 }
 
 void ocp_nlp_globalization_funnel_print_iteration(double objective_value, void* nlp_opts_, void* mem_)
 {
     ocp_nlp_globalization_funnel_memory* mem = (ocp_nlp_globalization_funnel_memory*) mem_;
-    printf("%10.4e   %10.4e   %10.4e   %10.4e   %7c   ",
+    printf("%10.4e   %8.2e   %10.4e   %10.4e   %7c   ",
             objective_value,
             mem->alpha,
             mem->funnel_width,

--- a/acados/ocp_nlp/ocp_nlp_globalization_funnel.c
+++ b/acados/ocp_nlp/ocp_nlp_globalization_funnel.c
@@ -543,6 +543,7 @@ int backtracking_line_search(ocp_nlp_config *config,
     }
 }
 
+
 int ocp_nlp_globalization_funnel_find_acceptable_iterate(void *nlp_config_, void *nlp_dims_, void *nlp_in_, void *nlp_out_, void *nlp_mem_, void *solver_mem, void *nlp_work_, void *nlp_opts_, double *step_size)
 {
     ocp_nlp_config *nlp_config = nlp_config_;
@@ -564,58 +565,24 @@ int ocp_nlp_globalization_funnel_find_acceptable_iterate(void *nlp_config_, void
     return linesearch_success;
 }
 
+/****************************************************
+Printing functions
+*****************************************************/
 
 void ocp_nlp_globalization_funnel_print_iteration_header()
 {
-    printf("%6s | %11s | %10s | %10s | %10s | %10s | %10s | %10s | %10s | %12s | %10s | %10s | %10s | %10s\n",
-    "iter.",
-    "objective",
-    "res_eq",
-    "res_ineq",
-    "res_stat",
-    "res_comp",
-    "alpha",
-    "step_norm",
-    "LM_reg.",
-    "funnel width",
-    "penalty",
-    "qp_status",
-    "qp_iter",
-    "iter. type");
+    printf("%10s   %10s   %10s   %10s   %7s   ", "obj", "alpha", "funnel_w", "penalty", "it_type");
 }
 
-
-void ocp_nlp_globalization_funnel_print_iteration(double objective_value,
-                                                int iter_count,
-                                                void* nlp_res_,
-                                                double step_norm,
-                                                double reg_param,
-                                                int qp_status,
-                                                int qp_iter,
-                                                void *nlp_opts_,
-                                                void *mem_)
+void ocp_nlp_globalization_funnel_print_iteration(double objective_value, void* nlp_opts_, void* mem_)
 {
-    ocp_nlp_res *nlp_res = nlp_res_;
     ocp_nlp_globalization_funnel_memory* mem = (ocp_nlp_globalization_funnel_memory*) mem_;
-    if ((iter_count % 10 == 0))
-    {
-        ocp_nlp_globalization_funnel_print_iteration_header();
-    }
-    printf("%6i | %11.4e | %10.4e | %10.4e | %10.4e | %10.4e | %10.4e | %10.4e | %10.4e | %12.4e | %10.4e | %10i | %10i | %10c\n",
-        iter_count,
-        objective_value,
-        nlp_res->inf_norm_res_eq,
-        nlp_res->inf_norm_res_ineq,
-        nlp_res->inf_norm_res_stat,
-        nlp_res->inf_norm_res_comp,
-        mem->alpha,
-        step_norm,
-        reg_param,
-        mem->funnel_width,
-        mem->penalty_parameter,
-        qp_status,
-        qp_iter,
-        mem->funnel_iter_type);
+    printf("%10.4e   %10.4e   %10.4e   %10.4e   %7c   ",
+            objective_value,
+            mem->alpha,
+            mem->funnel_width,
+            mem->penalty_parameter,
+            mem->funnel_iter_type);
 }
 
 int ocp_nlp_globalization_funnel_needs_objective_value()
@@ -623,6 +590,7 @@ int ocp_nlp_globalization_funnel_needs_objective_value()
     return 1;
 }
 
+// QP objective value! Do not delete :D
 int ocp_nlp_globalization_funnel_needs_qp_objective_value()
 {
     return 1;

--- a/acados/ocp_nlp/ocp_nlp_globalization_funnel.h
+++ b/acados/ocp_nlp/ocp_nlp_globalization_funnel.h
@@ -151,14 +151,8 @@ int ocp_nlp_globalization_funnel_find_acceptable_iterate(void *nlp_config_, void
 void ocp_nlp_globalization_funnel_print_iteration_header();
 //
 void ocp_nlp_globalization_funnel_print_iteration(double objective_value,
-                                                int iter_count,
-                                                void* nlp_res_,
-                                                double step_norm,
-                                                double reg_param,
-                                                int qp_status,
-                                                int qp_iter,
-                                                void* nlp_opts_,
-                                                void* mem_);
+                                                    void* nlp_opts_,
+                                                    void* mem_);
 //
 int ocp_nlp_globalization_funnel_needs_objective_value();
 //

--- a/acados/ocp_nlp/ocp_nlp_globalization_merit_backtracking.c
+++ b/acados/ocp_nlp/ocp_nlp_globalization_merit_backtracking.c
@@ -269,7 +269,7 @@ int ocp_nlp_line_search(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *
 
 void ocp_nlp_globalization_merit_backtracking_print_iteration_header()
 {
-    printf("%10s   ", "alpha");
+    printf("%8s   ", "alpha");
 }
 
 void ocp_nlp_globalization_merit_backtracking_print_iteration(double objective_value,
@@ -277,7 +277,7 @@ void ocp_nlp_globalization_merit_backtracking_print_iteration(double objective_v
                                                                 void* mem_)
 {
     ocp_nlp_globalization_merit_backtracking_memory* mem = mem_;
-    printf("%10.4e   ", mem->alpha);
+    printf("%8.2e   ", mem->alpha);
 }
 
 static double ocp_nlp_get_violation_inf_norm(ocp_nlp_config *config, ocp_nlp_dims *dims,

--- a/acados/ocp_nlp/ocp_nlp_globalization_merit_backtracking.c
+++ b/acados/ocp_nlp/ocp_nlp_globalization_merit_backtracking.c
@@ -269,34 +269,15 @@ int ocp_nlp_line_search(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nlp_in *
 
 void ocp_nlp_globalization_merit_backtracking_print_iteration_header()
 {
-    printf("# it\tstat\t\teq\t\tineq\t\tcomp\t\tqp_stat\tqp_iter\talpha\n");
+    printf("%10s   ", "alpha");
 }
 
 void ocp_nlp_globalization_merit_backtracking_print_iteration(double objective_value,
-                                                            int iter_count,
-                                                            void* nlp_res_,
-                                                            double step_norm,
-                                                            double reg_param,
-                                                            int qp_status,
-                                                            int qp_iter,
-                                                            void* nlp_opts_,
-                                                            void* mem_)
+                                                                void* nlp_opts_,
+                                                                void* mem_)
 {
-    ocp_nlp_res *nlp_res = nlp_res_;
     ocp_nlp_globalization_merit_backtracking_memory* mem = mem_;
-
-    if ((iter_count % 10 == 0)){
-        ocp_nlp_globalization_merit_backtracking_print_iteration_header();
-    }
-    printf("%i\t%e\t%e\t%e\t%e\t%d\t%d\t%e\n",
-        iter_count,
-        nlp_res->inf_norm_res_stat,
-        nlp_res->inf_norm_res_eq,
-        nlp_res->inf_norm_res_ineq,
-        nlp_res->inf_norm_res_comp,
-        qp_status,
-        qp_iter,
-        mem->alpha);
+    printf("%10.4e   ", mem->alpha);
 }
 
 static double ocp_nlp_get_violation_inf_norm(ocp_nlp_config *config, ocp_nlp_dims *dims,

--- a/acados/ocp_nlp/ocp_nlp_globalization_merit_backtracking.h
+++ b/acados/ocp_nlp/ocp_nlp_globalization_merit_backtracking.h
@@ -112,14 +112,8 @@ int ocp_nlp_globalization_merit_backtracking_find_acceptable_iterate_for_ddp(voi
 void ocp_nlp_globalization_merit_backtracking_print_iteration_header();
 //
 void ocp_nlp_globalization_merit_backtracking_print_iteration(double objective_value,
-                                                            int iter_count,
-                                                            void *nlp_res_,
-                                                            double step_norm,
-                                                            double reg_param,
-                                                            int qp_status,
-                                                            int qp_iter,
-                                                            void* nlp_opts_,
-                                                            void* mem_);
+                                                                void* nlp_opts_,
+                                                                void* mem_);
 //
 int ocp_nlp_globalization_merit_backtracking_needs_objective_value();
 //

--- a/acados/ocp_nlp/ocp_nlp_sqp.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp.c
@@ -549,13 +549,13 @@ static void print_iteration(int iter, ocp_nlp_config *config, ocp_nlp_res *nlp_r
     if (iter % 10 == 0)
     {
         ocp_nlp_common_print_iteration_header();
-        printf("%10s   %10s  %7s   %7s   ", "step_norm", "lm_reg.", "qp_stat", "qp_iter");
+        printf("%7s   %7s  %9s   %8s  ", "qp_stat", "qp_iter", "step_norm", "lm_reg.");
         config->globalization->print_iteration_header();
         printf("\n");
     }
     // print iteration
     ocp_nlp_common_print_iteration(iter, nlp_res);
-    printf("%10.4e   %10.4e  %7d   %7d   ", mem->step_norm, prev_levenberg_marquardt, qp_status, qp_iter);
+    printf("%7d   %7d   %8.2e   %8.2e  ", qp_status, qp_iter, mem->step_norm, prev_levenberg_marquardt);
     config->globalization->print_iteration(nlp_mem->cost_value, nlp_opts->globalization, nlp_mem->globalization);
     printf("\n");
 }

--- a/acados/ocp_nlp/ocp_nlp_sqp.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp.c
@@ -548,13 +548,13 @@ static void print_iteration(int iter, ocp_nlp_config *config, ocp_nlp_res *nlp_r
     // print iteration header
     if (iter % 10 == 0)
     {
-        ocp_nlp_print_iteration_header(); //print common stuff
+        ocp_nlp_common_print_iteration_header();
         printf("%10s   %10s   %9s   %7s   ", "step_norm", "lm_reg.", "qp_status", "qp_iter");
         config->globalization->print_iteration_header();
         printf("\n");
     }
     // print iteration
-    ocp_nlp_print_iteration(iter, nlp_res);
+    ocp_nlp_common_print_iteration(iter, nlp_res);
     printf("%10.4e   %10.4e   %9d   %7d   ", mem->step_norm, prev_levenberg_marquardt, qp_status, qp_iter);
     config->globalization->print_iteration(nlp_mem->cost_value, nlp_opts->globalization, nlp_mem->globalization);
     printf("\n");

--- a/acados/ocp_nlp/ocp_nlp_sqp.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp.c
@@ -549,13 +549,13 @@ static void print_iteration(int iter, ocp_nlp_config *config, ocp_nlp_res *nlp_r
     if (iter % 10 == 0)
     {
         ocp_nlp_common_print_iteration_header();
-        printf("%10s   %10s   %9s   %7s   ", "step_norm", "lm_reg.", "qp_status", "qp_iter");
+        printf("%10s   %10s  %7s   %7s   ", "step_norm", "lm_reg.", "qp_stat", "qp_iter");
         config->globalization->print_iteration_header();
         printf("\n");
     }
     // print iteration
     ocp_nlp_common_print_iteration(iter, nlp_res);
-    printf("%10.4e   %10.4e   %9d   %7d   ", mem->step_norm, prev_levenberg_marquardt, qp_status, qp_iter);
+    printf("%10.4e   %10.4e  %7d   %7d   ", mem->step_norm, prev_levenberg_marquardt, qp_status, qp_iter);
     config->globalization->print_iteration(nlp_mem->cost_value, nlp_opts->globalization, nlp_mem->globalization);
     printf("\n");
 }

--- a/acados/ocp_nlp/ocp_nlp_sqp.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp.c
@@ -538,6 +538,28 @@ static bool check_termination(int n_iter, ocp_nlp_dims *dims, ocp_nlp_res *nlp_r
     return false;
 }
 
+/************************************************
+ * output
+ ************************************************/
+static void print_iteration(int iter, ocp_nlp_config *config, ocp_nlp_res *nlp_res, ocp_nlp_sqp_memory *mem,
+                            ocp_nlp_opts *nlp_opts, double prev_levenberg_marquardt)
+{
+    ocp_nlp_memory *nlp_mem = mem->nlp_mem;
+    // print iteration header
+    if (iter % 10 == 0)
+    {
+        ocp_nlp_print_iteration_header(); //print common stuff
+        printf("%10s   %10s   ", "step_norm", "LM_reg.");
+        config->globalization->print_iteration_header();
+        printf("\n");
+    }
+    // print iteration
+    ocp_nlp_print_iteration(iter, nlp_res);
+    printf("%10.4e   %10.4e   ", mem->step_norm, prev_levenberg_marquardt);
+    config->globalization->print_iteration(nlp_mem->cost_value, nlp_opts->globalization, nlp_mem->globalization);
+    printf("\n");
+}
+
 
 /************************************************
  * functions
@@ -649,15 +671,7 @@ int ocp_nlp_sqp(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
         // Output
         if (nlp_opts->print_level > 0)
         {
-            config->globalization->print_iteration(nlp_mem->cost_value,
-                                                   sqp_iter,
-                                                   nlp_res,
-                                                   mem->step_norm,
-                                                   prev_levenberg_marquardt,
-                                                   qp_status,
-                                                   qp_iter,
-                                                   nlp_opts,
-                                                   nlp_mem->globalization);
+            print_iteration(sqp_iter, config, nlp_res, mem, nlp_opts, prev_levenberg_marquardt);
         }
         prev_levenberg_marquardt = nlp_opts->levenberg_marquardt;
 

--- a/acados/ocp_nlp/ocp_nlp_sqp.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp.c
@@ -542,20 +542,20 @@ static bool check_termination(int n_iter, ocp_nlp_dims *dims, ocp_nlp_res *nlp_r
  * output
  ************************************************/
 static void print_iteration(int iter, ocp_nlp_config *config, ocp_nlp_res *nlp_res, ocp_nlp_sqp_memory *mem,
-                            ocp_nlp_opts *nlp_opts, double prev_levenberg_marquardt)
+                            ocp_nlp_opts *nlp_opts, double prev_levenberg_marquardt, int qp_status, int qp_iter)
 {
     ocp_nlp_memory *nlp_mem = mem->nlp_mem;
     // print iteration header
     if (iter % 10 == 0)
     {
         ocp_nlp_print_iteration_header(); //print common stuff
-        printf("%10s   %10s   ", "step_norm", "LM_reg.");
+        printf("%10s   %10s   %9s   %7s   ", "step_norm", "lm_reg.", "qp_status", "qp_iter");
         config->globalization->print_iteration_header();
         printf("\n");
     }
     // print iteration
     ocp_nlp_print_iteration(iter, nlp_res);
-    printf("%10.4e   %10.4e   ", mem->step_norm, prev_levenberg_marquardt);
+    printf("%10.4e   %10.4e   %9d   %7d   ", mem->step_norm, prev_levenberg_marquardt, qp_status, qp_iter);
     config->globalization->print_iteration(nlp_mem->cost_value, nlp_opts->globalization, nlp_mem->globalization);
     printf("\n");
 }
@@ -671,7 +671,7 @@ int ocp_nlp_sqp(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
         // Output
         if (nlp_opts->print_level > 0)
         {
-            print_iteration(sqp_iter, config, nlp_res, mem, nlp_opts, prev_levenberg_marquardt);
+            print_iteration(sqp_iter, config, nlp_res, mem, nlp_opts, prev_levenberg_marquardt, qp_status, qp_iter);
         }
         prev_levenberg_marquardt = nlp_opts->levenberg_marquardt;
 


### PR DESCRIPTION
The printing of iterations was made more versatile such that it can be adjusted more easily for different solvers, different globalization strategies, or other future developments.

- the printing of # it, rest_stat, res_eq, res_ineq, res_comp was moved to `ocp_nlp_common.c`
- solver specific stuff like step_norm, lm_reg., qp_status, and qp_iter was moved to `ocp_nlp_sqp` and `ocp_nlp_ddp`
- globalization specific stuff was moved to the globalization modules

The print_iteration function is now called within the solver file, and then internally the different print functions of the different print modules are called sequentially. Also the iteration log has now a unified appearance.