### PR TITLE
Condensing: call `d_cond_qp_expand_sol` with options as `d_cond_qp_expand_primal_sol` was removed in HPIPM

### DIFF
--- a/acados/ocp_qp/ocp_qp_full_condensing.c
+++ b/acados/ocp_qp/ocp_qp_full_condensing.c
@@ -565,14 +565,7 @@ int ocp_qp_full_expansion(void *fcond_qp_out_, void *qp_out_, void *opts_, void 
     acados_tic(&timer);
 
     // expand solution
-    if (opts->expand_dual_sol == 0)
-    {
-        d_cond_qp_expand_primal_sol(mem->red_qp, fcond_qp_out, mem->red_sol, opts->hpipm_cond_opts, mem->hpipm_cond_work);
-    }
-    else
-    {
-        d_cond_qp_expand_sol(mem->red_qp, fcond_qp_out, mem->red_sol, opts->hpipm_cond_opts, mem->hpipm_cond_work);
-    }
+    d_cond_qp_expand_sol(mem->red_qp, fcond_qp_out, mem->red_sol, opts->hpipm_cond_opts, mem->hpipm_cond_work);
 
     // restore solution
     d_ocp_qp_restore_eq_dof(mem->ptr_qp_in, mem->red_sol, qp_out, opts->hpipm_red_opts, mem->hpipm_red_work);

--- a/acados/ocp_qp/ocp_qp_full_condensing.c
+++ b/acados/ocp_qp/ocp_qp_full_condensing.c
@@ -229,8 +229,6 @@ void ocp_qp_full_condensing_opts_initialize_default(void *dims_, void *opts_)
 
     // condense both Hessian and gradient by default
     opts->cond_hess = 1;
-    // expand only primal solution (linear MPC, Gauss-Newton)
-    opts->expand_dual_sol = 1;
 
     // hpipm_cond_opts
     d_cond_qp_arg_set_default(opts->hpipm_cond_opts);
@@ -275,13 +273,6 @@ void ocp_qp_full_condensing_opts_set(void *opts_, const char *field, void* value
     {
         int *tmp_ptr = value;
         opts->cond_hess = *tmp_ptr;
-    }
-    else if(!strcmp(field, "dual_sol"))
-    {
-        int *tmp_ptr = value;
-        opts->expand_dual_sol = *tmp_ptr;
-        d_ocp_qp_reduce_eq_dof_arg_set_comp_dual_sol_eq(tmp_ptr, opts->hpipm_red_opts);
-        d_ocp_qp_reduce_eq_dof_arg_set_comp_dual_sol_ineq(tmp_ptr, opts->hpipm_red_opts);
     }
     else
     {
@@ -565,14 +556,7 @@ int ocp_qp_full_expansion(void *fcond_qp_out_, void *qp_out_, void *opts_, void 
     acados_tic(&timer);
 
     // expand solution
-    if (opts->expand_dual_sol == 0)
-    {
-        d_cond_qp_expand_primal_sol(mem->red_qp, fcond_qp_out, mem->red_sol, opts->hpipm_cond_opts, mem->hpipm_cond_work);
-    }
-    else
-    {
-        d_cond_qp_expand_sol(mem->red_qp, fcond_qp_out, mem->red_sol, opts->hpipm_cond_opts, mem->hpipm_cond_work);
-    }
+    d_cond_qp_expand_sol(mem->red_qp, fcond_qp_out, mem->red_sol, opts->hpipm_cond_opts, mem->hpipm_cond_work);
 
     // restore solution
     d_ocp_qp_restore_eq_dof(mem->ptr_qp_in, mem->red_sol, qp_out, opts->hpipm_red_opts, mem->hpipm_red_work);

--- a/acados/ocp_qp/ocp_qp_full_condensing.c
+++ b/acados/ocp_qp/ocp_qp_full_condensing.c
@@ -229,6 +229,8 @@ void ocp_qp_full_condensing_opts_initialize_default(void *dims_, void *opts_)
 
     // condense both Hessian and gradient by default
     opts->cond_hess = 1;
+    // expand only primal solution (linear MPC, Gauss-Newton)
+    opts->expand_dual_sol = 1;
 
     // hpipm_cond_opts
     d_cond_qp_arg_set_default(opts->hpipm_cond_opts);
@@ -273,6 +275,13 @@ void ocp_qp_full_condensing_opts_set(void *opts_, const char *field, void* value
     {
         int *tmp_ptr = value;
         opts->cond_hess = *tmp_ptr;
+    }
+    else if(!strcmp(field, "dual_sol"))
+    {
+        int *tmp_ptr = value;
+        opts->expand_dual_sol = *tmp_ptr;
+        d_ocp_qp_reduce_eq_dof_arg_set_comp_dual_sol_eq(tmp_ptr, opts->hpipm_red_opts);
+        d_ocp_qp_reduce_eq_dof_arg_set_comp_dual_sol_ineq(tmp_ptr, opts->hpipm_red_opts);
     }
     else
     {
@@ -556,7 +565,14 @@ int ocp_qp_full_expansion(void *fcond_qp_out_, void *qp_out_, void *opts_, void 
     acados_tic(&timer);
 
     // expand solution
-    d_cond_qp_expand_sol(mem->red_qp, fcond_qp_out, mem->red_sol, opts->hpipm_cond_opts, mem->hpipm_cond_work);
+    if (opts->expand_dual_sol == 0)
+    {
+        d_cond_qp_expand_primal_sol(mem->red_qp, fcond_qp_out, mem->red_sol, opts->hpipm_cond_opts, mem->hpipm_cond_work);
+    }
+    else
+    {
+        d_cond_qp_expand_sol(mem->red_qp, fcond_qp_out, mem->red_sol, opts->hpipm_cond_opts, mem->hpipm_cond_work);
+    }
 
     // restore solution
     d_ocp_qp_restore_eq_dof(mem->ptr_qp_in, mem->red_sol, qp_out, opts->hpipm_red_opts, mem->hpipm_red_work);

--- a/acados/ocp_qp/ocp_qp_full_condensing.h
+++ b/acados/ocp_qp/ocp_qp_full_condensing.h
@@ -60,6 +60,7 @@ typedef struct ocp_qp_full_condensing_opts_
     struct d_ocp_qp_reduce_eq_dof_arg *hpipm_red_opts;
 //    dense_qp_dims *fcond_dims;  // TODO(all): move to dims
     int cond_hess; // 0 cond only rhs, 1 cond hess + rhs
+    int expand_dual_sol; // 0 primal sol only, 1 primal + dual sol
     int ric_alg;
     int mem_qp_in; // allocate qp_in in memory
 } ocp_qp_full_condensing_opts;

--- a/acados/ocp_qp/ocp_qp_full_condensing.h
+++ b/acados/ocp_qp/ocp_qp_full_condensing.h
@@ -60,7 +60,6 @@ typedef struct ocp_qp_full_condensing_opts_
     struct d_ocp_qp_reduce_eq_dof_arg *hpipm_red_opts;
 //    dense_qp_dims *fcond_dims;  // TODO(all): move to dims
     int cond_hess; // 0 cond only rhs, 1 cond hess + rhs
-    int expand_dual_sol; // 0 primal sol only, 1 primal + dual sol
     int ric_alg;
     int mem_qp_in; // allocate qp_in in memory
 } ocp_qp_full_condensing_opts;

--- a/examples/c/no_interface_examples/mass_spring_offline_fcond_qpoases_split.c
+++ b/examples/c/no_interface_examples/mass_spring_offline_fcond_qpoases_split.c
@@ -162,8 +162,9 @@ int main() {
 
 	if(OFFLINE_CONDENSING == 1)
     {
-        cond_opts->cond_hess = 0;
-		cond_opts->expand_dual_sol = 0;
+        int tmp_int = 0;
+        ocp_qp_full_condensing_opts_set(cond_opts, "dual_sol", tmp_int);
+        ocp_qp_full_condensing_opts_set(cond_opts, "hess", tmp_int);
 
         ocp_qp_full_condensing_opts_update(qp_in->dim, cond_opts);
         ocp_qp_full_condensing_opts_update(qp_in->dim, cond_opts);

--- a/examples/c/no_interface_examples/mass_spring_offline_fcond_qpoases_split.c
+++ b/examples/c/no_interface_examples/mass_spring_offline_fcond_qpoases_split.c
@@ -163,7 +163,6 @@ int main() {
 	if(OFFLINE_CONDENSING == 1)
     {
         cond_opts->cond_hess = 0;
-		cond_opts->expand_dual_sol = 0;
 
         ocp_qp_full_condensing_opts_update(qp_in->dim, cond_opts);
         ocp_qp_full_condensing_opts_update(qp_in->dim, cond_opts);

--- a/examples/c/no_interface_examples/mass_spring_offline_fcond_qpoases_split.c
+++ b/examples/c/no_interface_examples/mass_spring_offline_fcond_qpoases_split.c
@@ -163,6 +163,7 @@ int main() {
 	if(OFFLINE_CONDENSING == 1)
     {
         cond_opts->cond_hess = 0;
+		cond_opts->expand_dual_sol = 0;
 
         ocp_qp_full_condensing_opts_update(qp_in->dim, cond_opts);
         ocp_qp_full_condensing_opts_update(qp_in->dim, cond_opts);


### PR DESCRIPTION
- Plus update HPIPM
- See https://github.com/giaf/hpipm/commit/f49620429d79146a3a891f618ff4816f04a9481b