### PR TITLE
Remove: no global data warnings

### DIFF
--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.c
@@ -2729,7 +2729,7 @@ int {{ name }}_acados_set_p_global_and_precompute_dependencies({{ name }}_solver
     fun->casadi_fun((const double **) fun->args, fun->res, fun->int_work, fun->float_work, NULL);
 
 {%- else %}
-    printf("No global_data, {{ name }}_acados_set_p_global_and_precompute_dependencies does nothing.\n");
+    // printf("No global_data, {{ name }}_acados_set_p_global_and_precompute_dependencies does nothing.\n");
 {%- endif %}
     return 0;
 }

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -2765,7 +2765,7 @@ int {{ name }}_acados_set_p_global_and_precompute_dependencies({{ name }}_solver
     fun->casadi_fun((const double **) fun->args, fun->res, fun->int_work, fun->float_work, NULL);
 
 {%- else %}
-    printf("No global_data, {{ name }}_acados_set_p_global_and_precompute_dependencies does nothing.\n");
+    // printf("No global_data, {{ name }}_acados_set_p_global_and_precompute_dependencies does nothing.\n");
 {%- endif %}
     return 0;
 }


### PR DESCRIPTION
Remove warning in `set_p_global_and_precompute_dependencies` if global data is empty as it can be distracting, especially when using a `AcadosOcpBatchSolver`.