### PR TITLE
Implement adaptive epsilon for regularizations: `MIRROR` and `PROJECT`

### DIFF
--- a/acados/ocp_nlp/ocp_nlp_common.c
+++ b/acados/ocp_nlp/ocp_nlp_common.c
@@ -3715,6 +3715,7 @@ void ocp_nlp_dump_qp_in_to_file(ocp_qp_in *qp_in, int sqp_iter, int soc)
     FILE *out_file = fopen(filename, "w");
     print_ocp_qp_in_to_file(out_file, qp_in);
     fclose(out_file);
+    printf("qp_in dumped to %s\n", filename);
 }
 
 

--- a/acados/ocp_nlp/ocp_nlp_cost_external.c
+++ b/acados/ocp_nlp/ocp_nlp_cost_external.c
@@ -760,7 +760,7 @@ void ocp_nlp_cost_external_update_qp_matrices(void *config_, void *dims_, void *
     }
 
     // slack update gradient
-    // grad_s = z + Z * slack
+    // grad_s (z_QP) = z_NLP + Z_NLP * slack
     blasfeo_dveccp(2*ns, &model->z, 0, &memory->grad, nu+nx);
     blasfeo_dvecmulacc(2*ns, &model->Z, 0, memory->ux, nu+nx, &memory->grad, nu+nx);
 

--- a/acados/ocp_nlp/ocp_nlp_cost_external.c
+++ b/acados/ocp_nlp/ocp_nlp_cost_external.c
@@ -760,6 +760,7 @@ void ocp_nlp_cost_external_update_qp_matrices(void *config_, void *dims_, void *
     }
 
     // slack update gradient
+    // grad_s = z + Z * slack
     blasfeo_dveccp(2*ns, &model->z, 0, &memory->grad, nu+nx);
     blasfeo_dvecmulacc(2*ns, &model->Z, 0, memory->ux, nu+nx, &memory->grad, nu+nx);
 

--- a/acados/ocp_nlp/ocp_nlp_reg_common.c
+++ b/acados/ocp_nlp/ocp_nlp_reg_common.c
@@ -250,5 +250,32 @@ void acados_project(int dim, double *A, double *V, double *d, double *e, double 
 }
 
 
+void acados_project_adaptive_eps(int dim, double *A, double *V, double *d, double *e, double max_eig_block)
+{
+    int i;
+    acados_eigen_decomposition(dim, A, V, d, e);
+    double max_eig = 0.0;
+    double min_eig = ACADOS_INFTY;
+    double eps;
 
+    // compute max and min eigenvalues
+    for (i=0; i < dim; i++)
+    {
+        max_eig = MAX(max_eig, fabs(d[i]));
+        min_eig = MIN(min_eig, fabs(d[i]));
+    }
+    if (min_eig == 0.0 && max_eig == 0.0)
+        eps = 1.0;
+    else
+        eps = max_eig*1e-6;
+    // printf("eps = %5.e\n", eps);
 
+    // project
+    for (i = 0; i < dim; i++)
+    {
+        if (d[i] < eps)
+            d[i] = eps;
+    }
+
+    acados_reconstruct_A(dim, A, V, d);
+}

--- a/acados/ocp_nlp/ocp_nlp_reg_common.c
+++ b/acados/ocp_nlp/ocp_nlp_reg_common.c
@@ -256,14 +256,17 @@ void acados_project_adaptive_eps(int dim, double *A, double *V, double *d, doubl
     double max_eig = 0.0;
     double min_eig = ACADOS_INFTY;
     double eps;
+    int eig_0_count = 0;
 
     // compute max and min eigenvalues
     for (i=0; i < dim; i++)
     {
-        max_eig = MAX(max_eig, fabs(d[i]));
+        max_eig = MAX(max_eig, d[i]); // negative eigenvalues are clipped, i.e., not important for condition number
         min_eig = MIN(min_eig, fabs(d[i]));
+        if (fabs(d[i]) == 0.0)
+            eig_0_count += 1;
     }
-    if (min_eig == 0.0 && max_eig == 0.0)
+    if (eig_0_count == dim)
         eps = 1.0;
     else
         eps = max_eig/max_cond_block;

--- a/acados/ocp_nlp/ocp_nlp_reg_common.c
+++ b/acados/ocp_nlp/ocp_nlp_reg_common.c
@@ -33,6 +33,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <math.h>
 
 #include "acados/utils/math.h"
 
@@ -187,12 +188,11 @@ void acados_mirror(int dim, double *A, double *V, double *d, double *e, double e
 
     acados_eigen_decomposition(dim, A, V, d, e);
 
+    // mirror
     for (i = 0; i < dim; i++)
     {
-        // project
         if (d[i] >= -epsilon && d[i] <= epsilon)
             d[i] = epsilon;
-        // mirror
         else if (d[i] < 0)
             d[i] = -d[i];
     }
@@ -200,7 +200,37 @@ void acados_mirror(int dim, double *A, double *V, double *d, double *e, double e
     acados_reconstruct_A(dim, A, V, d);
 }
 
+void acados_mirror_adaptive_eps(int dim, double *A, double *V, double *d, double *e, double max_eig_block)
+{
+    int i;
+    acados_eigen_decomposition(dim, A, V, d, e);
+    double max_eig = 0.0;
+    double min_eig = ACADOS_INFTY;
+    double eps;
 
+    // compute max and min eigenvalues
+    for (i=0; i < dim; i++)
+    {
+        max_eig = MAX(max_eig, fabs(d[i]));
+        min_eig = MIN(min_eig, fabs(d[i]));
+    }
+    if (min_eig == 0.0 && max_eig == 0.0)
+        eps = 1.0;
+    else
+        eps = max_eig*1e-6;
+    // printf("eps = %5.e\n", eps);
+
+    // mirror
+    for (i = 0; i < dim; i++)
+    {
+        if (d[i] >= -eps && d[i] <= eps)
+            d[i] = eps;
+        else if (d[i] < 0)
+            d[i] = -d[i];
+    }
+
+    acados_reconstruct_A(dim, A, V, d);
+}
 
 // projecting regularization
 void acados_project(int dim, double *A, double *V, double *d, double *e, double epsilon)

--- a/acados/ocp_nlp/ocp_nlp_reg_common.c
+++ b/acados/ocp_nlp/ocp_nlp_reg_common.c
@@ -205,16 +205,14 @@ void acados_mirror_adaptive_eps(int dim, double *A, double *V, double *d, double
     int i;
     acados_eigen_decomposition(dim, A, V, d, e);
     double max_eig = 0.0;
-    double min_eig = ACADOS_INFTY;
     double eps;
 
     // compute max and min eigenvalues
     for (i=0; i < dim; i++)
     {
         max_eig = MAX(max_eig, fabs(d[i]));
-        min_eig = MIN(min_eig, fabs(d[i]));
     }
-    if (min_eig == 0.0 && max_eig == 0.0)
+    if (max_eig == 0.0)
         eps = 1.0;
     else
         eps = max_eig/max_cond_block;
@@ -255,16 +253,13 @@ void acados_project_adaptive_eps(int dim, double *A, double *V, double *d, doubl
     acados_eigen_decomposition(dim, A, V, d, e);
     double max_eig = 0.0;
     double eps;
-    int eig_0_count = 0;
 
     // compute max and min eigenvalues
     for (i=0; i < dim; i++)
     {
-        max_eig = MAX(max_eig, d[i]); // negative eigenvalues are clipped, i.e., not important for condition number
-        if (fabs(d[i]) == 0.0)
-            eig_0_count += 1;
+        max_eig = MAX(max_eig, d[i]);
     }
-    if (eig_0_count == dim)
+    if (max_eig == 0.0)
         eps = 1.0;
     else
         eps = max_eig/max_cond_block;

--- a/acados/ocp_nlp/ocp_nlp_reg_common.c
+++ b/acados/ocp_nlp/ocp_nlp_reg_common.c
@@ -200,7 +200,7 @@ void acados_mirror(int dim, double *A, double *V, double *d, double *e, double e
     acados_reconstruct_A(dim, A, V, d);
 }
 
-void acados_mirror_adaptive_eps(int dim, double *A, double *V, double *d, double *e, double max_eig_block)
+void acados_mirror_adaptive_eps(int dim, double *A, double *V, double *d, double *e, double max_cond_block)
 {
     int i;
     acados_eigen_decomposition(dim, A, V, d, e);
@@ -250,7 +250,7 @@ void acados_project(int dim, double *A, double *V, double *d, double *e, double 
 }
 
 
-void acados_project_adaptive_eps(int dim, double *A, double *V, double *d, double *e, double max_eig_block)
+void acados_project_adaptive_eps(int dim, double *A, double *V, double *d, double *e, double max_cond_block)
 {
     int i;
     acados_eigen_decomposition(dim, A, V, d, e);

--- a/acados/ocp_nlp/ocp_nlp_reg_common.c
+++ b/acados/ocp_nlp/ocp_nlp_reg_common.c
@@ -254,7 +254,6 @@ void acados_project_adaptive_eps(int dim, double *A, double *V, double *d, doubl
     int i;
     acados_eigen_decomposition(dim, A, V, d, e);
     double max_eig = 0.0;
-    double min_eig = ACADOS_INFTY;
     double eps;
     int eig_0_count = 0;
 
@@ -262,7 +261,6 @@ void acados_project_adaptive_eps(int dim, double *A, double *V, double *d, doubl
     for (i=0; i < dim; i++)
     {
         max_eig = MAX(max_eig, d[i]); // negative eigenvalues are clipped, i.e., not important for condition number
-        min_eig = MIN(min_eig, fabs(d[i]));
         if (fabs(d[i]) == 0.0)
             eig_0_count += 1;
     }

--- a/acados/ocp_nlp/ocp_nlp_reg_common.c
+++ b/acados/ocp_nlp/ocp_nlp_reg_common.c
@@ -217,8 +217,7 @@ void acados_mirror_adaptive_eps(int dim, double *A, double *V, double *d, double
     if (min_eig == 0.0 && max_eig == 0.0)
         eps = 1.0;
     else
-        eps = max_eig*1e-6;
-    // printf("eps = %5.e\n", eps);
+        eps = max_eig/max_cond_block;
 
     // mirror
     for (i = 0; i < dim; i++)
@@ -267,8 +266,7 @@ void acados_project_adaptive_eps(int dim, double *A, double *V, double *d, doubl
     if (min_eig == 0.0 && max_eig == 0.0)
         eps = 1.0;
     else
-        eps = max_eig*1e-6;
-    // printf("eps = %5.e\n", eps);
+        eps = max_eig/max_cond_block;
 
     // project
     for (i = 0; i < dim; i++)

--- a/acados/ocp_nlp/ocp_nlp_reg_common.h
+++ b/acados/ocp_nlp/ocp_nlp_reg_common.h
@@ -113,7 +113,7 @@ void acados_reconstruct_A(int dim, double *A, double *V, double *d);
 void acados_mirror(int dim, double *A, double *V, double *d, double *e, double epsilon);
 void acados_mirror_adaptive_eps(int dim, double *A, double *V, double *d, double *e, double max_eig_block);
 void acados_project(int dim, double *A, double *V, double *d, double *e, double epsilon);
-
+void acados_project_adaptive_eps(int dim, double *A, double *V, double *d, double *e, double max_eig_block);
 
 
 #ifdef __cplusplus

--- a/acados/ocp_nlp/ocp_nlp_reg_common.h
+++ b/acados/ocp_nlp/ocp_nlp_reg_common.h
@@ -111,6 +111,7 @@ void *ocp_nlp_reg_config_assign(void *raw_memory);
 /* regularization help functions */
 void acados_reconstruct_A(int dim, double *A, double *V, double *d);
 void acados_mirror(int dim, double *A, double *V, double *d, double *e, double epsilon);
+void acados_mirror_adaptive_eps(int dim, double *A, double *V, double *d, double *e, double max_eig_block);
 void acados_project(int dim, double *A, double *V, double *d, double *e, double epsilon);
 
 

--- a/acados/ocp_nlp/ocp_nlp_reg_common.h
+++ b/acados/ocp_nlp/ocp_nlp_reg_common.h
@@ -111,9 +111,9 @@ void *ocp_nlp_reg_config_assign(void *raw_memory);
 /* regularization help functions */
 void acados_reconstruct_A(int dim, double *A, double *V, double *d);
 void acados_mirror(int dim, double *A, double *V, double *d, double *e, double epsilon);
-void acados_mirror_adaptive_eps(int dim, double *A, double *V, double *d, double *e, double max_eig_block);
+void acados_mirror_adaptive_eps(int dim, double *A, double *V, double *d, double *e, double max_cond_block);
 void acados_project(int dim, double *A, double *V, double *d, double *e, double epsilon);
-void acados_project_adaptive_eps(int dim, double *A, double *V, double *d, double *e, double max_eig_block);
+void acados_project_adaptive_eps(int dim, double *A, double *V, double *d, double *e, double max_cond_block);
 
 
 #ifdef __cplusplus

--- a/acados/ocp_nlp/ocp_nlp_reg_mirror.c
+++ b/acados/ocp_nlp/ocp_nlp_reg_mirror.c
@@ -68,7 +68,7 @@ void ocp_nlp_reg_mirror_opts_initialize_default(void *config_, ocp_nlp_reg_dims 
 
     opts->epsilon = 1e-4;
     opts->adaptive_eps = false;
-    opts->max_eig_block = 1e7;
+    opts->max_cond_block = 1e7;
 
     return;
 }
@@ -85,10 +85,10 @@ void ocp_nlp_reg_mirror_opts_set(void *config_, void *opts_, const char *field, 
         double *d_ptr = value;
         opts->epsilon = *d_ptr;
     }
-    else if (!strcmp(field, "max_eig_block"))
+    else if (!strcmp(field, "max_cond_block"))
     {
         double *d_ptr = value;
-        opts->max_eig_block = *d_ptr;
+        opts->max_cond_block = *d_ptr;
     }
     else if (!strcmp(field, "adaptive_eps"))
     {
@@ -299,7 +299,7 @@ void ocp_nlp_reg_mirror_regularize(void *config, ocp_nlp_reg_dims *dims, void *o
         blasfeo_unpack_dmat(nu[ii]+nx[ii], nu[ii]+nx[ii], mem->RSQrq[ii], 0, 0, mem->reg_hess, nu[ii]+nx[ii]);
         if (opts->adaptive_eps)
         {
-            acados_mirror_adaptive_eps(nu[ii]+nx[ii], mem->reg_hess, mem->V, mem->d, mem->e, opts->max_eig_block);
+            acados_mirror_adaptive_eps(nu[ii]+nx[ii], mem->reg_hess, mem->V, mem->d, mem->e, opts->max_cond_block);
         }
         else
         {

--- a/acados/ocp_nlp/ocp_nlp_reg_mirror.h
+++ b/acados/ocp_nlp/ocp_nlp_reg_mirror.h
@@ -64,6 +64,8 @@ extern "C" {
 typedef struct
 {
     double epsilon;
+    bool adaptive_eps;
+    double max_eig_block;
 } ocp_nlp_reg_mirror_opts;
 
 //

--- a/acados/ocp_nlp/ocp_nlp_reg_mirror.h
+++ b/acados/ocp_nlp/ocp_nlp_reg_mirror.h
@@ -65,7 +65,7 @@ typedef struct
 {
     double epsilon;
     bool adaptive_eps;
-    double max_eig_block;
+    double max_cond_block;
 } ocp_nlp_reg_mirror_opts;
 
 //

--- a/acados/ocp_nlp/ocp_nlp_reg_project.c
+++ b/acados/ocp_nlp/ocp_nlp_reg_project.c
@@ -68,7 +68,7 @@ void ocp_nlp_reg_project_opts_initialize_default(void *config_, ocp_nlp_reg_dims
 
     opts->epsilon = 1e-4;
     opts->adaptive_eps = false;
-    opts->max_eig_block = 1e7;
+    opts->max_cond_block = 1e7;
 
     return;
 }
@@ -85,10 +85,10 @@ void ocp_nlp_reg_project_opts_set(void *config_, void *opts_, const char *field,
         double *d_ptr = value;
         opts->epsilon = *d_ptr;
     }
-    else if (!strcmp(field, "max_eig_block"))
+    else if (!strcmp(field, "max_cond_block"))
     {
         double *d_ptr = value;
-        opts->max_eig_block = *d_ptr;
+        opts->max_cond_block = *d_ptr;
     }
     else if (!strcmp(field, "adaptive_eps"))
     {
@@ -298,7 +298,7 @@ void ocp_nlp_reg_project_regularize(void *config, ocp_nlp_reg_dims *dims, void *
         blasfeo_unpack_dmat(nu[ii]+nx[ii], nu[ii]+nx[ii], mem->RSQrq[ii], 0, 0, mem->reg_hess, nu[ii]+nx[ii]);
         if (opts->adaptive_eps)
         {
-            acados_project_adaptive_eps(nu[ii]+nx[ii], mem->reg_hess, mem->V, mem->d, mem->e, opts->max_eig_block);
+            acados_project_adaptive_eps(nu[ii]+nx[ii], mem->reg_hess, mem->V, mem->d, mem->e, opts->max_cond_block);
         }
         else
         {

--- a/acados/ocp_nlp/ocp_nlp_reg_project.c
+++ b/acados/ocp_nlp/ocp_nlp_reg_project.c
@@ -67,6 +67,8 @@ void ocp_nlp_reg_project_opts_initialize_default(void *config_, ocp_nlp_reg_dims
     ocp_nlp_reg_project_opts *opts = opts_;
 
     opts->epsilon = 1e-4;
+    opts->adaptive_eps = false;
+    opts->max_eig_block = 1e7;
 
     return;
 }
@@ -82,6 +84,16 @@ void ocp_nlp_reg_project_opts_set(void *config_, void *opts_, const char *field,
     {
         double *d_ptr = value;
         opts->epsilon = *d_ptr;
+    }
+    else if (!strcmp(field, "max_eig_block"))
+    {
+        double *d_ptr = value;
+        opts->max_eig_block = *d_ptr;
+    }
+    else if (!strcmp(field, "adaptive_eps"))
+    {
+        bool *b_ptr = value;
+        opts->adaptive_eps = *b_ptr;
     }
     else
     {
@@ -284,7 +296,14 @@ void ocp_nlp_reg_project_regularize(void *config, ocp_nlp_reg_dims *dims, void *
 
         // regularize
         blasfeo_unpack_dmat(nu[ii]+nx[ii], nu[ii]+nx[ii], mem->RSQrq[ii], 0, 0, mem->reg_hess, nu[ii]+nx[ii]);
-        acados_project(nu[ii]+nx[ii], mem->reg_hess, mem->V, mem->d, mem->e, opts->epsilon);
+        if (opts->adaptive_eps)
+        {
+            acados_project_adaptive_eps(nu[ii]+nx[ii], mem->reg_hess, mem->V, mem->d, mem->e, opts->max_eig_block);
+        }
+        else
+        {
+            acados_project(nu[ii]+nx[ii], mem->reg_hess, mem->V, mem->d, mem->e, opts->epsilon);
+        }
         blasfeo_pack_dmat(nu[ii]+nx[ii], nu[ii]+nx[ii], mem->reg_hess, nu[ii]+nx[ii], mem->RSQrq[ii], 0, 0);
     }
 }

--- a/acados/ocp_nlp/ocp_nlp_reg_project.h
+++ b/acados/ocp_nlp/ocp_nlp_reg_project.h
@@ -65,7 +65,7 @@ typedef struct
 {
     double epsilon;
     bool adaptive_eps;
-    double max_eig_block;
+    double max_cond_block;
 } ocp_nlp_reg_project_opts;
 
 //

--- a/acados/ocp_nlp/ocp_nlp_reg_project.h
+++ b/acados/ocp_nlp/ocp_nlp_reg_project.h
@@ -64,6 +64,8 @@ extern "C" {
 typedef struct
 {
     double epsilon;
+    bool adaptive_eps;
+    double max_eig_block;
 } ocp_nlp_reg_project_opts;
 
 //

--- a/examples/acados_python/non_ocp_nlp/adaptive_eps_reg_test.py
+++ b/examples/acados_python/non_ocp_nlp/adaptive_eps_reg_test.py
@@ -119,22 +119,23 @@ def test_reg_adaptive_eps(regularize_method='MIRROR'):
     W_mats = [np.zeros((nx+nu, nx+nu)), W_mat2, W_mat3]
     W_mat_e = np.zeros((nx, nx))
 
-    for i in range(3):
+    for i, W_mat in enumerate(W_mats):
         print(f"{regularize_method} i={i}")
         print("---------------------")
-        W_mat = W_mats[i]
 
         # Test zero matrix
         set_cost_matrix(ocp_solver, W_mat, W_mat_e)
 
-        _ = ocp_solver.solve()
+        status = ocp_solver.solve()
         ocp_solver.print_statistics()
         nlp_iter = ocp_solver.get_stats("nlp_iter")
-        print(f"{nlp_iter=}")
 
         qp_diagnostics = ocp_solver.qp_diagnostics()
         assert qp_diagnostics['condition_number_stage'][0] <= ocp.solver_options.reg_max_cond_block +1e-8, f"Condition number must be <= {ocp.solver_options.reg_max_cond_block} per stage, got {qp_diagnostics['condition_number_stage'][0]} for i = {i}"
         assert qp_diagnostics['condition_number_stage'][1] <= ocp.solver_options.reg_max_cond_block +1e-8, f"Condition number must be <= {ocp.solver_options.reg_max_cond_block} per stage, got {qp_diagnostics['condition_number_stage'][1]} for i = {i}"
+
+        assert nlp_iter == 1, f"Number of NLP iterations should be 1, got {nlp_iter} for i = {i}"
+        assert status == 0, f"acados returned status {status} for i = {i}"
 
         hessian_0 = ocp_solver.get_hessian_block(0)
         if i == 0:

--- a/examples/acados_python/non_ocp_nlp/adaptive_eps_reg_test.py
+++ b/examples/acados_python/non_ocp_nlp/adaptive_eps_reg_test.py
@@ -33,6 +33,7 @@ import numpy as np
 import casadi as ca
 from acados_template import AcadosOcp, AcadosModel, AcadosOcpSolver, latexify_plot
 import matplotlib.pyplot as plt
+from scipy.linalg import block_diag
 latexify_plot()
 
 def export_parametric_ocp() -> AcadosOcp:
@@ -99,21 +100,64 @@ def test_reg():
 
     nx = ocp.dims.nx
     nu = ocp.dims.nu
-    # TODO: test different matrices
+
     # Test zero matrix
     W_mat = np.zeros((nx+nu, nx+nu))
     W_mat_e = np.zeros((nx, nx))
     ocp_solver.cost_set(0, 'W', W_mat)
     ocp_solver.cost_set(1, 'W', W_mat_e)
 
-    status = ocp_solver.solve()
+    _ = ocp_solver.solve()
+
     hessian_0 = ocp_solver.get_hessian_block(0)
-    print(hessian_0)
+    assert np.equal(hessian_0, np.eye(nx+nu)).all(), "Zero Hessian matrix should be transformed into identity"
     hessian_1 = ocp_solver.get_hessian_block(1)
-    print(hessian_1)
+    assert np.equal(hessian_1, np.eye(nx)).all(), "Zero Hessian matrix should be transformed into identity"
+    qp_diagnostics = ocp_solver.qp_diagnostics()
+    assert qp_diagnostics['condition_number_stage'][0] <= ocp.solver_options.reg_max_cond_block, "Condition number must be <= ocp.solver_options.reg_max_cond_block per stage"
+    assert qp_diagnostics['condition_number_stage'][1] <= ocp.solver_options.reg_max_cond_block, "Condition number must be <= ocp.solver_options.reg_max_cond_block per stage"
 
 
     # Second test
+    W_mat = np.zeros((nx+nu, nx+nu))
+    W_mat[0,0] = 1e6
+    W_mat[nx+nu-1, nx+nu-1] = 1e-4
+    W_mat_e = np.zeros((nx, nx))
+    ocp_solver.cost_set(0, 'W', W_mat)
+    ocp_solver.cost_set(1, 'W', W_mat_e)
+    _ = ocp_solver.solve()
+
+    hessian_0 = ocp_solver.get_hessian_block(0)
+    assert np.equal(hessian_0, np.diag([1e3, 1e3, 1e6, 1e3, 1e3, 1e3])).all(), "Something in adaptive mirror went wrong!"
+    qp_diagnostics = ocp_solver.qp_diagnostics()
+    assert qp_diagnostics['condition_number_stage'][0] <= ocp.solver_options.reg_max_cond_block, "Condition number must be <= ocp.solver_options.reg_max_cond_block per stage"
+
+    # Third test
+    p = np.pi/2
+    A_u = np.array([[np.cos(p), -np.sin(p)], [np.sin(p), np.cos(p)]])
+    mat_u = A_u.T @ np.diag([-1, -1e-3]) @ A_u
+
+    # cf. https://stackoverflow.com/questions/65190660/orthogonality-of-a-4x4-matrix
+    A_x = np.array([[0.5000,   0.5000,   0.5000,   0.5000],
+                    [0.6533,   0.2706,  -0.2706,  -0.6533],
+                    [0.5000,  -0.5000,  -0.5000,   0.5000],
+                    [0.2706,  -0.6533,   0.6533,  -0.2706]])
+
+    mat_x = A_x.T @ np.diag([15, 4.0, -2e5, 1e-6]) @ A_x
+
+    W_mat = block_diag(mat_x, mat_u)
+    # print(np.linalg.eigvals(W_mat))
+    # print(W_mat)
+    W_mat_e = np.zeros((nx, nx))
+    ocp_solver.cost_set(0, 'W', W_mat)
+    ocp_solver.cost_set(1, 'W', W_mat_e)
+    _ = ocp_solver.solve()
+    hessian_0 = ocp_solver.get_hessian_block(0)
+    # print(hessian_0)
+    # print(np.linalg.eigvals(hessian_0))
+    assert np.allclose(np.linalg.eigvals(hessian_0), np.diag([2e5, 2e2, 2e2, 2e2, 2e2, 2e2])), "Something in adaptive mirror went wrong!"
+    qp_diagnostics = ocp_solver.qp_diagnostics()
+    assert qp_diagnostics['condition_number_stage'][0] <= ocp.solver_options.reg_max_cond_block, "Condition number must be <= ocp.solver_options.reg_max_cond_block per stage"
 
 
 if __name__ == "__main__":

--- a/examples/acados_python/non_ocp_nlp/regularization_test.py
+++ b/examples/acados_python/non_ocp_nlp/regularization_test.py
@@ -1,0 +1,103 @@
+# -*- coding: future_fstrings -*-
+#
+# Copyright (c) The acados authors.
+#
+# This file is part of acados.
+#
+# The 2-Clause BSD License
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.;
+#
+
+import numpy as np
+import casadi as ca
+from acados_template import AcadosOcp, AcadosModel, AcadosOcpSolver, latexify_plot
+import matplotlib.pyplot as plt
+latexify_plot()
+
+def export_parametric_ocp() -> AcadosOcp:
+    nx = 4
+    nu = 2
+    model = AcadosModel()
+    ocp = AcadosOcp()
+    model.x = ca.SX.sym("x", nx)
+    model.u = ca.SX.sym("u", nu)
+
+    x_next = model.x
+    x_next[:nu] += model.u
+    model.disc_dyn_expr = x_next
+
+    # define cost
+    ny = nx+nu
+    Vx = np.zeros((ny, nx))
+    Vx[:nx, :] = np.eye(nx)
+    Vu = np.zeros((ny, nu))
+    Vu[nx:, :] = np.eye(nu)
+    Vx_e = np.eye(nx)
+
+    ocp.cost.Vx = Vx
+    ocp.cost.Vx_e = Vx_e
+    ocp.cost.Vu = Vu
+    ocp.cost.cost_type = "LINEAR_LS"
+    ocp.cost.cost_type_e = "LINEAR_LS"
+    ocp.cost.W = np.eye(ny)
+    ocp.cost.W_e = np.eye(nx)
+    ocp.cost.yref = np.zeros((ny, ))
+    ocp.cost.yref_e = np.zeros((nx, ))
+
+    model.name = "non_ocp"
+    ocp.model = model
+
+    ocp.constraints.lbx_0 = np.array([-1.0])
+    ocp.constraints.ubx_0 = np.array([1.0])
+    ocp.constraints.idxbx_0 = np.array([0])
+
+    ocp.solver_options.integrator_type = "DISCRETE"
+    ocp.solver_options.qp_solver = "FULL_CONDENSING_HPIPM"
+    ocp.solver_options.hessian_approx = "EXACT"
+    ocp.solver_options.N_horizon = 1
+    ocp.solver_options.tf = 1.0
+
+    ocp.p_global_values = np.zeros((1,))
+    ocp.solver_options.with_solution_sens_wrt_params = True
+    ocp.solver_options.with_value_sens_wrt_params = True
+    ocp.solver_options.nlp_solver_ext_qp_res = 1
+
+    return ocp
+
+def test_reg():
+
+    ocp = export_parametric_ocp()
+    ocp.solver_options.qp_solver_t0_init = 0
+    ocp.solver_options.nlp_solver_max_iter = 2 # QP should converge in one iteration
+    # TODO: set regularization options
+
+    ocp_solver = AcadosOcpSolver(ocp, json_file="parameter_augmented_acados_ocp.json", verbose=False)
+
+    # TODO: test different matrices
+    W_mat = np.zeros()
+    # ...
+
+
+if __name__ == "__main__":
+    test_reg()

--- a/interfaces/acados_matlab_octave/AcadosOcpOptions.m
+++ b/interfaces/acados_matlab_octave/AcadosOcpOptions.m
@@ -80,6 +80,8 @@ classdef AcadosOcpOptions < handle
         cost_discretization
         regularize_method
         reg_epsilon
+        reg_max_cond_block
+        reg_adaptive_eps
         exact_hess_cost
         exact_hess_dyn
         exact_hess_constr
@@ -175,6 +177,8 @@ classdef AcadosOcpOptions < handle
             obj.cost_discretization = 'EULER';
             obj.regularize_method = 'NO_REGULARIZE';
             obj.reg_epsilon = 1e-4;
+            obj.reg_adaptive_eps = false;
+            obj.reg_max_cond_block = 1e-7;
             obj.shooting_nodes = [];
             obj.cost_scaling = [];
             obj.exact_hess_cost = 1;

--- a/interfaces/acados_template/acados_template/acados_ocp_options.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_options.py
@@ -89,6 +89,8 @@ class AcadosOcpOptions:
         self.__cost_discretization = 'EULER'
         self.__regularize_method = 'NO_REGULARIZE'
         self.__reg_epsilon = 1e-4
+        self.__reg_max_cond_block = 1e-7
+        self.__reg_adaptive_eps = False
         self.__exact_hess_cost = 1
         self.__exact_hess_dyn = 1
         self.__exact_hess_constr = 1
@@ -736,6 +738,28 @@ class AcadosOcpOptions:
         return self.__reg_epsilon
 
     @property
+    def reg_max_cond_block(self):
+        """Maximum condition number per block when using regularize_method in ['PROJECT', 'MIRROR'] with reg_adaptive_eps = True
+
+        Type: float
+        Default: 1e-7
+        """
+        return self.__reg_max_cond_block
+
+    @property
+    def reg_adaptive_eps(self):
+        """Determines if epsilon is chosen adaptively in regularization
+        used if regularize_method in ['PROJECT', 'MIRROR']
+
+        If true, epsilon is chosen block-wise based on reg_max_cond_block.
+        Otherwise, epsilon is chosen globally based on reg_epsilon.
+
+        Type: bool
+        Default: False
+        """
+        return self.__reg_adaptive_eps
+
+    @property
     def globalization_alpha_reduction(self):
         """Step size reduction factor for globalization MERIT_BACKTRACKING,
 
@@ -1271,6 +1295,16 @@ class AcadosOcpOptions:
     @reg_epsilon.setter
     def reg_epsilon(self, reg_epsilon):
         self.__reg_epsilon = reg_epsilon
+
+    @reg_max_cond_block.setter
+    def reg_max_cond_block(self, reg_max_cond_block):
+        self.__reg_max_cond_block = reg_max_cond_block
+
+    @reg_adaptive_eps.setter
+    def reg_adaptive_eps(self, reg_adaptive_eps):
+        if not isinstance(reg_adaptive_eps, bool):
+            raise Exception(f'Invalid reg_adaptive_eps value, expected bool, got {reg_adaptive_eps}')
+        self.__reg_adaptive_eps = reg_adaptive_eps
 
     @globalization_alpha_min.setter
     def globalization_alpha_min(self, globalization_alpha_min):

--- a/interfaces/acados_template/acados_template/acados_ocp_options.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_options.py
@@ -739,7 +739,7 @@ class AcadosOcpOptions:
 
     @property
     def reg_max_cond_block(self):
-        """Maximum condition number per block when using regularize_method in ['PROJECT', 'MIRROR'] with reg_adaptive_eps = True
+        """Maximum condition number of each Hessian block after regularization with regularize_method in ['PROJECT', 'MIRROR'] and reg_adaptive_eps = True
 
         Type: float
         Default: 1e-7

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.c
@@ -2271,6 +2271,14 @@ void {{ name }}_acados_create_set_opts({{ name }}_solver_capsule* capsule)
     ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "reg_epsilon", &reg_epsilon);
 {%- endif %}
 
+{%- if solver_options.regularize_method == "PROJECT" or solver_options.regularize_method == "MIRROR" %}
+    double reg_max_cond_block = {{ solver_options.reg_max_cond_block }};
+    ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "reg_max_cond_block", &reg_max_cond_block);
+
+    bool reg_adaptive_eps = {{ solver_options.reg_adaptive_eps }};
+    ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "reg_adaptive_eps", &reg_adaptive_eps);
+{%- endif %}
+
     bool store_iterates = {{ solver_options.store_iterates }};
     ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "store_iterates", &store_iterates);
 

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -2388,6 +2388,19 @@ static void {{ model.name }}_acados_create_set_opts({{ model.name }}_solver_caps
     ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "reg_epsilon", &reg_epsilon);
 {%- endif %}
 
+{%- if solver_options.regularize_method == "PROJECT" or solver_options.regularize_method == "MIRROR" or solver_options.regularize_method == "CONVEXIFY" %}
+    double reg_epsilon = {{ solver_options.reg_epsilon }};
+    ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "reg_epsilon", &reg_epsilon);
+{%- endif %}
+
+{%- if solver_options.regularize_method == "PROJECT" or solver_options.regularize_method == "MIRROR" %}
+    double reg_max_cond_block = {{ solver_options.reg_max_cond_block }};
+    ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "reg_max_cond_block", &reg_max_cond_block);
+
+    bool reg_adaptive_eps = {{ solver_options.reg_adaptive_eps }};
+    ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "reg_adaptive_eps", &reg_adaptive_eps);
+{%- endif %}
+
     int nlp_solver_ext_qp_res = {{ solver_options.nlp_solver_ext_qp_res }};
     ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "ext_qp_res", &nlp_solver_ext_qp_res);
 

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -2388,11 +2388,6 @@ static void {{ model.name }}_acados_create_set_opts({{ model.name }}_solver_caps
     ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "reg_epsilon", &reg_epsilon);
 {%- endif %}
 
-{%- if solver_options.regularize_method == "PROJECT" or solver_options.regularize_method == "MIRROR" or solver_options.regularize_method == "CONVEXIFY" %}
-    double reg_epsilon = {{ solver_options.reg_epsilon }};
-    ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "reg_epsilon", &reg_epsilon);
-{%- endif %}
-
 {%- if solver_options.regularize_method == "PROJECT" or solver_options.regularize_method == "MIRROR" %}
     double reg_max_cond_block = {{ solver_options.reg_max_cond_block }};
     ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "reg_max_cond_block", &reg_max_cond_block);


### PR DESCRIPTION
New options:
- `reg_max_cond_block`: Maximum condition number per block when using regularize_method in ['PROJECT', 'MIRROR'] with `reg_adaptive_eps` = True, Default: 1e-7
- `reg_adaptive_eps`: Determines if epsilon is chosen adaptively in regularization used if regularize_method in ['PROJECT', 'MIRROR']
If true, epsilon is chosen block-wise based on `reg_max_cond_block`.
Otherwise, epsilon is chosen globally based on `reg_epsilon`.
Default: False

Inspired by "A nonmonotone filter SQP method: local convergence and numerical results" by NICHOLAS I. M. GOULD, YUELING LOH,  DANIEL P. ROBINSON, Sec. 5.1