### PR TITLE
Follow up to #1462

### DIFF
--- a/acados/ocp_nlp/ocp_nlp_reg_common.c
+++ b/acados/ocp_nlp/ocp_nlp_reg_common.c
@@ -200,7 +200,7 @@ void acados_mirror(int dim, double *A, double *V, double *d, double *e, double e
     acados_reconstruct_A(dim, A, V, d);
 }
 
-void acados_mirror_adaptive_eps(int dim, double *A, double *V, double *d, double *e, double max_cond_block)
+void acados_mirror_adaptive_eps(int dim, double *A, double *V, double *d, double *e, double max_cond_block, double min_eps)
 {
     int i;
     acados_eigen_decomposition(dim, A, V, d, e);
@@ -212,10 +212,7 @@ void acados_mirror_adaptive_eps(int dim, double *A, double *V, double *d, double
     {
         max_eig = MAX(max_eig, fabs(d[i]));
     }
-    if (max_eig == 0.0)
-        eps = 1.0;
-    else
-        eps = max_eig/max_cond_block;
+    eps = MAX(max_eig/max_cond_block, min_eps);
 
     // mirror
     for (i = 0; i < dim; i++)
@@ -247,7 +244,7 @@ void acados_project(int dim, double *A, double *V, double *d, double *e, double 
 }
 
 
-void acados_project_adaptive_eps(int dim, double *A, double *V, double *d, double *e, double max_cond_block)
+void acados_project_adaptive_eps(int dim, double *A, double *V, double *d, double *e, double max_cond_block, double min_eps)
 {
     int i;
     acados_eigen_decomposition(dim, A, V, d, e);
@@ -259,10 +256,7 @@ void acados_project_adaptive_eps(int dim, double *A, double *V, double *d, doubl
     {
         max_eig = MAX(max_eig, d[i]);
     }
-    if (max_eig == 0.0)
-        eps = 1.0;
-    else
-        eps = max_eig/max_cond_block;
+    eps = MAX(max_eig/max_cond_block, min_eps);
 
     // project
     for (i = 0; i < dim; i++)

--- a/acados/ocp_nlp/ocp_nlp_reg_common.h
+++ b/acados/ocp_nlp/ocp_nlp_reg_common.h
@@ -111,9 +111,9 @@ void *ocp_nlp_reg_config_assign(void *raw_memory);
 /* regularization help functions */
 void acados_reconstruct_A(int dim, double *A, double *V, double *d);
 void acados_mirror(int dim, double *A, double *V, double *d, double *e, double epsilon);
-void acados_mirror_adaptive_eps(int dim, double *A, double *V, double *d, double *e, double max_cond_block);
+void acados_mirror_adaptive_eps(int dim, double *A, double *V, double *d, double *e, double max_cond_block, double min_eps);
 void acados_project(int dim, double *A, double *V, double *d, double *e, double epsilon);
-void acados_project_adaptive_eps(int dim, double *A, double *V, double *d, double *e, double max_cond_block);
+void acados_project_adaptive_eps(int dim, double *A, double *V, double *d, double *e, double max_cond_block, double min_eps);
 
 
 #ifdef __cplusplus

--- a/acados/ocp_nlp/ocp_nlp_reg_mirror.c
+++ b/acados/ocp_nlp/ocp_nlp_reg_mirror.c
@@ -67,6 +67,7 @@ void ocp_nlp_reg_mirror_opts_initialize_default(void *config_, ocp_nlp_reg_dims 
     ocp_nlp_reg_mirror_opts *opts = opts_;
 
     opts->epsilon = 1e-4;
+    opts->min_epsilon = 1e-8;
     opts->adaptive_eps = false;
     opts->max_cond_block = 1e7;
 
@@ -84,6 +85,11 @@ void ocp_nlp_reg_mirror_opts_set(void *config_, void *opts_, const char *field, 
     {
         double *d_ptr = value;
         opts->epsilon = *d_ptr;
+    }
+    else if (!strcmp(field, "min_epsilon"))
+    {
+        double *d_ptr = value;
+        opts->min_epsilon = *d_ptr;
     }
     else if (!strcmp(field, "max_cond_block"))
     {
@@ -299,7 +305,7 @@ void ocp_nlp_reg_mirror_regularize(void *config, ocp_nlp_reg_dims *dims, void *o
         blasfeo_unpack_dmat(nu[ii]+nx[ii], nu[ii]+nx[ii], mem->RSQrq[ii], 0, 0, mem->reg_hess, nu[ii]+nx[ii]);
         if (opts->adaptive_eps)
         {
-            acados_mirror_adaptive_eps(nu[ii]+nx[ii], mem->reg_hess, mem->V, mem->d, mem->e, opts->max_cond_block);
+            acados_mirror_adaptive_eps(nu[ii]+nx[ii], mem->reg_hess, mem->V, mem->d, mem->e, opts->max_cond_block, opts->min_epsilon);
         }
         else
         {

--- a/acados/ocp_nlp/ocp_nlp_reg_mirror.h
+++ b/acados/ocp_nlp/ocp_nlp_reg_mirror.h
@@ -64,6 +64,7 @@ extern "C" {
 typedef struct
 {
     double epsilon;
+    double min_epsilon;
     bool adaptive_eps;
     double max_cond_block;
 } ocp_nlp_reg_mirror_opts;

--- a/acados/ocp_nlp/ocp_nlp_reg_project.c
+++ b/acados/ocp_nlp/ocp_nlp_reg_project.c
@@ -67,6 +67,7 @@ void ocp_nlp_reg_project_opts_initialize_default(void *config_, ocp_nlp_reg_dims
     ocp_nlp_reg_project_opts *opts = opts_;
 
     opts->epsilon = 1e-4;
+    opts->min_epsilon = 1e-8;
     opts->adaptive_eps = false;
     opts->max_cond_block = 1e7;
 
@@ -84,6 +85,11 @@ void ocp_nlp_reg_project_opts_set(void *config_, void *opts_, const char *field,
     {
         double *d_ptr = value;
         opts->epsilon = *d_ptr;
+    }
+    else if (!strcmp(field, "min_epsilon"))
+    {
+        double *d_ptr = value;
+        opts->min_epsilon = *d_ptr;
     }
     else if (!strcmp(field, "max_cond_block"))
     {
@@ -298,7 +304,7 @@ void ocp_nlp_reg_project_regularize(void *config, ocp_nlp_reg_dims *dims, void *
         blasfeo_unpack_dmat(nu[ii]+nx[ii], nu[ii]+nx[ii], mem->RSQrq[ii], 0, 0, mem->reg_hess, nu[ii]+nx[ii]);
         if (opts->adaptive_eps)
         {
-            acados_project_adaptive_eps(nu[ii]+nx[ii], mem->reg_hess, mem->V, mem->d, mem->e, opts->max_cond_block);
+            acados_project_adaptive_eps(nu[ii]+nx[ii], mem->reg_hess, mem->V, mem->d, mem->e, opts->max_cond_block, opts->min_epsilon);
         }
         else
         {

--- a/acados/ocp_nlp/ocp_nlp_reg_project.h
+++ b/acados/ocp_nlp/ocp_nlp_reg_project.h
@@ -64,6 +64,7 @@ extern "C" {
 typedef struct
 {
     double epsilon;
+    double min_epsilon;
     bool adaptive_eps;
     double max_cond_block;
 } ocp_nlp_reg_project_opts;

--- a/examples/acados_python/non_ocp_nlp/adaptive_eps_reg_test.py
+++ b/examples/acados_python/non_ocp_nlp/adaptive_eps_reg_test.py
@@ -79,6 +79,7 @@ def export_parametric_ocp() -> AcadosOcp:
     ocp.solver_options.eval_residual_at_max_iter = False
     ocp.solver_options.reg_adaptive_eps = True
     ocp.solver_options.reg_max_cond_block = 1e3
+    ocp.solver_options.reg_min_epsilon = 1e-7
 
     return ocp
 
@@ -93,10 +94,12 @@ def test_reg_adaptive_eps(regularize_method='MIRROR'):
     ocp.solver_options.nlp_solver_max_iter = 2 # QP should converge in one iteration
     ocp.solver_options.regularize_method = regularize_method
 
-    ocp_solver = AcadosOcpSolver(ocp, json_file="parameter_augmented_acados_ocp.json", verbose=True)
+    ocp_solver = AcadosOcpSolver(ocp, json_file="parameter_augmented_acados_ocp.json", verbose=False)
 
     nx = ocp.dims.nx
     nu = ocp.dims.nu
+
+    eps_min = ocp.solver_options.reg_min_epsilon
 
     W_mat2 = np.zeros((nx+nu, nx+nu))
     W_mat2[0,0] = 1e6
@@ -112,7 +115,8 @@ def test_reg_adaptive_eps(regularize_method='MIRROR'):
                     [0.5000,  -0.5000,  -0.5000,   0.5000],
                     [0.2706,  -0.6533,   0.6533,  -0.2706]])
 
-    mat_x = A_x.T @ np.diag([15, 4.0, -2e5, 1e-6]) @ A_x
+    W3_eig = [15, 4.0, -2e5, 1e-6]
+    mat_x = A_x.T @ np.diag(W3_eig) @ A_x
 
     W_mat3 = block_diag(mat_x, mat_u)
 
@@ -129,7 +133,7 @@ def test_reg_adaptive_eps(regularize_method='MIRROR'):
         nlp_iter = ocp_solver.get_stats("nlp_iter")
         hess_0 = ocp_solver.get_hessian_block(0)
         hess_1 = ocp_solver.get_hessian_block(1)
-        breakpoint()
+
         # check condition numbers
         qp_diagnostics = ocp_solver.qp_diagnostics()
         assert qp_diagnostics['condition_number_stage'][0] <= ocp.solver_options.reg_max_cond_block +1e-8, f"Condition number must be <= {ocp.solver_options.reg_max_cond_block} per stage, got {qp_diagnostics['condition_number_stage'][0]}"
@@ -140,21 +144,23 @@ def test_reg_adaptive_eps(regularize_method='MIRROR'):
 
         # check hessian
         if i == 0:
-            assert np.equal(hess_0, np.eye(nx+nu)).all(), f"Zero Hessian matrix should be transformed into identity for {regularize_method}"
+            assert np.equal(hess_0, eps_min*np.eye(nx+nu)).all(), f"Zero matrix should be regularized to eps_min * eye for {regularize_method}"
         elif i == 1:
             assert np.equal(hess_0, np.diag([1e3, 1e3, 1e6, 1e3, 1e3, 1e3])).all(), f"Something in adaptive {regularize_method} went wrong!"
         elif i == 2:
             # print(np.linalg.eigvals(W_mat))
-            # print(hess_0)
-            # print(np.real(np.linalg.eigvals(hess_0)))
+            print(hess_0)
+            print(np.real(np.linalg.eigvals(hess_0)))
             if regularize_method == 'MIRROR':
-                reg_eps = 2e5/ocp.solver_options.reg_max_cond_block
-                assert np.allclose(np.linalg.eigvals(hess_0), np.array([reg_eps, 2e5, reg_eps, reg_eps, reg_eps, reg_eps])), f"Something in adaptive {regularize_method} went wrong!"
+                max_abs_eig = np.max(np.abs(W3_eig))
+                reg_eps = max(max_abs_eig/ocp.solver_options.reg_max_cond_block, eps_min)
+                assert np.allclose(np.linalg.eigvals(hess_0), np.array([reg_eps, max_abs_eig, reg_eps, reg_eps, reg_eps, reg_eps])), f"Something in adaptive {regularize_method} went wrong!"
             elif regularize_method == 'PROJECT':
-                reg_eps = 15/ocp.solver_options.reg_max_cond_block
+                max_pos_eig = np.max(W3_eig)
+                reg_eps = max(max_pos_eig/ocp.solver_options.reg_max_cond_block, eps_min)
                 assert np.allclose(np.real(np.linalg.eigvals(hess_0)), np.array([15, 4, reg_eps, reg_eps, reg_eps, reg_eps]), rtol=1e-03, atol=1e-3), f"Something in adaptive {regularize_method} went wrong!"
 
-        assert np.equal(hess_1, np.eye(nx)).all(), f"Zero Hessian matrix should be transformed into identity for {regularize_method}"
+        assert np.equal(hess_1, eps_min*np.eye(nx)).all(), f"Zero matrix should be regularized to eps_min * eye for {regularize_method}"
 
 
 if __name__ == "__main__":

--- a/interfaces/CMakeLists.txt
+++ b/interfaces/CMakeLists.txt
@@ -258,6 +258,10 @@ add_test(NAME python_pendulum_ocp_example_cmake
         COMMAND "${CMAKE_COMMAND}" -E chdir ${PROJECT_SOURCE_DIR}/examples/acados_python/non_ocp_nlp
         python maratos_test_problem.py)
 
+    add_test(NAME python_test_adaptive_reg
+        COMMAND "${CMAKE_COMMAND}" -E chdir ${PROJECT_SOURCE_DIR}/examples/acados_python/non_ocp_nlp
+        python adaptive_eps_reg_test.py)
+
     # Convex test problem where full step SQP does not converge, but globalized SQP does
     add_test(NAME python_convex_test_problem_globalization
         COMMAND "${CMAKE_COMMAND}" -E chdir ${PROJECT_SOURCE_DIR}/examples/acados_python/convex_problem_globalization_needed
@@ -415,6 +419,9 @@ add_test(NAME python_pendulum_ocp_example_cmake
     # Directory getting_started
     set_tests_properties(python_pendulum_sim_example PROPERTIES DEPENDS python_pendulum_ocp_example)
     set_tests_properties(python_pendulum_closed_loop_example PROPERTIES DEPENDS python_pendulum_sim_example)
+
+    # Directory non_ocp_nlp
+    set_tests_properties(python_maratos_test_problem_globalization PROPERTIES DEPENDS python_test_adaptive_reg)
 
     # Directory acados_python/tests
     set_tests_properties(python_test_cython_vs_ctypes PROPERTIES DEPENDS python_test_reset)

--- a/interfaces/acados_matlab_octave/AcadosOcpOptions.m
+++ b/interfaces/acados_matlab_octave/AcadosOcpOptions.m
@@ -81,6 +81,7 @@ classdef AcadosOcpOptions < handle
         regularize_method
         reg_epsilon
         reg_max_cond_block
+        reg_min_epsilon
         reg_adaptive_eps
         exact_hess_cost
         exact_hess_dyn
@@ -187,6 +188,7 @@ classdef AcadosOcpOptions < handle
             obj.reg_epsilon = 1e-4;
             obj.reg_adaptive_eps = false;
             obj.reg_max_cond_block = 1e-7;
+            obj.reg_min_epsilon = 1e-8;
             obj.shooting_nodes = [];
             obj.cost_scaling = [];
             obj.exact_hess_cost = 1;

--- a/interfaces/acados_matlab_octave/AcadosOcpOptions.m
+++ b/interfaces/acados_matlab_octave/AcadosOcpOptions.m
@@ -187,7 +187,7 @@ classdef AcadosOcpOptions < handle
             obj.regularize_method = 'NO_REGULARIZE';
             obj.reg_epsilon = 1e-4;
             obj.reg_adaptive_eps = false;
-            obj.reg_max_cond_block = 1e-7;
+            obj.reg_max_cond_block = 1e7;
             obj.reg_min_epsilon = 1e-8;
             obj.shooting_nodes = [];
             obj.cost_scaling = [];

--- a/interfaces/acados_template/acados_template/acados_ocp_options.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_options.py
@@ -91,6 +91,7 @@ class AcadosOcpOptions:
         self.__reg_epsilon = 1e-4
         self.__reg_max_cond_block = 1e-7
         self.__reg_adaptive_eps = False
+        self.__reg_min_epsilon = 1e-8
         self.__exact_hess_cost = 1
         self.__exact_hess_dyn = 1
         self.__exact_hess_constr = 1
@@ -791,6 +792,15 @@ class AcadosOcpOptions:
         return self.__reg_adaptive_eps
 
     @property
+    def reg_min_epsilon(self):
+        """Minimum value for epsilon if regularize_method in ['PROJECT', 'MIRROR'] is used with reg_adaptive_eps.
+
+        Type: float
+        Default: 1e-8
+        """
+        return self.__reg_min_epsilon
+
+    @property
     def globalization_alpha_reduction(self):
         """Step size reduction factor for globalization MERIT_BACKTRACKING,
 
@@ -1400,6 +1410,12 @@ class AcadosOcpOptions:
         if not isinstance(reg_adaptive_eps, bool):
             raise Exception(f'Invalid reg_adaptive_eps value, expected bool, got {reg_adaptive_eps}')
         self.__reg_adaptive_eps = reg_adaptive_eps
+
+    @reg_min_epsilon.setter
+    def reg_min_epsilon(self, reg_min_epsilon):
+        if not isinstance(reg_min_epsilon, float) or reg_min_epsilon < 0:
+            raise Exception(f'Invalid reg_min_epsilon value, expected float > 0, got {reg_min_epsilon}')
+        self.__reg_min_epsilon = reg_min_epsilon
 
     @globalization_alpha_min.setter
     def globalization_alpha_min(self, globalization_alpha_min):

--- a/interfaces/acados_template/acados_template/acados_ocp_options.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_options.py
@@ -89,7 +89,7 @@ class AcadosOcpOptions:
         self.__cost_discretization = 'EULER'
         self.__regularize_method = 'NO_REGULARIZE'
         self.__reg_epsilon = 1e-4
-        self.__reg_max_cond_block = 1e-7
+        self.__reg_max_cond_block = 1e7
         self.__reg_adaptive_eps = False
         self.__reg_min_epsilon = 1e-8
         self.__exact_hess_cost = 1
@@ -774,7 +774,7 @@ class AcadosOcpOptions:
         """Maximum condition number of each Hessian block after regularization with regularize_method in ['PROJECT', 'MIRROR'] and reg_adaptive_eps = True
 
         Type: float
-        Default: 1e-7
+        Default: 1e7
         """
         return self.__reg_max_cond_block
 

--- a/interfaces/acados_template/acados_template/acados_ocp_options.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_options.py
@@ -1403,6 +1403,8 @@ class AcadosOcpOptions:
 
     @reg_max_cond_block.setter
     def reg_max_cond_block(self, reg_max_cond_block):
+        if not isinstance(reg_max_cond_block, float) or reg_max_cond_block < 1.0:
+            raise Exception('Invalid reg_max_cond_block value, expected float > 1.0.')
         self.__reg_max_cond_block = reg_max_cond_block
 
     @reg_adaptive_eps.setter

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.c
@@ -2280,6 +2280,9 @@ void {{ name }}_acados_create_set_opts({{ name }}_solver_capsule* capsule)
     double reg_max_cond_block = {{ solver_options.reg_max_cond_block }};
     ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "reg_max_cond_block", &reg_max_cond_block);
 
+    double reg_min_epsilon = {{ solver_options.reg_min_epsilon }};
+    ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "reg_min_epsilon", &reg_min_epsilon);
+
     bool reg_adaptive_eps = {{ solver_options.reg_adaptive_eps }};
     ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "reg_adaptive_eps", &reg_adaptive_eps);
 {%- endif %}

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -2395,6 +2395,9 @@ static void {{ model.name }}_acados_create_set_opts({{ model.name }}_solver_caps
     double reg_max_cond_block = {{ solver_options.reg_max_cond_block }};
     ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "reg_max_cond_block", &reg_max_cond_block);
 
+    double reg_min_epsilon = {{ solver_options.reg_min_epsilon }};
+    ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "reg_min_epsilon", &reg_min_epsilon);
+
     bool reg_adaptive_eps = {{ solver_options.reg_adaptive_eps }};
     ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "reg_adaptive_eps", &reg_adaptive_eps);
 {%- endif %}


### PR DESCRIPTION
- fix test, run test on CI
- add option: `reg_min_epsilon`: Minimum value for epsilon if regularize_method in ['PROJECT', 'MIRROR'] is used with reg_adaptive_eps. Default: 1e-8.
- fix `reg_max_cond_block` default: 1e7 instead of 1e-7. Add check that it must be >= 1.0.