### PR TITLE
Gershgorin Levenberg Marquardt regularization

### DIFF
--- a/acados/ocp_nlp/ocp_nlp_reg_glm.c
+++ b/acados/ocp_nlp/ocp_nlp_reg_glm.c
@@ -1,0 +1,326 @@
+/*
+ * Copyright (c) The acados authors.
+ *
+ * This file is part of acados.
+ *
+ * The 2-Clause BSD License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.;
+ */
+
+
+#include "acados/ocp_nlp/ocp_nlp_reg_glm.h"
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+
+#include "acados/ocp_nlp/ocp_nlp_reg_common.h"
+#include "acados/utils/math.h"
+
+#include "blasfeo_d_aux.h"
+#include "blasfeo_d_blas.h"
+
+
+
+/************************************************
+ * opts
+ ************************************************/
+
+acados_size_t ocp_nlp_reg_glm_opts_calculate_size(void)
+{
+    return sizeof(ocp_nlp_reg_glm_opts);
+}
+
+
+
+void *ocp_nlp_reg_glm_opts_assign(void *raw_memory)
+{
+    return raw_memory;
+}
+
+
+
+void ocp_nlp_reg_glm_opts_initialize_default(void *config_, ocp_nlp_reg_dims *dims, void *opts_)
+{
+    // ocp_nlp_reg_glm_opts *opts = opts_;
+    return;
+}
+
+
+
+void ocp_nlp_reg_glm_opts_set(void *config_, void *opts_, const char *field, void* value)
+{
+
+    // ocp_nlp_reg_glm_opts *opts = opts_;
+    printf("\nerror: field %s not available in ocp_nlp_reg_glm_opts_set\n", field);
+    exit(1);
+    // if (!strcmp(field, "epsilon"))
+    // {
+    //     double *d_ptr = value;
+    //     opts->epsilon = *d_ptr;
+    // }
+    // else
+    // {
+    //     printf("\nerror: field %s not available in ocp_nlp_reg_glm_opts_set\n", field);
+    //     exit(1);
+    // }
+
+    return;
+}
+
+
+
+/************************************************
+ * memory
+ ************************************************/
+
+acados_size_t ocp_nlp_reg_glm_memory_calculate_size(void *config_, ocp_nlp_reg_dims *dims, void *opts_)
+{
+    int *nx = dims->nx;
+    int *nu = dims->nu;
+    int N = dims->N;
+
+    int ii;
+
+    int nuxM = nu[0]+nx[0];
+    for(ii=1; ii<=N; ii++)
+    {
+        nuxM = nu[ii]+nx[ii]>nuxM ? nu[ii]+nx[ii] : nuxM;
+    }
+
+    acados_size_t size = 0;
+
+    size += sizeof(ocp_nlp_reg_glm_memory);
+
+    size += (N+1)*sizeof(struct blasfeo_dmat *); // RSQrq
+
+    return size;
+}
+
+
+
+void *ocp_nlp_reg_glm_memory_assign(void *config_, ocp_nlp_reg_dims *dims, void *opts_, void *raw_memory)
+{
+    int *nx = dims->nx;
+    int *nu = dims->nu;
+    int N = dims->N;
+
+    int ii;
+
+    int nuxM = nu[0]+nx[0];
+    for(ii=1; ii<=N; ii++)
+    {
+        nuxM = nu[ii]+nx[ii]>nuxM ? nu[ii]+nx[ii] : nuxM;
+    }
+
+    char *c_ptr = (char *) raw_memory;
+
+    ocp_nlp_reg_glm_memory *mem = (ocp_nlp_reg_glm_memory *) c_ptr;
+    c_ptr += sizeof(ocp_nlp_reg_glm_memory);
+
+    mem->RSQrq = (struct blasfeo_dmat **) c_ptr;
+    c_ptr += (N+1)*sizeof(struct blasfeo_dmat *); // RSQrq
+
+    assert((char *) mem + ocp_nlp_reg_glm_memory_calculate_size(config_, dims, opts_) >= c_ptr);
+
+    return mem;
+}
+
+
+
+void ocp_nlp_reg_glm_memory_set_RSQrq_ptr(ocp_nlp_reg_dims *dims, struct blasfeo_dmat *RSQrq, void *memory_)
+{
+    ocp_nlp_reg_glm_memory *memory = memory_;
+
+    int ii;
+
+    int N = dims->N;
+    // int *nx = dims->nx;
+    // int *nu = dims->nu;
+
+    for(ii=0; ii<=N; ii++)
+    {
+        memory->RSQrq[ii] = RSQrq+ii;
+//        blasfeo_print_dmat(nu[ii]+nx[ii]+1, nu[ii]+nx[ii], memory->RSQrq[ii], 0, 0);
+    }
+
+    return;
+}
+
+
+
+void ocp_nlp_reg_glm_memory_set_rq_ptr(ocp_nlp_reg_dims *dims, struct blasfeo_dvec *rq, void *memory_)
+{
+    return;
+}
+
+
+
+void ocp_nlp_reg_glm_memory_set_BAbt_ptr(ocp_nlp_reg_dims *dims, struct blasfeo_dmat *BAbt, void *memory_)
+{
+    return;
+}
+
+
+
+void ocp_nlp_reg_glm_memory_set_b_ptr(ocp_nlp_reg_dims *dims, struct blasfeo_dvec *b, void *memory_)
+{
+    return;
+}
+
+
+
+void ocp_nlp_reg_glm_memory_set_idxb_ptr(ocp_nlp_reg_dims *dims, int **idxb, void *memory_)
+{
+    return;
+}
+
+
+
+void ocp_nlp_reg_glm_memory_set_DCt_ptr(ocp_nlp_reg_dims *dims, struct blasfeo_dmat *DCt, void *memory_)
+{
+    return;
+}
+
+
+
+void ocp_nlp_reg_glm_memory_set_ux_ptr(ocp_nlp_reg_dims *dims, struct blasfeo_dvec *ux, void *memory_)
+{
+    return;
+}
+
+
+
+void ocp_nlp_reg_glm_memory_set_pi_ptr(ocp_nlp_reg_dims *dims, struct blasfeo_dvec *pi, void *memory_)
+{
+    return;
+}
+
+
+
+void ocp_nlp_reg_glm_memory_set_lam_ptr(ocp_nlp_reg_dims *dims, struct blasfeo_dvec *lam, void *memory_)
+{
+    return;
+}
+
+
+
+void ocp_nlp_reg_glm_memory_set(void *config_, ocp_nlp_reg_dims *dims, void *memory_, char *field, void *value)
+{
+
+    if(!strcmp(field, "RSQrq_ptr"))
+    {
+        struct blasfeo_dmat *RSQrq = value;
+        ocp_nlp_reg_glm_memory_set_RSQrq_ptr(dims, RSQrq, memory_);
+    }
+    else
+    {
+        printf("\nerror: field %s not available in ocp_nlp_reg_glm_set\n", field);
+        exit(1);
+    }
+
+    return;
+}
+
+
+
+/************************************************
+ * functions
+ ************************************************/
+
+void ocp_nlp_reg_glm_regularize(void *config, ocp_nlp_reg_dims *dims, void *opts_, void *mem_)
+{
+    ocp_nlp_reg_glm_memory *mem = (ocp_nlp_reg_glm_memory *) mem_;
+    // ocp_nlp_reg_glm_opts *opts = opts_;
+
+    int ii;
+
+    int *nx = dims->nx;
+    int *nu = dims->nu;
+    double tmp;
+
+    for(ii=0; ii<=dims->N; ii++)
+    {
+        // make symmetric
+        blasfeo_dtrtr_l(nu[ii]+nx[ii], mem->RSQrq[ii], 0, 0, mem->RSQrq[ii], 0, 0);
+
+        // regularize
+        compute_gershgorin_min_eig_estimate(nu[ii]+nx[ii], mem->RSQrq[ii], &tmp);
+
+        blasfeo_ddiare(nu[ii]+nx[ii], tmp, mem->RSQrq[ii], 0, 0);
+    }
+}
+
+
+void ocp_nlp_reg_glm_regularize_lhs(void *config, ocp_nlp_reg_dims *dims, void *opts_, void *mem_)
+{
+    ocp_nlp_reg_glm_regularize(config, dims, opts_, mem_);
+}
+
+
+void ocp_nlp_reg_glm_regularize_rhs(void *config, ocp_nlp_reg_dims *dims, void *opts_, void *mem_)
+{
+    return;
+}
+
+
+void ocp_nlp_reg_glm_correct_dual_sol(void *config, ocp_nlp_reg_dims *dims, void *opts_, void *mem_)
+{
+    return;
+}
+
+
+
+void ocp_nlp_reg_glm_config_initialize_default(ocp_nlp_reg_config *config)
+{
+    // dims
+    config->dims_calculate_size = &ocp_nlp_reg_dims_calculate_size;
+    config->dims_assign = &ocp_nlp_reg_dims_assign;
+    config->dims_set = &ocp_nlp_reg_dims_set;
+    // opts
+    config->opts_calculate_size = &ocp_nlp_reg_glm_opts_calculate_size;
+    config->opts_assign = &ocp_nlp_reg_glm_opts_assign;
+    config->opts_initialize_default = &ocp_nlp_reg_glm_opts_initialize_default;
+    config->opts_set = &ocp_nlp_reg_glm_opts_set;
+    // memory
+    config->memory_calculate_size = &ocp_nlp_reg_glm_memory_calculate_size;
+    config->memory_assign = &ocp_nlp_reg_glm_memory_assign;
+    config->memory_set = &ocp_nlp_reg_glm_memory_set;
+    config->memory_set_RSQrq_ptr = &ocp_nlp_reg_glm_memory_set_RSQrq_ptr;
+    config->memory_set_rq_ptr = &ocp_nlp_reg_glm_memory_set_rq_ptr;
+    config->memory_set_BAbt_ptr = &ocp_nlp_reg_glm_memory_set_BAbt_ptr;
+    config->memory_set_b_ptr = &ocp_nlp_reg_glm_memory_set_b_ptr;
+    config->memory_set_idxb_ptr = &ocp_nlp_reg_glm_memory_set_idxb_ptr;
+    config->memory_set_DCt_ptr = &ocp_nlp_reg_glm_memory_set_DCt_ptr;
+    config->memory_set_ux_ptr = &ocp_nlp_reg_glm_memory_set_ux_ptr;
+    config->memory_set_pi_ptr = &ocp_nlp_reg_glm_memory_set_pi_ptr;
+    config->memory_set_lam_ptr = &ocp_nlp_reg_glm_memory_set_lam_ptr;
+    // functions
+    config->regularize = &ocp_nlp_reg_glm_regularize;
+    config->regularize_rhs = &ocp_nlp_reg_glm_regularize_rhs;
+    config->regularize_lhs = &ocp_nlp_reg_glm_regularize_lhs;
+    config->correct_dual_sol = &ocp_nlp_reg_glm_correct_dual_sol;
+}
+

--- a/acados/ocp_nlp/ocp_nlp_reg_glm.c
+++ b/acados/ocp_nlp/ocp_nlp_reg_glm.c
@@ -157,13 +157,10 @@ void ocp_nlp_reg_glm_memory_set_RSQrq_ptr(ocp_nlp_reg_dims *dims, struct blasfeo
     int ii;
 
     int N = dims->N;
-    // int *nx = dims->nx;
-    // int *nu = dims->nu;
 
     for(ii=0; ii<=N; ii++)
     {
         memory->RSQrq[ii] = RSQrq+ii;
-//        blasfeo_print_dmat(nu[ii]+nx[ii]+1, nu[ii]+nx[ii], memory->RSQrq[ii], 0, 0);
     }
 
     return;
@@ -229,17 +226,9 @@ void ocp_nlp_reg_glm_memory_set_lam_ptr(ocp_nlp_reg_dims *dims, struct blasfeo_d
 
 void ocp_nlp_reg_glm_memory_set(void *config_, ocp_nlp_reg_dims *dims, void *memory_, char *field, void *value)
 {
-
-    if(!strcmp(field, "RSQrq_ptr"))
-    {
-        struct blasfeo_dmat *RSQrq = value;
-        ocp_nlp_reg_glm_memory_set_RSQrq_ptr(dims, RSQrq, memory_);
-    }
-    else
-    {
-        printf("\nerror: field %s not available in ocp_nlp_reg_glm_set\n", field);
-        exit(1);
-    }
+    // TODO: remove this function in all regularizaiton modules
+    printf("\nerror: field %s not available in ocp_nlp_reg_glm_set\n", field);
+    exit(1);
 
     return;
 }

--- a/acados/ocp_nlp/ocp_nlp_reg_glm.h
+++ b/acados/ocp_nlp/ocp_nlp_reg_glm.h
@@ -63,7 +63,7 @@ extern "C" {
 
 typedef struct
 {
-    int dummy;
+    double epsilon;
 } ocp_nlp_reg_glm_opts;
 
 //
@@ -83,11 +83,6 @@ void ocp_nlp_reg_glm_opts_set(void *config_, void *opts_, const char *field, voi
 
 typedef struct
 {
-    double *reg_hess; // TODO move to workspace
-    double *V; // TODO move to workspace
-    double *d; // TODO move to workspace
-    double *e; // TODO move to workspace
-
     struct blasfeo_dmat **RSQrq;  // pointer to RSQrq in qp_in
 } ocp_nlp_reg_glm_memory;
 
@@ -95,12 +90,6 @@ typedef struct
 acados_size_t ocp_nlp_reg_glm_memory_calculate_size(void *config, ocp_nlp_reg_dims *dims, void *opts);
 //
 void *ocp_nlp_reg_glm_memory_assign(void *config, ocp_nlp_reg_dims *dims, void *opts, void *raw_memory);
-
-/************************************************
- * workspace
- ************************************************/
-
- // TODO
 
 /************************************************
  * functions

--- a/acados/ocp_nlp/ocp_nlp_reg_glm.h
+++ b/acados/ocp_nlp/ocp_nlp_reg_glm.h
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) The acados authors.
+ *
+ * This file is part of acados.
+ *
+ * The 2-Clause BSD License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.;
+ */
+
+
+/// \addtogroup ocp_nlp
+/// @{
+/// \addtogroup ocp_nlp_reg
+/// @{
+
+#ifndef ACADOS_OCP_NLP_OCP_NLP_REG_PROJECT_H_
+#define ACADOS_OCP_NLP_OCP_NLP_REG_PROJECT_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+
+// blasfeo
+#include "blasfeo_common.h"
+
+// acados
+#include "acados/ocp_nlp/ocp_nlp_reg_common.h"
+
+
+
+/************************************************
+ * dims
+ ************************************************/
+
+// use the functions in ocp_nlp_reg_common
+
+/************************************************
+ * options
+ ************************************************/
+
+typedef struct
+{
+    int dummy;
+} ocp_nlp_reg_glm_opts;
+
+//
+acados_size_t ocp_nlp_reg_glm_opts_calculate_size(void);
+//
+void *ocp_nlp_reg_glm_opts_assign(void *raw_memory);
+//
+void ocp_nlp_reg_glm_opts_initialize_default(void *config_, ocp_nlp_reg_dims *dims, void *opts_);
+//
+void ocp_nlp_reg_glm_opts_set(void *config_, void *opts_, const char *field, void* value);
+
+
+
+/************************************************
+ * memory
+ ************************************************/
+
+typedef struct
+{
+    double *reg_hess; // TODO move to workspace
+    double *V; // TODO move to workspace
+    double *d; // TODO move to workspace
+    double *e; // TODO move to workspace
+
+    struct blasfeo_dmat **RSQrq;  // pointer to RSQrq in qp_in
+} ocp_nlp_reg_glm_memory;
+
+//
+acados_size_t ocp_nlp_reg_glm_memory_calculate_size(void *config, ocp_nlp_reg_dims *dims, void *opts);
+//
+void *ocp_nlp_reg_glm_memory_assign(void *config, ocp_nlp_reg_dims *dims, void *opts, void *raw_memory);
+
+/************************************************
+ * workspace
+ ************************************************/
+
+ // TODO
+
+/************************************************
+ * functions
+ ************************************************/
+
+//
+void ocp_nlp_reg_glm_config_initialize_default(ocp_nlp_reg_config *config);
+
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // ACADOS_OCP_NLP_OCP_NLP_REG_PROJECT_H_
+/// @}
+/// @}

--- a/acados/ocp_nlp/ocp_nlp_reg_glm.h
+++ b/acados/ocp_nlp/ocp_nlp_reg_glm.h
@@ -34,8 +34,8 @@
 /// \addtogroup ocp_nlp_reg
 /// @{
 
-#ifndef ACADOS_OCP_NLP_OCP_NLP_REG_PROJECT_H_
-#define ACADOS_OCP_NLP_OCP_NLP_REG_PROJECT_H_
+#ifndef ACADOS_OCP_NLP_OCP_NLP_REG_GLM_H_
+#define ACADOS_OCP_NLP_OCP_NLP_REG_GLM_H_
 
 #ifdef __cplusplus
 extern "C" {
@@ -104,6 +104,6 @@ void ocp_nlp_reg_glm_config_initialize_default(ocp_nlp_reg_config *config);
 }
 #endif
 
-#endif  // ACADOS_OCP_NLP_OCP_NLP_REG_PROJECT_H_
+#endif  // ACADOS_OCP_NLP_OCP_NLP_REG_GLM_H_
 /// @}
 /// @}

--- a/acados/utils/math.c
+++ b/acados/utils/math.c
@@ -1110,6 +1110,51 @@ void acados_eigen_decomposition(int dim, double *A, double *V, double *d, double
 }
 
 
+void compute_gershgorin_max_abs_eig_estimate(int n, struct blasfeo_dmat *A, double *out)
+{
+    double max_abs_eig = 0.0;
+    double r_i, lam, rho, a;
+    for (int ii = 0; ii < n; ii++)
+    {
+        r_i = 0.0;
+        for (int jj = 0; jj < n; jj++)
+        {
+            if (jj != ii)
+            {
+                r_i += fabs(BLASFEO_DMATEL(A, ii, jj));
+            }
+        }
+        a = BLASFEO_DMATEL(A, ii, ii);
+        lam = a - r_i;
+        rho = a + r_i;
+        max_abs_eig = fmax(max_abs_eig, fmax(fabs(lam), fabs(rho)));
+    }
+    *out = max_abs_eig;
+}
+
+void compute_gershgorin_min_eig_estimate(int n, struct blasfeo_dmat *A, double *out)
+{
+    // returns a lower bound for the minimum eigenvalue of A
+    double lam = ACADOS_INFTY;
+    double a, r_i, lam_i;
+    for (int ii = 0; ii < n; ii++)
+    {
+        r_i = 0.0;
+        for (int jj = 0; jj < n; jj++)
+        {
+            if (jj != ii)
+            {
+                r_i += fabs(BLASFEO_DMATEL(A, ii, jj));
+            }
+        }
+        a = BLASFEO_DMATEL(A, ii, ii);
+        lam_i = a - r_i;
+        lam = fmin(lam, lam_i);
+    }
+    *out = lam;
+}
+
+
 
 double minimum_of_doubles(double *x, int n)
 {

--- a/acados/utils/math.h
+++ b/acados/utils/math.h
@@ -36,6 +36,7 @@ extern "C" {
 #endif
 
 #include "acados/utils/types.h"
+#include "blasfeo_common.h"
 
 #if defined(__MABX2__)
 double fmax(double a, double b);
@@ -99,6 +100,11 @@ void acados_eigen_decomposition(int dim, double *A, double *V, double *d, double
 double minimum_of_doubles(double *x, int n);
 
 void neville_algorithm(double xx, int n, double *x, double *Q, double *out);
+
+void compute_gershgorin_max_abs_eig_estimate(int n, struct blasfeo_dmat *A, double *out);
+
+void compute_gershgorin_min_eig_estimate(int n, struct blasfeo_dmat *A, double *out);
+
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/examples/acados_python/non_ocp_nlp/adaptive_eps_reg_test.py
+++ b/examples/acados_python/non_ocp_nlp/adaptive_eps_reg_test.py
@@ -73,7 +73,7 @@ def export_parametric_ocp() -> AcadosOcp:
     ocp.solver_options.nlp_solver_type = "SQP"
     ocp.solver_options.N_horizon = 1
     ocp.solver_options.tf = 1.0
-    ocp.solver_options.print_level = 1
+    ocp.solver_options.print_level = 0
     ocp.solver_options.nlp_solver_ext_qp_res = 1
     ocp.solver_options.nlp_solver_max_iter = 2
     ocp.solver_options.eval_residual_at_max_iter = False
@@ -94,12 +94,12 @@ def test_reg_adaptive_eps(regularize_method='MIRROR'):
     ocp.solver_options.nlp_solver_max_iter = 2 # QP should converge in one iteration
     ocp.solver_options.regularize_method = regularize_method
 
-    ocp_solver = AcadosOcpSolver(ocp, json_file="parameter_augmented_acados_ocp.json", verbose=False)
+    ocp_solver = AcadosOcpSolver(ocp, verbose=False)
 
     nx = ocp.dims.nx
     nu = ocp.dims.nu
 
-    eps_min = ocp.solver_options.reg_min_epsilon
+    eps_min = ocp.solver_options.reg_min_epsilon if regularize_method != "GERSHGORIN_LEVENBERG_MARQUARDT" else ocp.solver_options.reg_epsilon
 
     W_mat2 = np.zeros((nx+nu, nx+nu))
     W_mat2[0,0] = 1e6
@@ -134,31 +134,36 @@ def test_reg_adaptive_eps(regularize_method='MIRROR'):
         hess_0 = ocp_solver.get_hessian_block(0)
         hess_1 = ocp_solver.get_hessian_block(1)
 
-        # check condition numbers
-        qp_diagnostics = ocp_solver.qp_diagnostics()
-        assert qp_diagnostics['condition_number_stage'][0] <= ocp.solver_options.reg_max_cond_block +1e-8, f"Condition number must be <= {ocp.solver_options.reg_max_cond_block} per stage, got {qp_diagnostics['condition_number_stage'][0]}"
-        assert qp_diagnostics['condition_number_stage'][1] <= ocp.solver_options.reg_max_cond_block +1e-8, f"Condition number must be <= {ocp.solver_options.reg_max_cond_block} per stage, got {qp_diagnostics['condition_number_stage'][1]}"
-
         # check solver stats
         assert status == 0, f"acados returned status {status}"
+        # check eigenvalues
+        eigvals_0 = np.real(np.linalg.eigvals(hess_0))
+        assert np.min(eigvals_0) >= eps_min*0.99, f"Eigenvalues of Hessian must be >= {eps_min} = eps_min, got {eigvals_0}"
 
         # check hessian
-        if i == 0:
-            assert np.equal(hess_0, eps_min*np.eye(nx+nu)).all(), f"Zero matrix should be regularized to eps_min * eye for {regularize_method}"
-        elif i == 1:
-            assert np.equal(hess_0, np.diag([1e3, 1e3, 1e6, 1e3, 1e3, 1e3])).all(), f"Something in adaptive {regularize_method} went wrong!"
-        elif i == 2:
-            # print(np.linalg.eigvals(W_mat))
-            print(hess_0)
-            print(np.real(np.linalg.eigvals(hess_0)))
-            if regularize_method == 'MIRROR':
-                max_abs_eig = np.max(np.abs(W3_eig))
-                reg_eps = max(max_abs_eig/ocp.solver_options.reg_max_cond_block, eps_min)
-                assert np.allclose(np.linalg.eigvals(hess_0), np.array([reg_eps, max_abs_eig, reg_eps, reg_eps, reg_eps, reg_eps])), f"Something in adaptive {regularize_method} went wrong!"
-            elif regularize_method == 'PROJECT':
-                max_pos_eig = np.max(W3_eig)
-                reg_eps = max(max_pos_eig/ocp.solver_options.reg_max_cond_block, eps_min)
-                assert np.allclose(np.real(np.linalg.eigvals(hess_0)), np.array([15, 4, reg_eps, reg_eps, reg_eps, reg_eps]), rtol=1e-03, atol=1e-3), f"Something in adaptive {regularize_method} went wrong!"
+        if regularize_method in ['MIRROR', 'PROJECT']:
+            # check condition numbers
+            qp_diagnostics = ocp_solver.qp_diagnostics()
+            assert qp_diagnostics['condition_number_stage'][0] <= ocp.solver_options.reg_max_cond_block +1e-8, f"Condition number must be <= {ocp.solver_options.reg_max_cond_block} per stage, got {qp_diagnostics['condition_number_stage'][0]}"
+            assert qp_diagnostics['condition_number_stage'][1] <= ocp.solver_options.reg_max_cond_block +1e-8, f"Condition number must be <= {ocp.solver_options.reg_max_cond_block} per stage, got {qp_diagnostics['condition_number_stage'][1]}"
+            if i == 0:
+                print(hess_0)
+                assert np.equal(hess_0, eps_min*np.eye(nx+nu)).all(), f"Zero matrix should be regularized to eps_min * eye for {regularize_method}"
+            elif i == 1:
+                min_eig = np.max(eigvals_0) / ocp.solver_options.reg_max_cond_block
+                assert np.equal(hess_0, np.diag([min_eig, min_eig, 1e6, min_eig, min_eig, min_eig])).all(), f"Something in adaptive {regularize_method} went wrong!"
+            elif i == 2:
+                # print(np.linalg.eigvals(W_mat))
+                # print(hess_0)
+                # print(eigvals_0)
+                if regularize_method == 'MIRROR':
+                    max_abs_eig = np.max(np.abs(W3_eig))
+                    reg_eps = max(max_abs_eig/ocp.solver_options.reg_max_cond_block, eps_min)
+                    assert np.allclose(eigvals_0, np.array([reg_eps, max_abs_eig, reg_eps, reg_eps, reg_eps, reg_eps])), f"Something in adaptive {regularize_method} went wrong!"
+                elif regularize_method == 'PROJECT':
+                    max_pos_eig = np.max(W3_eig)
+                    reg_eps = max(max_pos_eig/ocp.solver_options.reg_max_cond_block, eps_min)
+                    assert np.allclose(eigvals_0, np.array([15, 4, reg_eps, reg_eps, reg_eps, reg_eps]), rtol=1e-03, atol=1e-3), f"Something in adaptive {regularize_method} went wrong!"
 
         assert np.equal(hess_1, eps_min*np.eye(nx)).all(), f"Zero matrix should be regularized to eps_min * eye for {regularize_method}"
 
@@ -166,3 +171,4 @@ def test_reg_adaptive_eps(regularize_method='MIRROR'):
 if __name__ == "__main__":
     test_reg_adaptive_eps("MIRROR")
     test_reg_adaptive_eps("PROJECT")
+    test_reg_adaptive_eps("GERSHGORIN_LEVENBERG_MARQUARDT")

--- a/interfaces/acados_c/ocp_nlp_interface.c
+++ b/interfaces/acados_c/ocp_nlp_interface.c
@@ -48,6 +48,7 @@
 #include "acados/ocp_nlp/ocp_nlp_constraints_bgh.h"
 #include "acados/ocp_nlp/ocp_nlp_constraints_bgp.h"
 #include "acados/ocp_nlp/ocp_nlp_reg_convexify.h"
+#include "acados/ocp_nlp/ocp_nlp_reg_glm.h"
 #include "acados/ocp_nlp/ocp_nlp_reg_mirror.h"
 #include "acados/ocp_nlp/ocp_nlp_reg_project.h"
 #include "acados/ocp_nlp/ocp_nlp_reg_project_reduc_hess.h"
@@ -236,6 +237,9 @@ ocp_nlp_config *ocp_nlp_config_create(ocp_nlp_plan_t plan)
             break;
         case CONVEXIFY:
             ocp_nlp_reg_convexify_config_initialize_default(config->regularize);
+            break;
+        case GERSHGORIN_LEVENBERG_MARQUARDT:
+            ocp_nlp_reg_glm_config_initialize_default(config->regularize);
             break;
         default:
             printf("\nerror: ocp_nlp_config_create: unsupported plan->regularization\n");

--- a/interfaces/acados_c/ocp_nlp_interface.h
+++ b/interfaces/acados_c/ocp_nlp_interface.h
@@ -92,6 +92,7 @@ typedef enum
     PROJECT,
     PROJECT_REDUC_HESS,
     CONVEXIFY,
+    GERSHGORIN_LEVENBERG_MARQUARDT,
     INVALID_REGULARIZE,
 } ocp_nlp_reg_t;
 

--- a/interfaces/acados_template/acados_template/acados_ocp_options.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_options.py
@@ -324,7 +324,7 @@ class AcadosOcpOptions:
     @property
     def regularize_method(self):
         """Regularization method for the Hessian.
-        String in ('NO_REGULARIZE', 'MIRROR', 'PROJECT', 'PROJECT_REDUC_HESS', 'CONVEXIFY') or :code:`None`.
+        String in ('NO_REGULARIZE', 'MIRROR', 'PROJECT', 'PROJECT_REDUC_HESS', 'CONVEXIFY', 'GERSHGORIN_LEVENBERG_MARQUARDT').
 
         - MIRROR: performs eigenvalue decomposition H = V^T D V and sets D_ii = max(eps, abs(D_ii))
         - PROJECT: performs eigenvalue decomposition H = V^T D V and sets D_ii = max(eps, D_ii)

--- a/interfaces/acados_template/acados_template/acados_ocp_options.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_options.py
@@ -766,7 +766,7 @@ class AcadosOcpOptions:
 
     @property
     def reg_epsilon(self):
-        """Epsilon for regularization, used if regularize_method in ['PROJECT', 'MIRROR', 'CONVEXIFY']"""
+        """Epsilon for regularization, used if regularize_method in ['PROJECT', 'MIRROR', 'CONVEXIFY', 'GERSHGORIN_LEVENBERG_MARQUARDT']."""
         return self.__reg_epsilon
 
     @property
@@ -1239,7 +1239,7 @@ class AcadosOcpOptions:
     @regularize_method.setter
     def regularize_method(self, regularize_method):
         regularize_methods = ('NO_REGULARIZE', 'MIRROR', 'PROJECT', \
-                                'PROJECT_REDUC_HESS', 'CONVEXIFY')
+                                'PROJECT_REDUC_HESS', 'CONVEXIFY', 'GERSHGORIN_LEVENBERG_MARQUARDT')
         if regularize_method in regularize_methods:
             self.__regularize_method = regularize_method
         else:

--- a/interfaces/acados_template/acados_template/acados_ocp_options.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_options.py
@@ -330,8 +330,7 @@ class AcadosOcpOptions:
         - PROJECT: performs eigenvalue decomposition H = V^T D V and sets D_ii = max(eps, D_ii)
         - CONVEXIFY: Algorithm 6 from Verschueren2017, https://cdn.syscop.de/publications/Verschueren2017.pdf, does not support nonlinear constraints
         - PROJECT_REDUC_HESS: experimental
-
-        Note: default eps = 1e-4
+        - GERSHGORIN_LEVENBERG_MARQUARDT: estimates the smallest eigenvalue block-wise using Gershgorin circles and adds multiple of identity to the block, such that smallest eigenvalue after regularization is at least reg_epsilon
 
         Default: 'NO_REGULARIZE'.
         """

--- a/interfaces/acados_template/acados_template/acados_ocp_options.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_options.py
@@ -330,7 +330,7 @@ class AcadosOcpOptions:
         - PROJECT: performs eigenvalue decomposition H = V^T D V and sets D_ii = max(eps, D_ii)
         - CONVEXIFY: Algorithm 6 from Verschueren2017, https://cdn.syscop.de/publications/Verschueren2017.pdf, does not support nonlinear constraints
         - PROJECT_REDUC_HESS: experimental
-        - GERSHGORIN_LEVENBERG_MARQUARDT: estimates the smallest eigenvalue block-wise using Gershgorin circles and adds multiple of identity to the block, such that smallest eigenvalue after regularization is at least reg_epsilon
+        - GERSHGORIN_LEVENBERG_MARQUARDT: estimates the smallest eigenvalue of each Hessian block using Gershgorin circles and adds multiple of identity to each block, such that smallest eigenvalue after regularization is at least reg_epsilon
 
         Default: 'NO_REGULARIZE'.
         """

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -1568,7 +1568,6 @@ class AcadosOcpSolver:
             nlp_iter = self.get_stats("nlp_iter")
             stat_m = self.get_stats("stat_m")
             stat_n = self.get_stats("stat_n")
-            print("stat_n: ", stat_n)
             min_size = min([stat_m, nlp_iter+1])
             out = np.zeros((stat_n+1, min_size), dtype=np.float64, order="C")
             out_data = cast(out.ctypes.data, POINTER(c_double))

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.c
@@ -2271,7 +2271,7 @@ void {{ name }}_acados_create_set_opts({{ name }}_solver_capsule* capsule)
     {%- endif %}
 {%- endif %}
 
-{%- if solver_options.regularize_method == "PROJECT" or solver_options.regularize_method == "MIRROR" or solver_options.regularize_method == "CONVEXIFY" %}
+{%- if solver_options.regularize_method == "PROJECT" or solver_options.regularize_method == "MIRROR" or solver_options.regularize_method == "CONVEXIFY" or solver_options.regularize_method == "GERSHGORIN_LEVENBERG_MARQUARDT"%}
     double reg_epsilon = {{ solver_options.reg_epsilon }};
     ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "reg_epsilon", &reg_epsilon);
 {%- endif %}

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -2386,7 +2386,7 @@ static void {{ model.name }}_acados_create_set_opts({{ model.name }}_solver_caps
     {%- endif %}
 {%- endif %}
 
-{%- if solver_options.regularize_method == "PROJECT" or solver_options.regularize_method == "MIRROR" or solver_options.regularize_method == "CONVEXIFY" %}
+{%- if solver_options.regularize_method == "PROJECT" or solver_options.regularize_method == "MIRROR" or solver_options.regularize_method == "CONVEXIFY" or solver_options.regularize_method == "GERSHGORIN_LEVENBERG_MARQUARDT"%}
     double reg_epsilon = {{ solver_options.reg_epsilon }};
     ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "reg_epsilon", &reg_epsilon);
 {%- endif %}


### PR DESCRIPTION
Implement new regularization module: `GERSHGORIN_LEVENBERG_MARQUARDT`.
Estimates the smallest eigenvalue of each Hessian block using Gershgorin circles and adds multiple of identity to each block, such that smallest eigenvalue after regularization is at least `reg_epsilon`.

