### PR TITLE
Python: checks on external checks

### DIFF
--- a/examples/acados_python/tests/armijo_test.py
+++ b/examples/acados_python/tests/armijo_test.py
@@ -30,7 +30,7 @@
 
 from acados_template import AcadosOcp, AcadosOcpSolver, AcadosModel
 import numpy as np
-from casadi import *
+import casadi as ca
 from itertools import product
 
 # tests different globalization settings on simple test problem
@@ -70,12 +70,12 @@ def solve_armijo_problem_with_setting(setting):
 
     # set model
     model = AcadosModel()
-    x = SX.sym('x')
+    x = ca.SX.sym('x')
 
     # dynamics: identity
     model.disc_dyn_expr = x
     model.x = x
-    model.u = SX.sym('u', 0, 0) # [] / None doesnt work
+    model.u = ca.SX.sym('u', 0, 0) # [] / None doesnt work
     model.p = []
     model.name = f'armijo_problem'
     ocp.model = model
@@ -89,7 +89,7 @@ def solve_armijo_problem_with_setting(setting):
     # cost
     ocp.cost.cost_type_e = 'EXTERNAL'
     ocp.model.cost_expr_ext_cost_e = x @ x
-    ocp.model.cost_expr_ext_cost_custom_hess_e = 1.0 # 2.0 is the actual hessian
+    ocp.model.cost_expr_ext_cost_custom_hess_e = ca.DM(1.0) # 2.0 is the actual hessian
 
     # constarints
     ocp.constraints.idxbx = np.array([0])

--- a/interfaces/acados_template/acados_template/acados_ocp.py
+++ b/interfaces/acados_template/acados_template/acados_ocp.py
@@ -242,7 +242,9 @@ class AcadosOcp:
                 "GAUSS_NEWTON or EXACT with 'exact_hess_cost' == False.\n")
 
         elif cost.cost_type_0 == 'EXTERNAL':
-            if not isinstance(model.cost_expr_ext_cost_0, (ca.MX, ca.SX)):
+            if isinstance(model.cost_expr_ext_cost_0, float):
+                model.cost_expr_ext_cost_0 = ca.DM(model.cost_expr_ext_cost_0)
+            if not isinstance(model.cost_expr_ext_cost_0, (ca.MX, ca.SX, ca.DM)):
                 raise Exception('cost_expr_ext_cost_0 should be casadi expression.')
             if not casadi_length(model.cost_expr_ext_cost_0) == 1:
                 raise Exception('cost_expr_ext_cost_0 should be scalar-valued.')
@@ -317,7 +319,9 @@ class AcadosOcp:
                 "GAUSS_NEWTON or EXACT with 'exact_hess_cost' == False.\n")
 
         elif cost.cost_type == 'EXTERNAL':
-            if not isinstance(model.cost_expr_ext_cost, (ca.MX, ca.SX)):
+            if isinstance(model.cost_expr_ext_cost, float):
+                model.cost_expr_ext_cost = ca.DM(model.cost_expr_ext_cost)
+            if not isinstance(model.cost_expr_ext_cost, (ca.MX, ca.SX, ca.DM)):
                 raise Exception('cost_expr_ext_cost should be casadi expression.')
             if not casadi_length(model.cost_expr_ext_cost) == 1:
                 raise Exception('cost_expr_ext_cost should be scalar-valued.')
@@ -366,7 +370,9 @@ class AcadosOcp:
                 "GAUSS_NEWTON or EXACT with 'exact_hess_cost' == False.\n")
 
         elif cost.cost_type_e == 'EXTERNAL':
-            if not isinstance(model.cost_expr_ext_cost_e, (ca.MX, ca.SX)):
+            if isinstance(model.cost_expr_ext_cost_e, float):
+                model.cost_expr_ext_cost_e = ca.DM(model.cost_expr_ext_cost_e)
+            if not isinstance(model.cost_expr_ext_cost_e, (ca.MX, ca.SX, ca.DM)):
                 raise Exception('cost_expr_ext_cost_e should be casadi expression.')
             if not casadi_length(model.cost_expr_ext_cost_e) == 1:
                 raise Exception('cost_expr_ext_cost_e should be scalar-valued.')

--- a/interfaces/acados_template/acados_template/acados_ocp.py
+++ b/interfaces/acados_template/acados_template/acados_ocp.py
@@ -242,7 +242,7 @@ class AcadosOcp:
                 "GAUSS_NEWTON or EXACT with 'exact_hess_cost' == False.\n")
 
         elif cost.cost_type_0 == 'EXTERNAL':
-            if isinstance(model.cost_expr_ext_cost_0, float):
+            if isinstance(model.cost_expr_ext_cost_0, (float, int)):
                 model.cost_expr_ext_cost_0 = ca.DM(model.cost_expr_ext_cost_0)
             if not isinstance(model.cost_expr_ext_cost_0, (ca.MX, ca.SX, ca.DM)):
                 raise Exception('cost_expr_ext_cost_0 should be casadi expression.')
@@ -319,7 +319,7 @@ class AcadosOcp:
                 "GAUSS_NEWTON or EXACT with 'exact_hess_cost' == False.\n")
 
         elif cost.cost_type == 'EXTERNAL':
-            if isinstance(model.cost_expr_ext_cost, float):
+            if isinstance(model.cost_expr_ext_cost, (float, int)):
                 model.cost_expr_ext_cost = ca.DM(model.cost_expr_ext_cost)
             if not isinstance(model.cost_expr_ext_cost, (ca.MX, ca.SX, ca.DM)):
                 raise Exception('cost_expr_ext_cost should be casadi expression.')
@@ -370,10 +370,10 @@ class AcadosOcp:
                 "GAUSS_NEWTON or EXACT with 'exact_hess_cost' == False.\n")
 
         elif cost.cost_type_e == 'EXTERNAL':
-            if isinstance(model.cost_expr_ext_cost_e, float):
+            if isinstance(model.cost_expr_ext_cost_e, (float, int)):
                 model.cost_expr_ext_cost_e = ca.DM(model.cost_expr_ext_cost_e)
             if not isinstance(model.cost_expr_ext_cost_e, (ca.MX, ca.SX, ca.DM)):
-                raise Exception('cost_expr_ext_cost_e should be casadi expression.')
+                raise Exception(f'cost_expr_ext_cost_e should be casadi expression, got {model.cost_expr_ext_cost_e}.')
             if not casadi_length(model.cost_expr_ext_cost_e) == 1:
                 raise Exception('cost_expr_ext_cost_e should be scalar-valued.')
             if not is_empty(model.cost_expr_ext_cost_custom_hess_e):

--- a/interfaces/acados_template/acados_template/acados_ocp.py
+++ b/interfaces/acados_template/acados_template/acados_ocp.py
@@ -241,6 +241,15 @@ class AcadosOcp:
                 raise Exception("\nWith CONVEX_OVER_NONLINEAR cost type, possible Hessian approximations are:\n"
                 "GAUSS_NEWTON or EXACT with 'exact_hess_cost' == False.\n")
 
+        elif cost.cost_type_0 == 'EXTERNAL':
+            if not isinstance(model.cost_expr_ext_cost_0, (ca.MX, ca.SX)):
+                raise Exception('cost_expr_ext_cost_0 should be casadi expression.')
+            if not casadi_length(model.cost_expr_ext_cost_0) == 1:
+                raise Exception('cost_expr_ext_cost_0 should be scalar-valued.')
+            if not is_empty(model.cost_expr_ext_cost_custom_hess_0):
+                if model.cost_expr_ext_cost_custom_hess_0.shape != (dims.nx+dims.nu, dims.nx+dims.nu):
+                    raise Exception('cost_expr_ext_cost_custom_hess_0 should have shape (nx+nu, nx+nu).')
+
         # GN check
         gn_warning_0 = (cost.cost_type_0 == 'EXTERNAL' and opts.hessian_approx == 'GAUSS_NEWTON' and opts.ext_cost_num_hess == 0 and is_empty(model.cost_expr_ext_cost_custom_hess_0))
         gn_warning_path = (cost.cost_type == 'EXTERNAL' and opts.hessian_approx == 'GAUSS_NEWTON' and opts.ext_cost_num_hess == 0 and is_empty(model.cost_expr_ext_cost_custom_hess))
@@ -307,6 +316,14 @@ class AcadosOcp:
                 raise Exception("\nWith CONVEX_OVER_NONLINEAR cost type, possible Hessian approximations are:\n"
                 "GAUSS_NEWTON or EXACT with 'exact_hess_cost' == False.\n")
 
+        elif cost.cost_type == 'EXTERNAL':
+            if not isinstance(model.cost_expr_ext_cost, (ca.MX, ca.SX)):
+                raise Exception('cost_expr_ext_cost should be casadi expression.')
+            if not casadi_length(model.cost_expr_ext_cost) == 1:
+                raise Exception('cost_expr_ext_cost should be scalar-valued.')
+            if not is_empty(model.cost_expr_ext_cost_custom_hess):
+                if model.cost_expr_ext_cost_custom_hess.shape != (dims.nx+dims.nu, dims.nx+dims.nu):
+                    raise Exception('cost_expr_ext_cost_custom_hess should have shape (nx+nu, nx+nu).')
         # terminal
         if cost.cost_type_e == 'AUTO':
             self.detect_cost_type(model, cost, dims, "terminal")
@@ -347,6 +364,15 @@ class AcadosOcp:
             if not (opts.hessian_approx=='EXACT' and opts.exact_hess_cost==False) and opts.hessian_approx != 'GAUSS_NEWTON':
                 raise Exception("\nWith CONVEX_OVER_NONLINEAR cost type, possible Hessian approximations are:\n"
                 "GAUSS_NEWTON or EXACT with 'exact_hess_cost' == False.\n")
+
+        elif cost.cost_type_e == 'EXTERNAL':
+            if not isinstance(model.cost_expr_ext_cost_e, (ca.MX, ca.SX)):
+                raise Exception('cost_expr_ext_cost_e should be casadi expression.')
+            if not casadi_length(model.cost_expr_ext_cost_e) == 1:
+                raise Exception('cost_expr_ext_cost_e should be scalar-valued.')
+            if not is_empty(model.cost_expr_ext_cost_custom_hess_e):
+                if model.cost_expr_ext_cost_custom_hess_e.shape != (dims.nx, dims.nx):
+                    raise Exception('cost_expr_ext_cost_custom_hess_e should have shape (nx, nx).')
 
         # cost integration
         supports_cost_integration = lambda type : type in ['NONLINEAR_LS', 'CONVEX_OVER_NONLINEAR']

--- a/interfaces/acados_template/acados_template/utils.py
+++ b/interfaces/acados_template/acados_template/utils.py
@@ -65,6 +65,7 @@ ALLOWED_CASADI_VERSIONS = (
     '3.6.5',
     '3.6.6',
     '3.6.7',
+    '3.6.7+',
 )
 
 TERA_VERSION = "0.0.34"


### PR DESCRIPTION
Breaking: `cost_expr_ext_cost_custom_hess*` can not be float or int anymore in Python, but should be a CasADi MX/SX/DM