### PR TITLE
Symbolic cost parameters

### DIFF
--- a/.github/workflows/full_build.yml
+++ b/.github/workflows/full_build.yml
@@ -202,6 +202,8 @@ jobs:
         python value_gradient_example_linear.py
         python batch_adjoint_solution_sensitivity_example.py
         python non_ocp_example.py
+        cd ${{runner.workspace}}/acados/examples/acados_python/pendulum_on_cart/ocp
+        python ocp_example_cost_formulations.py
 
 
     - name: Python Furuta pendulum timeout test

--- a/examples/acados_python/pendulum_on_cart/ocp/ocp_example_cost_formulations.py
+++ b/examples/acados_python/pendulum_on_cart/ocp/ocp_example_cost_formulations.py
@@ -204,7 +204,7 @@ def formulate_ocp(cost_version: str) -> AcadosOcp:
         ocp.cost.cost_type = 'NONLINEAR_LS'
         ocp.cost.cost_type_e = 'NONLINEAR_LS'
 
-        p_global =struct_symSX([
+        p_global = struct_symSX([
             entry('W', shape=(ny, ny)),
             entry('yref', shape=(ny, )),
             entry('W_e', shape=(ny_e, ny_e)),

--- a/examples/acados_python/pendulum_on_cart/ocp/ocp_example_cost_formulations.py
+++ b/examples/acados_python/pendulum_on_cart/ocp/ocp_example_cost_formulations.py
@@ -229,14 +229,6 @@ def formulate_ocp(cost_version: str) -> AcadosOcp:
         p_global_values['yref_e'] = np.zeros((ny_e, ))
 
         ocp.p_global_values = p_global_values.cat.full().flatten()
-
-        ocp.cost.W_0 = np.zeros((0,0))
-        ocp.cost.W   = np.zeros((0,0))
-        ocp.cost.W_e = np.zeros((0,0))
-
-        ocp.cost.yref_0 = np.array([])
-        ocp.cost.yref   = np.array([])
-        ocp.cost.yref_e = np.array([])
     else:
         raise Exception('Unknown cost_version.')
 
@@ -378,10 +370,10 @@ def main(cost_version: str, formulation_type='ocp', integrator_type='IRK', refor
 
 if __name__ == "__main__":
     main(cost_version='LS', formulation_type='mocp', integrator_type=['IRK', 'ERK'], plot=False)
-    for cost_version in COST_VERSIONS:
-        for formulation_type in ['ocp', 'mocp']:
-            print(f"cost version: {cost_version}, formulation type: {formulation_type}")
-            main(cost_version=cost_version, formulation_type=formulation_type, plot=False)
+    # for cost_version in COST_VERSIONS:
+    #     for formulation_type in ['ocp', 'mocp']:
+    #         print(f"cost version: {cost_version}, formulation type: {formulation_type}")
+    #         main(cost_version=cost_version, formulation_type=formulation_type, plot=False)
 
     for cost_version in ["NLS_TO_EXTERNAL_P_GLOBAL"]:
         print(f"cost version: {cost_version} reformulated as EXTERNAL cost")

--- a/examples/acados_python/pendulum_on_cart/ocp/ocp_example_cost_formulations.py
+++ b/examples/acados_python/pendulum_on_cart/ocp/ocp_example_cost_formulations.py
@@ -370,10 +370,10 @@ def main(cost_version: str, formulation_type='ocp', integrator_type='IRK', refor
 
 if __name__ == "__main__":
     main(cost_version='LS', formulation_type='mocp', integrator_type=['IRK', 'ERK'], plot=False)
-    # for cost_version in COST_VERSIONS:
-    #     for formulation_type in ['ocp', 'mocp']:
-    #         print(f"cost version: {cost_version}, formulation type: {formulation_type}")
-    #         main(cost_version=cost_version, formulation_type=formulation_type, plot=False)
+    for cost_version in COST_VERSIONS:
+        for formulation_type in ['ocp', 'mocp']:
+            print(f"cost version: {cost_version}, formulation type: {formulation_type}")
+            main(cost_version=cost_version, formulation_type=formulation_type, plot=False)
 
     for cost_version in ["NLS_TO_EXTERNAL_P_GLOBAL"]:
         print(f"cost version: {cost_version} reformulated as EXTERNAL cost")

--- a/examples/acados_python/pendulum_on_cart/ocp/ocp_example_cost_formulations.py
+++ b/examples/acados_python/pendulum_on_cart/ocp/ocp_example_cost_formulations.py
@@ -38,6 +38,7 @@ import numpy as np
 import scipy.linalg
 from utils import plot_pendulum
 import casadi as ca
+from casadi.tools import entry, struct_symSX
 
 COST_VERSIONS = ['LS', 'EXTERNAL', 'EXTERNAL_Z', 'NLS', 'NLS_TO_EXTERNAL', 'NLS_Z', 'LS_Z', 'CONL', 'CONL_Z', 'AUTO']
 HESSIAN_APPROXIMATION = 'GAUSS_NEWTON' # 'GAUSS_NEWTON
@@ -199,6 +200,43 @@ def formulate_ocp(cost_version: str) -> AcadosOcp:
         ocp.model.cost_y_expr = ca.vertcat(x, u)
         ocp.model.cost_y_expr_e = x
         ocp.translate_cost_to_external_cost(cost_hessian='GAUSS_NEWTON')
+    elif cost_version == 'NLS_TO_EXTERNAL_P_GLOBAL':
+        ocp.cost.cost_type = 'NONLINEAR_LS'
+        ocp.cost.cost_type_e = 'NONLINEAR_LS'
+
+        p_global =struct_symSX([
+            entry('W', shape=(ny, ny)),
+            entry('yref', shape=(ny, )),
+            entry('W_e', shape=(ny_e, ny_e)),
+            entry('yref_e', shape=(ny_e, ))
+        ])
+        ocp.model.p_global = p_global.cat
+
+        ocp.cost.W = p_global['W']
+        ocp.cost.yref = p_global['yref']
+        ocp.cost.W_e = p_global['W_e']
+        ocp.cost.yref_e = p_global['yref_e']
+
+        ocp.model.cost_y_expr = ca.vertcat(x, u)
+        ocp.model.cost_y_expr_e = x
+
+        ocp.translate_cost_to_external_cost(cost_hessian='GAUSS_NEWTON')
+
+        p_global_values = p_global(0)
+        p_global_values['W'] = cost_W
+        p_global_values['yref'] = np.zeros((ny, ))
+        p_global_values['W_e'] = Q_mat
+        p_global_values['yref_e'] = np.zeros((ny_e, ))
+
+        ocp.p_global_values = p_global_values.cat.full().flatten()
+
+        ocp.cost.W_0 = np.zeros((0,0))
+        ocp.cost.W   = np.zeros((0,0))
+        ocp.cost.W_e = np.zeros((0,0))
+
+        ocp.cost.yref_0 = np.array([])
+        ocp.cost.yref   = np.array([])
+        ocp.cost.yref_e = np.array([])
     else:
         raise Exception('Unknown cost_version.')
 
@@ -345,6 +383,7 @@ if __name__ == "__main__":
             print(f"cost version: {cost_version}, formulation type: {formulation_type}")
             main(cost_version=cost_version, formulation_type=formulation_type, plot=False)
 
+    for cost_version in ["NLS_TO_EXTERNAL_P_GLOBAL"]:
         print(f"cost version: {cost_version} reformulated as EXTERNAL cost")
         main(cost_version=cost_version, formulation_type='ocp', plot=False, reformulate_to_external=True)
 

--- a/interfaces/CMakeLists.txt
+++ b/interfaces/CMakeLists.txt
@@ -323,10 +323,6 @@ add_test(NAME python_pendulum_ocp_example_cmake
         COMMAND "${CMAKE_COMMAND}" -E chdir ${PROJECT_SOURCE_DIR}/examples/acados_python/pendulum_on_cart/mhe
         python closed_loop_mhe_ocp.py)
 
-    add_test(NAME python_pendulum_ocp_cost_example
-        COMMAND "${CMAKE_COMMAND}" -E chdir ${PROJECT_SOURCE_DIR}/examples/acados_python/pendulum_on_cart/ocp
-        python ocp_example_cost_formulations.py)
-
     add_test(NAME python_custom_update_example
         COMMAND "${CMAKE_COMMAND}" -E chdir ${PROJECT_SOURCE_DIR}/examples/acados_python/pendulum_on_cart/custom_update
         python example_custom_rti_loop.py)

--- a/interfaces/acados_template/acados_template/acados_ocp.py
+++ b/interfaces/acados_template/acados_template/acados_ocp.py
@@ -1468,10 +1468,6 @@ class AcadosOcp:
         self.cost.cost_type_e = 'EXTERNAL'
 
 
-
-
-
-
     @staticmethod
     def __translate_ls_cost_to_external_cost(x, u, z, Vx, Vu, Vz, yref, W):
         res = 0

--- a/interfaces/acados_template/acados_template/acados_ocp.py
+++ b/interfaces/acados_template/acados_template/acados_ocp.py
@@ -1404,6 +1404,7 @@ class AcadosOcp:
 
             if cost_hessian == 'GAUSS_NEWTON':
                 self.model.cost_expr_ext_cost_custom_hess_0 = self.__get_gn_hessian_expression_from_nls_cost(self.model.cost_y_expr_0, yref_0, W_0, self.model.x, self.model.u, self.model.z)
+                # TODO maybe: Set W to empty numpary array or whatever acados default. The same for the yref etc.
         elif self.cost.cost_type_0 == "CONVEX_OVER_NONLINEAR":
             self.model.cost_expr_ext_cost_0 = \
                 self.__translate_conl_cost_to_external_cost(self.model.cost_r_in_psi_expr_0, self.model.cost_psi_expr_0,
@@ -1419,6 +1420,7 @@ class AcadosOcp:
                 self.__translate_nls_cost_to_external_cost(self.model.cost_y_expr, yref, W)
             if cost_hessian == 'GAUSS_NEWTON':
                 self.model.cost_expr_ext_cost_custom_hess = self.__get_gn_hessian_expression_from_nls_cost(self.model.cost_y_expr, yref, W, self.model.x, self.model.u, self.model.z)
+                # TODO maybe: Set W to empty numpary array or whatever acados default. The same for the yref etc.
         elif self.cost.cost_type == "CONVEX_OVER_NONLINEAR":
             self.model.cost_expr_ext_cost = \
                 self.__translate_conl_cost_to_external_cost(self.model.cost_r_in_psi_expr, self.model.cost_psi_expr,
@@ -1434,6 +1436,7 @@ class AcadosOcp:
                 self.__translate_nls_cost_to_external_cost(self.model.cost_y_expr_e, yref_e, W_e)
             if cost_hessian == 'GAUSS_NEWTON':
                 self.model.cost_expr_ext_cost_custom_hess_e = self.__get_gn_hessian_expression_from_nls_cost(self.model.cost_y_expr_e, yref_e, W_e, self.model.x, [], self.model.z)
+                # TODO maybe: Set W to empty numpary array or whatever acados default. The same for the yref etc.
         elif self.cost.cost_type_e == "CONVEX_OVER_NONLINEAR":
             self.model.cost_expr_ext_cost_e = \
                 self.__translate_conl_cost_to_external_cost(self.model.cost_r_in_psi_expr_e, self.model.cost_psi_expr_e,

--- a/interfaces/acados_template/acados_template/acados_ocp.py
+++ b/interfaces/acados_template/acados_template/acados_ocp.py
@@ -198,11 +198,12 @@ class AcadosOcp:
         if cost.cost_type_0 == 'AUTO':
             self.detect_cost_type(model, cost, dims, "initial")
 
-        if isinstance(cost.yref_0, (ca.SX, ca.MX, ca.DM)):
-            raise Exception("yref_0 should be numpy array, symbolics are only supported before solver creation, to allow reformulating costs, e.g. using translate_cost_to_external_cost().")
+        if cost.cost_type_0 in ['LINEAR_LS', 'NONLINEAR_LS']:
+            if isinstance(cost.yref_0, (ca.SX, ca.MX, ca.DM)):
+                raise Exception("yref_0 should be numpy array, symbolics are only supported before solver creation, to allow reformulating costs, e.g. using translate_cost_to_external_cost().")
 
-        if isinstance(cost.W_0, (ca.SX, ca.MX, ca.DM)):
-            raise Exception("W_0 should be numpy array, symbolics are only supported before solver creation, to allow reformulating costs, e.g. using translate_cost_to_external_cost().")
+            if isinstance(cost.W_0, (ca.SX, ca.MX, ca.DM)):
+                raise Exception("W_0 should be numpy array, symbolics are only supported before solver creation, to allow reformulating costs, e.g. using translate_cost_to_external_cost().")
 
         if cost.cost_type_0 == 'LINEAR_LS':
             check_if_square(cost.W_0, 'W_0')
@@ -281,11 +282,12 @@ class AcadosOcp:
         if cost.cost_type == 'AUTO':
             self.detect_cost_type(model, cost, dims, "path")
 
-        if isinstance(cost.yref, (ca.SX, ca.MX, ca.DM)):
-            raise Exception("yref should be numpy array, symbolics are only supported before solver creation, to allow reformulating costs, e.g. using translate_cost_to_external_cost().")
+        if cost.cost_type in ['LINEAR_LS', 'NONLINEAR_LS']:
+            if isinstance(cost.yref, (ca.SX, ca.MX, ca.DM)):
+                raise Exception("yref should be numpy array, symbolics are only supported before solver creation, to allow reformulating costs, e.g. using translate_cost_to_external_cost().")
 
-        if isinstance(cost.W, (ca.SX, ca.MX, ca.DM)):
-            raise Exception("W should be numpy array, symbolics are only supported before solver creation, to allow reformulating costs, e.g. using translate_cost_to_external_cost().")
+            if isinstance(cost.W, (ca.SX, ca.MX, ca.DM)):
+                raise Exception("W should be numpy array, symbolics are only supported before solver creation, to allow reformulating costs, e.g. using translate_cost_to_external_cost().")
 
         if cost.cost_type == 'LINEAR_LS':
             ny = cost.W.shape[0]
@@ -344,11 +346,12 @@ class AcadosOcp:
         if cost.cost_type_e == 'AUTO':
             self.detect_cost_type(model, cost, dims, "terminal")
 
-        if isinstance(cost.yref_e, (ca.SX, ca.MX, ca.DM)):
-            raise Exception("yref_e should be numpy array, symbolics are only supported before solver creation, to allow reformulating costs, e.g. using translate_cost_to_external_cost().")
-        
-        if isinstance(cost.W_e, (ca.SX, ca.MX, ca.DM)):
-            raise Exception("W_e should be numpy array, symbolics are only supported before solver creation, to allow reformulating costs, e.g. using translate_cost_to_external_cost().")
+        if cost.cost_type_e in ['LINEAR_LS', 'NONLINEAR_LS']:
+            if isinstance(cost.yref_e, (ca.SX, ca.MX, ca.DM)):
+                raise Exception("yref_e should be numpy array, symbolics are only supported before solver creation, to allow reformulating costs, e.g. using translate_cost_to_external_cost().")
+
+            if isinstance(cost.W_e, (ca.SX, ca.MX, ca.DM)):
+                raise Exception("W_e should be numpy array, symbolics are only supported before solver creation, to allow reformulating costs, e.g. using translate_cost_to_external_cost().")
 
         if cost.cost_type_e == 'LINEAR_LS':
             ny_e = cost.W_e.shape[0]
@@ -1422,10 +1425,7 @@ class AcadosOcp:
 
             if cost_hessian == 'GAUSS_NEWTON':
                 self.model.cost_expr_ext_cost_custom_hess_0 = self.__get_gn_hessian_expression_from_nls_cost(self.model.cost_y_expr_0, yref_0, W_0, self.model.x, self.model.u, self.model.z)
-                if not isinstance(self.cost.W_0, np.ndarray):
-                    self.cost.W_0 = np.zeros((0,0))
-                if not isinstance(self.cost.yref_0, np.ndarray):
-                    self.cost.yref_0 = np.array([])
+
         elif self.cost.cost_type_0 == "CONVEX_OVER_NONLINEAR":
             self.model.cost_expr_ext_cost_0 = \
                 self.__translate_conl_cost_to_external_cost(self.model.cost_r_in_psi_expr_0, self.model.cost_psi_expr_0,
@@ -1441,10 +1441,7 @@ class AcadosOcp:
                 self.__translate_nls_cost_to_external_cost(self.model.cost_y_expr, yref, W)
             if cost_hessian == 'GAUSS_NEWTON':
                 self.model.cost_expr_ext_cost_custom_hess = self.__get_gn_hessian_expression_from_nls_cost(self.model.cost_y_expr, yref, W, self.model.x, self.model.u, self.model.z)
-                if not isinstance(self.cost.W, np.ndarray):
-                    self.cost.W   = np.zeros((0,0))
-                if not isinstance(self.cost.yref, np.ndarray):
-                    self.cost.yref   = np.array([])
+
         elif self.cost.cost_type == "CONVEX_OVER_NONLINEAR":
             self.model.cost_expr_ext_cost = \
                 self.__translate_conl_cost_to_external_cost(self.model.cost_r_in_psi_expr, self.model.cost_psi_expr,
@@ -1460,10 +1457,7 @@ class AcadosOcp:
                 self.__translate_nls_cost_to_external_cost(self.model.cost_y_expr_e, yref_e, W_e)
             if cost_hessian == 'GAUSS_NEWTON':
                 self.model.cost_expr_ext_cost_custom_hess_e = self.__get_gn_hessian_expression_from_nls_cost(self.model.cost_y_expr_e, yref_e, W_e, self.model.x, [], self.model.z)
-                if not isinstance(self.cost.W_e, np.ndarray):
-                    self.cost.W_e = np.zeros((0,0))
-                if not isinstance(self.cost.yref_e, np.ndarray):
-                    self.cost.yref_e = np.array([])
+
         elif self.cost.cost_type_e == "CONVEX_OVER_NONLINEAR":
             self.model.cost_expr_ext_cost_e = \
                 self.__translate_conl_cost_to_external_cost(self.model.cost_r_in_psi_expr_e, self.model.cost_psi_expr_e,

--- a/interfaces/acados_template/acados_template/acados_ocp.py
+++ b/interfaces/acados_template/acados_template/acados_ocp.py
@@ -1465,6 +1465,23 @@ class AcadosOcp:
         self.cost.cost_type_e = 'EXTERNAL'
 
 
+        # Set default values after translation
+        if not isinstance(self.cost.W_0, np.ndarray):
+            self.cost.W_0 = np.zeros((0,0))
+        if not isinstance(self.cost.yref_0, np.ndarray):
+            self.cost.yref_0 = np.array([])
+
+        if not isinstance(self.cost.W, np.ndarray):
+            self.cost.W   = np.zeros((0,0))
+        if not isinstance(self.cost.yref, np.ndarray):
+            self.cost.yref   = np.array([])
+
+        if not isinstance(self.cost.W_e, np.ndarray):
+            self.cost.W_e = np.zeros((0,0))
+        if not isinstance(self.cost.yref_e, np.ndarray):
+            self.cost.yref_e = np.array([])
+
+
     @staticmethod
     def __translate_ls_cost_to_external_cost(x, u, z, Vx, Vu, Vz, yref, W):
         res = 0

--- a/interfaces/acados_template/acados_template/acados_ocp.py
+++ b/interfaces/acados_template/acados_template/acados_ocp.py
@@ -1422,7 +1422,10 @@ class AcadosOcp:
 
             if cost_hessian == 'GAUSS_NEWTON':
                 self.model.cost_expr_ext_cost_custom_hess_0 = self.__get_gn_hessian_expression_from_nls_cost(self.model.cost_y_expr_0, yref_0, W_0, self.model.x, self.model.u, self.model.z)
-                # TODO maybe: Set W to empty numpary array or whatever acados default. The same for the yref etc.
+                if not isinstance(self.cost.W_0, np.ndarray):
+                    self.cost.W_0 = np.zeros((0,0))
+                if not isinstance(self.cost.yref_0, np.ndarray):
+                    self.cost.yref_0 = np.array([])
         elif self.cost.cost_type_0 == "CONVEX_OVER_NONLINEAR":
             self.model.cost_expr_ext_cost_0 = \
                 self.__translate_conl_cost_to_external_cost(self.model.cost_r_in_psi_expr_0, self.model.cost_psi_expr_0,
@@ -1438,7 +1441,10 @@ class AcadosOcp:
                 self.__translate_nls_cost_to_external_cost(self.model.cost_y_expr, yref, W)
             if cost_hessian == 'GAUSS_NEWTON':
                 self.model.cost_expr_ext_cost_custom_hess = self.__get_gn_hessian_expression_from_nls_cost(self.model.cost_y_expr, yref, W, self.model.x, self.model.u, self.model.z)
-                # TODO maybe: Set W to empty numpary array or whatever acados default. The same for the yref etc.
+                if not isinstance(self.cost.W, np.ndarray):
+                    self.cost.W   = np.zeros((0,0))
+                if not isinstance(self.cost.yref, np.ndarray):
+                    self.cost.yref   = np.array([])
         elif self.cost.cost_type == "CONVEX_OVER_NONLINEAR":
             self.model.cost_expr_ext_cost = \
                 self.__translate_conl_cost_to_external_cost(self.model.cost_r_in_psi_expr, self.model.cost_psi_expr,
@@ -1454,7 +1460,10 @@ class AcadosOcp:
                 self.__translate_nls_cost_to_external_cost(self.model.cost_y_expr_e, yref_e, W_e)
             if cost_hessian == 'GAUSS_NEWTON':
                 self.model.cost_expr_ext_cost_custom_hess_e = self.__get_gn_hessian_expression_from_nls_cost(self.model.cost_y_expr_e, yref_e, W_e, self.model.x, [], self.model.z)
-                # TODO maybe: Set W to empty numpary array or whatever acados default. The same for the yref etc.
+                if not isinstance(self.cost.W_e, np.ndarray):
+                    self.cost.W_e = np.zeros((0,0))
+                if not isinstance(self.cost.yref_e, np.ndarray):
+                    self.cost.yref_e = np.array([])
         elif self.cost.cost_type_e == "CONVEX_OVER_NONLINEAR":
             self.model.cost_expr_ext_cost_e = \
                 self.__translate_conl_cost_to_external_cost(self.model.cost_r_in_psi_expr_e, self.model.cost_psi_expr_e,
@@ -1465,21 +1474,8 @@ class AcadosOcp:
         self.cost.cost_type_e = 'EXTERNAL'
 
 
-        # Set default values after translation
-        if not isinstance(self.cost.W_0, np.ndarray):
-            self.cost.W_0 = np.zeros((0,0))
-        if not isinstance(self.cost.yref_0, np.ndarray):
-            self.cost.yref_0 = np.array([])
 
-        if not isinstance(self.cost.W, np.ndarray):
-            self.cost.W   = np.zeros((0,0))
-        if not isinstance(self.cost.yref, np.ndarray):
-            self.cost.yref   = np.array([])
 
-        if not isinstance(self.cost.W_e, np.ndarray):
-            self.cost.W_e = np.zeros((0,0))
-        if not isinstance(self.cost.yref_e, np.ndarray):
-            self.cost.yref_e = np.array([])
 
 
     @staticmethod

--- a/interfaces/acados_template/acados_template/acados_ocp.py
+++ b/interfaces/acados_template/acados_template/acados_ocp.py
@@ -198,6 +198,12 @@ class AcadosOcp:
         if cost.cost_type_0 == 'AUTO':
             self.detect_cost_type(model, cost, dims, "initial")
 
+        if isinstance(cost.yref_0, (ca.SX, ca.MX, ca.DM)):
+            raise Exception("yref_0 should be numpy array, symbolics are only supported before solver creation, to allow reformulating costs, e.g. using translate_cost_to_external_cost().")
+
+        if isinstance(cost.W_0, (ca.SX, ca.MX, ca.DM)):
+            raise Exception("W_0 should be numpy array, symbolics are only supported before solver creation, to allow reformulating costs, e.g. using translate_cost_to_external_cost().")
+
         if cost.cost_type_0 == 'LINEAR_LS':
             check_if_square(cost.W_0, 'W_0')
             ny_0 = cost.W_0.shape[0]
@@ -275,6 +281,12 @@ class AcadosOcp:
         if cost.cost_type == 'AUTO':
             self.detect_cost_type(model, cost, dims, "path")
 
+        if isinstance(cost.yref, (ca.SX, ca.MX, ca.DM)):
+            raise Exception("yref should be numpy array, symbolics are only supported before solver creation, to allow reformulating costs, e.g. using translate_cost_to_external_cost().")
+
+        if isinstance(cost.W, (ca.SX, ca.MX, ca.DM)):
+            raise Exception("W should be numpy array, symbolics are only supported before solver creation, to allow reformulating costs, e.g. using translate_cost_to_external_cost().")
+
         if cost.cost_type == 'LINEAR_LS':
             ny = cost.W.shape[0]
             check_if_square(cost.W, 'W')
@@ -331,6 +343,12 @@ class AcadosOcp:
         # terminal
         if cost.cost_type_e == 'AUTO':
             self.detect_cost_type(model, cost, dims, "terminal")
+
+        if isinstance(cost.yref_e, (ca.SX, ca.MX, ca.DM)):
+            raise Exception("yref_e should be numpy array, symbolics are only supported before solver creation, to allow reformulating costs, e.g. using translate_cost_to_external_cost().")
+        
+        if isinstance(cost.W_e, (ca.SX, ca.MX, ca.DM)):
+            raise Exception("W_e should be numpy array, symbolics are only supported before solver creation, to allow reformulating costs, e.g. using translate_cost_to_external_cost().")
 
         if cost.cost_type_e == 'LINEAR_LS':
             ny_e = cost.W_e.shape[0]

--- a/interfaces/acados_template/acados_template/acados_ocp_cost.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_cost.py
@@ -30,7 +30,7 @@
 #
 
 import numpy as np
-from .utils import check_if_nparray_and_flatten, check_if_2d_nparray, check_if_2d_nparray_or_symbolic, check_if_nparray_or_symbolic_and_flatten
+from .utils import check_if_nparray_and_flatten, check_if_2d_nparray, check_if_2d_nparray_or_casadi_symbolic, check_if_nparray_or_casadi_symbolic_and_flatten
 
 class AcadosOcpCost:
     r"""
@@ -169,12 +169,12 @@ class AcadosOcpCost:
 
     @yref_0.setter
     def yref_0(self, yref_0):
-        yref_0 = check_if_nparray_or_symbolic_and_flatten(yref_0, "yref_0")
+        yref_0 = check_if_nparray_or_casadi_symbolic_and_flatten(yref_0, "yref_0")
         self.__yref_0 = yref_0
 
     @W_0.setter
     def W_0(self, W_0):
-        check_if_2d_nparray_or_symbolic(W_0, "W_0")
+        check_if_2d_nparray_or_casadi_symbolic(W_0, "W_0")
         self.__W_0 = W_0
 
     @Vx_0.setter
@@ -298,7 +298,7 @@ class AcadosOcpCost:
 
     @W.setter
     def W(self, W):
-        check_if_2d_nparray_or_symbolic(W, "W")
+        check_if_2d_nparray_or_casadi_symbolic(W, "W")
         self.__W = W
 
 
@@ -319,7 +319,7 @@ class AcadosOcpCost:
 
     @yref.setter
     def yref(self, yref):
-        yref = check_if_nparray_or_symbolic_and_flatten(yref, "yref")
+        yref = check_if_nparray_or_casadi_symbolic_and_flatten(yref, "yref")
         self.__yref = yref
 
     @Zl.setter
@@ -463,7 +463,7 @@ class AcadosOcpCost:
 
     @W_e.setter
     def W_e(self, W_e):
-        check_if_2d_nparray_or_symbolic(W_e, "W_e")
+        check_if_2d_nparray_or_casadi_symbolic(W_e, "W_e")
         self.__W_e = W_e
 
     @Vx_e.setter
@@ -473,7 +473,7 @@ class AcadosOcpCost:
 
     @yref_e.setter
     def yref_e(self, yref_e):
-        yref_e = check_if_nparray_or_symbolic_and_flatten(yref_e, "yref_e")
+        yref_e = check_if_nparray_or_casadi_symbolic_and_flatten(yref_e, "yref_e")
         self.__yref_e = yref_e
 
     @Zl_e.setter

--- a/interfaces/acados_template/acados_template/acados_ocp_cost.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_cost.py
@@ -30,7 +30,7 @@
 #
 
 import numpy as np
-from .utils import check_if_nparray_and_flatten, check_if_2d_nparray
+from .utils import check_if_nparray_and_flatten, check_if_2d_nparray, check_if_2d_nparray_or_symbolic, check_if_nparray_or_symbolic_and_flatten
 
 class AcadosOcpCost:
     r"""
@@ -169,12 +169,12 @@ class AcadosOcpCost:
 
     @yref_0.setter
     def yref_0(self, yref_0):
-        yref_0 = check_if_nparray_and_flatten(yref_0, "yref_0")
+        yref_0 = check_if_nparray_or_symbolic_and_flatten(yref_0, "yref_0")
         self.__yref_0 = yref_0
 
     @W_0.setter
     def W_0(self, W_0):
-        check_if_2d_nparray(W_0, "W_0")
+        check_if_2d_nparray_or_symbolic(W_0, "W_0")
         self.__W_0 = W_0
 
     @Vx_0.setter
@@ -298,7 +298,7 @@ class AcadosOcpCost:
 
     @W.setter
     def W(self, W):
-        check_if_2d_nparray(W, "W")
+        check_if_2d_nparray_or_symbolic(W, "W")
         self.__W = W
 
 
@@ -319,7 +319,7 @@ class AcadosOcpCost:
 
     @yref.setter
     def yref(self, yref):
-        yref = check_if_nparray_and_flatten(yref, "yref")
+        yref = check_if_nparray_or_symbolic_and_flatten(yref, "yref")
         self.__yref = yref
 
     @Zl.setter
@@ -463,7 +463,7 @@ class AcadosOcpCost:
 
     @W_e.setter
     def W_e(self, W_e):
-        check_if_2d_nparray(W_e, "W_e")
+        check_if_2d_nparray_or_symbolic(W_e, "W_e")
         self.__W_e = W_e
 
     @Vx_e.setter
@@ -473,7 +473,7 @@ class AcadosOcpCost:
 
     @yref_e.setter
     def yref_e(self, yref_e):
-        yref_e = check_if_nparray_and_flatten(yref_e, "yref_e")
+        yref_e = check_if_nparray_or_symbolic_and_flatten(yref_e, "yref_e")
         self.__yref_e = yref_e
 
     @Zl_e.setter

--- a/interfaces/acados_template/acados_template/utils.py
+++ b/interfaces/acados_template/acados_template/utils.py
@@ -412,7 +412,7 @@ def check_if_nparray_and_flatten(val, name) -> np.ndarray:
         raise Exception(f"{name} must be a numpy array, got {type(val)}")
     return val.reshape(-1)
 
-def check_if_nparray_or_symbolic_and_flatten(val, name) -> np.ndarray:
+def check_if_nparray_or_casadi_symbolic_and_flatten(val, name) -> np.ndarray:
     if not isinstance(val, (np.ndarray, SX, MX)):
         raise Exception(f"{name} must be array of type np.ndarray, casadi.SX, or casadi.MX, got {type(val)}")
 
@@ -430,7 +430,7 @@ def check_if_2d_nparray(val, name) -> None:
     return
 
 
-def check_if_2d_nparray_or_symbolic(val, name) -> None:
+def check_if_2d_nparray_or_casadi_symbolic(val, name) -> None:
     if isinstance(val, (SX, MX, DM)):
         return
     if not isinstance(val, np.ndarray):

--- a/interfaces/acados_template/acados_template/utils.py
+++ b/interfaces/acados_template/acados_template/utils.py
@@ -429,17 +429,15 @@ def check_if_2d_nparray(val, name) -> None:
         raise Exception(f"{name} must be a 2D numpy array, got shape {val.shape}")
     return
 
-def check_if_2d_nparray_or_symbolic(val, name) -> None:
-    if not isinstance(val, (np.ndarray, SX, MX)):
-        raise Exception(f"{name} must be a array of type np.ndarray, casadi.SX, or casadi.MX, got {type(val)}")
 
-    if isinstance(val, (np.ndarray)):
-        if val.ndim != 2:
-            raise Exception(f"{name} must be a 2D array of type np.ndarray, casadi.SX, or casadi.MX, got shape {val.shape}")
-    else:
-        if len(val.size()) != 2:
-            raise Exception(f"{name} must be a 2D array of type np.ndarray, casadi.SX, or casadi.MX, got shape {val.size()}")
-    return
+def check_if_2d_nparray_or_symbolic(val, name) -> None:
+    if isinstance(val, (SX, MX, DM)):
+        return
+    if not isinstance(val, np.ndarray):
+        raise Exception(f"{name} must be a array of type np.ndarray, casadi.SX, or casadi.MX, got {type(val)}")
+    if val.ndim != 2:
+        raise Exception(f"{name} must be a 2D array of type np.ndarray, casadi.SX, or casadi.MX, got shape {val.shape}")
+
 
 def print_J_to_idx_note():
     print("NOTE: J* matrix is converted to zero based vector idx* vector, which is returned here.")

--- a/interfaces/acados_template/acados_template/utils.py
+++ b/interfaces/acados_template/acados_template/utils.py
@@ -43,6 +43,7 @@ else:
     from ctypes import CDLL as DllLoader
 import numpy as np
 from casadi import DM, MX, SX, CasadiMeta, Function
+import casadi as ca
 from contextlib import contextmanager
 
 
@@ -411,12 +412,33 @@ def check_if_nparray_and_flatten(val, name) -> np.ndarray:
         raise Exception(f"{name} must be a numpy array, got {type(val)}")
     return val.reshape(-1)
 
+def check_if_nparray_or_symbolic_and_flatten(val, name) -> np.ndarray:
+    if not isinstance(val, (np.ndarray, SX, MX)):
+        raise Exception(f"{name} must be array of type np.ndarray, casadi.SX, or casadi.MX, got {type(val)}")
+
+    if isinstance(val, (SX, MX)):
+        return ca.reshape(val, val.numel(), 1)
+    else:
+        return val.reshape(-1)
+
 
 def check_if_2d_nparray(val, name) -> None:
     if not isinstance(val, np.ndarray):
         raise Exception(f"{name} must be a numpy array, got {type(val)}")
     if val.ndim != 2:
         raise Exception(f"{name} must be a 2D numpy array, got shape {val.shape}")
+    return
+
+def check_if_2d_nparray_or_symbolic(val, name) -> None:
+    if not isinstance(val, (np.ndarray, SX, MX)):
+        raise Exception(f"{name} must be a array of type np.ndarray, casadi.SX, or casadi.MX, got {type(val)}")
+
+    if isinstance(val, (np.ndarray)):
+        if val.ndim != 2:
+            raise Exception(f"{name} must be a 2D array of type np.ndarray, casadi.SX, or casadi.MX, got shape {val.shape}")
+    else:
+        if len(val.size()) != 2:
+            raise Exception(f"{name} must be a 2D array of type np.ndarray, casadi.SX, or casadi.MX, got shape {val.size()}")
     return
 
 def print_J_to_idx_note():


### PR DESCRIPTION
## Enhancement: Symbolic Expressions for Cost Matrices in acados Python Interface
This PR extends the Python interface to acados by enabling symbolic expressions for the following cost matrices and reference vectors:
- `W_0` (initial stage cost weight matrix)
- `W` (stage cost weight matrix)
- `W_e` (terminal cost weight matrix) 
- `yref_0` (initial stage reference vector)
- `yref` (stage reference vector)
- `yref_e` (terminal reference vector)

### Benefits
This enhancement allows for parameterized least-squares cost functions. The least-squares cost is translated to an external cost, and parameters can be dynamically modified at runtime.

### Use Case
This is particularly valuable for advanced two-solver implementations where:
1. A forward solver leverages a Gauss-Newton Hessian approximation
2. A backward solver employs an exact Hessian for exact sensitivity computation