### PR TITLE
Dynamic num threads in batch solvers

### DIFF
--- a/examples/acados_python/pendulum_on_cart/ocp/minimal_example_batch_ocp_solver.py
+++ b/examples/acados_python/pendulum_on_cart/ocp/minimal_example_batch_ocp_solver.py
@@ -123,6 +123,12 @@ def main_batch(Xinit, simU, tol, num_threads_in_batch_solve=1):
     N_batch = Xinit.shape[0] - 1
     ocp = setup_ocp(tol)
     batch_solver = AcadosOcpBatchSolver(ocp, N_batch, num_threads_in_batch_solve=num_threads_in_batch_solve, verbose=False)
+    
+    assert batch_solver.num_threads_in_batch_solve == num_threads_in_batch_solve
+    batch_solver.num_threads_in_batch_solve = 1337
+    assert batch_solver.num_threads_in_batch_solve == 1337
+    batch_solver.num_threads_in_batch_solve = num_threads_in_batch_solve
+    assert batch_solver.num_threads_in_batch_solve == num_threads_in_batch_solve
 
     for n in range(N_batch):
         batch_solver.ocp_solvers[n].constraints_set(0, "lbx", Xinit[n])

--- a/examples/acados_python/pendulum_on_cart/ocp/minimal_example_batch_ocp_solver.py
+++ b/examples/acados_python/pendulum_on_cart/ocp/minimal_example_batch_ocp_solver.py
@@ -44,10 +44,10 @@ This example shows how the AcadosOcpBatchSolver can be used to parallelize multi
 
 If you want to use the batch solver, make sure to compile acados with openmp and num_threads set to 1,
 i.e. with the flags -DACADOS_WITH_OPENMP=ON -DACADOS_NUM_THREADS=1
-The number of threads for the batch solver is then set via the option `num_threads_in_batch_solve`, see below.
+The number of threads for the batch solver is given in its constructor, see below.
 """
 
-def setup_ocp(num_threads_in_batch_solve=1, tol=1e-7):
+def setup_ocp(tol=1e-7):
 
     ocp = AcadosOcp()
 
@@ -89,7 +89,6 @@ def setup_ocp(num_threads_in_batch_solve=1, tol=1e-7):
     ocp.solver_options.nlp_solver_tol_eq = tol
     ocp.solver_options.nlp_solver_tol_ineq = tol
     ocp.solver_options.nlp_solver_tol_comp = tol
-    ocp.solver_options.num_threads_in_batch_solve = num_threads_in_batch_solve
 
     ocp.solver_options.tf = Tf
 
@@ -122,8 +121,8 @@ def main_sequential(x0, N_sim, tol):
 def main_batch(Xinit, simU, tol, num_threads_in_batch_solve=1):
 
     N_batch = Xinit.shape[0] - 1
-    ocp = setup_ocp(num_threads_in_batch_solve, tol)
-    batch_solver = AcadosOcpBatchSolver(ocp, N_batch, verbose=False)
+    ocp = setup_ocp(tol)
+    batch_solver = AcadosOcpBatchSolver(ocp, N_batch, num_threads_in_batch_solve=num_threads_in_batch_solve, verbose=False)
 
     for n in range(N_batch):
         batch_solver.ocp_solvers[n].constraints_set(0, "lbx", Xinit[n])

--- a/examples/acados_python/pendulum_on_cart/sim/minimal_example_batch_sim_solver.py
+++ b/examples/acados_python/pendulum_on_cart/sim/minimal_example_batch_sim_solver.py
@@ -43,11 +43,11 @@ This example shows how the AcadosSimBatchSolver can be used to parallelize mulit
 
 If you want to use the batch solver, make sure to compile acados with openmp and num_threads set to 1,
 i.e. with the flags -DACADOS_WITH_OPENMP=ON -DACADOS_NUM_THREADS=1
-The number of threads for the batch solver is then set via the option `num_threads_in_batch_solve`, see below.
+The number of threads for the batch solver is then set in its constructor, see below.
 """
 
 
-def setup_integrator(num_threads_in_batch_solve=1):
+def setup_integrator():
 
     sim = AcadosSim()
     sim.model = export_pendulum_ode_model()
@@ -57,7 +57,6 @@ def setup_integrator(num_threads_in_batch_solve=1):
     sim.solver_options.num_steps = 10
     sim.solver_options.newton_iter = 10 # for implicit integrator
     sim.solver_options.collocation_type = "GAUSS_RADAU_IIA"
-    sim.solver_options.num_threads_in_batch_solve = num_threads_in_batch_solve
 
     return sim
 
@@ -85,8 +84,8 @@ def main_sequential(x0, u0, N_sim):
 def main_batch(Xinit, u0, num_threads_in_batch_solve=1):
 
     N_batch = Xinit.shape[0] - 1
-    sim = setup_integrator(num_threads_in_batch_solve)
-    batch_integrator = AcadosSimBatchSolver(sim, N_batch, verbose=False)
+    sim = setup_integrator()
+    batch_integrator = AcadosSimBatchSolver(sim, N_batch, num_threads_in_batch_solve=num_threads_in_batch_solve, verbose=False)
 
     for n in range(N_batch):
         batch_integrator.sim_solvers[n].set("u", u0)

--- a/examples/acados_python/pendulum_on_cart/sim/minimal_example_batch_sim_solver.py
+++ b/examples/acados_python/pendulum_on_cart/sim/minimal_example_batch_sim_solver.py
@@ -86,6 +86,12 @@ def main_batch(Xinit, u0, num_threads_in_batch_solve=1):
     N_batch = Xinit.shape[0] - 1
     sim = setup_integrator()
     batch_integrator = AcadosSimBatchSolver(sim, N_batch, num_threads_in_batch_solve=num_threads_in_batch_solve, verbose=False)
+    
+    assert batch_integrator.num_threads_in_batch_solve == num_threads_in_batch_solve
+    batch_integrator.num_threads_in_batch_solve = 1337
+    assert batch_integrator.num_threads_in_batch_solve == 1337
+    batch_integrator.num_threads_in_batch_solve = num_threads_in_batch_solve
+    assert batch_integrator.num_threads_in_batch_solve == num_threads_in_batch_solve
 
     for n in range(N_batch):
         batch_integrator.sim_solvers[n].set("u", u0)

--- a/examples/acados_python/solution_sensitivities_convex_example/batch_adjoint_solution_sensitivity_example.py
+++ b/examples/acados_python/solution_sensitivities_convex_example/batch_adjoint_solution_sensitivity_example.py
@@ -81,10 +81,10 @@ def main_batch(Xinit, simU, param_vals, adjoints_ref, tol, num_threads_in_batch_
     N_batch = Xinit.shape[0] - 1
 
     learnable_params = ["A", "Q", "b"]
-    ocp = export_parametric_ocp(PARAM_VALUE_DICT, learnable_params=learnable_params, num_threads_in_batch_solve = num_threads_in_batch_solve)
+    ocp = export_parametric_ocp(PARAM_VALUE_DICT, learnable_params=learnable_params)
     ocp.solver_options.with_solution_sens_wrt_params = True
 
-    batch_solver = AcadosOcpBatchSolver(ocp, N_batch, verbose=False)
+    batch_solver = AcadosOcpBatchSolver(ocp, N_batch, num_threads_in_batch_solve=num_threads_in_batch_solve, verbose=False)
 
     # reset, set bounds and p_global
     t0 = time.time()

--- a/examples/acados_python/solution_sensitivities_convex_example/setup_parametric_ocp.py
+++ b/examples/acados_python/solution_sensitivities_convex_example/setup_parametric_ocp.py
@@ -89,7 +89,6 @@ def export_parametric_ocp(
     param: dict[str, np.ndarray],
     name: str = "lti",
     learnable_params: Optional[list[str]] = None,
-    num_threads_in_batch_solve: int = 1,
 ) -> AcadosOcp:
 
     if learnable_params is None:
@@ -107,8 +106,6 @@ def export_parametric_ocp(
     ocp.solver_options.integrator_type = 'DISCRETE'
     ocp.solver_options.hessian_approx = 'EXACT'
     ocp.solver_options.nlp_solver_type = "SQP"
-
-    ocp.solver_options.num_threads_in_batch_solve = num_threads_in_batch_solve
 
     # Add learnable parameters to p_global
     if len(learnable_params) != 0:

--- a/interfaces/acados_matlab_octave/AcadosOcpOptions.m
+++ b/interfaces/acados_matlab_octave/AcadosOcpOptions.m
@@ -134,7 +134,6 @@ classdef AcadosOcpOptions < handle
         custom_update_header_filename
         custom_templates
         custom_update_copy
-        num_threads_in_batch_solve
         with_batch_functionality
 
         compile_interface
@@ -252,7 +251,6 @@ classdef AcadosOcpOptions < handle
             obj.custom_update_header_filename = '';
             obj.custom_templates = [];
             obj.custom_update_copy = true;
-            obj.num_threads_in_batch_solve = 1;
             obj.with_batch_functionality = false;
 
             obj.compile_interface = []; % corresponds to automatic detection, possible values: true, false, []

--- a/interfaces/acados_matlab_octave/AcadosOcpOptions.m
+++ b/interfaces/acados_matlab_octave/AcadosOcpOptions.m
@@ -135,6 +135,7 @@ classdef AcadosOcpOptions < handle
         custom_templates
         custom_update_copy
         num_threads_in_batch_solve
+        with_batch_functionality
 
         compile_interface
 
@@ -252,6 +253,7 @@ classdef AcadosOcpOptions < handle
             obj.custom_templates = [];
             obj.custom_update_copy = true;
             obj.num_threads_in_batch_solve = 1;
+            obj.with_batch_functionality = false;
 
             obj.compile_interface = []; % corresponds to automatic detection, possible values: true, false, []
         end

--- a/interfaces/acados_matlab_octave/AcadosSimOptions.m
+++ b/interfaces/acados_matlab_octave/AcadosSimOptions.m
@@ -48,6 +48,7 @@ classdef AcadosSimOptions < handle
         ext_fun_expand_dyn
         num_threads_in_batch_solve
         compile_interface
+        with_batch_functionality
     end
 
     methods
@@ -74,6 +75,7 @@ classdef AcadosSimOptions < handle
             end
             obj.ext_fun_expand_dyn = false;
             obj.num_threads_in_batch_solve = 1;
+            obj.with_batch_functionality = false;
             obj.compile_interface = []; % corresponds to automatic detection, possible values: true, false, []
         end
 

--- a/interfaces/acados_matlab_octave/AcadosSimOptions.m
+++ b/interfaces/acados_matlab_octave/AcadosSimOptions.m
@@ -46,7 +46,6 @@ classdef AcadosSimOptions < handle
         output_z
         ext_fun_compile_flags
         ext_fun_expand_dyn
-        num_threads_in_batch_solve
         compile_interface
         with_batch_functionality
     end
@@ -74,7 +73,6 @@ classdef AcadosSimOptions < handle
                 obj.ext_fun_compile_flags = env_var;
             end
             obj.ext_fun_expand_dyn = false;
-            obj.num_threads_in_batch_solve = 1;
             obj.with_batch_functionality = false;
             obj.compile_interface = []; % corresponds to automatic detection, possible values: true, false, []
         end

--- a/interfaces/acados_template/acados_template/acados_ocp_batch_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_batch_solver.py
@@ -129,6 +129,10 @@ class AcadosOcpBatchSolver():
     def num_threads_in_batch_solve(self):
         """Number of threads used for parallelizing the batch methods."""
         return self.__num_threads_in_batch_solve
+    
+    @num_threads_in_batch_solve.setter
+    def num_threads_in_batch_solve(self, num_threads_in_batch_solve):
+        self.__num_threads_in_batch_solve = num_threads_in_batch_solve
 
 
     def solve(self):

--- a/interfaces/acados_template/acados_template/acados_ocp_batch_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_batch_solver.py
@@ -76,19 +76,19 @@ class AcadosOcpBatchSolver():
         self.__status = np.zeros((self.N_batch,), dtype=np.intc, order="C")
         self.__status_p = cast(self.__status.ctypes.data, POINTER(c_int))
 
-        getattr(self.__shared_lib, f"{self.__name}_acados_batch_solve").argtypes = [POINTER(c_void_p), POINTER(c_int), c_int]
+        getattr(self.__shared_lib, f"{self.__name}_acados_batch_solve").argtypes = [POINTER(c_void_p), POINTER(c_int), c_int, c_int]
         getattr(self.__shared_lib, f"{self.__name}_acados_batch_solve").restype = c_void_p
 
-        getattr(self.__shared_lib, f"{self.__name}_acados_batch_eval_params_jac").argtypes = [POINTER(c_void_p), c_int]
+        getattr(self.__shared_lib, f"{self.__name}_acados_batch_eval_params_jac").argtypes = [POINTER(c_void_p), c_int, c_int]
         getattr(self.__shared_lib, f"{self.__name}_acados_batch_eval_params_jac").restype = c_void_p
 
-        getattr(self.__shared_lib, f"{self.__name}_acados_batch_eval_solution_sens_adj_p").argtypes = [POINTER(c_void_p), c_char_p, c_int, POINTER(c_double), c_int, c_int]
+        getattr(self.__shared_lib, f"{self.__name}_acados_batch_eval_solution_sens_adj_p").argtypes = [POINTER(c_void_p), c_char_p, c_int, POINTER(c_double), c_int, c_int, c_int]
         getattr(self.__shared_lib, f"{self.__name}_acados_batch_eval_solution_sens_adj_p").restype = c_void_p
 
-        getattr(self.__shared_lib, f"{self.__name}_acados_batch_set_flat").argtypes = [POINTER(c_void_p), c_char_p, POINTER(c_double), c_int, c_int]
+        getattr(self.__shared_lib, f"{self.__name}_acados_batch_set_flat").argtypes = [POINTER(c_void_p), c_char_p, POINTER(c_double), c_int, c_int, c_int]
         getattr(self.__shared_lib, f"{self.__name}_acados_batch_set_flat").restype = c_void_p
 
-        getattr(self.__shared_lib, f"{self.__name}_acados_batch_get_flat").argtypes = [POINTER(c_void_p), c_char_p, POINTER(c_double), c_int, c_int]
+        getattr(self.__shared_lib, f"{self.__name}_acados_batch_get_flat").argtypes = [POINTER(c_void_p), c_char_p, POINTER(c_double), c_int, c_int, c_int]
         getattr(self.__shared_lib, f"{self.__name}_acados_batch_get_flat").restype = c_void_p
 
         if self.ocp_solvers[0].acados_lib_uses_omp:

--- a/interfaces/acados_template/acados_template/acados_ocp_batch_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_batch_solver.py
@@ -32,7 +32,7 @@
 from .acados_ocp_solver import AcadosOcpSolver
 from .acados_ocp import AcadosOcp
 from .acados_ocp_iterate import AcadosOcpFlattenedBatchIterate
-from typing import Optional, List, Tuple, Sequence
+from typing import Optional, List, Tuple, Sequence, Union
 from ctypes import (POINTER, c_int, c_void_p, cast, c_double, c_char_p)
 import numpy as np
 import time
@@ -43,6 +43,7 @@ class AcadosOcpBatchSolver():
 
         :param ocp: type :py:class:`~acados_template.acados_ocp.AcadosOcp`
         :param N_batch: batch size, positive integer
+        :param num_threads_in_batch_solve: number of threads used for parallelizing the batch methods. Default: 1
         :param json_file: Default: 'acados_ocp.json'
         :param build: Flag indicating whether solver should be (re)compiled. If False an attempt is made to load an already compiled shared library for the solver. Default: True
         :param generate: Flag indicating whether problem functions should be code generated. Default: True
@@ -51,10 +52,18 @@ class AcadosOcpBatchSolver():
 
     __ocp_solvers : List[AcadosOcpSolver]
 
-    def __init__(self, ocp: AcadosOcp, N_batch: int, json_file: str = 'acados_ocp.json',  build: bool = True, generate: bool = True, verbose: bool=True):
+    def __init__(self, ocp: AcadosOcp, N_batch: int, num_threads_in_batch_solve: Union[int, None] = None, json_file: str = 'acados_ocp.json',  build: bool = True, generate: bool = True, verbose: bool=True):
 
         if not isinstance(N_batch, int) or N_batch <= 0:
             raise Exception("AcadosOcpBatchSolver: argument N_batch should be a positive integer.")
+        if num_threads_in_batch_solve is None:
+            num_threads_in_batch_solve = ocp.solver_options.num_threads_in_batch_solve
+            print(f"Warning: num_threads_in_batch_solve is None. Using value {num_threads_in_batch_solve} set in ocp.solver_options instead.")
+            print("In the future, it should be passed explicitly in the AcadosOcpBatchSolver constructor.")
+        if not isinstance(num_threads_in_batch_solve, int) or num_threads_in_batch_solve <= 0:
+            raise Exception("AcadosOcpBatchSolver: argument num_threads_in_batch_solve should be a positive integer.")
+        
+        self.__num_threads_in_batch_solve = num_threads_in_batch_solve
 
         self.__N_batch = N_batch
         self.__ocp_solvers = [AcadosOcpSolver(ocp,
@@ -111,6 +120,11 @@ class AcadosOcpBatchSolver():
     def N_batch(self):
         """Batch size."""
         return self.__N_batch
+    
+    @property
+    def num_threads_in_batch_solve(self):
+        """Number of threads used for parallelizing the batch methods."""
+        return self.__num_threads_in_batch_solve
 
 
     def solve(self):
@@ -118,7 +132,7 @@ class AcadosOcpBatchSolver():
         Call solve for all `N_batch` solvers.
         """
 
-        getattr(self.__shared_lib, f"{self.__name}_acados_batch_solve")(self.__ocp_solvers_pointer, self.__status_p, self.__N_batch)
+        getattr(self.__shared_lib, f"{self.__name}_acados_batch_solve")(self.__ocp_solvers_pointer, self.__status_p, self.__N_batch, self.__num_threads_in_batch_solve)
 
         # to be consistent with non-batched solve
         for s, solver in zip(self.__status, self.ocp_solvers):
@@ -130,7 +144,7 @@ class AcadosOcpBatchSolver():
         Call setup_qp_matrices_and_factorize for all `N_batch` solvers.
         """
 
-        getattr(self.__shared_lib, f"{self.__name}_acados_batch_setup_qp_matrices_and_factorize")(self.__ocp_solvers_pointer, self.__status_p, self.__N_batch)
+        getattr(self.__shared_lib, f"{self.__name}_acados_batch_setup_qp_matrices_and_factorize")(self.__ocp_solvers_pointer, self.__status_p, self.__N_batch, self.__num_threads_in_batch_solve)
 
         # to be consistent with non-batched solve
         for s, solver in zip(self.__status, self.ocp_solvers):
@@ -212,7 +226,7 @@ class AcadosOcpBatchSolver():
 
             # compute jacobian wrt params
             t0 = time.time()
-            getattr(self.__shared_lib, f"{self.__name}_acados_batch_eval_params_jac")(self.__ocp_solvers_pointer, self.__N_batch)
+            getattr(self.__shared_lib, f"{self.__name}_acados_batch_eval_params_jac")(self.__ocp_solvers_pointer, self.__N_batch, self.__num_threads_in_batch_solve)
             self.time_solution_sens_lin = time.time() - t0
 
             t1 = time.time()
@@ -235,7 +249,7 @@ class AcadosOcpBatchSolver():
 
                 # solve adjoint sensitivities
                 getattr(self.__shared_lib, f"{self.__name}_acados_batch_eval_solution_sens_adj_p")(
-                    self.__ocp_solvers_pointer, field, 0, c_grad_p, offset, self.__N_batch)
+                    self.__ocp_solvers_pointer, field, 0, c_grad_p, offset, self.__N_batch, self.__num_threads_in_batch_solve)
 
             self.time_solution_sens_solve = time.time() - t1
 
@@ -274,7 +288,7 @@ class AcadosOcpBatchSolver():
         value_ = value_.astype(float)
         value_data = cast(value_.ctypes.data, POINTER(c_double))
 
-        getattr(self.__shared_lib, f"{self.__name}_acados_batch_set_flat")(self.__ocp_solvers_pointer, field, value_data, N_data, self.__N_batch)
+        getattr(self.__shared_lib, f"{self.__name}_acados_batch_set_flat")(self.__ocp_solvers_pointer, field, value_data, N_data, self.__N_batch, self.__num_threads_in_batch_solve)
 
 
     def get_flat(self, field_: str) -> np.ndarray:
@@ -294,7 +308,7 @@ class AcadosOcpBatchSolver():
         out = np.ascontiguousarray(np.zeros((self.N_batch, dim,)), dtype=np.float64)
         out_data = cast(out.ctypes.data, POINTER(c_double))
 
-        getattr(self.__shared_lib, f"{self.__name}_acados_batch_get_flat")(self.__ocp_solvers_pointer, field, out_data, self.N_batch*dim, self.__N_batch)
+        getattr(self.__shared_lib, f"{self.__name}_acados_batch_get_flat")(self.__ocp_solvers_pointer, field, out_data, self.N_batch*dim, self.__N_batch, self.__num_threads_in_batch_solve)
 
         return out
 

--- a/interfaces/acados_template/acados_template/acados_ocp_batch_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_batch_solver.py
@@ -62,6 +62,10 @@ class AcadosOcpBatchSolver():
             print("In the future, it should be passed explicitly in the AcadosOcpBatchSolver constructor.")
         if not isinstance(num_threads_in_batch_solve, int) or num_threads_in_batch_solve <= 0:
             raise Exception("AcadosOcpBatchSolver: argument num_threads_in_batch_solve should be a positive integer.")
+        if not ocp.solver_options.with_batch_functionality:
+            print("Warning: Using AcadosOcpBatchSolver, but ocp.solver_options.with_batch_functionality is False.")
+            print("Attempting to compile with openmp nonetheless.")
+            ocp.solver_options.with_batch_functionality = True
         
         self.__num_threads_in_batch_solve = num_threads_in_batch_solve
 

--- a/interfaces/acados_template/acados_template/acados_ocp_options.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_options.py
@@ -1216,6 +1216,7 @@ class AcadosOcpOptions:
     @property
     def num_threads_in_batch_solve(self):
         """
+        DEPRECATED, use the flag with_batch_functionality instead and pass the number of threads directly to the BatchSolver.
         Integer indicating how many threads should be used within the batch solve.
         If more than one thread should be used, the solver is compiled with openmp.
         Default: 1.
@@ -1982,6 +1983,7 @@ class AcadosOcpOptions:
 
     @num_threads_in_batch_solve.setter
     def num_threads_in_batch_solve(self, num_threads_in_batch_solve):
+        print("Warning: num_threads_in_batch_solve is deprecated, set the flag with_batch_functionality instead and pass the number of threads directly to the BatchSolver.")
         if isinstance(num_threads_in_batch_solve, int) and num_threads_in_batch_solve > 0:
             self.__num_threads_in_batch_solve = num_threads_in_batch_solve
         else:

--- a/interfaces/acados_template/acados_template/acados_ocp_options.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_options.py
@@ -143,6 +143,7 @@ class AcadosOcpOptions:
         self.__custom_templates = []
         self.__custom_update_copy = True
         self.__num_threads_in_batch_solve: int = 1
+        self.__with_batch_functionality: bool = False
 
     @property
     def qp_solver(self):
@@ -1220,6 +1221,15 @@ class AcadosOcpOptions:
         Default: 1.
         """
         return self.__num_threads_in_batch_solve
+    
+    @property
+    def with_batch_functionality(self):
+        """
+        Whether the AcadosOcpBatchSolver can be used.
+        In this case, the solver is compiled with openmp.
+        Default: False.
+        """
+        return self.__with_batch_functionality
 
 
     @qp_solver.setter
@@ -1976,6 +1986,14 @@ class AcadosOcpOptions:
             self.__num_threads_in_batch_solve = num_threads_in_batch_solve
         else:
             raise Exception('Invalid num_threads_in_batch_solve value. num_threads_in_batch_solve must be a positive integer.')
+
+    @with_batch_functionality.setter
+    def with_batch_functionality(self, with_batch_functionality):
+        if isinstance(with_batch_functionality, bool):
+            self.__with_batch_functionality = with_batch_functionality
+        else:
+            raise Exception('Invalid with_batch_functionality value. Expected bool.')
+
 
     def set(self, attr, value):
         setattr(self, attr, value)

--- a/interfaces/acados_template/acados_template/acados_sim.py
+++ b/interfaces/acados_template/acados_template/acados_sim.py
@@ -69,6 +69,7 @@ class AcadosSimOptions:
         self.__ext_fun_compile_flags = '-O2' if 'ACADOS_EXT_FUN_COMPILE_FLAGS' not in env else env['ACADOS_EXT_FUN_COMPILE_FLAGS']
         self.__ext_fun_expand_dyn = False
         self.__num_threads_in_batch_solve: int = 1
+        self.__with_batch_functionality: bool = False
 
     @property
     def integrator_type(self):
@@ -169,7 +170,15 @@ class AcadosSimOptions:
         Default: 1.
         """
         return self.__num_threads_in_batch_solve
-
+    
+    @property
+    def with_batch_functionality(self):
+        """
+        Whether the AcadosSimBatchSolver can be used.
+        In this case, the sim solver is compiled with openmp.
+        Default: False.
+        """
+        return self.__with_batch_functionality
 
     @ext_fun_compile_flags.setter
     def ext_fun_compile_flags(self, ext_fun_compile_flags):
@@ -283,6 +292,13 @@ class AcadosSimOptions:
             self.__num_threads_in_batch_solve = num_threads_in_batch_solve
         else:
             raise Exception('Invalid num_threads_in_batch_solve value. num_threads_in_batch_solve must be a positive integer.')
+
+    @with_batch_functionality.setter
+    def with_batch_functionality(self, with_batch_functionality):
+        if isinstance(with_batch_functionality, bool):
+            self.__with_batch_functionality = with_batch_functionality
+        else:
+            raise Exception('Invalid with_batch_functionality value. Expected bool.')
 
 class AcadosSim:
     """

--- a/interfaces/acados_template/acados_template/acados_sim.py
+++ b/interfaces/acados_template/acados_template/acados_sim.py
@@ -165,6 +165,7 @@ class AcadosSimOptions:
     @property
     def num_threads_in_batch_solve(self):
         """
+        DEPRECATED, use the flag with_batch_functionality instead and pass the number of threads directly to the BatchSolver.
         Integer indicating how many threads should be used within the batch solve.
         If more than one thread should be used, the sim solver is compiled with openmp.
         Default: 1.
@@ -288,6 +289,7 @@ class AcadosSimOptions:
 
     @num_threads_in_batch_solve.setter
     def num_threads_in_batch_solve(self, num_threads_in_batch_solve):
+        print("Warning: num_threads_in_batch_solve is deprecated, set the flag with_batch_functionality instead and pass the number of threads directly to the BatchSolver.")
         if isinstance(num_threads_in_batch_solve, int) and num_threads_in_batch_solve > 0:
             self.__num_threads_in_batch_solve = num_threads_in_batch_solve
         else:

--- a/interfaces/acados_template/acados_template/acados_sim_batch_solver.py
+++ b/interfaces/acados_template/acados_template/acados_sim_batch_solver.py
@@ -103,4 +103,13 @@ class AcadosSimBatchSolver():
     def N_batch(self):
         """Batch size."""
         return self.__N_batch
+    
+    @property
+    def num_threads_in_batch_solve(self):
+        """Number of threads used for parallelizing the batch methods."""
+        return self.__num_threads_in_batch_solve
+    
+    @num_threads_in_batch_solve.setter
+    def num_threads_in_batch_solve(self, num_threads_in_batch_solve):
+        self.__num_threads_in_batch_solve = num_threads_in_batch_solve
 

--- a/interfaces/acados_template/acados_template/acados_sim_batch_solver.py
+++ b/interfaces/acados_template/acados_template/acados_sim_batch_solver.py
@@ -31,7 +31,7 @@
 
 from .acados_sim_solver import AcadosSimSolver
 from .acados_sim import AcadosSim
-from typing import List
+from typing import List, Union
 from ctypes import (POINTER, c_int, c_void_p)
 
 
@@ -49,11 +49,22 @@ class AcadosSimBatchSolver():
 
     __sim_solvers : List[AcadosSimSolver]
 
-    def __init__(self, sim: AcadosSim, N_batch: int, json_file: str = 'acados_sim.json', build: bool = True, generate: bool = True, verbose: bool=True):
+    def __init__(self, sim: AcadosSim, N_batch: int, num_threads_in_batch_solve: Union[int, None] = None , json_file: str = 'acados_sim.json', build: bool = True, generate: bool = True, verbose: bool=True):
 
         if not isinstance(N_batch, int) or N_batch <= 0:
             raise Exception("AcadosSimBatchSolver: argument N_batch should be a positive integer.")
+        if num_threads_in_batch_solve is None:
+            num_threads_in_batch_solve = sim.solver_options.num_threads_in_batch_solve
+            print(f"Warning: num_threads_in_batch_solve is None. Using value {num_threads_in_batch_solve} set in sim.solver_options instead.")
+            print("In the future, it should be passed explicitly in the AcadosOcpBatchSolver constructor.")
+        if not isinstance(num_threads_in_batch_solve, int) or num_threads_in_batch_solve <= 0:
+            raise Exception("AcadosOcpBatchSolver: argument num_threads_in_batch_solve should be a positive integer.")
+        if not sim.solver_options.with_batch_functionality:
+            print("Warning: Using AcadosSimBatchSolver, but sim.solver_options.with_batch_functionality is False.")
+            print("Attempting to compile with openmp nonetheless.")
+            sim.solver_options.with_batch_functionality = True
 
+        self.__num_threads_in_batch_solve = num_threads_in_batch_solve
         self.__N_batch = N_batch
         self.__sim_solvers = [AcadosSimSolver(sim,
                                               json_file=json_file,
@@ -69,7 +80,7 @@ class AcadosSimBatchSolver():
         for i in range(self.N_batch):
             self.__sim_solvers_pointer[i] = self.sim_solvers[i].capsule
 
-        getattr(self.__shared_lib, f"{self.__model_name}_acados_sim_batch_solve").argtypes = [POINTER(c_void_p), c_int]
+        getattr(self.__shared_lib, f"{self.__model_name}_acados_sim_batch_solve").argtypes = [POINTER(c_void_p), c_int, c_int]
         getattr(self.__shared_lib, f"{self.__model_name}_acados_sim_batch_solve").restype = c_void_p
 
         if not self.sim_solvers[0].acados_lib_uses_omp:
@@ -80,7 +91,7 @@ class AcadosSimBatchSolver():
         """
         Solve the simulation problem with current input for all `N_batch` integrators.
         """
-        getattr(self.__shared_lib, f"{self.__model_name}_acados_sim_batch_solve")(self.__sim_solvers_pointer, self.__N_batch)
+        getattr(self.__shared_lib, f"{self.__model_name}_acados_sim_batch_solve")(self.__sim_solvers_pointer, self.__N_batch, self.__num_threads_in_batch_solve)
 
 
     @property

--- a/interfaces/acados_template/acados_template/acados_sim_batch_solver.py
+++ b/interfaces/acados_template/acados_template/acados_sim_batch_solver.py
@@ -56,9 +56,9 @@ class AcadosSimBatchSolver():
         if num_threads_in_batch_solve is None:
             num_threads_in_batch_solve = sim.solver_options.num_threads_in_batch_solve
             print(f"Warning: num_threads_in_batch_solve is None. Using value {num_threads_in_batch_solve} set in sim.solver_options instead.")
-            print("In the future, it should be passed explicitly in the AcadosOcpBatchSolver constructor.")
+            print("In the future, it should be passed explicitly in the AcadosSimBatchSolver constructor.")
         if not isinstance(num_threads_in_batch_solve, int) or num_threads_in_batch_solve <= 0:
-            raise Exception("AcadosOcpBatchSolver: argument num_threads_in_batch_solve should be a positive integer.")
+            raise Exception("AcadosSimBatchSolver: argument num_threads_in_batch_solve should be a positive integer.")
         if not sim.solver_options.with_batch_functionality:
             print("Warning: Using AcadosSimBatchSolver, but sim.solver_options.with_batch_functionality is False.")
             print("Attempting to compile with openmp nonetheless.")

--- a/interfaces/acados_template/acados_template/c_templates_tera/CMakeLists.in.txt
+++ b/interfaces/acados_template/acados_template/c_templates_tera/CMakeLists.in.txt
@@ -188,7 +188,7 @@ set(CMAKE_C_FLAGS "-fPIC -std=c99 {{ openmp_flag }} {{ solver_options.ext_fun_co
 {%- if qp_solver == "PARTIAL_CONDENSING_QPDUNES" -%}
     -DACADOS_WITH_QPDUNES
 {%- endif -%}
-{%- if solver_options.num_threads_in_batch_solve > 1 -%}
+{%- if solver_options.with_batch_functionality -%}
     -fopenmp
 {%- endif -%}
 ")

--- a/interfaces/acados_template/acados_template/c_templates_tera/Makefile.in
+++ b/interfaces/acados_template/acados_template/c_templates_tera/Makefile.in
@@ -172,7 +172,7 @@ CPPFLAGS+= -I $(INCLUDE_PATH)/daqp/include
 {# c-compiler flags #}
 # define the c-compiler flags for make's implicit rules
 CFLAGS = -fPIC -std=c99 {{ openmp_flag }} {{ solver_options.ext_fun_compile_flags }}#-fno-diagnostics-show-line-numbers -g
-{% if solver_options.num_threads_in_batch_solve > 1%}
+{% if solver_options.with_batch_functionality%}
 CFLAGS += -fopenmp
 {%- endif %}
 # # Debugging
@@ -180,7 +180,7 @@ CFLAGS += -fopenmp
 
 # linker flags
 LDFLAGS+= -L$(LIB_PATH)
-{% if solver_options.num_threads_in_batch_solve > 1 %}
+{% if solver_options.with_batch_functionality%}
 LDFLAGS += -fopenmp
 {%- endif %}
 

--- a/interfaces/acados_template/acados_template/c_templates_tera/Makefile.in
+++ b/interfaces/acados_template/acados_template/c_templates_tera/Makefile.in
@@ -172,7 +172,7 @@ CPPFLAGS+= -I $(INCLUDE_PATH)/daqp/include
 {# c-compiler flags #}
 # define the c-compiler flags for make's implicit rules
 CFLAGS = -fPIC -std=c99 {{ openmp_flag }} {{ solver_options.ext_fun_compile_flags }}#-fno-diagnostics-show-line-numbers -g
-{% if solver_options.with_batch_functionality%}
+{% if solver_options.with_batch_functionality %}
 CFLAGS += -fopenmp
 {%- endif %}
 # # Debugging
@@ -180,7 +180,7 @@ CFLAGS += -fopenmp
 
 # linker flags
 LDFLAGS+= -L$(LIB_PATH)
-{% if solver_options.with_batch_functionality%}
+{% if solver_options.with_batch_functionality %}
 LDFLAGS += -fopenmp
 {%- endif %}
 

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_sim_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_sim_solver.in.c
@@ -39,7 +39,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-{%- if solver_options.num_threads_in_batch_solve > 1 %}
+{%- if solver_options.with_batch_functionality %}
 // openmp
 #include <omp.h>
 {%- endif %}
@@ -417,25 +417,27 @@ int {{ model.name }}_acados_sim_solve({{ model.name }}_sim_solver_capsule *capsu
 }
 
 
-void {{ model.name }}_acados_sim_batch_solve({{ model.name }}_sim_solver_capsule ** capsules, int N_batch)
-{
-{% if solver_options.num_threads_in_batch_solve > 1 %}
-    int num_threads_bkp = omp_get_num_threads();
-    omp_set_num_threads({{ solver_options.num_threads_in_batch_solve }});
-
-    #pragma omp parallel for
-{%- endif %}
-    for (int i = 0; i < N_batch; i++)
+{% if solver_options.with_batch_functionality %}
+    void {{ model.name }}_acados_sim_batch_solve({{ model.name }}_sim_solver_capsule ** capsules, int N_batch, int num_threads_in_batch_solve)
     {
-        sim_solve(capsules[i]->acados_sim_solver, capsules[i]->acados_sim_in, capsules[i]->acados_sim_out);
+        int num_threads_bkp;
+        if (num_threads_in_batch_solve > 1){
+            num_threads_bkp = omp_get_num_threads();
+            omp_set_num_threads({{ solver_options.num_threads_in_batch_solve }});
+        }
+
+        #pragma omp parallel for
+        for (int i = 0; i < N_batch; i++)
+        {
+            sim_solve(capsules[i]->acados_sim_solver, capsules[i]->acados_sim_in, capsules[i]->acados_sim_out);
+        }
+
+        if (num_threads_in_batch_solve > 1){
+            omp_set_num_threads( num_threads_bkp );
+        }
+        return;
     }
-
-{% if solver_options.num_threads_in_batch_solve > 1 %}
-    omp_set_num_threads( num_threads_bkp );
 {%- endif %}
-    return;
-}
-
 
 int {{ model.name }}_acados_sim_free({{ model.name }}_sim_solver_capsule *capsule)
 {

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_sim_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_sim_solver.in.c
@@ -418,25 +418,25 @@ int {{ model.name }}_acados_sim_solve({{ model.name }}_sim_solver_capsule *capsu
 
 
 {% if solver_options.with_batch_functionality %}
-    void {{ model.name }}_acados_sim_batch_solve({{ model.name }}_sim_solver_capsule ** capsules, int N_batch, int num_threads_in_batch_solve)
-    {
-        int num_threads_bkp;
-        if (num_threads_in_batch_solve > 1){
-            num_threads_bkp = omp_get_num_threads();
-            omp_set_num_threads({{ solver_options.num_threads_in_batch_solve }});
-        }
-
-        #pragma omp parallel for
-        for (int i = 0; i < N_batch; i++)
-        {
-            sim_solve(capsules[i]->acados_sim_solver, capsules[i]->acados_sim_in, capsules[i]->acados_sim_out);
-        }
-
-        if (num_threads_in_batch_solve > 1){
-            omp_set_num_threads( num_threads_bkp );
-        }
-        return;
+void {{ model.name }}_acados_sim_batch_solve({{ model.name }}_sim_solver_capsule ** capsules, int N_batch, int num_threads_in_batch_solve)
+{
+    int num_threads_bkp;
+    if (num_threads_in_batch_solve > 1){
+        num_threads_bkp = omp_get_num_threads();
+        omp_set_num_threads({{ solver_options.num_threads_in_batch_solve }});
     }
+
+    #pragma omp parallel for
+    for (int i = 0; i < N_batch; i++)
+    {
+        sim_solve(capsules[i]->acados_sim_solver, capsules[i]->acados_sim_in, capsules[i]->acados_sim_out);
+    }
+
+    if (num_threads_in_batch_solve > 1){
+        omp_set_num_threads( num_threads_bkp );
+    }
+    return;
+}
 {%- endif %}
 
 int {{ model.name }}_acados_sim_free({{ model.name }}_sim_solver_capsule *capsule)

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_sim_solver.in.h
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_sim_solver.in.h
@@ -80,7 +80,9 @@ typedef struct {{ model.name }}_sim_solver_capsule
 
 ACADOS_SYMBOL_EXPORT int {{ model.name }}_acados_sim_create({{ model.name }}_sim_solver_capsule *capsule);
 ACADOS_SYMBOL_EXPORT int {{ model.name }}_acados_sim_solve({{ model.name }}_sim_solver_capsule *capsule);
-ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_sim_batch_solve({{ model.name }}_sim_solver_capsule **capsules, int N_batch);
+{% if solver_options.with_batch_functionality %}
+    ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_sim_batch_solve({{ model.name }}_sim_solver_capsule **capsules, int N_batch, int num_threads_in_batch_solve);
+{% endif %}
 ACADOS_SYMBOL_EXPORT int {{ model.name }}_acados_sim_free({{ model.name }}_sim_solver_capsule *capsule);
 ACADOS_SYMBOL_EXPORT int {{ model.name }}_acados_sim_update_params({{ model.name }}_sim_solver_capsule *capsule, double *value, int np);
 

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_sim_solver.in.h
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_sim_solver.in.h
@@ -81,7 +81,7 @@ typedef struct {{ model.name }}_sim_solver_capsule
 ACADOS_SYMBOL_EXPORT int {{ model.name }}_acados_sim_create({{ model.name }}_sim_solver_capsule *capsule);
 ACADOS_SYMBOL_EXPORT int {{ model.name }}_acados_sim_solve({{ model.name }}_sim_solver_capsule *capsule);
 {% if solver_options.with_batch_functionality %}
-    ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_sim_batch_solve({{ model.name }}_sim_solver_capsule **capsules, int N_batch, int num_threads_in_batch_solve);
+ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_sim_batch_solve({{ model.name }}_sim_solver_capsule **capsules, int N_batch, int num_threads_in_batch_solve);
 {% endif %}
 ACADOS_SYMBOL_EXPORT int {{ model.name }}_acados_sim_free({{ model.name }}_sim_solver_capsule *capsule);
 ACADOS_SYMBOL_EXPORT int {{ model.name }}_acados_sim_update_params({{ model.name }}_sim_solver_capsule *capsule, double *value, int np);

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -2816,159 +2816,159 @@ int {{ model.name }}_acados_setup_qp_matrices_and_factorize({{ model.name }}_sol
 
 
 {% if solver_options.with_batch_functionality %}
-    void {{ model.name }}_acados_batch_solve({{ model.name }}_solver_capsule ** capsules, int * status_out, int N_batch, int num_threads_in_batch_solve)
+void {{ model.name }}_acados_batch_solve({{ model.name }}_solver_capsule ** capsules, int * status_out, int N_batch, int num_threads_in_batch_solve)
+{
+    int num_threads_bkp;
+    if (num_threads_in_batch_solve > 1)
     {
-        int num_threads_bkp;
-        if (num_threads_in_batch_solve > 1)
-        {
-            num_threads_bkp = omp_get_num_threads();
-            omp_set_num_threads(num_threads_in_batch_solve);
-        }
-
-        #pragma omp parallel for
-        for (int i = 0; i < N_batch; i++)
-        {
-            status_out[i] = ocp_nlp_solve(capsules[i]->nlp_solver, capsules[i]->nlp_in, capsules[i]->nlp_out);
-        }
-
-        if (num_threads_in_batch_solve > 1)
-        {
-            omp_set_num_threads( num_threads_bkp );
-        }
-        return;
+        num_threads_bkp = omp_get_num_threads();
+        omp_set_num_threads(num_threads_in_batch_solve);
     }
 
-
-    void {{ model.name }}_acados_batch_setup_qp_matrices_and_factorize({{ model.name }}_solver_capsule ** capsules, int * status_out, int N_batch, int num_threads_in_batch_solve)
+    #pragma omp parallel for
+    for (int i = 0; i < N_batch; i++)
     {
-        int num_threads_bkp;
-        if (num_threads_in_batch_solve > 1)
-        {
-            num_threads_bkp = omp_get_num_threads();
-            omp_set_num_threads(num_threads_in_batch_solve);
-        }
-
-        #pragma omp parallel for
-        for (int i = 0; i < N_batch; i++)
-        {
-            status_out[i] = ocp_nlp_setup_qp_matrices_and_factorize(capsules[i]->nlp_solver, capsules[i]->nlp_in, capsules[i]->nlp_out);
-        }
-
-        if (num_threads_in_batch_solve > 1)
-        {
-            omp_set_num_threads( num_threads_bkp );
-        }
-        return;
+        status_out[i] = ocp_nlp_solve(capsules[i]->nlp_solver, capsules[i]->nlp_in, capsules[i]->nlp_out);
     }
 
-
-    void {{ model.name }}_acados_batch_eval_params_jac({{ model.name }}_solver_capsule ** capsules, int N_batch, int num_threads_in_batch_solve)
+    if (num_threads_in_batch_solve > 1)
     {
-        int num_threads_bkp;
-        if (num_threads_in_batch_solve > 1)
-        {
-            num_threads_bkp = omp_get_num_threads();
-            omp_set_num_threads(num_threads_in_batch_solve);
-        }
+        omp_set_num_threads( num_threads_bkp );
+    }
+    return;
+}
 
-        #pragma omp parallel for
-        for (int i = 0; i < N_batch; i++)
-        {
-            ocp_nlp_eval_params_jac(capsules[i]->nlp_solver, capsules[i]->nlp_in, capsules[i]->nlp_out);
-        }
 
-        if (num_threads_in_batch_solve > 1)
-        {
-            omp_set_num_threads( num_threads_bkp );
-        }
-        return;
+void {{ model.name }}_acados_batch_setup_qp_matrices_and_factorize({{ model.name }}_solver_capsule ** capsules, int * status_out, int N_batch, int num_threads_in_batch_solve)
+{
+    int num_threads_bkp;
+    if (num_threads_in_batch_solve > 1)
+    {
+        num_threads_bkp = omp_get_num_threads();
+        omp_set_num_threads(num_threads_in_batch_solve);
     }
 
-
-
-    void {{ model.name }}_acados_batch_eval_solution_sens_adj_p({{ model.name }}_solver_capsule ** capsules, const char *field, int stage, double *out, int offset, int N_batch, int num_threads_in_batch_solve)
+    #pragma omp parallel for
+    for (int i = 0; i < N_batch; i++)
     {
-        int num_threads_bkp;
-        if (num_threads_in_batch_solve > 1)
-        {
-            num_threads_bkp = omp_get_num_threads();
-            omp_set_num_threads(num_threads_in_batch_solve);
-        }
-
-        #pragma omp parallel for
-        for (int i = 0; i < N_batch; i++)
-        {
-            ocp_nlp_eval_solution_sens_adj_p(capsules[i]->nlp_solver, capsules[i]->nlp_in, capsules[i]->sens_out, field, stage, out + i*offset);
-        }
-
-        if (num_threads_in_batch_solve > 1)
-        {
-            omp_set_num_threads( num_threads_bkp );
-        }
-        return;
+        status_out[i] = ocp_nlp_setup_qp_matrices_and_factorize(capsules[i]->nlp_solver, capsules[i]->nlp_in, capsules[i]->nlp_out);
     }
 
-
-    void {{ model.name }}_acados_batch_set_flat({{ model.name }}_solver_capsule ** capsules, const char *field, double *data, int N_data, int N_batch, int num_threads_in_batch_solve)
+    if (num_threads_in_batch_solve > 1)
     {
-        int offset = ocp_nlp_dims_get_total_from_attr(capsules[0]->nlp_solver->config, capsules[0]->nlp_solver->dims, capsules[0]->nlp_out, field);
+        omp_set_num_threads( num_threads_bkp );
+    }
+    return;
+}
 
-        if (N_batch*offset != N_data)
-        {
-            printf("batch_set_flat: wrong input dimension, expected %d, got %d\n", N_batch*offset, N_data);
-            exit(1);
-        }
 
-        int num_threads_bkp;
-        if (num_threads_in_batch_solve > 1)
-        {
-            num_threads_bkp = omp_get_num_threads();
-            omp_set_num_threads(num_threads_in_batch_solve);
-        }
-
-        #pragma omp parallel for
-        for (int i = 0; i < N_batch; i++)
-        {
-            ocp_nlp_set_all(capsules[i]->nlp_solver, capsules[i]->nlp_in, capsules[i]->nlp_out, field, data + i * offset);
-        }
-
-        if (num_threads_in_batch_solve > 1)
-        {
-            omp_set_num_threads( num_threads_bkp );
-        }
-        return;
+void {{ model.name }}_acados_batch_eval_params_jac({{ model.name }}_solver_capsule ** capsules, int N_batch, int num_threads_in_batch_solve)
+{
+    int num_threads_bkp;
+    if (num_threads_in_batch_solve > 1)
+    {
+        num_threads_bkp = omp_get_num_threads();
+        omp_set_num_threads(num_threads_in_batch_solve);
     }
 
-
-
-    void {{ model.name }}_acados_batch_get_flat({{ model.name }}_solver_capsule ** capsules, const char *field, double *data, int N_data, int N_batch, int num_threads_in_batch_solve)
+    #pragma omp parallel for
+    for (int i = 0; i < N_batch; i++)
     {
-        int offset = ocp_nlp_dims_get_total_from_attr(capsules[0]->nlp_solver->config, capsules[0]->nlp_solver->dims, capsules[0]->nlp_out, field);
-
-        if (N_batch*offset != N_data)
-        {
-            printf("batch_get_flat: wrong input dimension, expected %d, got %d\n", N_batch*offset, N_data);
-            exit(1);
-        }
-        int num_threads_bkp;
-        if (num_threads_in_batch_solve > 1)
-        {
-            num_threads_bkp = omp_get_num_threads();
-            omp_set_num_threads(num_threads_in_batch_solve);
-        }
-
-        #pragma omp parallel for
-        for (int i = 0; i < N_batch; i++)
-        {
-            ocp_nlp_get_all(capsules[i]->nlp_solver, capsules[i]->nlp_in, capsules[i]->nlp_out, field, data + i * offset);
-        }
-
-        if (num_threads_in_batch_solve > 1)
-        {
-            omp_set_num_threads( num_threads_bkp );
-        }
-        return;
+        ocp_nlp_eval_params_jac(capsules[i]->nlp_solver, capsules[i]->nlp_in, capsules[i]->nlp_out);
     }
+
+    if (num_threads_in_batch_solve > 1)
+    {
+        omp_set_num_threads( num_threads_bkp );
+    }
+    return;
+}
+
+
+
+void {{ model.name }}_acados_batch_eval_solution_sens_adj_p({{ model.name }}_solver_capsule ** capsules, const char *field, int stage, double *out, int offset, int N_batch, int num_threads_in_batch_solve)
+{
+    int num_threads_bkp;
+    if (num_threads_in_batch_solve > 1)
+    {
+        num_threads_bkp = omp_get_num_threads();
+        omp_set_num_threads(num_threads_in_batch_solve);
+    }
+
+    #pragma omp parallel for
+    for (int i = 0; i < N_batch; i++)
+    {
+        ocp_nlp_eval_solution_sens_adj_p(capsules[i]->nlp_solver, capsules[i]->nlp_in, capsules[i]->sens_out, field, stage, out + i*offset);
+    }
+
+    if (num_threads_in_batch_solve > 1)
+    {
+        omp_set_num_threads( num_threads_bkp );
+    }
+    return;
+}
+
+
+void {{ model.name }}_acados_batch_set_flat({{ model.name }}_solver_capsule ** capsules, const char *field, double *data, int N_data, int N_batch, int num_threads_in_batch_solve)
+{
+    int offset = ocp_nlp_dims_get_total_from_attr(capsules[0]->nlp_solver->config, capsules[0]->nlp_solver->dims, capsules[0]->nlp_out, field);
+
+    if (N_batch*offset != N_data)
+    {
+        printf("batch_set_flat: wrong input dimension, expected %d, got %d\n", N_batch*offset, N_data);
+        exit(1);
+    }
+
+    int num_threads_bkp;
+    if (num_threads_in_batch_solve > 1)
+    {
+        num_threads_bkp = omp_get_num_threads();
+        omp_set_num_threads(num_threads_in_batch_solve);
+    }
+
+    #pragma omp parallel for
+    for (int i = 0; i < N_batch; i++)
+    {
+        ocp_nlp_set_all(capsules[i]->nlp_solver, capsules[i]->nlp_in, capsules[i]->nlp_out, field, data + i * offset);
+    }
+
+    if (num_threads_in_batch_solve > 1)
+    {
+        omp_set_num_threads( num_threads_bkp );
+    }
+    return;
+}
+
+
+
+void {{ model.name }}_acados_batch_get_flat({{ model.name }}_solver_capsule ** capsules, const char *field, double *data, int N_data, int N_batch, int num_threads_in_batch_solve)
+{
+    int offset = ocp_nlp_dims_get_total_from_attr(capsules[0]->nlp_solver->config, capsules[0]->nlp_solver->dims, capsules[0]->nlp_out, field);
+
+    if (N_batch*offset != N_data)
+    {
+        printf("batch_get_flat: wrong input dimension, expected %d, got %d\n", N_batch*offset, N_data);
+        exit(1);
+    }
+    int num_threads_bkp;
+    if (num_threads_in_batch_solve > 1)
+    {
+        num_threads_bkp = omp_get_num_threads();
+        omp_set_num_threads(num_threads_in_batch_solve);
+    }
+
+    #pragma omp parallel for
+    for (int i = 0; i < N_batch; i++)
+    {
+        ocp_nlp_get_all(capsules[i]->nlp_solver, capsules[i]->nlp_in, capsules[i]->nlp_out, field, data + i * offset);
+    }
+
+    if (num_threads_in_batch_solve > 1)
+    {
+        omp_set_num_threads( num_threads_bkp );
+    }
+    return;
+}
 {% endif %}
 
 

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -2817,7 +2817,7 @@ int {{ model.name }}_acados_setup_qp_matrices_and_factorize({{ model.name }}_sol
 
 void {{ model.name }}_acados_batch_solve({{ model.name }}_solver_capsule ** capsules, int * status_out, int N_batch, int num_threads_in_batch_solve)
 {
-    int num_threads_bkp
+    int num_threads_bkp;
     if (num_threads_in_batch_solve > 1)
     {
         num_threads_bkp = omp_get_num_threads();
@@ -2840,7 +2840,7 @@ void {{ model.name }}_acados_batch_solve({{ model.name }}_solver_capsule ** caps
 
 void {{ model.name }}_acados_batch_setup_qp_matrices_and_factorize({{ model.name }}_solver_capsule ** capsules, int * status_out, int N_batch, int num_threads_in_batch_solve)
 {
-    int num_threads_bkp
+    int num_threads_bkp;
     if (num_threads_in_batch_solve > 1)
     {
         num_threads_bkp = omp_get_num_threads();
@@ -2863,7 +2863,7 @@ void {{ model.name }}_acados_batch_setup_qp_matrices_and_factorize({{ model.name
 
 void {{ model.name }}_acados_batch_eval_params_jac({{ model.name }}_solver_capsule ** capsules, int N_batch, int num_threads_in_batch_solve)
 {
-    int num_threads_bkp
+    int num_threads_bkp;
     if (num_threads_in_batch_solve > 1)
     {
         num_threads_bkp = omp_get_num_threads();
@@ -2887,7 +2887,7 @@ void {{ model.name }}_acados_batch_eval_params_jac({{ model.name }}_solver_capsu
 
 void {{ model.name }}_acados_batch_eval_solution_sens_adj_p({{ model.name }}_solver_capsule ** capsules, const char *field, int stage, double *out, int offset, int N_batch, int num_threads_in_batch_solve)
 {
-    int num_threads_bkp
+    int num_threads_bkp;
     if (num_threads_in_batch_solve > 1)
     {
         num_threads_bkp = omp_get_num_threads();
@@ -2918,7 +2918,7 @@ void {{ model.name }}_acados_batch_set_flat({{ model.name }}_solver_capsule ** c
         exit(1);
     }
 
-    int num_threads_bkp
+    int num_threads_bkp;
     if (num_threads_in_batch_solve > 1)
     {
         num_threads_bkp = omp_get_num_threads();
@@ -2949,7 +2949,7 @@ void {{ model.name }}_acados_batch_get_flat({{ model.name }}_solver_capsule ** c
         printf("batch_get_flat: wrong input dimension, expected %d, got %d\n", N_batch*offset, N_data);
         exit(1);
     }
-    int num_threads_bkp
+    int num_threads_bkp;
     if (num_threads_in_batch_solve > 1)
     {
         num_threads_bkp = omp_get_num_threads();

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -2815,159 +2815,161 @@ int {{ model.name }}_acados_setup_qp_matrices_and_factorize({{ model.name }}_sol
 
 
 
-void {{ model.name }}_acados_batch_solve({{ model.name }}_solver_capsule ** capsules, int * status_out, int N_batch, int num_threads_in_batch_solve)
-{
-    int num_threads_bkp;
-    if (num_threads_in_batch_solve > 1)
+{% if solver_options.with_batch_functionality %}
+    void {{ model.name }}_acados_batch_solve({{ model.name }}_solver_capsule ** capsules, int * status_out, int N_batch, int num_threads_in_batch_solve)
     {
-        num_threads_bkp = omp_get_num_threads();
-        omp_set_num_threads(num_threads_in_batch_solve);
+        int num_threads_bkp;
+        if (num_threads_in_batch_solve > 1)
+        {
+            num_threads_bkp = omp_get_num_threads();
+            omp_set_num_threads(num_threads_in_batch_solve);
+        }
+
+        #pragma omp parallel for
+        for (int i = 0; i < N_batch; i++)
+        {
+            status_out[i] = ocp_nlp_solve(capsules[i]->nlp_solver, capsules[i]->nlp_in, capsules[i]->nlp_out);
+        }
+
+        if (num_threads_in_batch_solve > 1)
+        {
+            omp_set_num_threads( num_threads_bkp );
+        }
+        return;
     }
 
-    #pragma omp parallel for
-    for (int i = 0; i < N_batch; i++)
+
+    void {{ model.name }}_acados_batch_setup_qp_matrices_and_factorize({{ model.name }}_solver_capsule ** capsules, int * status_out, int N_batch, int num_threads_in_batch_solve)
     {
-        status_out[i] = ocp_nlp_solve(capsules[i]->nlp_solver, capsules[i]->nlp_in, capsules[i]->nlp_out);
+        int num_threads_bkp;
+        if (num_threads_in_batch_solve > 1)
+        {
+            num_threads_bkp = omp_get_num_threads();
+            omp_set_num_threads(num_threads_in_batch_solve);
+        }
+
+        #pragma omp parallel for
+        for (int i = 0; i < N_batch; i++)
+        {
+            status_out[i] = ocp_nlp_setup_qp_matrices_and_factorize(capsules[i]->nlp_solver, capsules[i]->nlp_in, capsules[i]->nlp_out);
+        }
+
+        if (num_threads_in_batch_solve > 1)
+        {
+            omp_set_num_threads( num_threads_bkp );
+        }
+        return;
     }
 
-    if (num_threads_in_batch_solve > 1)
+
+    void {{ model.name }}_acados_batch_eval_params_jac({{ model.name }}_solver_capsule ** capsules, int N_batch, int num_threads_in_batch_solve)
     {
-        omp_set_num_threads( num_threads_bkp );
-    }
-    return;
-}
+        int num_threads_bkp;
+        if (num_threads_in_batch_solve > 1)
+        {
+            num_threads_bkp = omp_get_num_threads();
+            omp_set_num_threads(num_threads_in_batch_solve);
+        }
 
+        #pragma omp parallel for
+        for (int i = 0; i < N_batch; i++)
+        {
+            ocp_nlp_eval_params_jac(capsules[i]->nlp_solver, capsules[i]->nlp_in, capsules[i]->nlp_out);
+        }
 
-void {{ model.name }}_acados_batch_setup_qp_matrices_and_factorize({{ model.name }}_solver_capsule ** capsules, int * status_out, int N_batch, int num_threads_in_batch_solve)
-{
-    int num_threads_bkp;
-    if (num_threads_in_batch_solve > 1)
-    {
-        num_threads_bkp = omp_get_num_threads();
-        omp_set_num_threads(num_threads_in_batch_solve);
-    }
-
-    #pragma omp parallel for
-    for (int i = 0; i < N_batch; i++)
-    {
-        status_out[i] = ocp_nlp_setup_qp_matrices_and_factorize(capsules[i]->nlp_solver, capsules[i]->nlp_in, capsules[i]->nlp_out);
-    }
-
-    if (num_threads_in_batch_solve > 1)
-    {
-        omp_set_num_threads( num_threads_bkp );
-    }
-    return;
-}
-
-
-void {{ model.name }}_acados_batch_eval_params_jac({{ model.name }}_solver_capsule ** capsules, int N_batch, int num_threads_in_batch_solve)
-{
-    int num_threads_bkp;
-    if (num_threads_in_batch_solve > 1)
-    {
-        num_threads_bkp = omp_get_num_threads();
-        omp_set_num_threads(num_threads_in_batch_solve);
+        if (num_threads_in_batch_solve > 1)
+        {
+            omp_set_num_threads( num_threads_bkp );
+        }
+        return;
     }
 
-    #pragma omp parallel for
-    for (int i = 0; i < N_batch; i++)
+
+
+    void {{ model.name }}_acados_batch_eval_solution_sens_adj_p({{ model.name }}_solver_capsule ** capsules, const char *field, int stage, double *out, int offset, int N_batch, int num_threads_in_batch_solve)
     {
-        ocp_nlp_eval_params_jac(capsules[i]->nlp_solver, capsules[i]->nlp_in, capsules[i]->nlp_out);
+        int num_threads_bkp;
+        if (num_threads_in_batch_solve > 1)
+        {
+            num_threads_bkp = omp_get_num_threads();
+            omp_set_num_threads(num_threads_in_batch_solve);
+        }
+
+        #pragma omp parallel for
+        for (int i = 0; i < N_batch; i++)
+        {
+            ocp_nlp_eval_solution_sens_adj_p(capsules[i]->nlp_solver, capsules[i]->nlp_in, capsules[i]->sens_out, field, stage, out + i*offset);
+        }
+
+        if (num_threads_in_batch_solve > 1)
+        {
+            omp_set_num_threads( num_threads_bkp );
+        }
+        return;
     }
 
-    if (num_threads_in_batch_solve > 1)
+
+    void {{ model.name }}_acados_batch_set_flat({{ model.name }}_solver_capsule ** capsules, const char *field, double *data, int N_data, int N_batch, int num_threads_in_batch_solve)
     {
-        omp_set_num_threads( num_threads_bkp );
-    }
-    return;
-}
+        int offset = ocp_nlp_dims_get_total_from_attr(capsules[0]->nlp_solver->config, capsules[0]->nlp_solver->dims, capsules[0]->nlp_out, field);
 
+        if (N_batch*offset != N_data)
+        {
+            printf("batch_set_flat: wrong input dimension, expected %d, got %d\n", N_batch*offset, N_data);
+            exit(1);
+        }
 
+        int num_threads_bkp;
+        if (num_threads_in_batch_solve > 1)
+        {
+            num_threads_bkp = omp_get_num_threads();
+            omp_set_num_threads(num_threads_in_batch_solve);
+        }
 
-void {{ model.name }}_acados_batch_eval_solution_sens_adj_p({{ model.name }}_solver_capsule ** capsules, const char *field, int stage, double *out, int offset, int N_batch, int num_threads_in_batch_solve)
-{
-    int num_threads_bkp;
-    if (num_threads_in_batch_solve > 1)
-    {
-        num_threads_bkp = omp_get_num_threads();
-        omp_set_num_threads(num_threads_in_batch_solve);
-    }
+        #pragma omp parallel for
+        for (int i = 0; i < N_batch; i++)
+        {
+            ocp_nlp_set_all(capsules[i]->nlp_solver, capsules[i]->nlp_in, capsules[i]->nlp_out, field, data + i * offset);
+        }
 
-    #pragma omp parallel for
-    for (int i = 0; i < N_batch; i++)
-    {
-        ocp_nlp_eval_solution_sens_adj_p(capsules[i]->nlp_solver, capsules[i]->nlp_in, capsules[i]->sens_out, field, stage, out + i*offset);
-    }
-
-    if (num_threads_in_batch_solve > 1)
-    {
-        omp_set_num_threads( num_threads_bkp );
-    }
-    return;
-}
-
-
-void {{ model.name }}_acados_batch_set_flat({{ model.name }}_solver_capsule ** capsules, const char *field, double *data, int N_data, int N_batch, int num_threads_in_batch_solve)
-{
-    int offset = ocp_nlp_dims_get_total_from_attr(capsules[0]->nlp_solver->config, capsules[0]->nlp_solver->dims, capsules[0]->nlp_out, field);
-
-    if (N_batch*offset != N_data)
-    {
-        printf("batch_set_flat: wrong input dimension, expected %d, got %d\n", N_batch*offset, N_data);
-        exit(1);
+        if (num_threads_in_batch_solve > 1)
+        {
+            omp_set_num_threads( num_threads_bkp );
+        }
+        return;
     }
 
-    int num_threads_bkp;
-    if (num_threads_in_batch_solve > 1)
+
+
+    void {{ model.name }}_acados_batch_get_flat({{ model.name }}_solver_capsule ** capsules, const char *field, double *data, int N_data, int N_batch, int num_threads_in_batch_solve)
     {
-        num_threads_bkp = omp_get_num_threads();
-        omp_set_num_threads(num_threads_in_batch_solve);
+        int offset = ocp_nlp_dims_get_total_from_attr(capsules[0]->nlp_solver->config, capsules[0]->nlp_solver->dims, capsules[0]->nlp_out, field);
+
+        if (N_batch*offset != N_data)
+        {
+            printf("batch_get_flat: wrong input dimension, expected %d, got %d\n", N_batch*offset, N_data);
+            exit(1);
+        }
+        int num_threads_bkp;
+        if (num_threads_in_batch_solve > 1)
+        {
+            num_threads_bkp = omp_get_num_threads();
+            omp_set_num_threads(num_threads_in_batch_solve);
+        }
+
+        #pragma omp parallel for
+        for (int i = 0; i < N_batch; i++)
+        {
+            ocp_nlp_get_all(capsules[i]->nlp_solver, capsules[i]->nlp_in, capsules[i]->nlp_out, field, data + i * offset);
+        }
+
+        if (num_threads_in_batch_solve > 1)
+        {
+            omp_set_num_threads( num_threads_bkp );
+        }
+        return;
     }
-
-    #pragma omp parallel for
-    for (int i = 0; i < N_batch; i++)
-    {
-        ocp_nlp_set_all(capsules[i]->nlp_solver, capsules[i]->nlp_in, capsules[i]->nlp_out, field, data + i * offset);
-    }
-
-    if (num_threads_in_batch_solve > 1)
-    {
-        omp_set_num_threads( num_threads_bkp );
-    }
-    return;
-}
-
-
-
-void {{ model.name }}_acados_batch_get_flat({{ model.name }}_solver_capsule ** capsules, const char *field, double *data, int N_data, int N_batch, int num_threads_in_batch_solve)
-{
-    int offset = ocp_nlp_dims_get_total_from_attr(capsules[0]->nlp_solver->config, capsules[0]->nlp_solver->dims, capsules[0]->nlp_out, field);
-
-    if (N_batch*offset != N_data)
-    {
-        printf("batch_get_flat: wrong input dimension, expected %d, got %d\n", N_batch*offset, N_data);
-        exit(1);
-    }
-    int num_threads_bkp;
-    if (num_threads_in_batch_solve > 1)
-    {
-        num_threads_bkp = omp_get_num_threads();
-        omp_set_num_threads(num_threads_in_batch_solve);
-    }
-
-    #pragma omp parallel for
-    for (int i = 0; i < N_batch; i++)
-    {
-        ocp_nlp_get_all(capsules[i]->nlp_solver, capsules[i]->nlp_in, capsules[i]->nlp_out, field, data + i * offset);
-    }
-
-    if (num_threads_in_batch_solve > 1)
-    {
-        omp_set_num_threads( num_threads_bkp );
-    }
-    return;
-}
+{% endif %}
 
 
 int {{ model.name }}_acados_free({{ model.name }}_solver_capsule* capsule)

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -37,10 +37,8 @@
 #include "acados_c/ocp_nlp_interface.h"
 #include "acados_c/external_function_interface.h"
 
-{%- if solver_options.num_threads_in_batch_solve > 1 %}
 // openmp
 #include <omp.h>
-{%- endif %}
 
 // example specific
 #include "{{ model.name }}_model/{{ model.name }}_model.h"

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -2817,9 +2817,10 @@ int {{ model.name }}_acados_setup_qp_matrices_and_factorize({{ model.name }}_sol
 
 void {{ model.name }}_acados_batch_solve({{ model.name }}_solver_capsule ** capsules, int * status_out, int N_batch, int num_threads_in_batch_solve)
 {
+    int num_threads_bkp
     if (num_threads_in_batch_solve > 1)
     {
-        int num_threads_bkp = omp_get_num_threads();
+        num_threads_bkp = omp_get_num_threads();
         omp_set_num_threads(num_threads_in_batch_solve);
     }
 
@@ -2839,9 +2840,10 @@ void {{ model.name }}_acados_batch_solve({{ model.name }}_solver_capsule ** caps
 
 void {{ model.name }}_acados_batch_setup_qp_matrices_and_factorize({{ model.name }}_solver_capsule ** capsules, int * status_out, int N_batch, int num_threads_in_batch_solve)
 {
+    int num_threads_bkp
     if (num_threads_in_batch_solve > 1)
     {
-        int num_threads_bkp = omp_get_num_threads();
+        num_threads_bkp = omp_get_num_threads();
         omp_set_num_threads(num_threads_in_batch_solve);
     }
 
@@ -2861,9 +2863,10 @@ void {{ model.name }}_acados_batch_setup_qp_matrices_and_factorize({{ model.name
 
 void {{ model.name }}_acados_batch_eval_params_jac({{ model.name }}_solver_capsule ** capsules, int N_batch, int num_threads_in_batch_solve)
 {
+    int num_threads_bkp
     if (num_threads_in_batch_solve > 1)
     {
-        int num_threads_bkp = omp_get_num_threads();
+        num_threads_bkp = omp_get_num_threads();
         omp_set_num_threads(num_threads_in_batch_solve);
     }
 
@@ -2884,10 +2887,10 @@ void {{ model.name }}_acados_batch_eval_params_jac({{ model.name }}_solver_capsu
 
 void {{ model.name }}_acados_batch_eval_solution_sens_adj_p({{ model.name }}_solver_capsule ** capsules, const char *field, int stage, double *out, int offset, int N_batch, int num_threads_in_batch_solve)
 {
-
+    int num_threads_bkp
     if (num_threads_in_batch_solve > 1)
     {
-        int num_threads_bkp = omp_get_num_threads();
+        num_threads_bkp = omp_get_num_threads();
         omp_set_num_threads(num_threads_in_batch_solve);
     }
 
@@ -2915,9 +2918,10 @@ void {{ model.name }}_acados_batch_set_flat({{ model.name }}_solver_capsule ** c
         exit(1);
     }
 
+    int num_threads_bkp
     if (num_threads_in_batch_solve > 1)
     {
-        int num_threads_bkp = omp_get_num_threads();
+        num_threads_bkp = omp_get_num_threads();
         omp_set_num_threads(num_threads_in_batch_solve);
     }
 
@@ -2945,10 +2949,10 @@ void {{ model.name }}_acados_batch_get_flat({{ model.name }}_solver_capsule ** c
         printf("batch_get_flat: wrong input dimension, expected %d, got %d\n", N_batch*offset, N_data);
         exit(1);
     }
-
+    int num_threads_bkp
     if (num_threads_in_batch_solve > 1)
     {
-        int num_threads_bkp = omp_get_num_threads();
+        num_threads_bkp = omp_get_num_threads();
         omp_set_num_threads(num_threads_in_batch_solve);
     }
 

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -2817,89 +2817,97 @@ int {{ model.name }}_acados_setup_qp_matrices_and_factorize({{ model.name }}_sol
 
 
 
-void {{ model.name }}_acados_batch_solve({{ model.name }}_solver_capsule ** capsules, int * status_out, int N_batch)
+void {{ model.name }}_acados_batch_solve({{ model.name }}_solver_capsule ** capsules, int * status_out, int N_batch, int num_threads_in_batch_solve)
 {
-{% if solver_options.num_threads_in_batch_solve > 1 %}
-    int num_threads_bkp = omp_get_num_threads();
-    omp_set_num_threads({{ solver_options.num_threads_in_batch_solve }});
+    if (num_threads_in_batch_solve > 1)
+    {
+        int num_threads_bkp = omp_get_num_threads();
+        omp_set_num_threads(num_threads_in_batch_solve);
+    }
 
     #pragma omp parallel for
-{%- endif %}
     for (int i = 0; i < N_batch; i++)
     {
         status_out[i] = ocp_nlp_solve(capsules[i]->nlp_solver, capsules[i]->nlp_in, capsules[i]->nlp_out);
     }
 
-{% if solver_options.num_threads_in_batch_solve > 1 %}
-    omp_set_num_threads( num_threads_bkp );
-{%- endif %}
+    if (num_threads_in_batch_solve > 1)
+    {
+        omp_set_num_threads( num_threads_bkp );
+    }
     return;
 }
 
 
-void {{ model.name }}_acados_batch_setup_qp_matrices_and_factorize({{ model.name }}_solver_capsule ** capsules, int * status_out, int N_batch)
+void {{ model.name }}_acados_batch_setup_qp_matrices_and_factorize({{ model.name }}_solver_capsule ** capsules, int * status_out, int N_batch, int num_threads_in_batch_solve)
 {
-{% if solver_options.num_threads_in_batch_solve > 1 %}
-    int num_threads_bkp = omp_get_num_threads();
-    omp_set_num_threads({{ solver_options.num_threads_in_batch_solve }});
+    if (num_threads_in_batch_solve > 1)
+    {
+        int num_threads_bkp = omp_get_num_threads();
+        omp_set_num_threads(num_threads_in_batch_solve);
+    }
 
     #pragma omp parallel for
-{%- endif %}
     for (int i = 0; i < N_batch; i++)
     {
         status_out[i] = ocp_nlp_setup_qp_matrices_and_factorize(capsules[i]->nlp_solver, capsules[i]->nlp_in, capsules[i]->nlp_out);
     }
 
-{% if solver_options.num_threads_in_batch_solve > 1 %}
-    omp_set_num_threads( num_threads_bkp );
-{%- endif %}
+    if (num_threads_in_batch_solve > 1)
+    {
+        omp_set_num_threads( num_threads_bkp );
+    }
     return;
 }
 
 
-void {{ model.name }}_acados_batch_eval_params_jac({{ model.name }}_solver_capsule ** capsules, int N_batch)
+void {{ model.name }}_acados_batch_eval_params_jac({{ model.name }}_solver_capsule ** capsules, int N_batch, int num_threads_in_batch_solve)
 {
-{% if solver_options.num_threads_in_batch_solve > 1 %}
-    int num_threads_bkp = omp_get_num_threads();
-    omp_set_num_threads({{ solver_options.num_threads_in_batch_solve }});
+    if (num_threads_in_batch_solve > 1)
+    {
+        int num_threads_bkp = omp_get_num_threads();
+        omp_set_num_threads(num_threads_in_batch_solve);
+    }
 
     #pragma omp parallel for
-{%- endif %}
     for (int i = 0; i < N_batch; i++)
     {
         ocp_nlp_eval_params_jac(capsules[i]->nlp_solver, capsules[i]->nlp_in, capsules[i]->nlp_out);
     }
 
-{% if solver_options.num_threads_in_batch_solve > 1 %}
-    omp_set_num_threads( num_threads_bkp );
-{%- endif %}
+    if (num_threads_in_batch_solve > 1)
+    {
+        omp_set_num_threads( num_threads_bkp );
+    }
     return;
 }
 
 
 
-void {{ model.name }}_acados_batch_eval_solution_sens_adj_p({{ model.name }}_solver_capsule ** capsules, const char *field, int stage, double *out, int offset, int N_batch)
+void {{ model.name }}_acados_batch_eval_solution_sens_adj_p({{ model.name }}_solver_capsule ** capsules, const char *field, int stage, double *out, int offset, int N_batch, int num_threads_in_batch_solve)
 {
 
-{% if solver_options.num_threads_in_batch_solve > 1 %}
-    int num_threads_bkp = omp_get_num_threads();
-    omp_set_num_threads({{ solver_options.num_threads_in_batch_solve }});
+    if (num_threads_in_batch_solve > 1)
+    {
+        int num_threads_bkp = omp_get_num_threads();
+        omp_set_num_threads(num_threads_in_batch_solve);
+    }
 
     #pragma omp parallel for
-{%- endif %}
     for (int i = 0; i < N_batch; i++)
     {
         ocp_nlp_eval_solution_sens_adj_p(capsules[i]->nlp_solver, capsules[i]->nlp_in, capsules[i]->sens_out, field, stage, out + i*offset);
     }
 
-{% if solver_options.num_threads_in_batch_solve > 1 %}
-    omp_set_num_threads( num_threads_bkp );
-{%- endif %}
+    if (num_threads_in_batch_solve > 1)
+    {
+        omp_set_num_threads( num_threads_bkp );
+    }
     return;
 }
 
 
-void {{ model.name }}_acados_batch_set_flat({{ model.name }}_solver_capsule ** capsules, const char *field, double *data, int N_data, int N_batch)
+void {{ model.name }}_acados_batch_set_flat({{ model.name }}_solver_capsule ** capsules, const char *field, double *data, int N_data, int N_batch, int num_threads_in_batch_solve)
 {
     int offset = ocp_nlp_dims_get_total_from_attr(capsules[0]->nlp_solver->config, capsules[0]->nlp_solver->dims, capsules[0]->nlp_out, field);
 
@@ -2909,26 +2917,28 @@ void {{ model.name }}_acados_batch_set_flat({{ model.name }}_solver_capsule ** c
         exit(1);
     }
 
-{% if solver_options.num_threads_in_batch_solve > 1 %}
-    int num_threads_bkp = omp_get_num_threads();
-    omp_set_num_threads({{ solver_options.num_threads_in_batch_solve }});
+    if (num_threads_in_batch_solve > 1)
+    {
+        int num_threads_bkp = omp_get_num_threads();
+        omp_set_num_threads(num_threads_in_batch_solve);
+    }
 
     #pragma omp parallel for
-{%- endif %}
     for (int i = 0; i < N_batch; i++)
     {
         ocp_nlp_set_all(capsules[i]->nlp_solver, capsules[i]->nlp_in, capsules[i]->nlp_out, field, data + i * offset);
     }
 
-{% if solver_options.num_threads_in_batch_solve > 1 %}
-    omp_set_num_threads( num_threads_bkp );
-{%- endif %}
+    if (num_threads_in_batch_solve > 1)
+    {
+        omp_set_num_threads( num_threads_bkp );
+    }
     return;
 }
 
 
 
-void {{ model.name }}_acados_batch_get_flat({{ model.name }}_solver_capsule ** capsules, const char *field, double *data, int N_data, int N_batch)
+void {{ model.name }}_acados_batch_get_flat({{ model.name }}_solver_capsule ** capsules, const char *field, double *data, int N_data, int N_batch, int num_threads_in_batch_solve)
 {
     int offset = ocp_nlp_dims_get_total_from_attr(capsules[0]->nlp_solver->config, capsules[0]->nlp_solver->dims, capsules[0]->nlp_out, field);
 
@@ -2938,20 +2948,22 @@ void {{ model.name }}_acados_batch_get_flat({{ model.name }}_solver_capsule ** c
         exit(1);
     }
 
-{% if solver_options.num_threads_in_batch_solve > 1 %}
-    int num_threads_bkp = omp_get_num_threads();
-    omp_set_num_threads({{ solver_options.num_threads_in_batch_solve }});
+    if (num_threads_in_batch_solve > 1)
+    {
+        int num_threads_bkp = omp_get_num_threads();
+        omp_set_num_threads(num_threads_in_batch_solve);
+    }
 
     #pragma omp parallel for
-{%- endif %}
     for (int i = 0; i < N_batch; i++)
     {
         ocp_nlp_get_all(capsules[i]->nlp_solver, capsules[i]->nlp_in, capsules[i]->nlp_out, field, data + i * offset);
     }
 
-{% if solver_options.num_threads_in_batch_solve > 1 %}
-    omp_set_num_threads( num_threads_bkp );
-{%- endif %}
+    if (num_threads_in_batch_solve > 1)
+    {
+        omp_set_num_threads( num_threads_bkp );
+    }
     return;
 }
 

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.h
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.h
@@ -295,13 +295,13 @@ ACADOS_SYMBOL_EXPORT int {{ name }}_acados_set_p_global_and_precompute_dependenc
 ACADOS_SYMBOL_EXPORT int {{ model.name }}_acados_solve({{ model.name }}_solver_capsule * capsule);
 ACADOS_SYMBOL_EXPORT int {{ model.name }}_acados_setup_qp_matrices_and_factorize({{ model.name }}_solver_capsule* capsule);
 
-ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_solve({{ model.name }}_solver_capsule ** capsules, int * status_out, int N_batch);
+ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_solve({{ model.name }}_solver_capsule ** capsules, int * status_out, int N_batch, int num_threads_in_batch_solve);
 
-ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_set_flat({{ model.name }}_solver_capsule ** capsules, const char *field, double *data, int N_data, int N_batch);
-ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_get_flat({{ model.name }}_solver_capsule ** capsules, const char *field, double *data, int N_data, int N_batch);
+ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_set_flat({{ model.name }}_solver_capsule ** capsules, const char *field, double *data, int N_data, int N_batch, int num_threads_in_batch_solve);
+ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_get_flat({{ model.name }}_solver_capsule ** capsules, const char *field, double *data, int N_data, int N_batch, int num_threads_in_batch_solve);
 
-ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_eval_solution_sens_adj_p({{ model.name }}_solver_capsule ** capsules, const char *field, int stage, double *out, int offset, int N_batch);
-ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_eval_params_jac({{ model.name }}_solver_capsule ** capsules, int N_batch);
+ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_eval_solution_sens_adj_p({{ model.name }}_solver_capsule ** capsules, const char *field, int stage, double *out, int offset, int N_batch, int num_threads_in_batch_solve);
+ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_eval_params_jac({{ model.name }}_solver_capsule ** capsules, int N_batch, int num_threads_in_batch_solve);
 
 
 ACADOS_SYMBOL_EXPORT int {{ model.name }}_acados_free({{ model.name }}_solver_capsule * capsule);

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.h
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.h
@@ -296,13 +296,13 @@ ACADOS_SYMBOL_EXPORT int {{ model.name }}_acados_solve({{ model.name }}_solver_c
 ACADOS_SYMBOL_EXPORT int {{ model.name }}_acados_setup_qp_matrices_and_factorize({{ model.name }}_solver_capsule* capsule);
 
 {% if solver_options.with_batch_functionality %}
-    ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_solve({{ model.name }}_solver_capsule ** capsules, int * status_out, int N_batch, int num_threads_in_batch_solve);
+ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_solve({{ model.name }}_solver_capsule ** capsules, int * status_out, int N_batch, int num_threads_in_batch_solve);
 
-    ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_set_flat({{ model.name }}_solver_capsule ** capsules, const char *field, double *data, int N_data, int N_batch, int num_threads_in_batch_solve);
-    ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_get_flat({{ model.name }}_solver_capsule ** capsules, const char *field, double *data, int N_data, int N_batch, int num_threads_in_batch_solve);
+ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_set_flat({{ model.name }}_solver_capsule ** capsules, const char *field, double *data, int N_data, int N_batch, int num_threads_in_batch_solve);
+ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_get_flat({{ model.name }}_solver_capsule ** capsules, const char *field, double *data, int N_data, int N_batch, int num_threads_in_batch_solve);
 
-    ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_eval_solution_sens_adj_p({{ model.name }}_solver_capsule ** capsules, const char *field, int stage, double *out, int offset, int N_batch, int num_threads_in_batch_solve);
-    ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_eval_params_jac({{ model.name }}_solver_capsule ** capsules, int N_batch, int num_threads_in_batch_solve);
+ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_eval_solution_sens_adj_p({{ model.name }}_solver_capsule ** capsules, const char *field, int stage, double *out, int offset, int N_batch, int num_threads_in_batch_solve);
+ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_eval_params_jac({{ model.name }}_solver_capsule ** capsules, int N_batch, int num_threads_in_batch_solve);
 {% endif %}
 
 ACADOS_SYMBOL_EXPORT int {{ model.name }}_acados_free({{ model.name }}_solver_capsule * capsule);

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.h
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.h
@@ -295,14 +295,15 @@ ACADOS_SYMBOL_EXPORT int {{ name }}_acados_set_p_global_and_precompute_dependenc
 ACADOS_SYMBOL_EXPORT int {{ model.name }}_acados_solve({{ model.name }}_solver_capsule * capsule);
 ACADOS_SYMBOL_EXPORT int {{ model.name }}_acados_setup_qp_matrices_and_factorize({{ model.name }}_solver_capsule* capsule);
 
-ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_solve({{ model.name }}_solver_capsule ** capsules, int * status_out, int N_batch, int num_threads_in_batch_solve);
+{% if solver_options.with_batch_functionality %}
+    ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_solve({{ model.name }}_solver_capsule ** capsules, int * status_out, int N_batch, int num_threads_in_batch_solve);
 
-ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_set_flat({{ model.name }}_solver_capsule ** capsules, const char *field, double *data, int N_data, int N_batch, int num_threads_in_batch_solve);
-ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_get_flat({{ model.name }}_solver_capsule ** capsules, const char *field, double *data, int N_data, int N_batch, int num_threads_in_batch_solve);
+    ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_set_flat({{ model.name }}_solver_capsule ** capsules, const char *field, double *data, int N_data, int N_batch, int num_threads_in_batch_solve);
+    ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_get_flat({{ model.name }}_solver_capsule ** capsules, const char *field, double *data, int N_data, int N_batch, int num_threads_in_batch_solve);
 
-ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_eval_solution_sens_adj_p({{ model.name }}_solver_capsule ** capsules, const char *field, int stage, double *out, int offset, int N_batch, int num_threads_in_batch_solve);
-ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_eval_params_jac({{ model.name }}_solver_capsule ** capsules, int N_batch, int num_threads_in_batch_solve);
-
+    ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_eval_solution_sens_adj_p({{ model.name }}_solver_capsule ** capsules, const char *field, int stage, double *out, int offset, int N_batch, int num_threads_in_batch_solve);
+    ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_eval_params_jac({{ model.name }}_solver_capsule ** capsules, int N_batch, int num_threads_in_batch_solve);
+{% endif %}
 
 ACADOS_SYMBOL_EXPORT int {{ model.name }}_acados_free({{ model.name }}_solver_capsule * capsule);
 ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_print_stats({{ model.name }}_solver_capsule * capsule);

--- a/interfaces/acados_template/acados_template/c_templates_tera/multi_Makefile.in
+++ b/interfaces/acados_template/acados_template/c_templates_tera/multi_Makefile.in
@@ -300,7 +300,7 @@ CPPFLAGS+= -I $(INCLUDE_PATH)/daqp/include
 
 # define the c-compiler flags for make's implicit rules
 CFLAGS = -fPIC -std=c99 {{ openmp_flag }} {{ solver_options.ext_fun_compile_flags }}#-fno-diagnostics-show-line-numbers -g
-{% if solver_options.num_threads_in_batch_solve > 1 %}
+{% if solver_options..with_batch_functionality %}
 CFLAGS += -fopenmp
 {%- endif %}
 # # Debugging
@@ -308,7 +308,7 @@ CFLAGS += -fopenmp
 
 # linker flags
 LDFLAGS+= -L$(LIB_PATH)
-{% if solver_options.num_threads_in_batch_solve > 1 %}
+{% if solver_options..with_batch_functionality %}
 LDFLAGS += -fopenmp
 {%- endif %}
 

--- a/interfaces/acados_template/acados_template/c_templates_tera/multi_Makefile.in
+++ b/interfaces/acados_template/acados_template/c_templates_tera/multi_Makefile.in
@@ -308,7 +308,7 @@ CFLAGS += -fopenmp
 
 # linker flags
 LDFLAGS+= -L$(LIB_PATH)
-{% if solver_options..with_batch_functionality %}
+{% if solver_options.with_batch_functionality %}
 LDFLAGS += -fopenmp
 {%- endif %}
 

--- a/interfaces/acados_template/acados_template/c_templates_tera/multi_Makefile.in
+++ b/interfaces/acados_template/acados_template/c_templates_tera/multi_Makefile.in
@@ -300,7 +300,7 @@ CPPFLAGS+= -I $(INCLUDE_PATH)/daqp/include
 
 # define the c-compiler flags for make's implicit rules
 CFLAGS = -fPIC -std=c99 {{ openmp_flag }} {{ solver_options.ext_fun_compile_flags }}#-fno-diagnostics-show-line-numbers -g
-{% if solver_options..with_batch_functionality %}
+{% if solver_options.with_batch_functionality %}
 CFLAGS += -fopenmp
 {%- endif %}
 # # Debugging


### PR DESCRIPTION
Previously, the number of threads to be used in the `AcadosOcpBatchSolver` or `AcadosSimBatchSolver` batched methods had to be set in the respective `AcadosOcpOptions` or `AcadosSimOptions` and could not be changed without rebuilding the solver.
Now, it is a property that can be set dynamically, even after building the solver.

The property `num_threads_in_batch_solve` in both `AcadosOcpOptions` and `AcadosSimOptions` is now deprecated,
and warnings will be printed if it is used.
Instead, the `AcadosOcpBatchSolver` and `AcadosSimBatchSolver` have a new (settable) property `num_threads_in_batch_solve` and take the initial value in their constructor via a new `num_threads_in_batch_solve` argument. 
The value of the new attribute is now used to determine how many threads the batched methods should use.

The property `num_threads_in_batch_solve` in `AcadosOcpOptions` or `AcadosSimOptions` was previously used for determining whether the solvers should be build with openmp and how the C code of the batched methods should be templated (if `num_threads_in_batch_solve > 1`).
Instead a new property `with_batch_functionality` is used as a flag to determine whether the solvers should be build with openmp and whether the C code of the batched methods should be created at all.
This new property is not required to be set by the user himself, but is being set by the BatchSolvers themselves by default (a warning is printed though, to notify the user that the code is still build with the openmp flag).

The matlab templates and the batch solver examples have been adjusted accordingly. Further, the minimal batch solver examples include new simple tests for the new `num_threads_in_batch_solve` property.
