### PR TITLE
Step norm logging

### DIFF
--- a/acados/ocp_nlp/ocp_nlp_common.c
+++ b/acados/ocp_nlp/ocp_nlp_common.c
@@ -3392,7 +3392,7 @@ void ocp_nlp_res_get_inf_norm(ocp_nlp_res *res, double *out)
 }
 
 
-double ocp_nlp_compute_delta_dual_norm(ocp_nlp_dims *dims, ocp_nlp_workspace *work, ocp_nlp_out *nlp_out, ocp_qp_out *qp_out)
+double ocp_nlp_compute_delta_dual_norm_inf(ocp_nlp_dims *dims, ocp_nlp_workspace *work, ocp_nlp_out *nlp_out, ocp_qp_out *qp_out)
 {
     /* computes the inf norm of multipliers in qp_out and nlp_out */
     int N = dims->N;

--- a/acados/ocp_nlp/ocp_nlp_common.h
+++ b/acados/ocp_nlp/ocp_nlp_common.h
@@ -299,6 +299,7 @@ typedef struct ocp_nlp_opts
     int print_level;
     int fixed_hess;
     int log_primal_step_norm; // compute and log the max norm of the primal steps
+    int log_dual_step_norm; // compute and log the max norm of the dual steps
     int max_iter; // maximum number of (SQP/DDP) iterations
     int qp_iter_max; // maximum iter of QP solver, stored to remember.
     double tau_min;  // minimum value of the barrier parameter, for IPMs
@@ -447,6 +448,7 @@ typedef struct ocp_nlp_memory
 
     bool *set_sim_guess; // indicate if there is new explicitly provided guess for integration variables
     double *primal_step_norm;
+    double *dual_step_norm;
 
     struct blasfeo_dvec *sim_guess;
     acados_size_t workspace_size;
@@ -546,6 +548,8 @@ void ocp_nlp_initialize_qp_from_nlp(ocp_nlp_config *config, ocp_nlp_dims *dims, 
 //
 void ocp_nlp_res_compute(ocp_nlp_dims *dims, ocp_nlp_opts *opts, ocp_nlp_in *in, ocp_nlp_out *out,
                          ocp_nlp_res *res, ocp_nlp_memory *mem, ocp_nlp_workspace *work);
+
+double ocp_nlp_compute_delta_dual_norm(ocp_nlp_dims *dims, ocp_nlp_workspace *work, ocp_nlp_out *nlp_out, ocp_qp_out *qp_out);
 //
 void copy_ocp_nlp_out(ocp_nlp_dims *dims, ocp_nlp_out *from, ocp_nlp_out *to);
 

--- a/acados/ocp_nlp/ocp_nlp_common.h
+++ b/acados/ocp_nlp/ocp_nlp_common.h
@@ -446,6 +446,8 @@ typedef struct ocp_nlp_memory
     double adaptive_levenberg_marquardt_mu_bar;
 
     bool *set_sim_guess; // indicate if there is new explicitly provided guess for integration variables
+    double *primal_step_norm;
+
     struct blasfeo_dvec *sim_guess;
     acados_size_t workspace_size;
 

--- a/acados/ocp_nlp/ocp_nlp_common.h
+++ b/acados/ocp_nlp/ocp_nlp_common.h
@@ -549,7 +549,7 @@ void ocp_nlp_initialize_qp_from_nlp(ocp_nlp_config *config, ocp_nlp_dims *dims, 
 void ocp_nlp_res_compute(ocp_nlp_dims *dims, ocp_nlp_opts *opts, ocp_nlp_in *in, ocp_nlp_out *out,
                          ocp_nlp_res *res, ocp_nlp_memory *mem, ocp_nlp_workspace *work);
 
-double ocp_nlp_compute_delta_dual_norm(ocp_nlp_dims *dims, ocp_nlp_workspace *work, ocp_nlp_out *nlp_out, ocp_qp_out *qp_out);
+double ocp_nlp_compute_delta_dual_norm_inf(ocp_nlp_dims *dims, ocp_nlp_workspace *work, ocp_nlp_out *nlp_out, ocp_qp_out *qp_out);
 //
 void copy_ocp_nlp_out(ocp_nlp_dims *dims, ocp_nlp_out *from, ocp_nlp_out *to);
 

--- a/acados/ocp_nlp/ocp_nlp_sqp.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp.c
@@ -844,7 +844,7 @@ int ocp_nlp_sqp(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
         {
             if (nlp_opts->log_dual_step_norm)
             {
-                nlp_mem->dual_step_norm[sqp_iter] = ocp_nlp_compute_delta_dual_norm(dims, nlp_work, nlp_out, qp_out);
+                nlp_mem->dual_step_norm[sqp_iter] = ocp_nlp_compute_delta_dual_norm_inf(dims, nlp_work, nlp_out, qp_out);
             }
         }
         /* end solve QP */

--- a/acados/ocp_nlp/ocp_nlp_sqp.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp.c
@@ -836,9 +836,16 @@ int ocp_nlp_sqp(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
         // Compute the step norm
         if (opts->tol_min_step_norm > 0.0 || nlp_opts->log_primal_step_norm)
         {
-            mem->step_norm = ocp_qp_out_compute_primal_nrm_inf(nlp_mem->qp_out);
+            mem->step_norm = ocp_qp_out_compute_primal_nrm_inf(qp_out);
             if (nlp_opts->log_primal_step_norm)
                 nlp_mem->primal_step_norm[sqp_iter] = mem->step_norm;
+        }
+        if (nlp_opts->log_dual_step_norm)
+        {
+            if (nlp_opts->log_dual_step_norm)
+            {
+                nlp_mem->dual_step_norm[sqp_iter] = ocp_nlp_compute_delta_dual_norm(dims, nlp_work, nlp_out, qp_out);
+            }
         }
         /* end solve QP */
 

--- a/acados/ocp_nlp/ocp_nlp_sqp.h
+++ b/acados/ocp_nlp/ocp_nlp_sqp.h
@@ -62,7 +62,6 @@ typedef struct
     double tol_comp;     // exit tolerance on complementarity condition
     double tol_unbounded; // exit threshold when objective function seems to be unbounded
     double tol_min_step_norm; // exit tolerance for small step
-    int ext_qp_res;      // compute external QP residuals (i.e. at SQP level) at each SQP iteration (for debugging)
     int log_primal_step_norm; // compute and log the max norm of the primal steps
     bool warm_start_first_qp; // to set qp_warm_start in first iteration
     bool warm_start_first_qp_from_nlp;  // if True first QP will be initialized using values from NLP iterate, otherwise from previous QP solution.

--- a/acados/ocp_nlp/ocp_nlp_sqp_with_feasible_qp.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp_with_feasible_qp.c
@@ -1686,7 +1686,7 @@ int ocp_nlp_sqp_wfqp(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
         }
         if (nlp_opts->log_dual_step_norm)
         {
-            nlp_mem->dual_step_norm[sqp_iter] = ocp_nlp_compute_delta_dual_norm(dims, nlp_work, nlp_out, nominal_qp_out);
+            nlp_mem->dual_step_norm[sqp_iter] = ocp_nlp_compute_delta_dual_norm_inf(dims, nlp_work, nlp_out, nominal_qp_out);
         }
 
         /* globalization */

--- a/acados/ocp_nlp/ocp_nlp_sqp_with_feasible_qp.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp_with_feasible_qp.c
@@ -1684,6 +1684,10 @@ int ocp_nlp_sqp_wfqp(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
             if (nlp_opts->log_primal_step_norm)
                 nlp_mem->primal_step_norm[sqp_iter] = mem->step_norm;
         }
+        if (nlp_opts->log_dual_step_norm)
+        {
+            nlp_mem->dual_step_norm[sqp_iter] = ocp_nlp_compute_delta_dual_norm(dims, nlp_work, nlp_out, nominal_qp_out);
+        }
 
         /* globalization */
         // Calculate optimal QP objective (needed for globalization)

--- a/acados/ocp_nlp/ocp_nlp_sqp_with_feasible_qp.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp_with_feasible_qp.c
@@ -316,11 +316,6 @@ acados_size_t ocp_nlp_sqp_wfqp_memory_calculate_size(void *config_, void *dims_,
     size += ocp_qp_in_calculate_size(dims->relaxed_qp_solver->orig_dims);
     size += ocp_qp_out_calculate_size(dims->relaxed_qp_solver->orig_dims);
 
-    // primal step norm
-    if (opts->nlp_opts->log_primal_step_norm)
-    {
-        size += opts->nlp_opts->max_iter*sizeof(double);
-    }
     // stat
     int stat_m = opts->nlp_opts->max_iter+1;
     int stat_n = 13;
@@ -433,13 +428,6 @@ void *ocp_nlp_sqp_wfqp_memory_assign(void *config_, void *dims_, void *opts_, vo
     assign_and_advance_blasfeo_dmat_structs(N + 1, &mem->RSQ_cost, &c_ptr);
     // RSQ_constr
     assign_and_advance_blasfeo_dmat_structs(N + 1, &mem->RSQ_constr, &c_ptr);
-
-    // primal step norm
-    if (opts->nlp_opts->log_primal_step_norm)
-    {
-        mem->primal_step_norm = (double *) c_ptr;
-        c_ptr += opts->nlp_opts->max_iter*sizeof(double);
-    }
 
     // stat
     mem->stat_m = opts->nlp_opts->max_iter+1;
@@ -1694,7 +1682,7 @@ int ocp_nlp_sqp_wfqp(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
         {
             mem->step_norm = ocp_qp_out_compute_primal_nrm_inf(nominal_qp_out);
             if (nlp_opts->log_primal_step_norm)
-                mem->primal_step_norm[sqp_iter] = mem->step_norm;
+                nlp_mem->primal_step_norm[sqp_iter] = mem->step_norm;
         }
 
         /* globalization */
@@ -1962,7 +1950,7 @@ void ocp_nlp_sqp_wfqp_get(void *config_, void *dims_, void *mem_, const char *fi
     ocp_nlp_config *config = config_;
     ocp_nlp_dims *dims = dims_;
     ocp_nlp_sqp_wfqp_memory *mem = mem_;
-
+    ocp_nlp_memory *nlp_mem = mem->nlp_mem;
 
     char module[MAX_STR_LEN];
     char *ptr_module = NULL;
@@ -1982,32 +1970,16 @@ void ocp_nlp_sqp_wfqp_get(void *config_, void *dims_, void *mem_, const char *fi
     if ( ptr_module!=NULL && (!strcmp(ptr_module, "time")) )
     {
         // call timings getter
-        ocp_nlp_timings_get(config, mem->nlp_mem->nlp_timings, field, return_value_);
+        ocp_nlp_timings_get(config, nlp_mem->nlp_timings, field, return_value_);
     }
     else if (!strcmp("stat", field))
     {
         double **value = return_value_;
         *value = mem->stat;
     }
-    else if (!strcmp("primal_step_norm", field))
-    {
-        if (mem->primal_step_norm == NULL)
-        {
-            printf("\nerror: options log_primal_step_norm was not set\n");
-            exit(1);
-        }
-        else
-        {
-            double *value = return_value_;
-            for (int ii=0; ii<mem->nlp_mem->iter; ii++)
-            {
-                value[ii] = mem->primal_step_norm[ii];
-            }
-        }
-    }
     else if (!strcmp("statistics", field))
     {
-        int n_row = mem->stat_m<mem->nlp_mem->iter+1 ? mem->stat_m : mem->nlp_mem->iter+1;
+        int n_row = mem->stat_m<nlp_mem->iter+1 ? mem->stat_m : nlp_mem->iter+1;
         double *value = return_value_;
         for (int ii=0; ii<n_row; ii++)
         {
@@ -2038,7 +2010,7 @@ void ocp_nlp_sqp_wfqp_get(void *config_, void *dims_, void *mem_, const char *fi
     }
     else
     {
-        ocp_nlp_memory_get(config, mem->nlp_mem, field, return_value_);
+        ocp_nlp_memory_get(config, nlp_mem, field, return_value_);
     }
 }
 

--- a/acados/ocp_nlp/ocp_nlp_sqp_with_feasible_qp.h
+++ b/acados/ocp_nlp/ocp_nlp_sqp_with_feasible_qp.h
@@ -61,7 +61,6 @@ typedef struct
     double tol_unbounded; // exit threshold when objective function seems to be unbounded
     double tol_min_step_norm; // exit tolerance for small step
     int max_iter;
-    int log_primal_step_norm; // compute and log the max norm of the primal steps
     bool log_pi_norm_inf; // compute and log the max norm of the pi multipliers
     bool log_lam_norm_inf; // compute and log the max norm of the lam multipliers
     bool warm_start_first_qp;
@@ -101,7 +100,6 @@ typedef struct
     ocp_nlp_memory *nlp_mem;
 
     double alpha;
-    double *primal_step_norm;
 
     int *nns;  // number of non-slacked constraints in NLP
     int **idxns;  // indices of non-slacked constraints in NLP

--- a/acados/ocp_nlp/ocp_nlp_sqp_with_feasible_qp.h
+++ b/acados/ocp_nlp/ocp_nlp_sqp_with_feasible_qp.h
@@ -60,7 +60,6 @@ typedef struct
     double tol_comp;
     double tol_unbounded; // exit threshold when objective function seems to be unbounded
     double tol_min_step_norm; // exit tolerance for small step
-    int max_iter;
     bool log_pi_norm_inf; // compute and log the max norm of the pi multipliers
     bool log_lam_norm_inf; // compute and log the max norm of the lam multipliers
     bool warm_start_first_qp;

--- a/examples/acados_matlab_octave/getting_started/extensive_example_ocp.m
+++ b/examples/acados_matlab_octave/getting_started/extensive_example_ocp.m
@@ -83,6 +83,8 @@ ocp.solver_options.exact_hess_cost = 1;
 ocp.solver_options.exact_hess_constr = 1;
 ocp.solver_options.print_level = 1;
 ocp.solver_options.store_iterates = true;
+ocp.solver_options.log_dual_step_norm = true;
+ocp.solver_options.log_primal_step_norm = true;
 
 % can vary for integrators
 sim_method_num_stages = 1 * ones(N,1);
@@ -253,6 +255,13 @@ su = ocp_solver.get('su', N);
 
 % get cost value
 cost_val_ocp = ocp_solver.get_cost();
+
+primal_step_norm = ocp_solver.get('primal_step_norm');
+dual_step_norm = ocp_solver.get('dual_step_norm');
+disp('primal step norms')
+disp(primal_step_norm);
+disp('dual step norms')
+disp(dual_step_norm);
 
 %% get QP matrices:
 % See https://docs.acados.org/problem_formulation

--- a/examples/acados_python/pendulum_on_cart/ocp/example_ocp_dynamics_formulations.py
+++ b/examples/acados_python/pendulum_on_cart/ocp/example_ocp_dynamics_formulations.py
@@ -46,7 +46,7 @@ BUILD_SYSTEMS = ['cmake', 'make']
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='test Python interface on pendulum example.')
-    parser.add_argument('--INTEGRATOR_TYPE', dest='INTEGRATOR_TYPE',
+    parser.add_argument('--INTEGRATOR_TYPE', dest='INTEGRATOR_TYPE', default="ERK",
                         help=f'INTEGRATOR_TYPE: supports {INTEGRATOR_TYPES}')
     parser.add_argument('--BUILD_SYSTEM', dest='BUILD_SYSTEM',
                         default='make',
@@ -62,7 +62,7 @@ if __name__ == "__main__":
 
     build_system = args.BUILD_SYSTEM
     if build_system not in BUILD_SYSTEMS:
-        msg = f'Invalid unit test value {build_system} for parameter INTEGRATOR_TYPE. Possible values are' \
+        msg = f'Invalid unit test value {build_system} for parameter BUILD_SYSTEM. Possible values are' \
               f' {BUILD_SYSTEMS}, got {build_system}.'
         raise Exception(msg)
 

--- a/examples/acados_python/pendulum_on_cart/ocp/example_ocp_dynamics_formulations.py
+++ b/examples/acados_python/pendulum_on_cart/ocp/example_ocp_dynamics_formulations.py
@@ -118,6 +118,8 @@ if __name__ == "__main__":
     ocp.solver_options.hessian_approx = 'GAUSS_NEWTON'
     ocp.solver_options.integrator_type = integrator_type
     ocp.solver_options.print_level = 1
+    ocp.solver_options.log_dual_step_norm = True
+    ocp.solver_options.log_primal_step_norm = True
 
     if ocp.solver_options.integrator_type == 'GNSF':
         from acados_template import acados_dae_model_json_dump
@@ -170,5 +172,14 @@ if __name__ == "__main__":
         simX[i, :] = ocp_solver.get(i, "x")
         simU[i, :] = ocp_solver.get(i, "u")
     simX[N, :] = ocp_solver.get(N, "x")
+
+    # test getting step norms
+    primal_step_norms = ocp_solver.get_stats('primal_step_norm')
+    dual_step_norms = ocp_solver.get_stats('dual_step_norm')
+    print(f"primal step norms: {primal_step_norms}")
+    print(f"dual step norms: {dual_step_norms}")
+    # Assert that step norms are decreasing
+    assert np.all(np.diff(primal_step_norms)[1:] <= 0), "Primal step norms are not decreasing."
+    assert np.all(np.diff(dual_step_norms) <= 0), "Dual step norms are not decreasing."
 
     plot_pendulum(np.linspace(0, Tf, N+1), Fmax, simU, simX)

--- a/interfaces/acados_matlab_octave/AcadosOcpOptions.m
+++ b/interfaces/acados_matlab_octave/AcadosOcpOptions.m
@@ -116,6 +116,7 @@ classdef AcadosOcpOptions < handle
         adaptive_levenberg_marquardt_mu_min
         adaptive_levenberg_marquardt_mu0
         log_primal_step_norm
+        log_dual_step_norm
         store_iterates
         eval_residual_at_max_iter
 
@@ -228,6 +229,7 @@ classdef AcadosOcpOptions < handle
             obj.adaptive_levenberg_marquardt_mu_min = 1e-16;
             obj.adaptive_levenberg_marquardt_mu0 = 1e-3;
             obj.log_primal_step_norm = 0;
+            obj.log_dual_step_norm = 0;
             obj.store_iterates = false;
             obj.eval_residual_at_max_iter = [];
             obj.timeout_max_time = 0.;

--- a/interfaces/acados_matlab_octave/ocp_get.c
+++ b/interfaces/acados_matlab_octave/ocp_get.c
@@ -514,6 +514,14 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
                 mat_ptr[ii+(jj+1)*min_size] = stat[jj+ii*stat_n];
         }
     }
+    else if (!strcmp(field, "primal_step_norm") || !strcmp(field, "dual_step_norm"))
+    {
+        int nlp_iter;
+        ocp_nlp_get(solver, "nlp_iter", &nlp_iter);
+        plhs[0] = mxCreateNumericMatrix(nlp_iter, 1, mxDOUBLE_CLASS, mxREAL);
+        double *mat_ptr = mxGetPr( plhs[0] );
+        ocp_nlp_get(solver, field, mat_ptr);
+    }
     else if (!strcmp(field, "residuals"))
     {
         if (plan->nlp_solver == SQP_RTI)

--- a/interfaces/acados_template/acados_template/acados_ocp_options.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_options.py
@@ -650,7 +650,7 @@ class AcadosOcpOptions:
     def log_primal_step_norm(self,):
         """
         Flag indicating whether the max norm of the primal steps should be logged.
-        This is implemented only for solver type `SQP`.
+        This is implemented only for solver types `SQP`, `SQP_WITH_FEASIBLE_QP`.
         Default: False
         """
         return self.__log_primal_step_norm

--- a/interfaces/acados_template/acados_template/acados_ocp_options.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_options.py
@@ -125,6 +125,7 @@ class AcadosOcpOptions:
         self.__adaptive_levenberg_marquardt_mu_min = 1e-16
         self.__adaptive_levenberg_marquardt_mu0 = 1e-3
         self.__log_primal_step_norm: bool = False
+        self.__log_dual_step_norm: bool = False
         self.__store_iterates: bool = False
         self.__timeout_max_time = 0.
         self.__timeout_heuristic = 'LAST'
@@ -647,7 +648,7 @@ class AcadosOcpOptions:
         return self.__adaptive_levenberg_marquardt_mu0
 
     @property
-    def log_primal_step_norm(self,):
+    def log_primal_step_norm(self):
         """
         Flag indicating whether the max norm of the primal steps should be logged.
         This is implemented only for solver types `SQP`, `SQP_WITH_FEASIBLE_QP`.
@@ -656,7 +657,16 @@ class AcadosOcpOptions:
         return self.__log_primal_step_norm
 
     @property
-    def store_iterates(self,):
+    def log_dual_step_norm(self):
+        """
+        Flag indicating whether the max norm of the dual steps should be logged.
+        This is implemented only for solver types `SQP`, `SQP_WITH_FEASIBLE_QP`.
+        Default: False
+        """
+        return self.__log_dual_step_norm
+
+    @property
+    def store_iterates(self):
         """
         Flag indicating whether the intermediate primal-dual iterates should be stored.
         This is implemented only for solver types `SQP` and `DDP`.
@@ -665,7 +675,7 @@ class AcadosOcpOptions:
         return self.__store_iterates
 
     @property
-    def timeout_max_time(self,):
+    def timeout_max_time(self):
         """
         Maximum time before solver timeout. If 0, there is no timeout.
         A timeout is triggered if the condition
@@ -678,7 +688,7 @@ class AcadosOcpOptions:
         return self.__timeout_max_time
 
     @property
-    def timeout_heuristic(self,):
+    def timeout_heuristic(self):
         """
         Heuristic to be used for predicting the runtime of the next SQP iteration, cf. `timeout_max_time`.
         Possible values are "MAX_CALL", "MAX_OVERALL", "LAST", "AVERAGE", "ZERO".
@@ -1728,10 +1738,15 @@ class AcadosOcpOptions:
 
     @log_primal_step_norm.setter
     def log_primal_step_norm(self, val):
-        if isinstance(val, bool):
-            self.__log_primal_step_norm = val
-        else:
+        if not isinstance(val, bool):
             raise TypeError('Invalid log_primal_step_norm value. Expected bool.')
+        self.__log_primal_step_norm = val
+
+    @log_dual_step_norm.setter
+    def log_dual_step_norm(self, val):
+        if not isinstance(val, bool):
+            raise TypeError('Invalid log_dual_step_norm value. Expected bool.')
+        self.__log_dual_step_norm = val
 
     @store_iterates.setter
     def store_iterates(self, val):

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -1611,7 +1611,7 @@ class AcadosOcpSolver:
             self.__acados_lib.ocp_nlp_get(self.nlp_solver, field, out_data)
             return out
 
-        elif field_ == 'primal_step_norm':
+        elif field_ in ['primal_step_norm', 'dual_step_norm']:
             nlp_iter = self.get_stats("nlp_iter")
             out = np.zeros((nlp_iter,), dtype=np.float64, order="C")
             out_data = cast(out.ctypes.data, POINTER(c_double))

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.c
@@ -2301,6 +2301,9 @@ void {{ name }}_acados_create_set_opts({{ name }}_solver_capsule* capsule)
     int log_primal_step_norm = {{ solver_options.log_primal_step_norm }};
     ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "log_primal_step_norm", &log_primal_step_norm);
 
+    int log_dual_step_norm = {{ solver_options.log_dual_step_norm }};
+    ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "log_dual_step_norm", &log_dual_step_norm);
+
     double nlp_solver_tol_min_step_norm = {{ solver_options.nlp_solver_tol_min_step_norm }};
     ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "tol_min_step_norm", &nlp_solver_tol_min_step_norm);
 {%- endif %}

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.c
@@ -2291,11 +2291,19 @@ void {{ name }}_acados_create_set_opts({{ name }}_solver_capsule* capsule)
     ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "reg_adaptive_eps", &reg_adaptive_eps);
 {%- endif %}
 
+    int nlp_solver_ext_qp_res = {{ solver_options.nlp_solver_ext_qp_res }};
+    ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "ext_qp_res", &nlp_solver_ext_qp_res);
+
     bool store_iterates = {{ solver_options.store_iterates }};
     ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "store_iterates", &store_iterates);
 
-    int nlp_solver_ext_qp_res = {{ solver_options.nlp_solver_ext_qp_res }};
-    ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "ext_qp_res", &nlp_solver_ext_qp_res);
+{%- if solver_options.nlp_solver_type == "SQP" or solver_options.nlp_solver_type == "SQP_WITH_FEASIBLE_QP" %}
+    int log_primal_step_norm = {{ solver_options.log_primal_step_norm }};
+    ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "log_primal_step_norm", &log_primal_step_norm);
+
+    double nlp_solver_tol_min_step_norm = {{ solver_options.nlp_solver_tol_min_step_norm }};
+    ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "tol_min_step_norm", &nlp_solver_tol_min_step_norm);
+{%- endif %}
 
 {%- if solver_options.qp_solver is containing("HPIPM") %}
     // set HPIPM mode: should be done before setting other QP solver options

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -2412,6 +2412,9 @@ static void {{ model.name }}_acados_create_set_opts({{ model.name }}_solver_caps
     int log_primal_step_norm = {{ solver_options.log_primal_step_norm }};
     ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "log_primal_step_norm", &log_primal_step_norm);
 
+    int log_dual_step_norm = {{ solver_options.log_dual_step_norm }};
+    ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "log_dual_step_norm", &log_dual_step_norm);
+
     double nlp_solver_tol_min_step_norm = {{ solver_options.nlp_solver_tol_min_step_norm }};
     ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "tol_min_step_norm", &nlp_solver_tol_min_step_norm);
 {%- endif %}

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -2408,7 +2408,7 @@ static void {{ model.name }}_acados_create_set_opts({{ model.name }}_solver_caps
     bool store_iterates = {{ solver_options.store_iterates }};
     ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "store_iterates", &store_iterates);
 
-{%- if solver_options.nlp_solver_type == "SQP" %}
+{%- if solver_options.nlp_solver_type == "SQP" or solver_options.nlp_solver_type == "SQP_WITH_FEASIBLE_QP" %}
     int log_primal_step_norm = {{ solver_options.log_primal_step_norm }};
     ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "log_primal_step_norm", &log_primal_step_norm);
 


### PR DESCRIPTION
-  move primal_step_norm to common memory, as option is also there
-  Interfaces: fix log_primal_step_norm for SQP_WFQP and multi-phase 
- add option ` log_dual_step_norm`
- test getting step norms in MATLAB and Python

Bit unrelated:
-  SQP_WFQP: remove max_iter duplicated from common 