### PR TITLE
C: avoid using local variable `sqp_iter`

### DIFF
--- a/acados/ocp_nlp/ocp_nlp_sqp.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp.c
@@ -814,7 +814,7 @@ int ocp_nlp_sqp(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
         }
 
         // Compute the step norm
-        if (opts->tol_min_step_norm > 0.0 || nlp_opts->log_primal_step_norm)
+        if (opts->tol_min_step_norm > 0.0 || nlp_opts->log_primal_step_norm || nlp_opts->print_level > 0)
         {
             mem->step_norm = ocp_qp_out_compute_primal_nrm_inf(qp_out);
             if (nlp_opts->log_primal_step_norm)

--- a/acados/ocp_nlp/ocp_nlp_sqp_with_feasible_qp.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp_with_feasible_qp.c
@@ -985,7 +985,7 @@ static int prepare_and_solve_QP(ocp_nlp_config* config, ocp_nlp_sqp_wfqp_opts* o
         }
     }
 
-    if (mem->qps_solved_in_sqp_iter < 2 && (!solve_feasibility_qp || opts->use_constraint_hessian_in_feas_qp))
+    if (mem->qps_solved_in_iter < 2 && (!solve_feasibility_qp || opts->use_constraint_hessian_in_feas_qp))
     {
         if (solve_feasibility_qp && opts->use_constraint_hessian_in_feas_qp)
         {
@@ -1033,7 +1033,7 @@ static int prepare_and_solve_QP(ocp_nlp_config* config, ocp_nlp_sqp_wfqp_opts* o
                                                     NULL, NULL, NULL);
     }
 
-    mem->qps_solved_in_sqp_iter += 1;
+    mem->qps_solved_in_iter += 1;
 
     // restore default warm start
     if (nlp_mem->iter==0)
@@ -1439,7 +1439,7 @@ static int calculate_search_direction(ocp_nlp_dims *dims,
     qp_info* qp_info_;
     int qp_iter = 0;
     int search_direction_status;
-    mem->qps_solved_in_sqp_iter = 0;
+    mem->qps_solved_in_iter = 0;
 
     if (mem->search_direction_mode == NOMINAL_QP)
     {
@@ -1478,7 +1478,7 @@ static int calculate_search_direction(ocp_nlp_dims *dims,
     {
         // We solve two QPs and return the search direction that we found!
         // if the second QP is feasible, we change back to nominal QP mode.
-        if (mem->qps_solved_in_sqp_iter == 1)
+        if (mem->qps_solved_in_iter == 1)
         {
             mem->search_direction_type = "NFN";
         }

--- a/acados/ocp_nlp/ocp_nlp_sqp_with_feasible_qp.h
+++ b/acados/ocp_nlp/ocp_nlp_sqp_with_feasible_qp.h
@@ -124,7 +124,7 @@ typedef struct
     int watchdog_zero_slacks_counter; // counts number of consecutive BYRD_OMOJOKUN iter with slack sum == 0
     int absolute_nns; // sum of all nns[i]
 
-    int qps_solved_in_sqp_iter;
+    int qps_solved_in_iter;
 
     // QP solver with always feasible QPs
     ocp_qp_xcond_solver relaxed_qp_solver;

--- a/examples/acados_python/non_ocp_nlp/maratos_test_problem.py
+++ b/examples/acados_python/non_ocp_nlp/maratos_test_problem.py
@@ -212,8 +212,8 @@ def solve_maratos_problem_with_setting(setting):
             if any(alphas[:iter] != 1.0):
                 raise Exception(f"Expected all alphas = 1.0 when using full step SQP on Maratos problem")
         elif globalization == 'MERIT_BACKTRACKING':
-            if max_infeasibility > 1.5:
-                raise Exception(f"Expected max_infeasibility < 1.5 when using globalized SQP on Maratos problem")
+            if max_infeasibility > 0.5:
+                raise Exception(f"Expected max_infeasibility < 0.5 when using globalized SQP on Maratos problem")
             if globalization_use_SOC == 0:
                 if FOR_LOOPING and iter != 57:
                     raise Exception(f"Expected 57 SQP iterations when using globalized SQP without SOC on Maratos problem, got {iter}")
@@ -226,8 +226,8 @@ def solve_maratos_problem_with_setting(setting):
                     # Jonathan Laptop: merit_grad = -1.737950e-01, merit_grad_cost = -1.737950e-01, merit_grad_dyn = 0.000000e+00, merit_grad_ineq = 0.000000e+00
                     raise Exception(f"Expected SQP iterations in range(29, 37) when using globalized SQP with SOC on Maratos problem, got {iter}")
             else:
-                if iter != 10:
-                    raise Exception(f"Expected 10 SQP iterations when using globalized SQP with SOC on Maratos problem, got {iter}")
+                if iter != 16:
+                    raise Exception(f"Expected 16 SQP iterations when using globalized SQP with SOC on Maratos problem, got {iter}")
         elif globalization == 'FUNNEL_L1PEN_LINESEARCH':
             if iter > 12:
                     raise Exception(f"Expected not more than 12 SQP iterations when using Funnel Method SQP, got {iter}")


### PR DESCRIPTION
Follow-up of https://github.com/acados/acados/pull/1492.
The changed tests in https://github.com/acados/acados/pull/1492 have been reverted as the iteration reference was still wrong there. Now I verified by printing.