### PR TITLE
Fix typo: intial -> initial

### DIFF
--- a/examples/acados_matlab_octave/race_cars/main.m
+++ b/examples/acados_matlab_octave/race_cars/main.m
@@ -149,7 +149,7 @@ ocp_model.set('cost_zu', 100 * ones(nsh,1));
 ocp_model.set('cost_Zl', eye(nsh,nsh));
 ocp_model.set('cost_Zu', eye(nsh,nsh));
 
-% set intial condition
+% set initial condition
 ocp_model.set('constr_x0', model.x0);
 
 % cost = define linear cost on x and u
@@ -188,7 +188,7 @@ W_e = Qe / unscale;
 ocp_model.set('cost_W', W);
 ocp_model.set('cost_W_e', W_e);
 
-% set intial references
+% set initial references
 y_ref = zeros(ny,1);
 y_ref_e = zeros(ny_e,1);
 y_ref(1) = 1; % set reference on 's' to 1 to push the car forward (progress)

--- a/examples/acados_matlab_octave/test/create_ocp_qp_solver_formulation.m
+++ b/examples/acados_matlab_octave/test/create_ocp_qp_solver_formulation.m
@@ -36,7 +36,7 @@ Vu = zeros(ny,nu); Vu(nx+1:ny,:) = eye(nu);     % input-to-output matrix in lagr
 Vx_e = zeros(ny_e,nx); Vx_e(1:nx,:) = eye(nx);  % state-to-output matrix in mayer term
 W = eye(ny);
 W_e = 5 * W(1:ny_e,1:ny_e);                         % cost weights in mayer term
-y_ref = zeros(ny,1);                            % set intial references
+y_ref = zeros(ny,1);                            % set initial references
 y_ref_e = zeros(ny_e,1);
 
 % cost

--- a/examples/acados_matlab_octave/test/create_parametric_ocp_qp.m
+++ b/examples/acados_matlab_octave/test/create_parametric_ocp_qp.m
@@ -33,7 +33,7 @@ function [ocp, x0] = create_parametric_ocp_qp(N, np)
     Vx_e = zeros(ny_e,nx); Vx_e(1:nx,:) = eye(nx);  % state-to-output matrix in mayer term
     W = eye(ny);
     W_e = 5 * W(1:ny_e,1:ny_e);                         % cost weights in mayer term
-    y_ref = zeros(ny,1);                            % set intial references
+    y_ref = zeros(ny,1);                            % set initial references
     y_ref_e = zeros(ny_e,1);
 
     ocp.cost.cost_type = cost_type;

--- a/examples/acados_python/race_cars/acados_settings.py
+++ b/examples/acados_python/race_cars/acados_settings.py
@@ -102,7 +102,7 @@ def acados_settings(Tf, N, track_file):
     ocp.cost.zu = 100 * np.ones((ns,))
     ocp.cost.Zu = 0 * np.ones((ns,))
 
-    # set intial references
+    # set initial references
     ocp.cost.yref = np.array([1, 0, 0, 0, 0, 0, 0, 0])
     ocp.cost.yref_e = np.array([0, 0, 0, 0, 0, 0])
 
@@ -138,7 +138,7 @@ def acados_settings(Tf, N, track_file):
     ocp.constraints.ush = np.zeros(nsh)
     ocp.constraints.idxsh = np.array([0, 2])
 
-    # set intial condition
+    # set initial condition
     ocp.constraints.x0 = model.x0
 
     # set QP solver and integration

--- a/examples/acados_python/race_cars/acados_settings_dev.py
+++ b/examples/acados_python/race_cars/acados_settings_dev.py
@@ -106,7 +106,7 @@ def acados_settings(Tf, N, track_file):
     ocp.cost.Zl = 1 * np.ones((ns,))
     ocp.cost.Zu = 1 * np.ones((ns,))
 
-    # set intial references
+    # set initial references
     ocp.cost.yref = np.array([1, 0, 0, 0, 0, 0, 0, 0])
     ocp.cost.yref_e = np.array([0, 0, 0, 0, 0, 0])
 
@@ -144,7 +144,7 @@ def acados_settings(Tf, N, track_file):
     ocp.constraints.ush = np.zeros(nsh)
     ocp.constraints.idxsh = np.array(range(nsh))
 
-    # set intial condition
+    # set initial condition
     ocp.constraints.x0 = model.x0
 
     # set QP solver and integration

--- a/interfaces/acados_template/acados_template/acados_ocp.py
+++ b/interfaces/acados_template/acados_template/acados_ocp.py
@@ -584,7 +584,7 @@ class AcadosOcp:
                 cost.Zl_0 = cost.Zl
                 cost.Zu_0 = cost.Zu
                 print("Fields cost.[zl_0, zu_0, Zl_0, Zu_0] are not provided.")
-                print("Using entries [zl, zu, Zl, Zu] at intial node for slack penalties.\n")
+                print("Using entries [zl, zu, Zl, Zu] at initial node for slack penalties.\n")
             else:
                 raise ValueError("Fields cost.[zl_0, zu_0, Zl_0, Zu_0] are not provided and cannot be inferred from other fields.\n")
 
@@ -1500,12 +1500,12 @@ class AcadosOcp:
             self.model.p_global = ca.vertcat(self.model.p_global, p_global)
             self.p_global_values = np.concatenate((self.p_global_values, p_global_values))
 
-        self.translate_intial_cost_term_to_external(yref_0, W_0, cost_hessian)
+        self.translate_initial_cost_term_to_external(yref_0, W_0, cost_hessian)
         self.translate_intermediate_cost_term_to_external(yref, W, cost_hessian)
         self.translate_terminal_cost_term_to_external(yref_e, W_e, cost_hessian)
 
 
-    def translate_intial_cost_term_to_external(self, yref_0: Optional[Union[ca.SX, ca.MX]] = None, W_0: Optional[Union[ca.SX, ca.MX]] = None, cost_hessian: str = 'EXACT'):
+    def translate_initial_cost_term_to_external(self, yref_0: Optional[Union[ca.SX, ca.MX]] = None, W_0: Optional[Union[ca.SX, ca.MX]] = None, cost_hessian: str = 'EXACT'):
 
         if cost_hessian not in ['EXACT', 'GAUSS_NEWTON']:
             raise Exception(f"Invalid cost_hessian {cost_hessian}, should be 'EXACT' or 'GAUSS_NEWTON'.")


### PR DESCRIPTION
- NOTE: function `AcadosOcp.translate_initial_cost_term_to_external` recently introduced has now a new name.