### PR TITLE
Reorder variables in `AcadosCasadiOcpSolver`

### DIFF
--- a/interfaces/acados_template/acados_template/acados_casadi_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_casadi_ocp_solver.py
@@ -36,7 +36,7 @@ from typing import Union, Tuple
 import numpy as np
 from .acados_ocp import AcadosOcp
 from .acados_ocp_iterate import AcadosOcpIterate, AcadosOcpIterates, AcadosOcpFlattenedIterate
-
+from itertools import zip_longest
 
 class AcadosCasadiOcpSolver:
 
@@ -59,32 +59,36 @@ class AcadosCasadiOcpSolver:
         if any([dims.ns_0, dims.ns, dims.ns_e]):
             raise NotImplementedError("CasADi NLP formulation not implemented for formulations with soft constraints yet.")
 
-        # create variables
+        # create variables indexed by shooting nodes, vectorize in the end
         ca_symbol = model.get_casadi_symbol()
         xtraj = ca_symbol('x', dims.nx, solver_options.N_horizon+1)
+        xtraj_node = [xtraj[:, i] for i in range(xtraj.shape[-1])]
         utraj = ca_symbol('u', dims.nu, solver_options.N_horizon)
+        utraj_node = [utraj[:, i] for i in range(utraj.shape[-1])]
         if dims.nz > 0:
             raise NotImplementedError("CasADi NLP formulation not implemented for models with algebraic variables (z).")
         # parameters
         ptraj = ca_symbol('p', dims.np, solver_options.N_horizon+1)
+        ptraj_node = [ptraj[:, i] for i in range(ptraj.shape[-1])]
 
         ### Constraints: bounds
         # setup state bounds
-        lb_xtraj = -np.inf * ca.DM.ones((dims.nx, solver_options.N_horizon+1))
-        ub_xtraj = np.inf * ca.DM.ones((dims.nx, solver_options.N_horizon+1))
-        lb_xtraj[constraints.idxbx_0, 0] = constraints.lbx_0
-        ub_xtraj[constraints.idxbx_0, 0] = constraints.ubx_0
+        lb_xtraj_node = [-np.inf * ca.DM.ones((dims.nx, 1)) for _ in range(solver_options.N_horizon+1)]
+        ub_xtraj_node = [np.inf * ca.DM.ones((dims.nx, 1)) for _ in range(solver_options.N_horizon+1)]
+        lb_xtraj_node[0][constraints.idxbx_0]=constraints.lbx_0
+        ub_xtraj_node[0][constraints.idxbx_0]=constraints.ubx_0
         for i in range(1, solver_options.N_horizon):
-            lb_xtraj[constraints.idxbx, i] = constraints.lbx
-            ub_xtraj[constraints.idxbx, i] = constraints.ubx
-        lb_xtraj[constraints.idxbx_e, -1] = constraints.lbx_e
-        ub_xtraj[constraints.idxbx_e, -1] = constraints.ubx_e
+            lb_xtraj_node[i][constraints.idxbx] = constraints.lbx
+            ub_xtraj_node[i][constraints.idxbx] = constraints.ubx
+        lb_xtraj_node[-1][constraints.idxbx_e] = constraints.lbx_e
+        ub_xtraj_node[-1][constraints.idxbx_e] = constraints.ubx_e
+        
         # setup control bounds
-        lb_utraj = -np.inf * ca.DM.ones((dims.nu, solver_options.N_horizon))
-        ub_utraj = np.inf * ca.DM.ones((dims.nu, solver_options.N_horizon))
+        lb_utraj_node = [-np.inf * ca.DM.ones((dims.nu, 1)) for _ in range(solver_options.N_horizon)]
+        ub_utraj_node = [np.inf * ca.DM.ones((dims.nu, 1)) for _ in range(solver_options.N_horizon)]
         for i in range(solver_options.N_horizon):
-            lb_utraj[constraints.idxbu, i] = constraints.lbu
-            ub_utraj[constraints.idxbu, i] = constraints.ubu
+            lb_utraj_node[i][constraints.idxbu] = constraints.lbu
+            ub_utraj_node[i][constraints.idxbu] = constraints.ubu
 
         ### Nonlinear constraints
         g = []
@@ -103,22 +107,22 @@ class AcadosCasadiOcpSolver:
         for i in range(solver_options.N_horizon):
             # add dynamics constraints
             if solver_options.integrator_type == "DISCRETE":
-                g.append(xtraj[:, i+1] - f_discr_fun(xtraj[:, i], utraj[:, i], ptraj[:, i], model.p_global))
+                g.apppend(xtraj_node[i+1] - f_discr_fun(xtraj_node[i], utraj_node[i], ptraj_node[i], model.p_global))
             elif solver_options.integrator_type == "ERK":
-                g.append(xtraj[:, i+1] - f_discr_fun(xtraj[:, i], utraj[:, i], solver_options.time_steps[i]))
+                g.append(xtraj_node[i+1] - f_discr_fun(xtraj_node[i], utraj_node[i], solver_options.time_steps[i]))
             lbg.append(np.zeros((dims.nx, 1)))
             ubg.append(np.zeros((dims.nx, 1)))
 
         # nonlinear constraints -- initial stage
         h0_fun = ca.Function('h0_fun', [model.x, model.u, model.p, model.p_global], [model.con_h_expr_0])
-        g.append(h0_fun(xtraj[:, 0], utraj[:, 0], ptraj[:, 0], model.p_global))
+        g.append(h0_fun(xtraj_node[0], utraj_node[0], ptraj_node[0], model.p_global))
         lbg.append(constraints.lh_0)
         ubg.append(constraints.uh_0)
 
         if dims.nphi_0 > 0:
             conl_constr_expr_0 = ca.substitute(model.con_phi_expr_0, model.con_r_in_phi_0, model.con_r_expr_0)
             conl_constr_0_fun = ca.Function('conl_constr_0_fun', [model.x, model.u, model.p, model.p_global], [conl_constr_expr_0])
-            g.append(conl_constr_0_fun(xtraj[:, 0], utraj[:, 0], ptraj[:, 0], model.p_global))
+            g.append(conl_constr_0_fun(xtraj_node[0], utraj_node[0], ptraj_node[0], model.p_global))
             lbg.append(constraints.lphi_0)
             ubg.append(constraints.uphi_0)
 
@@ -130,26 +134,26 @@ class AcadosCasadiOcpSolver:
             conl_constr_fun = ca.Function('conl_constr_fun', [model.x, model.u, model.p, model.p_global], [conl_constr_expr])
 
         for i in range(1, solver_options.N_horizon):
-            g.append(h_fun(xtraj[:, i], utraj[:, i], ptraj[:, i], model.p_global))
+            g.append(h_fun(xtraj_node[i], utraj_node[i], ptraj_node[i], model.p_global))
             lbg.append(constraints.lh)
             ubg.append(constraints.uh)
 
             if dims.nphi > 0:
-                g.append(conl_constr_fun(xtraj[:, i], utraj[:, i], ptraj[:, i], model.p_global))
+                g.append(conl_constr_fun(xtraj_node[i], utraj_node[i], ptraj_node[i], model.p_global))
                 lbg.append(constraints.lphi)
                 ubg.append(constraints.uphi)
 
         # nonlinear constraints -- terminal stage
         h_e_fun = ca.Function('h_e_fun', [model.x, model.p, model.p_global], [model.con_h_expr_e])
 
-        g.append(h_e_fun(xtraj[:, -1], ptraj[:, -1], model.p_global))
+        g.append(h_e_fun(xtraj_node[-1], ptraj_node[-1], model.p_global))
         lbg.append(constraints.lh_e)
         ubg.append(constraints.uh_e)
 
         if dims.nphi_e > 0:
             conl_constr_expr_e = ca.substitute(model.con_phi_expr_e, model.con_r_in_phi_e, model.con_r_expr_e)
             conl_constr_e_fun = ca.Function('conl_constr_e_fun', [model.x, model.p, model.p_global], [conl_constr_expr_e])
-            g.append(conl_constr_e_fun(xtraj[:, -1], ptraj[:, -1], model.p_global))
+            g.append(conl_constr_e_fun(xtraj_node[-1], ptraj_node[-1], model.p_global))
             lbg.append(constraints.lphi_e)
             ubg.append(constraints.uphi_e)
 
@@ -158,24 +162,28 @@ class AcadosCasadiOcpSolver:
         nlp_cost = 0
         cost_expr_0 = ocp.get_initial_cost_expression()
         cost_fun_0 = ca.Function('cost_fun_0', [model.x, model.u, model.p, model.p_global], [cost_expr_0])
-        nlp_cost += solver_options.cost_scaling[0] * cost_fun_0(xtraj[:, 0], utraj[:, 0], ptraj[:, 0], model.p_global)
+        nlp_cost += solver_options.cost_scaling[0] * cost_fun_0(xtraj_node[0], utraj_node[0], ptraj_node[0], model.p_global)
 
         # intermediate cost term
         cost_expr = ocp.get_path_cost_expression()
         cost_fun = ca.Function('cost_fun', [model.x, model.u, model.p, model.p_global], [cost_expr])
         for i in range(1, solver_options.N_horizon):
-            nlp_cost += solver_options.cost_scaling[i] * cost_fun(xtraj[:, i], utraj[:, i], ptraj[:, i], model.p_global)
+            nlp_cost += solver_options.cost_scaling[i] * cost_fun(xtraj_node[i], utraj_node[i], ptraj_node[i], model.p_global)
 
         # terminal cost term
         cost_expr_e = ocp.get_terminal_cost_expression()
         cost_fun_e = ca.Function('cost_fun_e', [model.x, model.p, model.p_global], [cost_expr_e])
-        nlp_cost += solver_options.cost_scaling[-1] * cost_fun_e(xtraj[:, -1], ptraj[:, -1], model.p_global)
+        nlp_cost += solver_options.cost_scaling[-1] * cost_fun_e(xtraj_node[-1], ptraj_node[-1], model.p_global)
 
-        # call w all primal variables
-        w = ca.vertcat(ca.vec(xtraj), ca.vec(utraj))
-        lbw = ca.vertcat(ca.vec(lb_xtraj), ca.vec(lb_utraj))
-        ubw = ca.vertcat(ca.vec(ub_xtraj), ca.vec(ub_utraj))
-        p_nlp = ca.vertcat(ca.vec(ptraj), model.p_global)
+        ### Formulation
+        # interleave primary variables w and bounds
+        w_interleaved = [x for pair in zip_longest(xtraj_node, utraj_node) for x in pair if x is not None]
+        w = ca.vertcat(*w_interleaved)
+        lbw_interleaved = [x for pair in zip_longest(lb_xtraj_node, lb_utraj_node) for x in pair if x is not None]
+        lbw = ca.vertcat(*lbw_interleaved)
+        ubw_interleaved = [x for pair in zip_longest(ub_xtraj_node, ub_utraj_node) for x in pair if x is not None]
+        ubw = ca.vertcat(*ubw_interleaved)
+        p_nlp = ca.vertcat(*ptraj_node, model.p_global)
 
         # create NLP
         nlp = {"x": w, "p": p_nlp, "g": ca.vertcat(*g), "f": nlp_cost}
@@ -184,14 +192,14 @@ class AcadosCasadiOcpSolver:
         return nlp, bounds
 
 
-    def __init__(self, acados_ocp: AcadosOcp, verbose=True):
+    def __init__(self, acados_ocp: AcadosOcp, solver: str = "ipopt", verbose=True):
 
         if not isinstance(acados_ocp, AcadosOcp):
             raise TypeError('acados_ocp should be of type AcadosOcp.')
 
         self.acados_ocp = acados_ocp
         self.casadi_nlp, self.bounds = self.create_casadi_nlp_formulation(acados_ocp)
-        self.casadi_solver = ca.nlpsol("nlp_solver", 'ipopt', self.casadi_nlp)
+        self.casadi_solver = ca.nlpsol("nlp_solver", solver, self.casadi_nlp)
         self.nlp_sol = None
 
 
@@ -244,14 +252,14 @@ class AcadosCasadiOcpSolver:
         if self.nlp_sol is None:
             raise ValueError('No solution available. Please call solve() first.')
         dims = self.acados_ocp.dims
+        pivot = stage*(dims.nx+dims.nu)
 
         if field == 'x':
             sol_w = self.nlp_sol['x']
-            return sol_w[stage*dims.nx:(stage+1)*dims.nx].full().flatten()
+            return sol_w[pivot:pivot+dims.nx].full().flatten()
         elif field == 'u':
             sol_w = self.nlp_sol['x']
-            offset_x = dims.nx*(self.acados_ocp.solver_options.N_horizon+1)
-            return sol_w[offset_x+stage*dims.nu: offset_x+(stage+1)*dims.nu].full().flatten()
+            return sol_w[pivot+dims.nx:pivot+dims.nx+dims.nu].full().flatten()
         else:
             raise NotImplementedError(f"Field '{field}' is not implemented in AcadosCasadiOcpSolver")
 


### PR DESCRIPTION
- organized the variables along time nodes as $x_0, x_1,....,x_{N+1}$ and $u_0, u_1...., u_N$ and then vectorized them in the interleaved order as $x_0, u_0, x_1, u_1...., x_N, u_N,x_{N+1}$.
- I also adjust the `get()` function to get solution values in an interleaved manner.