### PR TITLE
Fix `p_global` precomputation in case sparse data is detected

### DIFF
--- a/acados/utils/external_function_generic.c
+++ b/acados/utils/external_function_generic.c
@@ -1398,6 +1398,7 @@ static void external_function_external_param_casadi_set_global_data_pointer(void
 
     if (!fun->args_dense[fun->idx_in_global_data])
     {
+        // NOTE: sparsity is removed in MATLAB/Python interface
         printf("\nexternal_function_external_param_casadi_set_global_data_pointer: sparse global_data not supported!\n");
         exit(1);
     }

--- a/interfaces/acados_matlab_octave/GenerateContext.m
+++ b/interfaces/acados_matlab_octave/GenerateContext.m
@@ -195,6 +195,10 @@ classdef GenerateContext < handle
             global_data_expr_list = cellfun(@(pair) pair{2}, precompute_pairs, 'UniformOutput', false);
             self.global_data_expr = cse(vertcat(global_data_expr_list{:}));
 
+            % make sure global_data is dense
+            self.global_data_expr = sparsity_cast(self.global_data_expr, Sparsity.dense(self.global_data_expr.nnz()));
+            self.global_data_sym = sparsity_cast(self.global_data_sym, Sparsity.dense(self.global_data_sym.nnz()));
+
             % Assert length match
             assert(length(self.global_data_expr) == length(self.global_data_sym), ...
                    sprintf('Length mismatch: %d != %d', length(self.global_data_expr), length(self.global_data_sym)));

--- a/interfaces/acados_matlab_octave/GenerateContext.m
+++ b/interfaces/acados_matlab_octave/GenerateContext.m
@@ -196,8 +196,10 @@ classdef GenerateContext < handle
             self.global_data_expr = cse(vertcat(global_data_expr_list{:}));
 
             % make sure global_data is dense
-            self.global_data_expr = sparsity_cast(self.global_data_expr, Sparsity.dense(self.global_data_expr.nnz()));
-            self.global_data_sym = sparsity_cast(self.global_data_sym, Sparsity.dense(self.global_data_sym.nnz()));
+            if length(self.global_data_expr) > 0
+                self.global_data_expr = sparsity_cast(self.global_data_expr, Sparsity.dense(self.global_data_expr.nnz()));
+                self.global_data_sym = sparsity_cast(self.global_data_sym, Sparsity.dense(self.global_data_sym.nnz()));
+            end
 
             % Assert length match
             assert(length(self.global_data_expr) == length(self.global_data_sym), ...

--- a/interfaces/acados_template/acados_template/casadi_function_generation.py
+++ b/interfaces/acados_template/acados_template/casadi_function_generation.py
@@ -99,7 +99,7 @@ class GenerateContext:
                 fun = ca.Function(name, inputs, outputs, self.__casadi_fun_opts)
                 # print(f"Generating function {name} with inputs {inputs}")
             except RuntimeError as e:
-                print(f"\nError while creating function {name} with inputs {inputs} and outputs {outputs}")
+                print(f"\nError while creating function {name} with inputs \n{inputs} \n and outputs \n {outputs}")
                 print(e)
                 raise e
 

--- a/interfaces/acados_template/acados_template/casadi_function_generation.py
+++ b/interfaces/acados_template/acados_template/casadi_function_generation.py
@@ -177,8 +177,9 @@ class GenerateContext:
         self.global_data_expr = ca.cse(ca.vertcat(*global_data_expr_list))
 
         # make sure global_data is dense -> convert to dense only taking the non-zero elements into account.
-        self.global_data_expr = ca.sparsity_cast(self.global_data_expr, ca.Sparsity.dense(self.global_data_expr.nnz()))
-        self.global_data_sym = ca.sparsity_cast(self.global_data_sym, ca.Sparsity.dense(self.global_data_sym.nnz()))
+        if casadi_length(self.global_data_expr) > 0:
+            self.global_data_expr = ca.sparsity_cast(self.global_data_expr, ca.Sparsity.dense(self.global_data_expr.nnz()))
+            self.global_data_sym = ca.sparsity_cast(self.global_data_sym, ca.Sparsity.dense(self.global_data_sym.nnz()))
 
         assert casadi_length(self.global_data_expr) == casadi_length(self.global_data_sym), f"Length mismatch: {casadi_length(self.global_data_expr)} != {casadi_length(self.global_data_sym)}"
 

--- a/interfaces/acados_template/acados_template/casadi_function_generation.py
+++ b/interfaces/acados_template/acados_template/casadi_function_generation.py
@@ -170,9 +170,15 @@ class GenerateContext:
             for sym, expr in zip(symbols_to_add, param_expr_to_add):
                 precompute_pairs.append([sym, expr])
 
-        global_data_sym_list = [input for input, _ in precompute_pairs]
+        global_data_sym_list = [ca.vec(input) for input, _ in precompute_pairs]
+        global_data_expr_list = [ca.vec(output) for _, output in precompute_pairs]
+
         self.global_data_sym = ca.vertcat(*global_data_sym_list)
-        self.global_data_expr = ca.cse(ca.vertcat(*[output for _, output in precompute_pairs]))
+        self.global_data_expr = ca.cse(ca.vertcat(*global_data_expr_list))
+
+        # make sure global_data is dense -> convert to dense only taking the non-zero elements into account.
+        self.global_data_expr = ca.sparsity_cast(self.global_data_expr, ca.Sparsity.dense(self.global_data_expr.nnz()))
+        self.global_data_sym = ca.sparsity_cast(self.global_data_sym, ca.Sparsity.dense(self.global_data_sym.nnz()))
 
         assert casadi_length(self.global_data_expr) == casadi_length(self.global_data_sym), f"Length mismatch: {casadi_length(self.global_data_expr)} != {casadi_length(self.global_data_sym)}"
 


### PR DESCRIPTION
By making it dense in the MATLAB & Python interfaces.