### PR TITLE
fix `N_horizon` check in templates

### DIFF
--- a/interfaces/acados_template/acados_template/c_templates_tera/CMakeLists.in.txt
+++ b/interfaces/acados_template/acados_template/c_templates_tera/CMakeLists.in.txt
@@ -34,7 +34,7 @@
     {%- set qp_solver = "FULL_CONDENSING_HPIPM" %}
 {%- endif %}
 
-{%- if solver_options.N_horizon %}
+{% if problem_class != "SIM" %}
     {%- set N_horizon = solver_options.N_horizon %}
 {%- else %}
     {%- set N_horizon = 1 %}

--- a/interfaces/acados_template/acados_template/c_templates_tera/Makefile.in
+++ b/interfaces/acados_template/acados_template/c_templates_tera/Makefile.in
@@ -35,7 +35,7 @@
 	{%- set qp_solver = "FULL_CONDENSING_HPIPM" %}
 {%- endif %}
 
-{%- if solver_options.N_horizon %}
+{% if problem_class != "SIM" %}
 	{%- set N_horizon = solver_options.N_horizon %}
 {%- else %}
 	{%- set N_horizon = 1 %}

--- a/interfaces/acados_template/acados_template/c_templates_tera/main.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/main.in.c
@@ -77,6 +77,7 @@ int main()
     ocp_nlp_solver *nlp_solver = {{ name }}_acados_get_nlp_solver(acados_ocp_capsule);
     void *nlp_opts = {{ name }}_acados_get_nlp_opts(acados_ocp_capsule);
 
+{%- if dims.nbx_0 > 0 %}
     // initial condition
     double lbx0[NBX0];
     double ubx0[NBX0];
@@ -87,6 +88,7 @@ int main()
 
     ocp_nlp_constraints_model_set(nlp_config, nlp_dims, nlp_in, nlp_out, 0, "lbx", lbx0);
     ocp_nlp_constraints_model_set(nlp_config, nlp_dims, nlp_in, nlp_out, 0, "ubx", ubx0);
+{%- endif %}
 
     // initialization for state values
     double x_init[NX];


### PR DESCRIPTION
`N_horizon` should get the default value 1 in templates only if we render them to get a sim solver. Previously 0 was overwritten by 1 there.