### PR TITLE
[docs] Fix mistake in doc string of acados sim object for num of stages

### DIFF
--- a/interfaces/acados_template/acados_template/acados_sim.py
+++ b/interfaces/acados_template/acados_template/acados_sim.py
@@ -78,7 +78,7 @@ class AcadosSimOptions:
 
     @property
     def num_stages(self):
-        """Number of stages in the integrator. Default: 1"""
+        """Number of stages in the integrator. Default: 4"""
         return self.__sim_method_num_stages
 
     @property


### PR DESCRIPTION
The number of stages is per default 4 and not 1 as stated in the doc string.
Please look at the screenshot ([or code](https://github.com/acados/acados/blob/main/interfaces/acados_template/acados_template/acados_sim.py#L82)) to confirm.

To me this was a bit surprising since I tried to play around with this property.
![Screenshot from 2025-06-05 14-50-26](https://github.com/user-attachments/assets/adbdad20-7629-436a-8aad-b2a1954ef2b6)
