### PR TITLE
Python: convert `TERA_PATH` to absolute path

### DIFF
--- a/interfaces/acados_template/acados_template/utils.py
+++ b/interfaces/acados_template/acados_template/utils.py
@@ -99,6 +99,9 @@ def get_tera_exec_path():
     TERA_PATH = os.environ.get('TERA_PATH')
     if not TERA_PATH:
         TERA_PATH = os.path.join(get_acados_path(), 'bin', 't_renderer') + get_binary_ext()
+
+    # convert to absolute path
+    TERA_PATH = os.path.abspath(TERA_PATH)
     return TERA_PATH
 
 


### PR DESCRIPTION
Fixes https://github.com/acados/tera_renderer/issues/10 at least for some people.
I think relative paths lead to more issues down the line, but at least with better error messages.