### PR TITLE
Move options from solvers to `ocp_nlp_common`

### DIFF
--- a/acados/ocp_nlp/ocp_nlp_common.c
+++ b/acados/ocp_nlp/ocp_nlp_common.c
@@ -1265,6 +1265,25 @@ void ocp_nlp_opts_initialize_default(void *config_, void *dims_, void *opts_)
     opts->qp_warm_start = 0;
     opts->store_iterates = false;
 
+    opts->warm_start_first_qp = false;
+    opts->warm_start_first_qp_from_nlp = false;
+    opts->eval_residual_at_max_iter = false;
+
+    // tolerances
+    opts->tol_stat = 1e-8;
+    opts->tol_eq   = 1e-8;
+    opts->tol_ineq = 1e-8;
+    opts->tol_comp = 1e-8;
+    opts->tol_unbounded = -1e10;
+    opts->tol_min_step_norm = 1e-12;
+
+    // overwrite default submodules opts
+    // qp tolerance
+    qp_solver->opts_set(qp_solver, opts->qp_solver_opts, "tol_stat", &opts->tol_stat);
+    qp_solver->opts_set(qp_solver, opts->qp_solver_opts, "tol_eq", &opts->tol_eq);
+    qp_solver->opts_set(qp_solver, opts->qp_solver_opts, "tol_ineq", &opts->tol_ineq);
+    qp_solver->opts_set(qp_solver, opts->qp_solver_opts, "tol_comp", &opts->tol_comp);
+
     return;
 }
 
@@ -1516,6 +1535,54 @@ void ocp_nlp_opts_set(void *config_, void *opts_, const char *field, void* value
         {
             bool* with_anderson_acceleration = (bool *) value;
             opts->with_anderson_acceleration = *with_anderson_acceleration;
+        }
+        else if (!strcmp(field, "tol_stat"))
+        {
+            double* tol_stat = (double *) value;
+            opts->tol_stat = *tol_stat;
+            // TODO: set accuracy of the qp_solver to the minimum of current QP accuracy and the one specified.
+            config->qp_solver->opts_set(config->qp_solver, opts->qp_solver_opts, "tol_stat", value);
+        }
+        else if (!strcmp(field, "tol_eq"))
+        {
+            double* tol_eq = (double *) value;
+            opts->tol_eq = *tol_eq;
+            // TODO: set accuracy of the qp_solver to the minimum of current QP accuracy and the one specified.
+            config->qp_solver->opts_set(config->qp_solver, opts->qp_solver_opts, "tol_eq", value);
+        }
+        else if (!strcmp(field, "tol_ineq"))
+        {
+            double* tol_ineq = (double *) value;
+            opts->tol_ineq = *tol_ineq;
+            // TODO: set accuracy of the qp_solver to the minimum of current QP accuracy and the one specified.
+            config->qp_solver->opts_set(config->qp_solver, opts->qp_solver_opts, "tol_ineq", value);
+        }
+        else if (!strcmp(field, "tol_comp"))
+        {
+            double* tol_comp = (double *) value;
+            opts->tol_comp = *tol_comp;
+            // TODO: set accuracy of the qp_solver to the minimum of current QP accuracy and the one specified.
+            config->qp_solver->opts_set(config->qp_solver, opts->qp_solver_opts, "tol_comp", value);
+        }
+        else if (!strcmp(field, "tol_min_step_norm"))
+        {
+            double* tol_min_step_norm = (double *) value;
+            opts->tol_min_step_norm = *tol_min_step_norm;
+        }
+        else if (!strcmp(field, "warm_start_first_qp"))
+        {
+            bool* warm_start_first_qp = (bool *) value;
+            opts->warm_start_first_qp = *warm_start_first_qp;
+        }
+        else if (!strcmp(field, "warm_start_first_qp_from_nlp"))
+        {
+            bool* warm_start_first_qp_from_nlp = (bool *) value;
+            opts->warm_start_first_qp_from_nlp = *warm_start_first_qp_from_nlp;
+        }
+        else if (!strcmp(field, "eval_residual_at_max_iter"))
+        {
+            bool* eval_residual_at_max_iter = (bool *) value;
+            opts->eval_residual_at_max_iter = *eval_residual_at_max_iter;
         }
         else
         {

--- a/acados/ocp_nlp/ocp_nlp_common.h
+++ b/acados/ocp_nlp/ocp_nlp_common.h
@@ -336,9 +336,20 @@ typedef struct ocp_nlp_opts
     int ext_qp_res;
     int qp_warm_start;
 
+    bool warm_start_first_qp; // to set qp_warm_start in first iteration
+    bool warm_start_first_qp_from_nlp;  // if True first QP will be initialized using values from NLP iterate, otherwise from previous QP solution.
+    bool eval_residual_at_max_iter; // if convergence should be checked after last iterations or only throw max_iter reached
     bool store_iterates; // flag indicating whether intermediate iterates should be stored
 
     bool with_anderson_acceleration;
+
+    // termination tolerances
+    double tol_stat;     // exit tolerance on stationarity condition
+    double tol_eq;       // exit tolerance on equality constraints
+    double tol_ineq;     // exit tolerance on inequality constraints
+    double tol_comp;     // exit tolerance on complementarity condition
+    double tol_unbounded; // exit threshold when objective function seems to be unbounded
+    double tol_min_step_norm; // exit tolerance for small step
 
 } ocp_nlp_opts;
 

--- a/acados/ocp_nlp/ocp_nlp_ddp.c
+++ b/acados/ocp_nlp/ocp_nlp_ddp.c
@@ -111,22 +111,6 @@ void ocp_nlp_ddp_opts_initialize_default(void *config_, void *dims_, void *opts_
 
     // DDP opts
     opts->nlp_opts->max_iter = 20;
-    opts->tol_stat = 1e-8;
-    opts->tol_eq   = 1e-8;
-    opts->tol_ineq = 1e-8;
-    opts->tol_comp = 1e-8;
-    opts->tol_zero_res = 1e-12;
-
-    opts->warm_start_first_qp = false;
-    opts->warm_start_first_qp_from_nlp = false;
-    opts->eval_residual_at_max_iter = false;
-
-    // overwrite default submodules opts
-    // qp tolerance
-    qp_solver->opts_set(qp_solver, opts->nlp_opts->qp_solver_opts, "tol_stat", &opts->tol_stat);
-    qp_solver->opts_set(qp_solver, opts->nlp_opts->qp_solver_opts, "tol_eq", &opts->tol_eq);
-    qp_solver->opts_set(qp_solver, opts->nlp_opts->qp_solver_opts, "tol_ineq", &opts->tol_ineq);
-    qp_solver->opts_set(qp_solver, opts->nlp_opts->qp_solver_opts, "tol_comp", &opts->tol_comp);
 
     return;
 }
@@ -165,53 +149,7 @@ void ocp_nlp_ddp_opts_set(void *config_, void *opts_, const char *field, void* v
     }
     else // nlp opts
     {
-        if (!strcmp(field, "tol_stat"))
-        {
-            double* tol_stat = (double *) value;
-            opts->tol_stat = *tol_stat;
-            // TODO: set accuracy of the qp_solver to the minimum of current QP accuracy and the one specified.
-            config->qp_solver->opts_set(config->qp_solver, opts->nlp_opts->qp_solver_opts, "tol_stat", value);
-        }
-        else if (!strcmp(field, "tol_eq"))
-        {
-            double* tol_eq = (double *) value;
-            opts->tol_eq = *tol_eq;
-            // TODO: set accuracy of the qp_solver to the minimum of current QP accuracy and the one specified.
-            config->qp_solver->opts_set(config->qp_solver, opts->nlp_opts->qp_solver_opts, "tol_eq", value);
-        }
-        else if (!strcmp(field, "tol_ineq"))
-        {
-            double* tol_ineq = (double *) value;
-            opts->tol_ineq = *tol_ineq;
-            // TODO: set accuracy of the qp_solver to the minimum of current QP accuracy and the one specified.
-            config->qp_solver->opts_set(config->qp_solver, opts->nlp_opts->qp_solver_opts, "tol_ineq", value);
-        }
-        else if (!strcmp(field, "tol_comp"))
-        {
-            double* tol_comp = (double *) value;
-            opts->tol_comp = *tol_comp;
-            // TODO: set accuracy of the qp_solver to the minimum of current QP accuracy and the one specified.
-            config->qp_solver->opts_set(config->qp_solver, opts->nlp_opts->qp_solver_opts, "tol_comp", value);
-        }
-        else if (!strcmp(field, "warm_start_first_qp"))
-        {
-            bool* warm_start_first_qp = (bool *) value;
-            opts->warm_start_first_qp = *warm_start_first_qp;
-        }
-        else if (!strcmp(field, "warm_start_first_qp_from_nlp"))
-        {
-            bool* warm_start_first_qp_from_nlp = (bool *) value;
-            opts->warm_start_first_qp_from_nlp = *warm_start_first_qp_from_nlp;
-        }
-        else if (!strcmp(field, "eval_residual_at_max_iter"))
-        {
-            bool* eval_residual_at_max_iter = (bool *) value;
-            opts->eval_residual_at_max_iter = *eval_residual_at_max_iter;
-        }
-        else
-        {
-            ocp_nlp_opts_set(config, nlp_opts, field, value);
-        }
+        ocp_nlp_opts_set(config, nlp_opts, field, value);
     }
 
     return;
@@ -499,6 +437,7 @@ void ocp_nlp_ddp_compute_trial_iterate(void *config_, void *dims_,
 static bool check_termination(int ddp_iter, ocp_nlp_res *nlp_res, ocp_nlp_ddp_memory *mem, ocp_nlp_ddp_opts *opts)
 {
     ocp_nlp_memory *nlp_mem = mem->nlp_mem;
+    ocp_nlp_opts *nlp_opts = opts->nlp_opts;
     // check for nans
     if (isnan(nlp_res->inf_norm_res_stat) || isnan(nlp_res->inf_norm_res_eq) ||
             isnan(nlp_res->inf_norm_res_ineq))
@@ -513,12 +452,12 @@ static bool check_termination(int ddp_iter, ocp_nlp_res *nlp_res, ocp_nlp_ddp_me
 
     // We do not need to check for the complementarity condition and for the
     // inequalities since we have an unconstrainted OCP
-    if (nlp_res->inf_norm_res_eq < opts->tol_eq)
+    if (nlp_res->inf_norm_res_eq < nlp_opts->tol_eq)
     { // Check that iterate must be dynamically feasible
-        if (nlp_res->inf_norm_res_stat < opts->tol_stat)
+        if (nlp_res->inf_norm_res_stat < nlp_opts->tol_stat)
         {// Check Stationarity
             nlp_mem->status = ACADOS_SUCCESS;
-            if (opts->nlp_opts->print_level > 0)
+            if (nlp_opts->print_level > 0)
             {
                 printf("Optimal Solution found! Converged to KKT point.\n");
             }
@@ -526,10 +465,10 @@ static bool check_termination(int ddp_iter, ocp_nlp_res *nlp_res, ocp_nlp_ddp_me
         }
 
         // Check for zero-residual solution of a least-squares problem
-        if (opts->nlp_opts->with_adaptive_levenberg_marquardt && (nlp_mem->cost_value < opts->tol_zero_res))
+        if (nlp_opts->with_adaptive_levenberg_marquardt && (nlp_mem->cost_value < opts->tol_zero_res))
         {
             nlp_mem->status = ACADOS_SUCCESS;
-            if (opts->nlp_opts->print_level > 0)
+            if (nlp_opts->print_level > 0)
             {
                 printf("Optimal Solution found! Converged To Zero Residual Solution.\n");
             }
@@ -538,11 +477,11 @@ static bool check_termination(int ddp_iter, ocp_nlp_res *nlp_res, ocp_nlp_ddp_me
     }
 
     // Check for small step
-    if ((ddp_iter > 0) && (mem->step_norm < opts->tol_eq))
+    if ((ddp_iter > 0) && (mem->step_norm < nlp_opts->tol_eq))
     {
-        if (opts->nlp_opts->print_level > 0)
+        if (nlp_opts->print_level > 0)
         {
-            if (nlp_res->inf_norm_res_eq < opts->tol_eq)
+            if (nlp_res->inf_norm_res_eq < nlp_opts->tol_eq)
             {
                 printf("Stopped: Converged To Feasible Point. Step size is < tol_eq.\n");
             }
@@ -556,10 +495,10 @@ static bool check_termination(int ddp_iter, ocp_nlp_res *nlp_res, ocp_nlp_ddp_me
     }
 
     // Check for maximum iterations
-    if (ddp_iter >= opts->nlp_opts->max_iter)
+    if (ddp_iter >= nlp_opts->max_iter)
     {
         nlp_mem->status = ACADOS_MAXITER;
-        if (opts->nlp_opts->print_level > 0){
+        if (nlp_opts->print_level > 0){
             printf("Stopped: Maximum Iterations Reached.\n");
         }
         return true;
@@ -672,7 +611,7 @@ int ocp_nlp_ddp(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
         // We always evaluate the residuals until the last iteration
         // If the option "eval_residual_at_max_iter" is set, then we will also
         // evaluate the data after the last iteration was performed
-        if (ddp_iter != opts->nlp_opts->max_iter || opts->eval_residual_at_max_iter)
+        if (ddp_iter != opts->nlp_opts->max_iter || nlp_opts->eval_residual_at_max_iter)
         {
             /* Prepare the QP data */
             // linearize NLP, update QP matrices, and add Levenberg-Marquardt term
@@ -705,7 +644,7 @@ int ocp_nlp_ddp(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
         }
 
         // Check if initial guess was infeasible
-        if ((infeasible_initial_guess == true) && (nlp_res->inf_norm_res_eq > opts->tol_eq))
+        if ((infeasible_initial_guess == true) && (nlp_res->inf_norm_res_eq > nlp_opts->tol_eq))
         {
             if (nlp_opts->print_level > 0)
             {
@@ -747,13 +686,13 @@ int ocp_nlp_ddp(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
         // warm start of first QP
         if (ddp_iter == 0)
         {
-            if (!opts->warm_start_first_qp)
+            if (!nlp_opts->warm_start_first_qp)
             {
                 // (typically) no warm start at first iteration
                 int tmp_int = 0;
                 qp_solver->opts_set(qp_solver, nlp_opts->qp_solver_opts, "warm_start", &tmp_int);
             }
-            else if (opts->warm_start_first_qp_from_nlp)
+            else if (nlp_opts->warm_start_first_qp_from_nlp)
             {
                 int tmp_bool = true;
                 qp_solver->opts_set(qp_solver, nlp_opts->qp_solver_opts, "initialize_next_xcond_qp_from_qp_out", &tmp_bool);

--- a/acados/ocp_nlp/ocp_nlp_ddp.h
+++ b/acados/ocp_nlp/ocp_nlp_ddp.h
@@ -56,14 +56,7 @@ extern "C" {
 typedef struct
 {
     ocp_nlp_opts *nlp_opts;
-    double tol_stat;     // exit tolerance on stationarity condition
-    double tol_eq;       // exit tolerance on equality constraints
-    double tol_ineq;     // exit tolerance on inequality constraints
-    double tol_comp;     // exit tolerance on complementarity condition
     double tol_zero_res; // exit tolerance if objective function is 0 for least-squares problem
-    bool warm_start_first_qp; // to set qp_warm_start in first iteration
-    bool warm_start_first_qp_from_nlp;
-    bool eval_residual_at_max_iter; // if convergence should be checked after last iterations or only throw max_iter reached
 } ocp_nlp_ddp_opts;
 
 //

--- a/acados/ocp_nlp/ocp_nlp_sqp.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp.c
@@ -107,32 +107,13 @@ void ocp_nlp_sqp_opts_initialize_default(void *config_, void *dims_, void *opts_
     ocp_nlp_sqp_opts *opts = opts_;
     ocp_nlp_opts *nlp_opts = opts->nlp_opts;
 
-    ocp_qp_xcond_solver_config *qp_solver = config->qp_solver;
-
     // this first !!!
     ocp_nlp_opts_initialize_default(config, dims, nlp_opts);
 
     // SQP opts
     opts->nlp_opts->max_iter = 20;
-    opts->tol_stat = 1e-8;
-    opts->tol_eq   = 1e-8;
-    opts->tol_ineq = 1e-8;
-    opts->tol_comp = 1e-8;
-    opts->tol_unbounded = -1e10;
-    opts->tol_min_step_norm = 1e-12;
-
-    opts->warm_start_first_qp = false;
-    opts->eval_residual_at_max_iter = false;
-
     opts->timeout_heuristic = ZERO;
     opts->timeout_max_time = 0; // corresponds to no timeout
-
-    // overwrite default submodules opts
-    // qp tolerance
-    qp_solver->opts_set(qp_solver, opts->nlp_opts->qp_solver_opts, "tol_stat", &opts->tol_stat);
-    qp_solver->opts_set(qp_solver, opts->nlp_opts->qp_solver_opts, "tol_eq", &opts->tol_eq);
-    qp_solver->opts_set(qp_solver, opts->nlp_opts->qp_solver_opts, "tol_ineq", &opts->tol_ineq);
-    qp_solver->opts_set(qp_solver, opts->nlp_opts->qp_solver_opts, "tol_comp", &opts->tol_comp);
 
     return;
 }
@@ -171,55 +152,7 @@ void ocp_nlp_sqp_opts_set(void *config_, void *opts_, const char *field, void* v
     }
     else // nlp opts
     {
-        if (!strcmp(field, "tol_stat"))
-        {
-            double* tol_stat = (double *) value;
-            opts->tol_stat = *tol_stat;
-            // TODO: set accuracy of the qp_solver to the minimum of current QP accuracy and the one specified.
-            config->qp_solver->opts_set(config->qp_solver, opts->nlp_opts->qp_solver_opts, "tol_stat", value);
-        }
-        else if (!strcmp(field, "tol_eq"))
-        {
-            double* tol_eq = (double *) value;
-            opts->tol_eq = *tol_eq;
-            // TODO: set accuracy of the qp_solver to the minimum of current QP accuracy and the one specified.
-            config->qp_solver->opts_set(config->qp_solver, opts->nlp_opts->qp_solver_opts, "tol_eq", value);
-        }
-        else if (!strcmp(field, "tol_ineq"))
-        {
-            double* tol_ineq = (double *) value;
-            opts->tol_ineq = *tol_ineq;
-            // TODO: set accuracy of the qp_solver to the minimum of current QP accuracy and the one specified.
-            config->qp_solver->opts_set(config->qp_solver, opts->nlp_opts->qp_solver_opts, "tol_ineq", value);
-        }
-        else if (!strcmp(field, "tol_comp"))
-        {
-            double* tol_comp = (double *) value;
-            opts->tol_comp = *tol_comp;
-            // TODO: set accuracy of the qp_solver to the minimum of current QP accuracy and the one specified.
-            config->qp_solver->opts_set(config->qp_solver, opts->nlp_opts->qp_solver_opts, "tol_comp", value);
-        }
-        else if (!strcmp(field, "tol_min_step_norm"))
-        {
-            double* tol_min_step_norm = (double *) value;
-            opts->tol_min_step_norm = *tol_min_step_norm;
-        }
-        else if (!strcmp(field, "warm_start_first_qp"))
-        {
-            bool* warm_start_first_qp = (bool *) value;
-            opts->warm_start_first_qp = *warm_start_first_qp;
-        }
-        else if (!strcmp(field, "warm_start_first_qp_from_nlp"))
-        {
-            bool* warm_start_first_qp_from_nlp = (bool *) value;
-            opts->warm_start_first_qp_from_nlp = *warm_start_first_qp_from_nlp;
-        }
-        else if (!strcmp(field, "eval_residual_at_max_iter"))
-        {
-            bool* eval_residual_at_max_iter = (bool *) value;
-            opts->eval_residual_at_max_iter = *eval_residual_at_max_iter;
-        }
-        else if (!strcmp(field, "timeout_max_time"))
+        if (!strcmp(field, "timeout_max_time"))
         {
             double* timeout_max_time = (double *) value;
             opts->timeout_max_time = *timeout_max_time;
@@ -418,13 +351,14 @@ void ocp_nlp_sqp_work_get(void *config_, void *dims_, void *work_,
 static bool check_termination(int n_iter, ocp_nlp_dims *dims, ocp_nlp_res *nlp_res, ocp_nlp_sqp_memory *mem, ocp_nlp_sqp_opts *opts)
 {
     // ocp_nlp_memory *nlp_mem = mem->nlp_mem;
+    ocp_nlp_opts *nlp_opts = opts->nlp_opts;
 
     // check for nans
     if (isnan(nlp_res->inf_norm_res_stat) || isnan(nlp_res->inf_norm_res_eq) ||
         isnan(nlp_res->inf_norm_res_ineq) || isnan(nlp_res->inf_norm_res_comp))
     {
         mem->nlp_mem->status = ACADOS_NAN_DETECTED;
-        if (opts->nlp_opts->print_level > 0)
+        if (nlp_opts->print_level > 0)
         {
             printf("Stopped: NaN detected in iterate.\n");
         }
@@ -432,10 +366,10 @@ static bool check_termination(int n_iter, ocp_nlp_dims *dims, ocp_nlp_res *nlp_r
     }
 
     // check for maximum iterations
-    if (!opts->eval_residual_at_max_iter && n_iter >= opts->nlp_opts->max_iter)
+    if (!nlp_opts->eval_residual_at_max_iter && n_iter >= nlp_opts->max_iter)
     {
         mem->nlp_mem->status = ACADOS_MAXITER;
-        if (opts->nlp_opts->print_level > 0)
+        if (nlp_opts->print_level > 0)
         {
             printf("Stopped: Maximum iterations reached.\n");
         }
@@ -443,13 +377,13 @@ static bool check_termination(int n_iter, ocp_nlp_dims *dims, ocp_nlp_res *nlp_r
     }
 
     // check if solved to tolerance
-    if ((nlp_res->inf_norm_res_stat < opts->tol_stat) &&
-        (nlp_res->inf_norm_res_eq < opts->tol_eq) &&
-        (nlp_res->inf_norm_res_ineq < opts->tol_ineq) &&
-        (nlp_res->inf_norm_res_comp < opts->tol_comp))
+    if ((nlp_res->inf_norm_res_stat < nlp_opts->tol_stat) &&
+        (nlp_res->inf_norm_res_eq < nlp_opts->tol_eq) &&
+        (nlp_res->inf_norm_res_ineq < nlp_opts->tol_ineq) &&
+        (nlp_res->inf_norm_res_comp < nlp_opts->tol_comp))
     {
         mem->nlp_mem->status = ACADOS_SUCCESS;
-        if (opts->nlp_opts->print_level > 0)
+        if (nlp_opts->print_level > 0)
         {
             printf("Optimal solution found! Converged to KKT point.\n");
         }
@@ -457,11 +391,11 @@ static bool check_termination(int n_iter, ocp_nlp_dims *dims, ocp_nlp_res *nlp_r
     }
 
     // check for small step
-    if (opts->tol_min_step_norm > 0.0 && (n_iter > 0) && (mem->step_norm < opts->tol_min_step_norm))
+    if (nlp_opts->tol_min_step_norm > 0.0 && (n_iter > 0) && (mem->step_norm < nlp_opts->tol_min_step_norm))
     {
-        if (opts->nlp_opts->print_level > 0)
+        if (nlp_opts->print_level > 0)
         {
-            if (nlp_res->inf_norm_res_eq < opts->tol_eq && nlp_res->inf_norm_res_ineq < opts->tol_ineq)
+            if (nlp_res->inf_norm_res_eq < nlp_opts->tol_eq && nlp_res->inf_norm_res_ineq < nlp_opts->tol_ineq)
             {
                 printf("Stopped: Converged to feasible point. Step size is < tol_eq.\n");
             }
@@ -475,10 +409,10 @@ static bool check_termination(int n_iter, ocp_nlp_dims *dims, ocp_nlp_res *nlp_r
     }
 
     // check for unbounded problem
-    if (mem->nlp_mem->cost_value <= opts->tol_unbounded)
+    if (mem->nlp_mem->cost_value <= nlp_opts->tol_unbounded)
     {
         mem->nlp_mem->status = ACADOS_UNBOUNDED;
-        if (opts->nlp_opts->print_level > 0)
+        if (nlp_opts->print_level > 0)
         {
             printf("Stopped: Problem seems to be unbounded.\n");
         }
@@ -486,10 +420,10 @@ static bool check_termination(int n_iter, ocp_nlp_dims *dims, ocp_nlp_res *nlp_r
     }
 
     // check for maximum iterations
-    if (n_iter >= opts->nlp_opts->max_iter)
+    if (n_iter >= nlp_opts->max_iter)
     {
         mem->nlp_mem->status = ACADOS_MAXITER;
-        if (opts->nlp_opts->print_level > 0)
+        if (nlp_opts->print_level > 0)
         {
             printf("Stopped: Maximum iterations reached.\n");
         }
@@ -601,7 +535,7 @@ int ocp_nlp_sqp(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
         // We always evaluate the residuals until the last iteration
         // If the option "eval_residual_at_max_iter" is set, we also
         // evaluate the residuals after the last iteration.
-        if (nlp_mem->iter != opts->nlp_opts->max_iter || opts->eval_residual_at_max_iter)
+        if (nlp_mem->iter != opts->nlp_opts->max_iter || nlp_opts->eval_residual_at_max_iter)
         {
             // store current iterate
             if (nlp_opts->store_iterates)
@@ -717,13 +651,13 @@ int ocp_nlp_sqp(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
         // warm start of first QP
         if (nlp_mem->iter == 0)
         {
-            if (!opts->warm_start_first_qp)
+            if (!nlp_opts->warm_start_first_qp)
             {
                 // (typically) no warm start at first iteration
                 int tmp_int = 0;
                 qp_solver->opts_set(qp_solver, nlp_opts->qp_solver_opts, "warm_start", &tmp_int);
             }
-            else if (opts->warm_start_first_qp_from_nlp)
+            else if (nlp_opts->warm_start_first_qp_from_nlp)
             {
                 int tmp_bool = true;
                 qp_solver->opts_set(qp_solver, nlp_opts->qp_solver_opts, "initialize_next_xcond_qp_from_qp_out", &tmp_bool);
@@ -818,7 +752,7 @@ int ocp_nlp_sqp(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
         }
 
         // Compute the step norm
-        if (opts->tol_min_step_norm > 0.0 || nlp_opts->log_primal_step_norm || nlp_opts->print_level > 0)
+        if (nlp_opts->tol_min_step_norm > 0.0 || nlp_opts->log_primal_step_norm || nlp_opts->print_level > 0)
         {
             mem->step_norm = ocp_qp_out_compute_primal_nrm_inf(qp_out);
             if (nlp_opts->log_primal_step_norm)

--- a/acados/ocp_nlp/ocp_nlp_sqp.h
+++ b/acados/ocp_nlp/ocp_nlp_sqp.h
@@ -56,16 +56,7 @@ extern "C" {
 typedef struct
 {
     ocp_nlp_opts *nlp_opts;
-    double tol_stat;     // exit tolerance on stationarity condition
-    double tol_eq;       // exit tolerance on equality constraints
-    double tol_ineq;     // exit tolerance on inequality constraints
-    double tol_comp;     // exit tolerance on complementarity condition
-    double tol_unbounded; // exit threshold when objective function seems to be unbounded
-    double tol_min_step_norm; // exit tolerance for small step
     int log_primal_step_norm; // compute and log the max norm of the primal steps
-    bool warm_start_first_qp; // to set qp_warm_start in first iteration
-    bool warm_start_first_qp_from_nlp;  // if True first QP will be initialized using values from NLP iterate, otherwise from previous QP solution.
-    bool eval_residual_at_max_iter; // if convergence should be checked after last iterations or only throw max_iter reached
     double timeout_max_time; // maximum time the solve may require before timeout is triggered. No timeout if 0.
     ocp_nlp_timeout_heuristic_t timeout_heuristic; // type of heuristic used to predict solve time of next QP
 } ocp_nlp_sqp_opts;

--- a/acados/ocp_nlp/ocp_nlp_sqp_rti.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp_rti.c
@@ -113,8 +113,7 @@ void ocp_nlp_sqp_rti_opts_initialize_default(void *config_,
     ocp_nlp_opts_initialize_default(config, dims, nlp_opts);
 
     // SQP RTI opts
-    opts->warm_start_first_qp = false;
-    opts->warm_start_first_qp_from_nlp = true;
+    opts->nlp_opts->warm_start_first_qp_from_nlp = true;
     opts->rti_phase = 0;
     opts->as_rti_level = STANDARD_RTI;
     opts->as_rti_advancement_strategy = SIMULATE_ADVANCE;
@@ -160,12 +159,7 @@ void ocp_nlp_sqp_rti_opts_set(void *config_, void *opts_,
     }
     else // nlp opts
     {
-        if (!strcmp(field, "warm_start_first_qp"))
-        {
-            bool* warm_start_first_qp = (bool *) value;
-            opts->warm_start_first_qp = *warm_start_first_qp;
-        }
-        else if (!strcmp(field, "rti_phase"))
+        if (!strcmp(field, "rti_phase"))
         {
             int* rti_phase = (int *) value;
             if (*rti_phase < 0 || *rti_phase > 2)
@@ -190,11 +184,6 @@ void ocp_nlp_sqp_rti_opts_set(void *config_, void *opts_,
         {
             int* rti_log_only_available_residuals = (int *) value;
             opts->rti_log_only_available_residuals = *rti_log_only_available_residuals;
-        }
-        else if (!strcmp(field, "warm_start_first_qp_from_nlp"))
-        {
-            bool* warm_start_first_qp_from_nlp = (bool *) value;
-            opts->warm_start_first_qp_from_nlp = *warm_start_first_qp_from_nlp;
         }
         else if (!strcmp(field, "as_rti_level"))
         {
@@ -571,13 +560,13 @@ static void ocp_nlp_sqp_rti_feedback_step(ocp_nlp_config *config, ocp_nlp_dims *
     // set QP warm start
     if (mem->is_first_call)
     {
-        if (!opts->warm_start_first_qp)
+        if (!nlp_opts->warm_start_first_qp)
         {
             int tmp_int = 0;
             config->qp_solver->opts_set(config->qp_solver,
                 opts->nlp_opts->qp_solver_opts, "warm_start", &tmp_int);
         }
-        else if (opts->warm_start_first_qp_from_nlp)
+        else if (nlp_opts->warm_start_first_qp_from_nlp)
         {
             int tmp_bool = true;
             config->qp_solver->opts_set(config->qp_solver, nlp_opts->qp_solver_opts, "initialize_next_xcond_qp_from_qp_out", &tmp_bool);

--- a/acados/ocp_nlp/ocp_nlp_sqp_rti.h
+++ b/acados/ocp_nlp/ocp_nlp_sqp_rti.h
@@ -80,8 +80,6 @@ typedef struct
 {
     ocp_nlp_opts *nlp_opts;
     int compute_dual_sol;
-    bool warm_start_first_qp; // to set qp_warm_start in first iteration
-    bool warm_start_first_qp_from_nlp;
     rti_phase_t rti_phase;
     as_rti_level_t as_rti_level;
     as_rti_advancement_strategy_t as_rti_advancement_strategy;

--- a/acados/ocp_nlp/ocp_nlp_sqp_with_feasible_qp.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp_with_feasible_qp.c
@@ -696,7 +696,7 @@ static double calculate_qp_l1_infeasibility_from_slacks(ocp_nlp_dims *dims, ocp_
             l1_inf += fmax(0.0, tmp2);
         }
     }
-    assert(l1_inf > -opts->tol_ineq);
+    assert(l1_inf > -opts->nlp_opts->tol_ineq);
     return l1_inf;
 }
 
@@ -782,7 +782,7 @@ static double calculate_qp_l1_infeasibility_manually(ocp_nlp_dims *dims, ocp_nlp
             }
         }
     }
-    assert(l1_inf > -opts->tol_ineq);
+    assert(l1_inf > -opts->nlp_opts->tol_ineq);
     return l1_inf;
 }
 

--- a/acados/ocp_nlp/ocp_nlp_sqp_with_feasible_qp.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp_with_feasible_qp.c
@@ -103,22 +103,13 @@ void ocp_nlp_sqp_wfqp_opts_initialize_default(void *config_, void *dims_, void *
     ocp_nlp_sqp_wfqp_opts *opts = opts_;
     ocp_nlp_opts *nlp_opts = opts->nlp_opts;
 
-    ocp_qp_xcond_solver_config *qp_solver = config->qp_solver;
-
     // this first !!!
     ocp_nlp_opts_initialize_default(config, dims, nlp_opts);
 
     // SQP opts
     opts->nlp_opts->max_iter = 20;
-    opts->tol_stat = 1e-8;
-    opts->tol_eq   = 1e-8;
-    opts->tol_ineq = 1e-8;
-    opts->tol_comp = 1e-8;
-    opts->tol_unbounded = -1e10;
-    opts->tol_min_step_norm = 1e-12;
 
-    opts->warm_start_first_qp = false;
-    opts->eval_residual_at_max_iter = true;
+    opts->nlp_opts->eval_residual_at_max_iter = true;
     opts->use_QP_l1_inf_from_slacks = false; // if manual calculation used, results seem more accurate and solver performs better!
 
     opts->use_constraint_hessian_in_feas_qp = false;
@@ -128,13 +119,6 @@ void ocp_nlp_sqp_wfqp_opts_initialize_default(void *config_, void *dims_, void *
     opts->feasibility_qp_hessian_scalar = 1e-4;
     opts->log_pi_norm_inf = true;
     opts->log_lam_norm_inf = true;
-
-    // overwrite default submodules opts
-    // qp tolerance
-    qp_solver->opts_set(qp_solver, opts->nlp_opts->qp_solver_opts, "tol_stat", &opts->tol_stat);
-    qp_solver->opts_set(qp_solver, opts->nlp_opts->qp_solver_opts, "tol_eq", &opts->tol_eq);
-    qp_solver->opts_set(qp_solver, opts->nlp_opts->qp_solver_opts, "tol_ineq", &opts->tol_ineq);
-    qp_solver->opts_set(qp_solver, opts->nlp_opts->qp_solver_opts, "tol_comp", &opts->tol_comp);
 
     return;
 }
@@ -185,55 +169,7 @@ void ocp_nlp_sqp_wfqp_opts_set(void *config_, void *opts_, const char *field, vo
     }
     else // nlp opts
     {
-        if (!strcmp(field, "tol_stat"))
-        {
-            double* tol_stat = (double *) value;
-            opts->tol_stat = *tol_stat;
-            // TODO: set accuracy of the qp_solver to the minimum of current QP accuracy and the one specified.
-            config->qp_solver->opts_set(config->qp_solver, opts->nlp_opts->qp_solver_opts, "tol_stat", value);
-        }
-        else if (!strcmp(field, "tol_eq"))
-        {
-            double* tol_eq = (double *) value;
-            opts->tol_eq = *tol_eq;
-            // TODO: set accuracy of the qp_solver to the minimum of current QP accuracy and the one specified.
-            config->qp_solver->opts_set(config->qp_solver, opts->nlp_opts->qp_solver_opts, "tol_eq", value);
-        }
-        else if (!strcmp(field, "tol_ineq"))
-        {
-            double* tol_ineq = (double *) value;
-            opts->tol_ineq = *tol_ineq;
-            // TODO: set accuracy of the qp_solver to the minimum of current QP accuracy and the one specified.
-            config->qp_solver->opts_set(config->qp_solver, opts->nlp_opts->qp_solver_opts, "tol_ineq", value);
-        }
-        else if (!strcmp(field, "tol_comp"))
-        {
-            double* tol_comp = (double *) value;
-            opts->tol_comp = *tol_comp;
-            // TODO: set accuracy of the qp_solver to the minimum of current QP accuracy and the one specified.
-            config->qp_solver->opts_set(config->qp_solver, opts->nlp_opts->qp_solver_opts, "tol_comp", value);
-        }
-        else if (!strcmp(field, "tol_min_step_norm"))
-        {
-            double* tol_min_step_norm = (double *) value;
-            opts->tol_min_step_norm = *tol_min_step_norm;
-        }
-        else if (!strcmp(field, "warm_start_first_qp"))
-        {
-            bool* warm_start_first_qp = (bool *) value;
-            opts->warm_start_first_qp = *warm_start_first_qp;
-        }
-        else if (!strcmp(field, "warm_start_first_qp_from_nlp"))
-        {
-            bool* warm_start_first_qp_from_nlp = (bool *) value;
-            opts->warm_start_first_qp_from_nlp = *warm_start_first_qp_from_nlp;
-        }
-        else if (!strcmp(field, "eval_residual_at_max_iter"))
-        {
-            bool* eval_residual_at_max_iter = (bool *) value;
-            opts->eval_residual_at_max_iter = *eval_residual_at_max_iter;
-        }
-        else if (!strcmp(field, "use_constraint_hessian_in_feas_qp"))
+        if (!strcmp(field, "use_constraint_hessian_in_feas_qp"))
         {
             bool* use_constraint_hessian_in_feas_qp = (bool *) value;
             opts->use_constraint_hessian_in_feas_qp = *use_constraint_hessian_in_feas_qp;
@@ -570,12 +506,14 @@ void ocp_nlp_sqp_wfqp_work_get(void *config_, void *dims_, void *work_,
 
 static bool check_termination(int n_iter, ocp_nlp_dims *dims, ocp_nlp_res *nlp_res, ocp_nlp_sqp_wfqp_memory *mem, ocp_nlp_sqp_wfqp_opts *opts)
 {
+    ocp_nlp_opts *nlp_opts = opts->nlp_opts;
+
     // check for nans
     if (isnan(nlp_res->inf_norm_res_stat) || isnan(nlp_res->inf_norm_res_eq) ||
         isnan(nlp_res->inf_norm_res_ineq) || isnan(nlp_res->inf_norm_res_comp))
     {
         mem->nlp_mem->status = ACADOS_NAN_DETECTED;
-        if (opts->nlp_opts->print_level > 0)
+        if (nlp_opts->print_level > 0)
         {
             printf("Stopped: NaN detected in iterate.\n");
         }
@@ -583,10 +521,10 @@ static bool check_termination(int n_iter, ocp_nlp_dims *dims, ocp_nlp_res *nlp_r
     }
 
     // check for maximum iterations
-    if (!opts->eval_residual_at_max_iter && n_iter >= opts->nlp_opts->max_iter)
+    if (!nlp_opts->eval_residual_at_max_iter && n_iter >= nlp_opts->max_iter)
     {
         mem->nlp_mem->status = ACADOS_MAXITER;
-        if (opts->nlp_opts->print_level > 0)
+        if (nlp_opts->print_level > 0)
         {
             printf("Stopped: Maximum iterations Reached.\n");
         }
@@ -594,13 +532,13 @@ static bool check_termination(int n_iter, ocp_nlp_dims *dims, ocp_nlp_res *nlp_r
     }
 
     // check if solved to tolerance
-    if ((nlp_res->inf_norm_res_stat < opts->tol_stat) &&
-        (nlp_res->inf_norm_res_eq < opts->tol_eq) &&
-        (nlp_res->inf_norm_res_ineq < opts->tol_ineq) &&
-        (nlp_res->inf_norm_res_comp < opts->tol_comp))
+    if ((nlp_res->inf_norm_res_stat < nlp_opts->tol_stat) &&
+        (nlp_res->inf_norm_res_eq < nlp_opts->tol_eq) &&
+        (nlp_res->inf_norm_res_ineq < nlp_opts->tol_ineq) &&
+        (nlp_res->inf_norm_res_comp < nlp_opts->tol_comp))
     {
         mem->nlp_mem->status = ACADOS_SUCCESS;
-        if (opts->nlp_opts->print_level > 0)
+        if (nlp_opts->print_level > 0)
         {
             printf("Optimal solution found! Converged to KKT point.\n");
         }
@@ -608,11 +546,11 @@ static bool check_termination(int n_iter, ocp_nlp_dims *dims, ocp_nlp_res *nlp_r
     }
 
     // check for small step
-    if (opts->tol_min_step_norm > 0.0 && (n_iter > 0) && (mem->step_norm < opts->tol_min_step_norm))
+    if (nlp_opts->tol_min_step_norm > 0.0 && (n_iter > 0) && (mem->step_norm < nlp_opts->tol_min_step_norm))
     {
-        if (opts->nlp_opts->print_level > 0)
+        if (nlp_opts->print_level > 0)
         {
-            if (nlp_res->inf_norm_res_eq < opts->tol_eq && nlp_res->inf_norm_res_ineq < opts->tol_ineq)
+            if (nlp_res->inf_norm_res_eq < nlp_opts->tol_eq && nlp_res->inf_norm_res_ineq < nlp_opts->tol_ineq)
             {
                 printf("Stopped: Converged to feasible point. Step size is < tol_eq.\n");
             }
@@ -626,10 +564,10 @@ static bool check_termination(int n_iter, ocp_nlp_dims *dims, ocp_nlp_res *nlp_r
     }
 
     // check for unbounded problem
-    if (mem->nlp_mem->cost_value <= opts->tol_unbounded)
+    if (mem->nlp_mem->cost_value <= nlp_opts->tol_unbounded)
     {
         mem->nlp_mem->status = ACADOS_UNBOUNDED;
-        if (opts->nlp_opts->print_level > 0)
+        if (nlp_opts->print_level > 0)
         {
             printf("Stopped: Problem seems to be unbounded.\n");
         }
@@ -637,10 +575,10 @@ static bool check_termination(int n_iter, ocp_nlp_dims *dims, ocp_nlp_res *nlp_r
     }
 
     // check for maximum iterations
-    if (n_iter >= opts->nlp_opts->max_iter)
+    if (n_iter >= nlp_opts->max_iter)
     {
         mem->nlp_mem->status = ACADOS_MAXITER;
-        if (opts->nlp_opts->print_level > 0)
+        if (nlp_opts->print_level > 0)
         {
             printf("Stopped: Maximum iterations reached.\n");
         }
@@ -718,7 +656,7 @@ static double calculate_pred_l1_inf(ocp_nlp_sqp_wfqp_opts* opts, ocp_nlp_sqp_wfq
     }
     else
     {
-        if (mem->l1_infeasibility < fmin(opts->tol_ineq, opts->tol_eq))
+        if (mem->l1_infeasibility < fmin(opts->nlp_opts->tol_ineq, opts->nlp_opts->tol_eq))
         {
             return 0.0;
         }
@@ -728,8 +666,6 @@ static double calculate_pred_l1_inf(ocp_nlp_sqp_wfqp_opts* opts, ocp_nlp_sqp_wfq
         }
     }
 }
-
-
 
 /*
 Calculates the QP l1 infeasibility by summing up the additional slack variables
@@ -860,7 +796,7 @@ static double calculate_qp_l1_infeasibility(ocp_nlp_dims *dims, ocp_nlp_sqp_wfqp
     // this is only possible if directly after a QP was solved
     if (opts->use_QP_l1_inf_from_slacks)
     {
-        // seems to be inaccurate. Results are worse!
+        // Inaccurate if QP solver tolerance is low!
         l1_inf = calculate_qp_l1_infeasibility_from_slacks(dims, mem, opts, qp_out);
     }
     else
@@ -979,13 +915,13 @@ static int prepare_and_solve_QP(ocp_nlp_config* config, ocp_nlp_sqp_wfqp_opts* o
     // warm start of first QP
     if (nlp_mem->iter == 0)
     {
-        if (!opts->warm_start_first_qp)
+        if (!nlp_opts->warm_start_first_qp)
         {
             // (typically) no warm start at first iteration
             int tmp_int = 0;
             qp_solver->opts_set(qp_solver, nlp_opts->qp_solver_opts, "warm_start", &tmp_int);
         }
-        else if (opts->warm_start_first_qp_from_nlp)
+        else if (nlp_opts->warm_start_first_qp_from_nlp)
         {
             int tmp_bool = true;
             qp_solver->opts_set(qp_solver, nlp_opts->qp_solver_opts, "initialize_next_xcond_qp_from_qp_out", &tmp_bool);
@@ -1527,7 +1463,7 @@ static int calculate_search_direction(ocp_nlp_dims *dims,
             mem->pred_l1_inf_QP = calculate_pred_l1_inf(opts, mem, l1_inf_QP_feasibility);
         }
 
-        if (l1_inf_QP_feasibility/(fmax(1.0, (double) mem->absolute_nns)) < opts->tol_ineq)
+        if (l1_inf_QP_feasibility/(fmax(1.0, (double) mem->absolute_nns)) < nlp_opts->tol_ineq)
         {
             mem->watchdog_zero_slacks_counter += 1;
         }
@@ -1627,7 +1563,7 @@ int ocp_nlp_sqp_wfqp(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
         // We always evaluate the residuals until the last iteration
         // If the option "eval_residual_at_max_iter" is set, we also
         // evaluate the residuals after the last iteration.
-        if (nlp_mem->iter != opts->nlp_opts->max_iter || opts->eval_residual_at_max_iter)
+        if (nlp_mem->iter != opts->nlp_opts->max_iter || nlp_opts->eval_residual_at_max_iter)
         {
             // store current iterate
             if (nlp_opts->store_iterates)
@@ -1722,7 +1658,7 @@ int ocp_nlp_sqp_wfqp(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
         }
 
         // Compute the step norm
-        if (opts->tol_min_step_norm > 0.0 || nlp_opts->log_primal_step_norm)
+        if (nlp_opts->tol_min_step_norm > 0.0 || nlp_opts->log_primal_step_norm)
         {
             mem->step_norm = ocp_qp_out_compute_primal_nrm_inf(nominal_qp_out);
             if (nlp_opts->log_primal_step_norm)

--- a/acados/ocp_nlp/ocp_nlp_sqp_with_feasible_qp.h
+++ b/acados/ocp_nlp/ocp_nlp_sqp_with_feasible_qp.h
@@ -54,18 +54,8 @@ extern "C" {
 typedef struct
 {
     ocp_nlp_opts *nlp_opts;
-    double tol_stat;
-    double tol_eq;
-    double tol_ineq;
-    double tol_comp;
-    double tol_unbounded; // exit threshold when objective function seems to be unbounded
-    double tol_min_step_norm; // exit tolerance for small step
     bool log_pi_norm_inf; // compute and log the max norm of the pi multipliers
     bool log_lam_norm_inf; // compute and log the max norm of the lam multipliers
-    bool warm_start_first_qp;
-    bool warm_start_first_qp_from_nlp;
-    bool eval_residual_at_max_iter; // if convergence should be checked after last iterations or only throw max_iter reached
-
     bool use_constraint_hessian_in_feas_qp; // Either use exact Hessian or identity matrix in feasibility QP
     bool use_QP_l1_inf_from_slacks; // True: sums up the slack variable values from qp_out; False: compute manually; Should give the same result.
     int search_direction_mode; // determines how the QPs should be solved


### PR DESCRIPTION
We moved the solution tolerances, `warm_start_qp`-opts, and `eval_residual_at_max_iter` to `ocp_nlp_common`.

This removes redundancy in the code and makes tolerances available in cases where only `ocp_nlp_opts` is available.