### PR TITLE
Bug fix in `ocp_nlp_compute_dual_lam_norm_inf`

### DIFF
--- a/acados/ocp_nlp/ocp_nlp_common.c
+++ b/acados/ocp_nlp/ocp_nlp_common.c
@@ -2599,7 +2599,7 @@ double ocp_nlp_compute_dual_lam_norm_inf(ocp_nlp_dims *dims, ocp_nlp_out *nlp_ou
     double norm_lam = 0.0;
 
     // compute inf norm of lam
-    for (i = 0; i < N; i++)
+    for (i = 0; i <= N; i++)
     {
         for (j=0; j<2*dims->ni[i]; j++)
         {


### PR DESCRIPTION
Bug fix in calculation of inf norm of lam. The for loop should go until N, i.e., `<=N`.