### PR TITLE
Python: solution sensitivity update

### DIFF
--- a/examples/acados_python/solution_sensitivities_convex_example/non_ocp_example.py
+++ b/examples/acados_python/solution_sensitivities_convex_example/non_ocp_example.py
@@ -36,6 +36,10 @@ import matplotlib.pyplot as plt
 latexify_plot()
 
 P_SQUARED = False
+if P_SQUARED:
+    PROBLEM_NAME = "non_ocp_p_squared"
+else:
+    PROBLEM_NAME = "non_ocp_p_linear"
 
 def export_parametric_nlp() -> AcadosOcp:
 
@@ -134,9 +138,9 @@ def main():
         sol_list.append(sol_tau)
 
     plot_solution_sensitivities_results(p_test, sol_list, sens_list, labels_list,
-                 title=None, parameter_name=r"$\theta$", fig_filename="solution_sens_non_ocp.pdf")
+                 title=None, parameter_name=r"$\theta$", fig_filename=f"solution_sens_{PROBLEM_NAME}.pdf")
     plot_solution_sensitivities_results(p_test, sol_list, sens_list, labels_list,
-                 title=None, parameter_name=r"$\theta$", fig_filename="solution_sens_non_ocp_transposed.pdf", horizontal_plot=True)
+                 title=None, parameter_name=r"$\theta$", fig_filename=f"solution_sens_{PROBLEM_NAME}_transposed.pdf", horizontal_plot=True)
 
 def plot_solution_sensitivities_results(p_test, sol_list, sens_list, labels_list, title=None, parameter_name="", fig_filename=None, horizontal_plot=False):
     p_min = p_test[0]

--- a/examples/acados_python/solution_sensitivities_convex_example/non_ocp_example.py
+++ b/examples/acados_python/solution_sensitivities_convex_example/non_ocp_example.py
@@ -87,6 +87,11 @@ def solve_and_compute_sens(p_test, tau):
             # print(f"OCP solver returned status {status} at {i}th p value {p}, {tau=}.")
             # breakpoint()
 
+        status = ocp_solver.setup_qp_matrices_and_factorize()
+        if status != 0:
+            ocp_solver.print_statistics()
+            raise Exception(f"OCP solver returned status {status} in setup_qp_matrices_and_factorize at {i}th p value {p}, {tau=}.")
+
         # Calculate the policy gradient
         out_dict = ocp_solver.eval_solution_sensitivity(0, "p_global", return_sens_x=True, return_sens_u=False)
         sens_x[i] = out_dict['sens_x'].item()

--- a/interfaces/acados_matlab_octave/AcadosOcp.m
+++ b/interfaces/acados_matlab_octave/AcadosOcp.m
@@ -212,6 +212,7 @@ classdef AcadosOcp < handle
             constraints = self.constraints;
             model = self.model;
             if self.solver_options.N_horizon == 0
+                dims.nbxe_0 = 0;
                 return
             end
 

--- a/interfaces/acados_template/acados_template/acados_ocp.py
+++ b/interfaces/acados_template/acados_template/acados_ocp.py
@@ -384,6 +384,7 @@ class AcadosOcp:
         model = self.model
         opts = self.solver_options
         if opts.N_horizon == 0:
+            dims.nbxe_0 = 0
             return
 
         nbx_0 = constraints.idxbx_0.shape[0]

--- a/interfaces/acados_template/acados_template/acados_ocp_options.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_options.py
@@ -853,7 +853,11 @@ class AcadosOcpOptions:
 
     @property
     def reg_epsilon(self):
-        """Epsilon for regularization, used if regularize_method in ['PROJECT', 'MIRROR', 'CONVEXIFY', 'GERSHGORIN_LEVENBERG_MARQUARDT']."""
+        """Epsilon for regularization, used if regularize_method in ['PROJECT', 'MIRROR', 'CONVEXIFY', 'GERSHGORIN_LEVENBERG_MARQUARDT'].
+
+        Type: float.
+        Default: 1e-4.
+        """
         return self.__reg_epsilon
 
     @property
@@ -1496,6 +1500,8 @@ class AcadosOcpOptions:
 
     @reg_epsilon.setter
     def reg_epsilon(self, reg_epsilon):
+        if not isinstance(reg_epsilon, float) or reg_epsilon < 0:
+            raise ValueError(f'Invalid reg_epsilon value, expected float >= 0, got {reg_epsilon}')
         self.__reg_epsilon = reg_epsilon
 
     @reg_max_cond_block.setter

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -627,10 +627,6 @@ class AcadosOcpSolver:
         :param with_respect_to: string in ["initial_state", "initial_control", "p_global"]
         """
 
-        if with_respect_to == "params_global":
-            print("Deprecation warning: 'params_global' is deprecated and has been renamed to 'p_global'.")
-            with_respect_to = "p_global"
-
         if with_respect_to == "initial_state":
             if not self.__has_x0:
                 raise ValueError("OCP does not have an initial state constraint.")
@@ -726,10 +722,6 @@ class AcadosOcpSolver:
         .. note:: Solution sensitivities with respect to parameters are currently implemented assuming the parameter vector p is global within the OCP, i.e. p=p_i with i=0, ..., N.
         .. note:: Solution sensitivities with respect to parameters are currently implemented only for parametric discrete dynamics, parametric external costs and parametric nonlinear constraints (h).
         """
-
-        if with_respect_to == "params_global":
-            print("Deprecation warning: 'params_global' is deprecated and has been renamed to 'p_global'.")
-            with_respect_to = "p_global"
 
         stages_is_list = isinstance(stages, list)
         stages_ = stages if stages_is_list else [stages]

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -482,8 +482,8 @@ class AcadosOcpSolver:
 
         This is only implemented for HPIPM QP solver without condensing.
         """
-        if self.__solver_options["qp_solver"] != 'PARTIAL_CONDENSING_HPIPM':
-            raise NotImplementedError('This function is only implemented for PARTIAL_CONDENSING_HPIPM!')
+        if self.__solver_options["qp_solver"] not in ['PARTIAL_CONDENSING_HPIPM', 'FULL_CONDENSING_HPIPM']:
+            raise NotImplementedError('This function is only implemented for PARTIAL_CONDENSING_HPIPM and FULL_CONDENSING_HPIPM!')
 
         self.status = getattr(self.shared_lib, f"{self.name}_acados_setup_qp_matrices_and_factorize")(self.capsule)
 


### PR DESCRIPTION
-  deprecate string "params_global"
-  example: call `setup_qp_matrices_and_factorize`, add variant without squared parameter
- Interface: `setup_qp_matrices_and_factorize` also works with `FULL_CONDENSING_HPIPM`
- set `dims.nbxe_0 = 0` for `N_horizon = 0` for consistency