### PR TITLE
Python: allow suppressing the note about `OpenMP` in `AcadosOcpBatchSolver`

### DIFF
--- a/interfaces/acados_template/acados_template/acados_ocp_batch_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_batch_solver.py
@@ -115,7 +115,9 @@ class AcadosOcpBatchSolver():
 
         msg += "i.e. with the flags -DACADOS_WITH_OPENMP=ON -DACADOS_NUM_THREADS=1.\n" + \
                    "See https://github.com/acados/acados/pull/1089 for more details."
-        print(msg)
+        
+        if verbose:
+            print(msg)
 
 
     @property


### PR DESCRIPTION
When `Verbose` is set to `False`, to reduce the amount of printing in projects such as `leap-c`