### PR TITLE
Update docstring on `setup_qp_matrices_and_factorize`

### DIFF
--- a/acados/ocp_nlp/ocp_nlp_common.c
+++ b/acados/ocp_nlp/ocp_nlp_common.c
@@ -1253,8 +1253,10 @@ void ocp_nlp_opts_initialize_default(void *config_, void *dims_, void *opts_)
         constraints[i]->opts_initialize_default(constraints[i], dims->constraints[i], opts->constraints[i]);
     }
 
+    // solution sens
     opts->with_solution_sens_wrt_params = 0;
     opts->with_value_sens_wrt_params = 0;
+    opts->solution_sens_qp_t_lam_min = 1e-9;
 
     // adaptive Levenberg-Marquardt options
     opts->adaptive_levenberg_marquardt_mu_min = 1e-16;

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -478,7 +478,7 @@ class AcadosOcpSolver:
         The t and lambda values are clipped according to `solution_sens_qp_t_lam_min` to avoid ill-conditioning.
         Then the Hessian matrix is factorized.
 
-        If a two-solver approach is used to obtain solution sensitivities from acados, this function should be called before calling `eval_solution_sensitivity`, or `eval_adjoint_solution_sensitivity()`.
+        To obtain accurate solution sensitivities from acados, this function should be called before calling `eval_solution_sensitivity`, or `eval_adjoint_solution_sensitivity()`.
 
         This is only implemented for HPIPM QP solver without condensing.
         """


### PR DESCRIPTION
-`setup_qp_matrices_and_factorize` is needed regardless of two-solver approach. Otherwise the Hessian factorization corresponds to the one of the last second QP iterate, instead of the last one. This can be quite inaccurate, see the examples in #1578 
- Additionally: initialize option in C