### PR TITLE
Major bug fix in `FUNNEL_L1PEN_LINESEARCH`

### DIFF
--- a/acados/ocp_nlp/ocp_nlp_globalization_funnel.c
+++ b/acados/ocp_nlp/ocp_nlp_globalization_funnel.c
@@ -307,7 +307,6 @@ bool is_switching_condition_satisfied(ocp_nlp_globalization_funnel_opts *opts, d
 bool is_armijo_condition_satisfied(ocp_nlp_globalization_opts *globalization_opts,
                                     double ared, double pred, double alpha)
 {
-    // if (-ared <= MIN(-globalization_opts->eps_sufficient_descent * alpha * MAX(pred, 0) + 1e-18, 0))
     if (ared >= globalization_opts->eps_sufficient_descent * alpha * MAX(0.0, pred-1e-9))
     {
         return true;

--- a/acados/ocp_nlp/ocp_nlp_globalization_funnel.c
+++ b/acados/ocp_nlp/ocp_nlp_globalization_funnel.c
@@ -292,8 +292,6 @@ bool is_funnel_sufficient_decrease_satisfied(ocp_nlp_globalization_funnel_memory
 
 bool is_switching_condition_satisfied(ocp_nlp_globalization_funnel_opts *opts, double pred_optimality, double step_size, double pred_infeasibility)
 {
-    // if (step_size * pred_optimality >= opts->fraction_switching_condition * pred_infeasibility)
-    // if (step_size * pred_optimality >= opts->fraction_switching_condition * pred_infeasibility * pred_infeasibility)
     if (step_size * pred_optimality >= opts->fraction_switching_condition * pred_infeasibility)
     {
         return true;

--- a/acados/ocp_nlp/ocp_nlp_globalization_funnel.c
+++ b/acados/ocp_nlp/ocp_nlp_globalization_funnel.c
@@ -365,7 +365,6 @@ bool is_trial_iterate_acceptable_to_funnel(ocp_nlp_globalization_funnel_memory *
                 {
                     print_debug_output("f-type step: Armijo condition NOT satisfied\n", nlp_opts->print_level, 1);
                 }
-
             }
             else if (is_funnel_sufficient_decrease_satisfied(mem, opts, trial_infeasibility))
             {
@@ -379,7 +378,7 @@ bool is_trial_iterate_acceptable_to_funnel(ocp_nlp_globalization_funnel_memory *
             {
                 print_debug_output("Switching condition is NOT satisfied!\n", nlp_opts->print_level, 1);
                 print_debug_output("Entered penalty check!\n", nlp_opts->print_level, 1);
-                if (is_armijo_condition_satisfied(globalization_opts, current_merit-trial_merit, pred_merit, alpha))
+                if (trial_infeasibility < current_infeasibility && is_armijo_condition_satisfied(globalization_opts, current_merit-trial_merit, pred_merit, alpha))
                 {
                     print_debug_output("Penalty Function accepted\n", nlp_opts->print_level, 1);
                     accept_step = true;

--- a/acados/ocp_nlp/ocp_nlp_globalization_funnel.h
+++ b/acados/ocp_nlp/ocp_nlp_globalization_funnel.h
@@ -119,10 +119,8 @@ bool is_funnel_sufficient_decrease_satisfied(ocp_nlp_globalization_funnel_memory
 //
 bool is_switching_condition_satisfied(ocp_nlp_globalization_funnel_opts *opts, double pred_optimality, double step_size, double pred_infeasibility);
 //
-bool is_f_type_armijo_condition_satisfied(ocp_nlp_globalization_opts *globalization_opts,
-                                        double negative_ared,
-                                        double pred,
-                                        double alpha);
+bool is_armijo_condition_satisfied(ocp_nlp_globalization_opts *globalization_opts,
+                                    double ared, double pred, double alpha);
 //
 bool is_trial_iterate_acceptable_to_funnel(ocp_nlp_globalization_funnel_memory *mem,
                                             ocp_nlp_opts *nlp_opts,

--- a/acados/ocp_nlp/ocp_nlp_globalization_funnel.h
+++ b/acados/ocp_nlp/ocp_nlp_globalization_funnel.h
@@ -126,7 +126,9 @@ bool is_f_type_armijo_condition_satisfied(ocp_nlp_globalization_opts *globalizat
 //
 bool is_trial_iterate_acceptable_to_funnel(ocp_nlp_globalization_funnel_memory *mem,
                                             ocp_nlp_opts *nlp_opts,
-                                            double pred, double ared, double alpha,
+                                            double pred_optimality,
+                                            double ared_optimality,
+                                            double alpha,
                                             double current_infeasibility,
                                             double trial_infeasibility,
                                             double current_objective,


### PR DESCRIPTION
The Armijo condition was wrong for the `f`-type steps and also for the `p`-type steps. This was corrected by introducing a funtion that checks the Armijo condition and which can be used either for `f`- or `p`-type steps.