### PR TITLE
MATLAB: add solver status checks to `getting_started` examples

### DIFF
--- a/examples/acados_matlab_octave/getting_started/extensive_example_ocp.m
+++ b/examples/acados_matlab_octave/getting_started/extensive_example_ocp.m
@@ -234,6 +234,7 @@ for i=1:n_executions
 
     % evaluation
     status = ocp_solver.get('status');
+    assert(status == 0, sprintf('solver failed with status %d', status))
     sqp_iter = ocp_solver.get('sqp_iter');
     time_tot(i) = ocp_solver.get('time_tot');
     time_lin(i) = ocp_solver.get('time_lin');

--- a/examples/acados_matlab_octave/getting_started/minimal_example_closed_loop.m
+++ b/examples/acados_matlab_octave/getting_started/minimal_example_closed_loop.m
@@ -59,6 +59,7 @@ ocp.solver_options.qp_solver = 'PARTIAL_CONDENSING_HPIPM';
 % FULL_CONDENSING_QPOASES, PARTIAL_CONDENSING_OSQP
 ocp.solver_options.qp_solver_cond_N = 5; % for partial condensing
 ocp.solver_options.globalization = 'MERIT_BACKTRACKING'; % turns on globalization
+ocp.solver_options.nlp_solver_max_iter = 200;
 
 % we add some model-plant mismatch by choosing different integration
 % methods for model (within the OCP) and plant:
@@ -184,6 +185,7 @@ for i=1:N_sim
     % get solution
     u0 = ocp_solver.get('u', 0);
     status = ocp_solver.get('status'); % 0 - success
+    assert(status == 0, sprintf('solver failed with status %d', status))
 
     % simulate one step
     x_sim(:,i+1) = sim_solver.simulate(x0, u0);

--- a/examples/acados_matlab_octave/getting_started/minimal_example_ocp.m
+++ b/examples/acados_matlab_octave/getting_started/minimal_example_ocp.m
@@ -131,6 +131,7 @@ utraj = ocp_solver.get('u');
 xtraj = ocp_solver.get('x');
 
 status = ocp_solver.get('status'); % 0 - success
+assert(status == 0, sprintf('solver failed with status %d', status))
 ocp_solver.print('stat')
 
 %% plots

--- a/interfaces/acados_matlab_octave/detect_constraint_structure.m
+++ b/interfaces/acados_matlab_octave/detect_constraint_structure.m
@@ -50,7 +50,7 @@ function model = detect_constraint_structure(model, constraints, stage_type)
     if isa(x, 'casadi.SX')
         isSX = true;
     else
-        error('constraint detection only works for casadi.SX!');
+        error('Constraint detection only works for casadi.SX!');
     end
 
     if strcmp(stage_type, 'initial')
@@ -79,7 +79,7 @@ function model = detect_constraint_structure(model, constraints, stage_type)
     if ~(isa(expr_constr, 'casadi.SX') || isa(expr_constr, 'casadi.MX'))
         disp('expr_constr =')
         disp(expr_constr)
-        error("Constraint type detection require definition of constraints as CasADi SX or MX.")
+        error("Constraint type detection requires definition of constraints as CasADi SX or MX.")
     end
 
     % initialize
@@ -108,8 +108,9 @@ function model = detect_constraint_structure(model, constraints, stage_type)
             constr_expr_h = vertcat(constr_expr_h, c);
             lh = [ lh; LB(ii)];
             uh = [ uh; UB(ii)];
-            disp(['constraint ', num2str(ii), ' is kept as nonlinear constraint.']);
-            disp(c);
+            disp(['Constraint ', num2str(ii), ' is kept as a nonlinear constraint.']);
+            disp('Constraint expression: ');
+            disp(c)
             disp(' ')
         else % c is linear in x and u
             Jc_fun = Function('Jc_fun', {x(1)}, {jacobian(c, [x;u])});
@@ -124,9 +125,10 @@ function model = detect_constraint_structure(model, constraints, stage_type)
                     Jbx(end, idb) = 1;
                     lbx = [lbx; LB(ii)/Jc(idb)];
                     ubx = [ubx; UB(ii)/Jc(idb)];
-                    disp(['constraint ', num2str(ii),...
-                          ' is reformulated as bound on x.']);
-                    disp(c);
+                    disp(['Constraint ', num2str(ii),...
+                          ' is reformulated as a bound on x.']);
+                    disp('Constraint expression: ');
+                    disp(c)
                     disp(' ')
                 else
                     % bound on u;
@@ -134,9 +136,10 @@ function model = detect_constraint_structure(model, constraints, stage_type)
                     Jbu(end, idb-nx) = 1;
                     lbu = [lbu; LB(ii)/Jc(idb)];
                     ubu = [ubu; UB(ii)/Jc(idb)];
-                    disp(['constraint ', num2str(ii),...
-                          ' is reformulated as bound on u.']);
-                    disp(c);
+                    disp(['Constraint ', num2str(ii),...
+                          ' is reformulated as a bound on u.']);
+                    disp('Constraint expression: ');
+                    disp(c)
                     disp(' ')
                 end
             else
@@ -145,9 +148,10 @@ function model = detect_constraint_structure(model, constraints, stage_type)
                 D = [D; Jc(nx+1:end)];
                 lg = [ lg; LB(ii)];
                 ug = [ ug; UB(ii)];
-                disp(['constraint ', num2str(ii),...
-                      ' is reformulated as general linear constraint.']);
-                disp(c);
+                disp(['Constraint ', num2str(ii),...
+                      ' is reformulated as a general linear constraint.']);
+                disp('Constraint expression: ');
+                disp(c)
                 disp(' ')
             end
         end
@@ -157,7 +161,7 @@ function model = detect_constraint_structure(model, constraints, stage_type)
     if strcmp(stage_type, 'terminal')
         % checks
         if any(expr_constr.which_depends(u)) || ~isempty(lbu) || (~isempty(D) && any(D))
-            error('terminal constraint may not depend on control input.');
+            error('Terminal constraint may not depend on control input.');
         end
         % h
         constraints.constr_type_e = 'BGH';


### PR DESCRIPTION
The closed-loop example was returning non-zero status (`ACADOS_MAXITER`) so I changed the solver settings.
Also made the printing in `detect_constraint_structure` slightly more understandable.