### PR TITLE
Added `qp_out` as function input to `config->step_update`

### DIFF
--- a/acados/ocp_nlp/ocp_nlp_common.h
+++ b/acados/ocp_nlp/ocp_nlp_common.h
@@ -99,7 +99,7 @@ typedef struct ocp_nlp_config
                         void *opts_, void *mem_, void *work_, void *sens_nlp_out,
                         const char *field, int stage, void *grad_p);
     void (*step_update)(void *config, void *dims, void *in,
-            void *out_start, void *opts, void *mem, void *work,
+            void *out_start, void *qp_out, void *opts, void *mem, void *work,
             void *out_destination, void* solver_mem, double alpha, bool full_step_dual);
     // prepare memory
     int (*precompute)(void *config, void *dims, void *nlp_in, void *nlp_out, void *opts_, void *mem, void *work);
@@ -580,7 +580,7 @@ void ocp_nlp_level_c_update(ocp_nlp_config *config,
     ocp_nlp_memory *mem, ocp_nlp_workspace *work);
 //
 void ocp_nlp_update_variables_sqp(void *config_, void *dims_,
-            void *in_, void *out_, void *opts_, void *mem_, void *work_,
+            void *in_, void *out_, void *qp_out_, void *opts_, void *mem_, void *work_,
             void *out_destination_, void *solver_mem, double alpha, bool full_step_dual);
 //
 void ocp_nlp_convert_primaldelta_absdual_step_to_delta_step(ocp_nlp_config *config, ocp_nlp_dims *dims,

--- a/acados/ocp_nlp/ocp_nlp_ddp.h
+++ b/acados/ocp_nlp/ocp_nlp_ddp.h
@@ -143,7 +143,7 @@ void ocp_nlp_ddp_eval_lagr_grad_p(void *config_, void *dims_, void *nlp_in_, voi
 void ocp_nlp_ddp_get(void *config_, void *dims_, void *mem_, const char *field, void *return_value_);
 //
 void ocp_nlp_ddp_compute_trial_iterate(void *config_, void *dims_,
-            void *in_, void *out_, void *opts_, void *mem_,
+            void *in_, void *out_, void *qp_out_, void *opts_, void *mem_,
             void *work_, void *out_destination_, void *solver_mem,
             double alpha, bool full_step_dual);
 

--- a/acados/ocp_nlp/ocp_nlp_globalization_fixed_step.c
+++ b/acados/ocp_nlp/ocp_nlp_globalization_fixed_step.c
@@ -210,7 +210,7 @@ int ocp_nlp_globalization_fixed_step_find_acceptable_iterate(void *nlp_config_, 
     }
     else
     {
-        config->step_update(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work, nlp_out, solver_mem, alpha, opts->globalization_opts->full_step_dual);
+        config->step_update(config, dims, nlp_in, nlp_out, qp_out, nlp_opts, nlp_mem, nlp_work, nlp_out, solver_mem, alpha, opts->globalization_opts->full_step_dual);
     }
     *step_size = alpha;
 

--- a/acados/ocp_nlp/ocp_nlp_globalization_funnel.c
+++ b/acados/ocp_nlp/ocp_nlp_globalization_funnel.c
@@ -341,11 +341,6 @@ bool is_trial_iterate_acceptable_to_funnel(ocp_nlp_globalization_funnel_memory *
     print_debug_output_double("predicted_reduction_infeasibility", predicted_reduction_infeasibility, nlp_opts->print_level, 2);
     print_debug_output_double("predicted_reduction_merit", predicted_reduction_merit, nlp_opts->print_level, 2);
 
-    if (alpha < 1.0 && trial_infeasibility > current_infeasibility)
-    {
-        printf("IPOPT would trigger SOC!\n");
-    }
-
     if (opts->use_merit_fun_only) // We only check the penalty method but not the funnel!
     {
         mem->funnel_penalty_mode = true;

--- a/acados/ocp_nlp/ocp_nlp_globalization_funnel.c
+++ b/acados/ocp_nlp/ocp_nlp_globalization_funnel.c
@@ -453,8 +453,8 @@ int backtracking_line_search(ocp_nlp_config *config,
     while (true)
     {
         // Calculate trial iterate: trial_iterate = current_iterate + alpha * direction
-        config->step_update(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem,
-                                     nlp_work, nlp_work->tmp_nlp_out, solver_mem, alpha, globalization_opts->full_step_dual);
+        config->step_update(config, dims, nlp_in, nlp_out, nlp_mem->qp_out, nlp_opts, nlp_mem,
+                            nlp_work, nlp_work->tmp_nlp_out, solver_mem, alpha, globalization_opts->full_step_dual);
 
         ///////////////////////////////////////////////////////////////////////
         // Evaluate cost function at trial iterate

--- a/acados/ocp_nlp/ocp_nlp_globalization_merit_backtracking.c
+++ b/acados/ocp_nlp/ocp_nlp_globalization_merit_backtracking.c
@@ -773,8 +773,8 @@ static int ocp_nlp_ddp_backtracking_line_search(ocp_nlp_config *config, ocp_nlp_
     while (true)
     {
         // Do the DDP forward sweep to get the trial iterate
-        config->step_update(config, dims, nlp_in, nlp_out, nlp_opts, nlp_mem,
-                                     nlp_work, nlp_work->tmp_nlp_out, solver_mem, alpha, globalization_opts->full_step_dual);
+        config->step_update(config, dims, nlp_in, nlp_out, nlp_mem->qp_out, nlp_opts, nlp_mem,
+                            nlp_work, nlp_work->tmp_nlp_out, solver_mem, alpha, globalization_opts->full_step_dual);
 
         ///////////////////////////////////////////////////////////////////////
         // Evaluate cost function at trial iterate
@@ -890,7 +890,7 @@ int ocp_nlp_globalization_merit_backtracking_find_acceptable_iterate(void *nlp_c
     }
 
     // update variables
-    nlp_config->step_update(nlp_config, nlp_dims, nlp_in, nlp_out, nlp_opts, nlp_mem, nlp_work, nlp_out, solver_mem, mem->alpha, globalization_opts->full_step_dual);
+    nlp_config->step_update(nlp_config, nlp_dims, nlp_in, nlp_out, nlp_mem->qp_out, nlp_opts, nlp_mem, nlp_work, nlp_out, solver_mem, mem->alpha, globalization_opts->full_step_dual);
     *step_size = mem->alpha;
     return ACADOS_SUCCESS;
 }


### PR DESCRIPTION
The `config->step_update` takes `qp_out` as input such that it is more modular. This enables Second-Order Corrections to use the same function for a step update while using different data structures to store the data.