### PR TITLE
Change of default `globalization_alpha_reduction` factor

### DIFF
--- a/interfaces/acados_matlab_octave/AcadosOcp.m
+++ b/interfaces/acados_matlab_octave/AcadosOcp.m
@@ -1019,15 +1019,6 @@ classdef AcadosOcp < handle
                 end
             end
 
-            if isempty(opts.globalization_alpha_reduction)
-                % if strcmp(opts.globalization, 'FUNNEL_L1PEN_LINESEARCH')
-                if ddp_with_merit_or_funnel
-                    opts.globalization_alpha_reduction = 0.5;
-                else
-                    opts.globalization_alpha_reduction = 0.7;
-                end
-            end
-
             if isempty(opts.globalization_eps_sufficient_descent)
                 % if strcmp(opts.globalization, 'FUNNEL_L1PEN_LINESEARCH')
                 if ddp_with_merit_or_funnel
@@ -1090,15 +1081,6 @@ classdef AcadosOcp < handle
                     opts.globalization_alpha_min = 1e-17;
                 else
                     opts.globalization_alpha_min = 0.05;
-                end
-            end
-
-            if isempty(opts.globalization_alpha_reduction)
-                % if strcmp(opts.globalization, 'FUNNEL_L1PEN_LINESEARCH')
-                if ddp_with_merit_or_funnel
-                    opts.globalization_alpha_reduction = 0.5;
-                else
-                    opts.globalization_alpha_reduction = 0.7;
                 end
             end
 

--- a/interfaces/acados_matlab_octave/AcadosOcpOptions.m
+++ b/interfaces/acados_matlab_octave/AcadosOcpOptions.m
@@ -210,7 +210,7 @@ classdef AcadosOcpOptions < handle
             obj.fixed_hess = 0;
             obj.ext_cost_num_hess = 0;
             obj.globalization_alpha_min = [];
-            obj.globalization_alpha_reduction = [];
+            obj.globalization_alpha_reduction = 0.7;
             obj.globalization_line_search_use_sufficient_descent = 0;
             obj.globalization_use_SOC = 0;
             obj.globalization_full_step_dual = [];

--- a/interfaces/acados_template/acados_template/acados_ocp.py
+++ b/interfaces/acados_template/acados_template/acados_ocp.py
@@ -1047,12 +1047,6 @@ class AcadosOcp:
             else:
                 opts.globalization_alpha_min = 0.05
 
-        if opts.globalization_alpha_reduction is None:
-            if ddp_with_merit_or_funnel:
-                opts.globalization_alpha_reduction = 0.5
-            else:
-                opts.globalization_alpha_reduction = 0.7
-
         if opts.globalization_eps_sufficient_descent is None:
             if ddp_with_merit_or_funnel:
                 opts.globalization_eps_sufficient_descent = 1e-6

--- a/interfaces/acados_template/acados_template/acados_ocp_options.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_options.py
@@ -115,7 +115,7 @@ class AcadosOcpOptions:
         self.__ext_cost_num_hess = 0
         self.__globalization_use_SOC = 0
         self.__globalization_alpha_min = None
-        self.__globalization_alpha_reduction = None
+        self.__globalization_alpha_reduction = 0.7
         self.__globalization_line_search_use_sufficient_descent = 0
         self.__globalization_full_step_dual = None
         self.__globalization_eps_sufficient_descent = None
@@ -893,15 +893,11 @@ class AcadosOcpOptions:
 
     @property
     def globalization_alpha_reduction(self):
-        """Step size reduction factor for globalization MERIT_BACKTRACKING,
+        """Step size reduction factor for globalization MERIT_BACKTRACKING and
+        FUNNEL_L1PEN_LINESEARCH
 
         Type: float
-        Default: None.
-
-        If None is given:
-        - in case of FUNNEL_L1PEN_LINESEARCH, value is set to 0.5.
-        - in case of MERIT_BACKTRACKING, value is set to 0.7.
-        default: 0.7.
+        Default: 0.7.
         """
         return self.__globalization_alpha_reduction
 


### PR DESCRIPTION
The default alpha reduction factor was changed. The `FUNNEL_L1PEN_LINESEARCH` method used `0.5` and the `MERIT_BACKTRACKING` used `0.7`. Now both methods use `0.7` and it works very well for the funnel.