### PR TITLE
`Python`: Fix compatibility `translate_to_feasibility_problem` and `AcadosCasadiOcpSolver`

### DIFF
--- a/interfaces/acados_template/acados_template/acados_ocp.py
+++ b/interfaces/acados_template/acados_template/acados_ocp.py
@@ -1898,10 +1898,10 @@ class AcadosOcp:
             for i in range(casadi_length(constr_expr)):
                 self.formulate_constraint_as_L2_penalty(constr_expr[i], weight=1.0, upper_bound=upper_bound[i], lower_bound=lower_bound[i])
 
-        model.con_h_expr = None
-        model.con_phi_expr = None
-        model.con_r_expr = None
-        model.con_r_in_phi = None
+        model.con_h_expr = []
+        model.con_phi_expr = []
+        model.con_r_expr = []
+        model.con_r_in_phi = []
 
         # formulate **terminal** constraints as L2 penalties
         expr_bound_list_e = [
@@ -1918,10 +1918,10 @@ class AcadosOcp:
             for i in range(casadi_length(constr_expr)):
                 self.formulate_constraint_as_L2_penalty(constr_expr[i], weight=1.0, upper_bound=upper_bound[i], lower_bound=lower_bound[i], constraint_type="terminal")
 
-        model.con_h_expr_e = None
-        model.con_phi_expr_e = None
-        model.con_r_expr_e = None
-        model.con_r_in_phi_e = None
+        model.con_h_expr_e = []
+        model.con_phi_expr_e = []
+        model.con_r_expr_e = []
+        model.con_r_in_phi_e = []
 
         # Convert initial conditions to l2 penalty
         # Expressions for control constraints on u
@@ -1956,10 +1956,10 @@ class AcadosOcp:
             for i in range(casadi_length(constr_expr)):
                 self.formulate_constraint_as_L2_penalty(constr_expr[i], weight=1.0, upper_bound=upper_bound[i], lower_bound=lower_bound[i], constraint_type="initial")
 
-        model.con_h_expr_0 = None
-        model.con_phi_expr_0 = None
-        model.con_r_expr_0 = None
-        model.con_r_in_phi_0 = None
+        model.con_h_expr_0 = []
+        model.con_phi_expr_0 = []
+        model.con_r_expr_0 = []
+        model.con_r_in_phi_0 = []
 
         # delete constraint fromulation from constraints object
         self.constraints = new_constraints


### PR DESCRIPTION
In the formulation of the feasibility problem some expressions needed to be formulated as `[]` instead of `None` such that it is compatible with the `AcadosCasadiOcpSolver`.