### PR TITLE
`AcadosOcpSolver.get_residuals()`: change default to `recompute=False`, fixes AS-RTI, breaking!

### DIFF
--- a/examples/acados_python/p_global_example/example_p_global.py
+++ b/examples/acados_python/p_global_example/example_p_global.py
@@ -211,11 +211,11 @@ def main(use_cython=False, lut=True, use_p_global=True, blazing=True, with_matla
     N_horizon = 20
 
     # set options
-    ocp.solver_options.qp_solver = 'PARTIAL_CONDENSING_HPIPM' # FULL_CONDENSING_QPOASES
+    ocp.solver_options.qp_solver = 'PARTIAL_CONDENSING_HPIPM'
     ocp.solver_options.hessian_approx = 'GAUSS_NEWTON'
     ocp.solver_options.integrator_type = 'ERK'
     ocp.solver_options.print_level = 0
-    ocp.solver_options.nlp_solver_type = 'SQP_RTI' # SQP_RTI, SQP
+    ocp.solver_options.nlp_solver_type = 'SQP_RTI'
     ocp.solver_options.ext_fun_compile_flags += ' -I' + ca.GlobalOptions.getCasadiIncludePath() + ' -ffast-math -march=native'
     if code_export_directory is not None:
         ocp.code_export_directory = code_export_directory
@@ -315,7 +315,7 @@ def main_mocp(lut=True, use_p_global=True, with_matlab_templates=False):
     timing = 0
     for i in range(20):
         status = ocp_solver.solve()
-        # ocp_solver.print_statistics() # encapsulates: stat = ocp_solver.get_stats("statistics")
+        # ocp_solver.print_statistics()
         residuals+= list(ocp_solver.get_residuals())
         timing += ocp_solver.get_stats('time_lin')
 

--- a/examples/acados_python/p_global_example/example_p_global.py
+++ b/examples/acados_python/p_global_example/example_p_global.py
@@ -249,7 +249,7 @@ def main(use_cython=False, lut=True, use_p_global=True, blazing=True, with_matla
     for i in range(20):
         status = ocp_solver.solve()
         # ocp_solver.print_statistics() # encapsulates: stat = ocp_solver.get_stats("statistics")
-        residuals+= list(ocp_solver.get_residuals())
+        residuals+= list(ocp_solver.get_residuals(recompute=True))
         timing += ocp_solver.get_stats("time_lin")
 
     # plot results
@@ -316,7 +316,7 @@ def main_mocp(lut=True, use_p_global=True, with_matlab_templates=False):
     for i in range(20):
         status = ocp_solver.solve()
         # ocp_solver.print_statistics()
-        residuals+= list(ocp_solver.get_residuals())
+        residuals+= list(ocp_solver.get_residuals(recompute=True))
         timing += ocp_solver.get_stats('time_lin')
 
     return residuals, timing

--- a/examples/acados_python/pendulum_on_cart/as_rti/as_rti_closed_loop_example.py
+++ b/examples/acados_python/pendulum_on_cart/as_rti/as_rti_closed_loop_example.py
@@ -177,6 +177,9 @@ def main(algorithm='RTI', as_rti_iter=1):
 
             t[i] = ocp_solver.get_stats('time_tot')
 
+        # test getting residuals
+        _ = ocp_solver.get_residuals()
+
         if status not in [0, 2, 5]:
             raise Exception(f'acados returned status {status}. Exiting.')
         # simulate system

--- a/examples/acados_python/pendulum_on_cart/custom_update/example_custom_rti_loop.py
+++ b/examples/acados_python/pendulum_on_cart/custom_update/example_custom_rti_loop.py
@@ -118,7 +118,7 @@ def main(use_cython=False):
         status = ocp_solver.solve()
         ocp_solver.custom_update(data)
         # ocp_solver.print_statistics() # encapsulates: stat = ocp_solver.get_stats("statistics")
-        residuals = ocp_solver.get_residuals()
+        residuals = ocp_solver.get_residuals(recompute=True)
         # print("residuals after ", i, "SQP_RTI iterations:\n", residuals)
         if max(residuals) < tol:
             break

--- a/examples/acados_python/pendulum_on_cart/ocp/example_sqp_rti_loop.py
+++ b/examples/acados_python/pendulum_on_cart/ocp/example_sqp_rti_loop.py
@@ -125,8 +125,8 @@ def main():
         else:
             status = ocp_solver.solve()
         # ocp_solver.custom_update(np.array([]))
-        ocp_solver.print_statistics() # encapsulates: stat = ocp_solver.get_stats("statistics")
-        residuals = ocp_solver.get_residuals()
+        ocp_solver.print_statistics()
+        residuals = ocp_solver.get_residuals(recompute=True)
         print("residuals after ", i, "SQP_RTI iterations:\n", residuals)
         if max(residuals) < tol:
             break
@@ -141,7 +141,7 @@ def main():
         simU[i,:] = ocp_solver.get(i, "u")
     simX[N,:] = ocp_solver.get(N, "x")
 
-    ocp_solver.print_statistics() # encapsulates: stat = ocp_solver.get_stats("statistics")
+    ocp_solver.print_statistics()
 
     cost = ocp_solver.get_cost()
     print("cost function value of solution = ", cost)

--- a/examples/acados_python/pendulum_on_cart/ros2/example_ros_minimal_ocp.py
+++ b/examples/acados_python/pendulum_on_cart/ros2/example_ros_minimal_ocp.py
@@ -49,7 +49,7 @@ def create_minimal_ocp(export_dir: str, N: int = 20, Tf: float = 1.0, Fmax: floa
     # set model
     model = export_pendulum_ode_model()
     ocp.model = model
-    
+
     nx = model.x.rows()
     nu = model.u.rows()
     ny = nx + nu
@@ -114,7 +114,7 @@ def main():
     Fmax = 80
     Tf = 1.0
     N = 20
-    
+
     export_dir = os.path.join(script_dir, 'generated_ocp')
     ocp = create_minimal_ocp(export_dir, N, Tf, Fmax)
     ocp_solver = AcadosOcpSolver(ocp, json_file = str(os.path.join(export_dir, 'acados_ocp.json')))
@@ -137,7 +137,7 @@ def main():
         else:
             status = ocp_solver.solve()
         ocp_solver.print_statistics()
-        residuals = ocp_solver.get_residuals()
+        residuals = ocp_solver.get_residuals(recompute=True)
         print("residuals after ", i, "SQP_RTI iterations:\n", residuals)
         if max(residuals) < tol:
             break

--- a/examples/acados_python/tests/test_rti_sqp_residuals.py
+++ b/examples/acados_python/tests/test_rti_sqp_residuals.py
@@ -154,7 +154,7 @@ def main(nlp_solver_type="SQP"):
                 assert res_next[2] == res_ineq_all[-1]
                 assert res_next[3] == res_comp_all[-1]
             # overwrite res_next
-            res_next = solver.get_residuals()
+            res_next = solver.get_residuals(recompute=True)
             print(f"res_next: {res_next}")
 
             if max([res_stat_all[-1], res_eq_all[-1], res_ineq_all[-1], res_comp_all[-1]]) < TOL:

--- a/interfaces/acados_template/acados_template/acados_ocp_solver_pyx.pyx
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver_pyx.pyx
@@ -636,7 +636,7 @@ cdef class AcadosOcpSolverCython:
         Returns an array of the form [res_stat, res_eq, res_ineq, res_comp].
         """
         # compute residuals if RTI
-        if self.nlp_solver_type == 'SQP_RTI' or recompute:
+        if recompute:
             acados_solver_common.ocp_nlp_eval_residuals(self.nlp_solver, self.nlp_in, self.nlp_out)
 
         # create output array


### PR DESCRIPTION
- add warning for AS-RTI, as recomputing residual breaks the reuse of the linearization which is essential for AS-RTI to work correctly.
- test AS-RTI with `get_residuals()`