### PR TITLE
Improve installation instructions

### DIFF
--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -1,9 +1,11 @@
 # Installation
 
 ## Linux/Mac
+Installation on Linux, Mac and Linux within Windows WSL is described here.
+Additional notes on [MacOS installation](#notes-for-macos)
 
 ### Prerequisites
-We assume you have: git, make, cmake installed on your system.
+We assume you have: `git`, `make`, `cmake` installed on your system.
 
 ### Clone acados
 Clone acados and its submodules by running:
@@ -60,8 +62,10 @@ Adjust these options based on your requirements.
 For more details on specific options, refer to the comments in the `CMakeLists.txt` file.
 
 
+
 ### Interfaces installation
 For the installation of Python/MATLAB/Octave interfaces, please refer to the [Interfaces](../interfaces/index.md) page.
+
 
 ## Windows 10+ (WSL)
 
@@ -183,7 +187,43 @@ cmake --build . -j10 --target INSTALL --config Release
 - Try a MATLAB example (see above).
 
 
-#### Deprecated: **Make** build system
+## Notes for MacOS
+#### Installing acados with OpenMP on macOS
+
+The standard `clang` compiler on macOS does not support OpenMP.
+Here, we solve this problem by installing `gcc` and make it the default compiler for `acados`.
+Using OpenMP allows for parallelization, which can significantly speed up computations, either within one OCP solution or for solving batches of OCPs or simulation problems.
+
+#### 1. Make `gcc` your default compiler for acados
+
+First, install `gcc` using Homebrew. If you do not have Homebrew installed, you can find instructions [here](https://brew.sh/).
+
+```bash
+# Install gcc via Homebrew
+brew install gcc
+```
+
+Next we link the `gcc` compiler to `cc` and `c++` so that acados uses `gcc` instead of the default `clang` compiler.
+
+```bash
+brew link gcc
+# you might need to force it
+# brew link gcc --overwrite --force
+```
+
+#### 2. Set environment variables
+
+Set in your shell configuration file `.bashrc`, `zshrc`, etc. the following environment variables to point to the installed `gcc` compiler.
+Adjust the version number (`gcc-15` and `g++-15`) if a different version is installed.
+You also might need to check whether the path `/opt/homebrew/bin/` is correct for your Homebrew installation:
+
+```bash
+export CC="/opt/homebrew/bin/gcc-15"
+export CXX="/opt/homebrew/bin/g++-15"
+```
+
+
+## Deprecated: **Make** build system
 NOTE: This build system is not actively tested and might be removed in the future! It is strongly recommended to use the `CMake` build system.
 
 Set the `BLASFEO_TARGET` in `<acados_root_folder>/Makefile.rule`.


### PR DESCRIPTION
- deprecate `make`
- add note on common issue of forgotten `..` in cmake
- add notes for `MacOS` and `openmp`