### PR TITLE
Update detect_constraint_structure.m to remove redundant assignments causing errors

### DIFF
--- a/interfaces/acados_matlab_octave/detect_constraint_structure.m
+++ b/interfaces/acados_matlab_octave/detect_constraint_structure.m
@@ -231,13 +231,6 @@ function model = detect_constraint_structure(model, constraints, stage_type)
             constraints.lbu = lbu;
             constraints.ubu = ubu;
         end
-        % g
-        if ~isempty(lg)
-            model.constr_C = C;
-            model.constr_D = D;
-            constraints.lg = lg;
-            constraints.ug = ug;
-        end
     end
 end
 


### PR DESCRIPTION
Removed some redundant and (presumed) incorrect code which would throw errors.  This errors were only encountered when constraints in con_h_expr and were being automatically rewritten as general linear constraints.

The removed lines attempted to assign variables C and D into invalid locations.  Based on the naming of the invalid locations I presume these were left over from before acados v0.4.0.  The C, D, lg, and, ug are already assigned within an identical if() case some some lines previous (lines 215-221), making the removed lines redundant anyway even if they were correct.