### PR TITLE
Python: refactors deprecation warnings

### DIFF
--- a/interfaces/acados_template/acados_template/acados_dims.py
+++ b/interfaces/acados_template/acados_template/acados_dims.py
@@ -29,6 +29,8 @@
 # POSSIBILITY OF SUCH DAMAGE.;
 #
 
+from deprecated.sphinx import deprecated
+
 def check_int_value(name, value, *, positive=False, nonnegative=False):
     if not isinstance(value, int):
         raise TypeError(f"Invalid {name} value: expected an integer, got {type(value).__name__}.")
@@ -387,11 +389,10 @@ class AcadosOcpDims:
         return self.__n_global_data
 
     @property
+    @deprecated(version="0.4.0", reason="Use `ocp.solver_options.N` instead.")
     def N(self):
         """
         :math:`N` - Number of shooting intervals.
-        DEPRECATED: use ocp.solver_options.N instead.
-
         Type: int; default: None"""
         return self.__N
 

--- a/interfaces/acados_template/acados_template/acados_model.py
+++ b/interfaces/acados_template/acados_template/acados_model.py
@@ -33,6 +33,7 @@ import inspect, warnings
 
 import casadi as ca
 import numpy as np
+from deprecated.sphinx import deprecated
 
 from casadi import MX, SX
 
@@ -911,8 +912,8 @@ class AcadosModel():
         return
 
 
+    @deprecated(version="0.4.0", reason="Use `reformulate_with_polynomial_control()` instead.")
     def augment_model_with_polynomial_control(self, degree: int) -> None:
-        print("Deprecation warning: augment_model_with_polynomial_control() is deprecated and has been renamed to reformulate_with_polynomial_control().")
         self.reformulate_with_polynomial_control(degree=degree)
 
 

--- a/interfaces/acados_template/acados_template/acados_ocp_options.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_options.py
@@ -31,6 +31,7 @@
 
 import os
 
+from deprecated.sphinx import deprecated
 from .utils import check_if_nparray_and_flatten
 
 INTEGRATOR_TYPES = ('ERK', 'IRK', 'GNSF', 'DISCRETE', 'LIFTED_IRK')
@@ -494,11 +495,11 @@ class AcadosOcpOptions:
         return self.__nlp_qp_tol_min_comp
 
     @property
+    @deprecated(version="0.4.0", reason="Use globalization_fixed_step_length instead.")
     def nlp_solver_step_length(self):
         """
         This option is deprecated and has new name: globalization_fixed_step_length
         """
-        print("The option nlp_solver_step_length is deprecated and has new name: globalization_fixed_step_length")
         return self.__globalization_fixed_step_length
 
     @property
@@ -940,11 +941,11 @@ class AcadosOcpOptions:
         return self.__globalization_alpha_min
 
     @property
+    @deprecated(version="0.4.0", reason="Use globalization_alpha_min instead.")
     def alpha_min(self):
         """
         The option alpha_min is deprecated and has new name: globalization_alpha_min
         """
-        print("The option alpha_min is deprecated and has new name: globalization_alpha_min")
         return self.globalization_alpha_min
 
     @property
@@ -998,11 +999,11 @@ class AcadosOcpOptions:
         return self.__globalization_alpha_reduction
 
     @property
+    @deprecated(version="0.4.0", reason="Use globalization_alpha_reduction instead.")
     def alpha_reduction(self):
         """
         The option alpha_reduction is deprecated and has new name: globalization_alpha_reduction
         """
-        print("The option alpha_reduction is deprecated and has new name: globalization_alpha_reduction")
         return self.globalization_alpha_reduction
 
     @property
@@ -1015,11 +1016,11 @@ class AcadosOcpOptions:
         return self.__globalization_line_search_use_sufficient_descent
 
     @property
+    @deprecated(version="0.4.0", reason="Use globalization_line_search_use_sufficient_descent instead.")
     def line_search_use_sufficient_descent(self):
         """
         The option line_search_use_sufficient_descent is deprecated and has new name: globalization_line_search_use_sufficient_descent
         """
-        print("The option line_search_use_sufficient_descent is deprecated and has new name: globalization_line_search_use_sufficient_descent")
         return self.globalization_line_search_use_sufficient_descent
 
     @property
@@ -1037,11 +1038,11 @@ class AcadosOcpOptions:
         return self.__globalization_eps_sufficient_descent
 
     @property
+    @deprecated(version="0.4.0", reason="Use globalization_line_search_use_sufficient_descent instead.")
     def eps_sufficient_descent(self):
         """
         The option eps_sufficient_descent is deprecated and has new name: globalization_line_search_use_sufficient_descent
         """
-        print("The option eps_sufficient_descent is deprecated and has new name: globalization_line_search_use_sufficient_descent")
         return self.globalization_line_search_use_sufficient_descent
 
     @property
@@ -1066,11 +1067,11 @@ class AcadosOcpOptions:
         return self.__globalization_full_step_dual
 
     @property
+    @deprecated(version="0.4.0", reason="Use globalization_full_step_dual instead.")
     def full_step_dual(self):
         """
         The option full_step_dual is deprecated and has new name: globalization_full_step_dual
         """
-        print("The option full_step_dual is deprecated and has new name: globalization_full_step_dual")
         return self.globalization_full_step_dual
 
     @property
@@ -1407,9 +1408,9 @@ class AcadosOcpOptions:
         return self.__with_value_sens_wrt_params
 
     @property
+    @deprecated(version="0.4.0", reason="Use with_batch_functionality instead and pass the number of threads directly to the BatchSolver.")
     def num_threads_in_batch_solve(self):
         """
-        DEPRECATED, use the flag with_batch_functionality instead and pass the number of threads directly to the BatchSolver.
         Integer indicating how many threads should be used within the batch solve.
         If more than one thread should be used, the solver is compiled with openmp.
         Default: 1.
@@ -1629,8 +1630,8 @@ class AcadosOcpOptions:
         self.__globalization_alpha_min = globalization_alpha_min
 
     @alpha_min.setter
+    @deprecated(version="0.4.0", reason="Use globalization_alpha_min instead.")
     def alpha_min(self, alpha_min):
-        print("This option is deprecated and has new name: globalization_alpha_min")
         self.globalization_alpha_min = alpha_min
 
     @globalization_alpha_reduction.setter
@@ -1638,8 +1639,8 @@ class AcadosOcpOptions:
         self.__globalization_alpha_reduction = globalization_alpha_reduction
 
     @alpha_reduction.setter
+    @deprecated(version="0.4.0", reason="Use globalization_alpha_reduction instead.")
     def alpha_reduction(self, globalization_alpha_reduction):
-        print("This option is deprecated and has new name: globalization_alpha_reduction")
         self.globalization_alpha_reduction = globalization_alpha_reduction
 
     @globalization_line_search_use_sufficient_descent.setter
@@ -1650,8 +1651,8 @@ class AcadosOcpOptions:
             raise ValueError(f'Invalid value for globalization_line_search_use_sufficient_descent. Possible values are 0, 1, got {globalization_line_search_use_sufficient_descent}')
 
     @line_search_use_sufficient_descent.setter
+    @deprecated(version="0.4.0", reason="Use globalization_line_search_use_sufficient_descent instead.")
     def line_search_use_sufficient_descent(self, globalization_line_search_use_sufficient_descent):
-        print("This option is deprecated and has new name: globalization_line_search_use_sufficient_descent")
         if globalization_line_search_use_sufficient_descent in [0, 1]:
             self.__globalization_line_search_use_sufficient_descent = globalization_line_search_use_sufficient_descent
         else:
@@ -1672,8 +1673,8 @@ class AcadosOcpOptions:
             raise ValueError(f'Invalid value for globalization_full_step_dual. Possible values are 0, 1, got {globalization_full_step_dual}')
 
     @full_step_dual.setter
+    @deprecated(version="0.4.0", reason="Use globalization_full_step_dual instead.")
     def full_step_dual(self, globalization_full_step_dual):
-        print("This option is deprecated and has new name: globalization_full_step_dual")
         self.globalization_full_step_dual = globalization_full_step_dual
 
 
@@ -1776,8 +1777,8 @@ class AcadosOcpOptions:
             raise ValueError('Invalid globalization_eps_sufficient_descent value. globalization_eps_sufficient_descent must be a positive float.')
 
     @eps_sufficient_descent.setter
+    @deprecated(version="0.4.0", reason="Use globalization_eps_sufficient_descent instead.")
     def eps_sufficient_descent(self, globalization_eps_sufficient_descent):
-        print("This option is deprecated and has new name: globalization_eps_sufficient_descent")
         self.globalization_eps_sufficient_descent = globalization_eps_sufficient_descent
 
     @sim_method_num_stages.setter
@@ -1891,8 +1892,8 @@ class AcadosOcpOptions:
         self.__nlp_qp_tol_safety_factor = nlp_qp_tol_safety_factor
 
     @nlp_solver_step_length.setter
+    @deprecated(version="0.4.0", reason="Use globalization_fixed_step_length instead.")
     def nlp_solver_step_length(self, nlp_solver_step_length):
-        print("The option nlp_solver_step_length is deprecated and has new name: globalization_fixed_step_length")
         self.globalization_fixed_step_length = nlp_solver_step_length
 
     @nlp_solver_warm_start_first_qp.setter
@@ -2252,8 +2253,8 @@ class AcadosOcpOptions:
             raise ValueError('Invalid ext_cost_num_hess value. ext_cost_num_hess takes one of the values 0, 1.')
 
     @num_threads_in_batch_solve.setter
+    @deprecated(version="0.4.0", reason="Set the flag with_batch_functionality instead and pass the number of threads directly to the BatchSolver.")
     def num_threads_in_batch_solve(self, num_threads_in_batch_solve):
-        print("Warning: num_threads_in_batch_solve is deprecated, set the flag with_batch_functionality instead and pass the number of threads directly to the BatchSolver.")
         if isinstance(num_threads_in_batch_solve, int) and num_threads_in_batch_solve > 0:
             self.__num_threads_in_batch_solve = num_threads_in_batch_solve
         else:

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -49,6 +49,7 @@ from typing import Union, Optional, List, Tuple, Sequence, Dict
 
 import numpy as np
 import scipy.linalg
+from deprecated.sphinx import deprecated
 from .builders import CMakeBuilder
 from .acados_ocp import AcadosOcp
 from .acados_multiphase_ocp import AcadosMultiphaseOcp
@@ -673,8 +674,8 @@ class AcadosOcpSolver:
         return grad
 
 
+    @deprecated(version="0.4.0", reason="Use eval_and_get_optimal_value_gradient() instead.")
     def get_optimal_value_gradient(self, with_respect_to: str = "initial_state") -> np.ndarray:
-        print("Deprecation warning: get_optimal_value_gradient() is deprecated and has been renamed to eval_and_get_optimal_value_gradient().")
         return self.eval_and_get_optimal_value_gradient(with_respect_to)
 
 
@@ -934,53 +935,6 @@ class AcadosOcpSolver:
             return grad_p
         else:
             raise NotImplementedError(f"with_respect_to {with_respect_to} not implemented.")
-
-
-
-    def eval_param_sens(self, index: int, stage: int=0, field="ex"):
-        """
-        Calculate the sensitivity of the current solution with respect to the initial state component of index.
-
-        NOTE: Correct computation of sensitivities requires
-
-        (1) HPIPM as QP solver,
-
-        (2) the usage of an exact Hessian,
-
-        (3) positive definiteness of the full-space Hessian if the square-root version of the Riccati recursion is used
-            OR positive definiteness of the reduced Hessian if the classic Riccati recursion is used (compare: `solver_options.qp_solver_ric_alg`),
-        (4) the solution of at least one QP in advance to evaluation of the sensitivities as the factorization is reused.
-
-        :param index: integer corresponding to initial state index in range(nx)
-        """
-
-        print("WARNING: eval_param_sens() is deprecated. Please use eval_solution_sensitivity() instead!")
-
-        self._ensure_solution_sensitivities_available(False)
-
-        field = field.encode('utf-8')
-
-        if not isinstance(index, int):
-            raise TypeError('AcadosOcpSolver.eval_param_sens(): index must be Integer.')
-
-        if field == "ex":
-            if not stage == 0:
-                raise NotImplementedError('AcadosOcpSolver.eval_param_sens(): only stage == 0 is supported.')
-            nx = self.__acados_lib.ocp_nlp_dims_get_from_attr(self.nlp_config, self.nlp_dims, self.nlp_out, stage, "x".encode('utf-8'))
-
-            if index < 0 or index > nx:
-                raise ValueError(f'AcadosOcpSolver.eval_param_sens(): index must be in [0, nx-1], got: {index}.')
-
-        elif field == "p_global":
-            nparam = self.__acados_lib.ocp_nlp_dims_get_from_attr(self.nlp_config, self.nlp_dims, self.nlp_out, 0, "p".encode('utf-8'))
-
-            if index < 0 or index > nparam:
-                raise IndexError(f'AcadosOcpSolver.eval_param_sens(): index must be in [0, nparam-1], got: {index}.')
-
-        # actual eval_param
-        self.__acados_lib.ocp_nlp_eval_param_sens(self.nlp_solver, field, stage, index, self.sens_out)
-
-        return
 
 
     def get(self, stage_: int, field_: str):

--- a/interfaces/acados_template/acados_template/acados_sim.py
+++ b/interfaces/acados_template/acados_template/acados_sim.py
@@ -33,6 +33,7 @@ import os, json
 import numpy as np
 from typing import Optional
 from copy import deepcopy
+from deprecated.sphinx import deprecated
 from .acados_model import AcadosModel
 from .acados_dims import AcadosSimDims
 from .builders import CMakeBuilder
@@ -171,9 +172,9 @@ class AcadosSimOptions:
 
 
     @property
+    @deprecated(version="0.4.0", reason="Set the flag with_batch_functionality instead and pass the number of threads directly to the BatchSolver.")
     def num_threads_in_batch_solve(self):
         """
-        DEPRECATED, use the flag with_batch_functionality instead and pass the number of threads directly to the BatchSolver.
         Integer indicating how many threads should be used within the batch solve.
         If more than one thread should be used, the sim solver is compiled with openmp.
         Default: 1.
@@ -296,8 +297,8 @@ class AcadosSimOptions:
             raise ValueError('Invalid sim_method_jac_reuse value. sim_method_jac_reuse must be 0 or 1.')
 
     @num_threads_in_batch_solve.setter
+    @deprecated(version="0.4.0", reason="Set the flag with_batch_functionality instead and pass the number of threads directly to the BatchSolver.")
     def num_threads_in_batch_solve(self, num_threads_in_batch_solve):
-        print("Warning: num_threads_in_batch_solve is deprecated, set the flag with_batch_functionality instead and pass the number of threads directly to the BatchSolver.")
         if isinstance(num_threads_in_batch_solve, int) and num_threads_in_batch_solve > 0:
             self.__num_threads_in_batch_solve = num_threads_in_batch_solve
         else:

--- a/interfaces/acados_template/acados_template/utils.py
+++ b/interfaces/acados_template/acados_template/utils.py
@@ -36,6 +36,7 @@ import shutil
 import sys
 import platform
 import urllib.request
+from deprecated.sphinx import deprecated
 from subprocess import DEVNULL, STDOUT, call
 if os.name == 'nt':
     from ctypes import wintypes
@@ -386,9 +387,8 @@ def format_class_dict(d):
         out[k.replace(k, out_key)] = v
     return out
 
+@deprecated(version="0.4.0", reason="Use get_simulink_default_opts() instead.")
 def get_default_simulink_opts() -> dict:
-    print("get_default_simulink_opts is deprecated, use get_simulink_default_opts instead."
-          + " This function will be removed in a future release.")
     return get_simulink_default_opts()
 
 

--- a/interfaces/acados_template/setup.py
+++ b/interfaces/acados_template/setup.py
@@ -33,16 +33,16 @@ from setuptools import setup, find_packages
 import sys
 print(sys.version_info)
 
-if sys.version_info < (3,5):
-    sys.exit('Python version 3.5 or later required. Exiting.')
+if sys.version_info < (3,8):
+    sys.exit('Python version 3.8 or later required. Exiting.')
 
 setup(name='acados_template',
-    version='0.1',
-    python_requires='>=3.5',
+    version='0.5.1',
+    python_requires='>=3.8',
     description='A templating framework for acados',
     url='http://github.com/acados/acados',
-    author='Andrea Zanelli',
-    maintainer="Jonathan Frey",
+    author='The acados authors.',
+    maintainer="The acados authors.",
     license='BSD 2-Clause',
     packages = find_packages(),
     include_package_data = True,
@@ -59,6 +59,7 @@ setup(name='acados_template',
        'matplotlib',
        'future-fstrings',
        'cython',
+       'Deprecated',
     ],
     package_data={'': [
         'simulink_default_opts.json',


### PR DESCRIPTION
This PR refactors all deprecation warnings in the Python interface to use the `@deprecated` decorator from the <a href="https://github.com/tantale/deprecated">`deprecated.sphinx`</a> module instead of print statements.
 
In addition, this removes the deprecated function `eval_param_sens` and updates `setup.py` to align version of `acados_template` with acados version
