### PR TITLE
MATLAB: remove duplicate expressions in `ocp_get.c`

### DIFF
--- a/interfaces/acados_matlab_octave/ocp_get.c
+++ b/interfaces/acados_matlab_octave/ocp_get.c
@@ -689,14 +689,6 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
              !strcmp(field, "qp_lbx") || !strcmp(field, "qp_ubx") || !strcmp(field, "qp_lbu") ||
              !strcmp(field, "qp_ubu") || !strcmp(field, "qp_zl") || !strcmp(field, "qp_zu") ||
              !strcmp(field, "qp_Zl") || !strcmp(field, "qp_Zu") ||
-             !strcmp(field, "qp_C") ||
-             !strcmp(field, "qp_D") ||
-             !strcmp(field, "qp_lg") ||
-             !strcmp(field, "qp_ug") ||
-             !strcmp(field, "qp_lbx") ||
-             !strcmp(field, "qp_ubx") ||
-             !strcmp(field, "qp_lbu") ||
-             !strcmp(field, "qp_ubu") ||
              !strcmp(field, "qp_lls") ||
              !strcmp(field, "qp_lus") ||
              !strcmp(field, "qp_lg_mask") ||


### PR DESCRIPTION
These were duplicates in a chain of `||` operators.