### PR TITLE
MATLAB: move `npi` assignment before its first use to prevent UB

### DIFF
--- a/interfaces/acados_matlab_octave/ocp_get.c
+++ b/interfaces/acados_matlab_octave/ocp_get.c
@@ -434,12 +434,12 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
             double *pi = mxGetPr( plhs[0] );
             for (ii=0; ii<N; ii++)
             {
+                npi = ocp_nlp_dims_get_from_attr(config, dims, out, ii, "pi");
                 if (npi0 != npi)
                 {
                     sprintf(buffer, "\nocp_get: cannot get multiple %s values at once due to varying dimension", field);
                     mexErrMsgTxt(buffer);
                 }
-                npi = ocp_nlp_dims_get_from_attr(config, dims, out, ii, "pi");
                 ocp_nlp_out_get(config, dims, sens_out, ii, "pi", pi+ii*npi);
             }
         }


### PR DESCRIPTION
I would guess that the code was supposed to look like this.