### PR TITLE
Properly initialise `opts_get` in `dense_qp_ooqp_config_initialize_default`

### DIFF
--- a/acados/dense_qp/dense_qp_ooqp.c
+++ b/acados/dense_qp/dense_qp_ooqp.c
@@ -672,7 +672,7 @@ void dense_qp_ooqp_config_initialize_default(void *config_)
         (void (*)(void *, void *, void *)) & dense_qp_ooqp_opts_initialize_default;
     config->opts_update = (void (*)(void *, void *, void *)) & dense_qp_ooqp_opts_update;
     config->opts_set = &dense_qp_ooqp_opts_set;
-    config->opts_set = &dense_qp_ooqp_opts_get;
+    config->opts_get = &dense_qp_ooqp_opts_get;
     config->memory_calculate_size =
         (acados_size_t (*)(void *, void *, void *)) & dense_qp_ooqp_memory_calculate_size;
     config->memory_assign =


### PR DESCRIPTION
I guess the code was intended to look like that.