### PR TITLE
Python example: solution sensitivities with parametric initial state

### DIFF
--- a/.github/workflows/full_build.yml
+++ b/.github/workflows/full_build.yml
@@ -567,7 +567,9 @@ jobs:
         cd ${{ github.workspace }}/examples/acados_python/pendulum_on_cart/solution_sensitivities
         python value_gradient_example.py
         python policy_gradient_example.py
-        python test_solution_sens_and_exact_hess.py
+        python run_hessian_comparison.py
+        python test_solution_sens_and_exact_hess.py --no-parametric-x0 --no-show
+        python test_solution_sens_and_exact_hess.py --parametric-x0 --no-show
         python forw_vs_adj_param_sens.py
         python smooth_policy_gradients.py
         cd ${{ github.workspace }}/examples/acados_python/solution_sensitivities_convex_example

--- a/examples/acados_python/pendulum_on_cart/solution_sensitivities/run_hessian_comparison.py
+++ b/examples/acados_python/pendulum_on_cart/solution_sensitivities/run_hessian_comparison.py
@@ -1,0 +1,45 @@
+from test_solution_sens_and_exact_hess import *
+
+
+def run_hessian_comparison(linearized_dynamics=False, discrete=False):
+    casadi_solver, lag_hess_fun, lbg, ubg = create_casadi_solver(
+        linearized_dynamics=linearized_dynamics,
+        discrete=discrete,
+    )
+
+    acados_ocp_solver_gn = create_solver(
+        hessian_approx='GAUSS_NEWTON',
+        linearized_dynamics=linearized_dynamics,
+        discrete=discrete,
+    )
+    acados_ocp_solver_exact = create_solver(
+        hessian_approx='EXACT',
+        linearized_dynamics=linearized_dynamics,
+        discrete=discrete,
+    )
+
+    x0 = X0.copy()
+    x0[1] = 0.1
+
+    nlp_sol = casadi_solver(p=x0, lbg=lbg, ubg=ubg)
+    casadi_hess_l = lag_hess_fun(
+        x=nlp_sol['x'],
+        p=x0,
+        lam_f=1.0,
+        lam_g=nlp_sol['lam_g'],
+    )['triu_hess_gamma_x_x']
+    casadi_hess = ca.triu2symm(ca.triu(casadi_hess_l)).full()
+    acados_ocp_solver_gn.solve_for_x0(x0)
+    iterate = acados_ocp_solver_gn.get_flat_iterate()
+    acados_ocp_solver_exact.set_iterate(iterate)
+    acados_ocp_solver_exact.solve_for_x0(
+        x0,
+        fail_on_nonzero_status=False,
+        print_stats_on_failure=False,
+    )
+
+    _ = compare_hessian(casadi_hess, acados_ocp_solver_exact)
+
+
+if __name__ == "__main__":
+    run_hessian_comparison(linearized_dynamics=False, discrete=True)

--- a/examples/acados_python/pendulum_on_cart/solution_sensitivities/test_solution_sens_and_exact_hess.py
+++ b/examples/acados_python/pendulum_on_cart/solution_sensitivities/test_solution_sens_and_exact_hess.py
@@ -29,6 +29,7 @@
 #
 
 import sys
+import argparse
 sys.path.insert(0, '../common')
 
 from acados_template import AcadosModel, AcadosOcp, AcadosOcpSolver, latexify_plot, casadi_length
@@ -142,7 +143,7 @@ def create_solver(hessian_approx, linearized_dynamics=False, discrete=False, par
         # implementation detail to avoid nonlinear-least squares module.
         ocp.translate_cost_to_external_cost()
 
-    acados_ocp_solver = AcadosOcpSolver(ocp, json_file=f'solver_f{hessian_approx}.json')
+    acados_ocp_solver = AcadosOcpSolver(ocp, json_file=f'solver_f{hessian_approx}.json', verbose=False)
 
     return acados_ocp_solver
 
@@ -422,27 +423,6 @@ def compute_K(solver: AcadosOcpSolver):
     K_regularized = -np.linalg.solve(P_mat_regularized, S_mat + B_mat.T @ P_mat @ A_mat)
     return K_mat, K_regularized
 
-
-def run_hessian_comparison(linearized_dynamics=False, discrete=False):
-    casadi_solver, lag_hess_fun, lbg, ubg = create_casadi_solver(linearized_dynamics=linearized_dynamics, discrete=discrete)
-
-    acados_ocp_solver_gn = create_solver(hessian_approx='GAUSS_NEWTON', linearized_dynamics=linearized_dynamics, discrete=discrete)
-    acados_ocp_solver_exact = create_solver(hessian_approx='EXACT', linearized_dynamics=linearized_dynamics, discrete=discrete)
-
-    x0 = X0.copy()
-    x0[1] = 0.1
-
-    nlp_sol = casadi_solver(p=x0, lbg=lbg, ubg=ubg)
-    # print(f"{nlp_sol=}")
-    casadi_hess_l = lag_hess_fun(x=nlp_sol['x'], p=x0, lam_f=1.0, lam_g=nlp_sol['lam_g'])['triu_hess_gamma_x_x']
-    casadi_hess = ca.triu2symm(ca.triu(casadi_hess_l)).full()
-    acados_ocp_solver_gn.solve_for_x0(x0)
-    iterate = acados_ocp_solver_gn.get_flat_iterate()
-    acados_ocp_solver_exact.set_iterate(iterate)
-    acados_ocp_solver_exact.solve_for_x0(x0, fail_on_nonzero_status=False, print_stats_on_failure=False)
-
-    _ = compare_hessian(casadi_hess, acados_ocp_solver_exact)
-
 def compare_hessian(casadi_hess, acados_solver: AcadosOcpSolver):
     offset = 0
     min_eigv_total = 1e12
@@ -488,7 +468,40 @@ def compare_hessian(casadi_hess, acados_solver: AcadosOcpSolver):
 
     return min_eigv_total, min_abs_eigv, hess_error_norm_total, min_abs_eig_proj_hess, min_eig_proj_hess, cond_proj_hess, min_eig_P, min_abs_eig_P
 
+
 if __name__ == "__main__":
-    sensitivity_experiment(linearized_dynamics=False, parametric_x0=True, discrete=True)
-    sensitivity_experiment(linearized_dynamics=False, parametric_x0=False, discrete=True)
-    run_hessian_comparison(linearized_dynamics=False, discrete=True)
+    parser = argparse.ArgumentParser(
+        description="Run sensitivity experiment with configurable parameters."
+    )
+    parser.add_argument(
+        "--linearized-dynamics",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Use linearized dynamics.",
+    )
+    parser.add_argument(
+        "--parametric-x0",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Use parametric x0 constraint.",
+    )
+    parser.add_argument(
+        "--discrete",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Use discrete dynamics.",
+    )
+    parser.add_argument(
+        "--show",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Display plots.",
+    )
+    args = parser.parse_args()
+
+    sensitivity_experiment(
+        linearized_dynamics=args.linearized_dynamics,
+        parametric_x0=args.parametric_x0,
+        discrete=args.discrete,
+        show=args.show,
+    )

--- a/examples/acados_python/pendulum_on_cart/solution_sensitivities/test_solution_sens_and_exact_hess.py
+++ b/examples/acados_python/pendulum_on_cart/solution_sensitivities/test_solution_sens_and_exact_hess.py
@@ -121,8 +121,26 @@ def create_ocp_description(hessian_approx, linearized_dynamics=False, discrete=F
     return ocp
 
 
-def create_solver(hessian_approx, linearized_dynamics=False, discrete=False) -> AcadosOcpSolver:
+def create_solver(hessian_approx, linearized_dynamics=False, discrete=False, parametric_x0=False) -> AcadosOcpSolver:
     ocp = create_ocp_description(hessian_approx, linearized_dynamics=linearized_dynamics, discrete=discrete)
+
+    # replace x0 with parametric constraint
+    if parametric_x0:
+        nx = len(ocp.constraints.lbx_0)
+        # remove classic x0 constraint
+        ocp.constraints.x0 = np.array([])
+        # add parameter
+        x0_param = ca.SX.sym('x0_param', nx, 1)
+        ocp.model.p_global = ca.vertcat(ocp.model.p_global, x0_param)
+        ocp.p_global_values = np.zeros((nx,)) # np.vstack((ocp.p_global_values,
+        # add parametric constraint
+        ocp.constraints.lh_0 = np.zeros((nx,))
+        ocp.constraints.uh_0 = np.zeros((nx,))
+        ocp.model.con_h_expr_0 = ocp.model.x - x0_param
+        # set option for parametric sens
+        ocp.solver_options.with_solution_sens_wrt_params = True
+        # implementation detail to avoid nonlinear-least squares module.
+        ocp.translate_cost_to_external_cost()
 
     acados_ocp_solver = AcadosOcpSolver(ocp, json_file=f'solver_f{hessian_approx}.json')
 
@@ -207,11 +225,18 @@ def create_casadi_solver(linearized_dynamics=False, discrete=False):
     ubg = np.zeros(ng)
     return casadi_solver, lag_hess_fun, lbg, ubg
 
+def parametric_x0_solve(solver: AcadosOcpSolver, x0: np.array):
+    solver.set_p_global_and_precompute_dependencies(x0)
+    status = solver.solve()
+    if status != 0:
+        print(f'AcadosOcpSolver returned status {status}')
+        solver.print_statistics()
+    return solver.get(0, "u")
 
+def sensitivity_experiment(linearized_dynamics=False, discrete=False, parametric_x0=False, show=True):
 
-def sensitivity_experiment(linearized_dynamics=False, discrete=False, show=True):
-    acados_ocp_solver_exact = create_solver(hessian_approx='EXACT', linearized_dynamics=linearized_dynamics, discrete=discrete)
-    acados_ocp_solver_gn = create_solver(hessian_approx='GAUSS_NEWTON', linearized_dynamics=linearized_dynamics, discrete=discrete)
+    acados_ocp_solver_exact = create_solver(hessian_approx='EXACT', linearized_dynamics=linearized_dynamics, discrete=discrete, parametric_x0=parametric_x0)
+    acados_ocp_solver_gn = create_solver(hessian_approx='GAUSS_NEWTON', linearized_dynamics=linearized_dynamics, discrete=discrete, parametric_x0=parametric_x0)
     casadi_solver, lag_hess_fun, lbg, ubg = create_casadi_solver(linearized_dynamics=linearized_dynamics, discrete=discrete)
 
     nval = 100
@@ -240,19 +265,34 @@ def sensitivity_experiment(linearized_dynamics=False, discrete=False, show=True)
     latexify_plot()
     for i, p0 in enumerate(p_vals):
         x0[idxp] = p0
-        u0 = acados_ocp_solver_gn.solve_for_x0(x0)
+        if parametric_x0:
+            u0 = parametric_x0_solve(acados_ocp_solver_gn, x0)
+        else:
+            u0 = acados_ocp_solver_gn.solve_for_x0(x0)
         u0_values[i] = u0[0]
 
     du0_dp_finite_diff = np.gradient(u0_values, p_vals[1]-p_vals[0])
     for i, p0 in enumerate(p_vals):
         x0[idxp] = p0
-        u0 = acados_ocp_solver_gn.solve_for_x0(x0)
+        if parametric_x0:
+            u0 = parametric_x0_solve(acados_ocp_solver_gn, x0)
+        else:
+            u0 = acados_ocp_solver_gn.solve_for_x0(x0)
         iterate = acados_ocp_solver_gn.get_flat_iterate()
         acados_ocp_solver_exact.set_iterate(iterate)
+        if parametric_x0:
+            acados_ocp_solver_exact.set_p_global_and_precompute_dependencies(x0)
         acados_ocp_solver_exact.setup_qp_matrices_and_factorize()
-        out_dict = acados_ocp_solver_exact.eval_solution_sensitivity(0, with_respect_to="initial_state", return_sens_x=False)
-        sens_u_ = out_dict['sens_u']
-        du0_dp_values[i] = sens_u_[0, idxp]
+
+        if parametric_x0:
+            u0_seed = np.ones((1, 1))
+            seed_u = [(0, u0_seed)]
+            grad_p = acados_ocp_solver_exact.eval_adjoint_solution_sensitivity(seed_u=seed_u, seed_x=None, with_respect_to="p_global")
+            du0_dp_values[i] = grad_p[0, idxp]
+        else:
+            out_dict = acados_ocp_solver_exact.eval_solution_sensitivity(0, with_respect_to="initial_state", return_sens_x=False)
+            sens_u_ = out_dict['sens_u']
+            du0_dp_values[i] = sens_u_[0, idxp]
 
         exact_hessian_status[i] = acados_ocp_solver_exact.get_stats('qp_stat')[-1]
 
@@ -444,5 +484,6 @@ def compare_hessian(casadi_hess, acados_solver: AcadosOcpSolver):
     return min_eigv_total, min_abs_eigv, hess_error_norm_total, min_abs_eig_proj_hess, min_eig_proj_hess, cond_proj_hess, min_eig_P, min_abs_eig_P
 
 if __name__ == "__main__":
-    sensitivity_experiment(linearized_dynamics=False, discrete=True)
+    sensitivity_experiment(linearized_dynamics=False, parametric_x0=True, discrete=True)
+    sensitivity_experiment(linearized_dynamics=False, parametric_x0=False, discrete=True)
     run_hessian_comparison(linearized_dynamics=False, discrete=True)

--- a/examples/acados_python/pendulum_on_cart/solution_sensitivities/test_solution_sens_and_exact_hess.py
+++ b/examples/acados_python/pendulum_on_cart/solution_sensitivities/test_solution_sens_and_exact_hess.py
@@ -249,9 +249,7 @@ def sensitivity_experiment(linearized_dynamics=False, discrete=False, show=True)
         u0 = acados_ocp_solver_gn.solve_for_x0(x0)
         iterate = acados_ocp_solver_gn.get_flat_iterate()
         acados_ocp_solver_exact.set_iterate(iterate)
-        acados_ocp_solver_exact.set(0, 'u', u0+1e-7)
-        acados_ocp_solver_exact.solve_for_x0(x0, fail_on_nonzero_status=False, print_stats_on_failure=False)
-
+        acados_ocp_solver_exact.setup_qp_matrices_and_factorize()
         out_dict = acados_ocp_solver_exact.eval_solution_sensitivity(0, with_respect_to="initial_state", return_sens_x=False)
         sens_u_ = out_dict['sens_u']
         du0_dp_values[i] = sens_u_[0, idxp]

--- a/examples/acados_python/pendulum_on_cart/solution_sensitivities/test_solution_sens_and_exact_hess.py
+++ b/examples/acados_python/pendulum_on_cart/solution_sensitivities/test_solution_sens_and_exact_hess.py
@@ -234,6 +234,11 @@ def parametric_x0_solve(solver: AcadosOcpSolver, x0: np.array):
     return solver.get(0, "u")
 
 def sensitivity_experiment(linearized_dynamics=False, discrete=False, parametric_x0=False, show=True):
+    """
+    parametric_x0:
+    - If true, use classic x0 API of acados.
+    - If False, replace x0 constraint by general parametric constraint, introduce a parameter for x0. This allows computing adjoint solution sensitivities.
+    """
 
     acados_ocp_solver_exact = create_solver(hessian_approx='EXACT', linearized_dynamics=linearized_dynamics, discrete=discrete, parametric_x0=parametric_x0)
     acados_ocp_solver_gn = create_solver(hessian_approx='GAUSS_NEWTON', linearized_dynamics=linearized_dynamics, discrete=discrete, parametric_x0=parametric_x0)


### PR DESCRIPTION
Example can now be run in two variants.
Results are the same

### Classic x0 API
- implemented before
- compute forward sensitivities via `ocp_solver.eval_solution_sensitivity(0, with_respect_to="initial_state") `

## General parametric API
- introduce global parameter for x0 value
- allows using adjoint using `solver.eval_adjoint_solution_sensitivity(seed_u=seed_u, seed_x=None, with_respect_to="p_global")`