### PR TITLE
GitHub actions: run docs workflow only in the main repo

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -13,6 +13,7 @@ concurrency:
 
 jobs:
   build-and-deploy:
+    if: github.repository == 'acados/acados'
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Avoids failed actions and manual disabling in forks.