### PR TITLE
MATLAB: breaking refactor `AcadosOcpSolver.set()`

### DIFF
--- a/acados/ocp_nlp/ocp_nlp_common.c
+++ b/acados/ocp_nlp/ocp_nlp_common.c
@@ -3487,6 +3487,12 @@ int ocp_nlp_precompute_common(ocp_nlp_config *config, ocp_nlp_dims *dims, ocp_nl
             "nh", &tmp);
         dims->nh_total += tmp;
     }
+    dims->ny_total = 0;
+    for (ii = 0; ii < N+1; ii++)
+    {
+        config->cost[ii]->dims_get(config->cost[ii], dims->cost[ii], "ny", &tmp);
+        dims->ny_total += tmp;
+    }
 
     /* precompute submodules */
     // dyn

--- a/acados/ocp_nlp/ocp_nlp_common.h
+++ b/acados/ocp_nlp/ocp_nlp_common.h
@@ -178,7 +178,9 @@ typedef struct ocp_nlp_dims
     int nbu_total;  // total number of control bounds
     int ng_total;  // total number of general linear constraints
     int nh_total;  // total number of nonlinear inequalities
-    int nphi_total;  // total number of nonlinear inequalities
+    // int nphi_total;  // total number of nonlinear inequalities TODO: seems to be unused
+    int ny_total;  // total number of cost residuals
+
 
     void *raw_memory; // Pointer to allocated memory, to be used for freeing
 } ocp_nlp_dims;

--- a/acados/ocp_nlp/ocp_nlp_cost_external.c
+++ b/acados/ocp_nlp/ocp_nlp_cost_external.c
@@ -118,9 +118,17 @@ void ocp_nlp_cost_external_dims_set(void *config_, void *dims_, const char *fiel
 
 void ocp_nlp_cost_external_dims_get(void *config_, void *dims_, const char *field, int* value)
 {
+    if (!strcmp(field, "ny"))
+    {
+        *value = 0;
+    }
+    else
+    {
         printf("error: ocp_nlp_cost_external_dims_get: attempt to get dimensions of non-existing field %s\n", field);
         exit(1);
+    }
 }
+
 
 
 

--- a/examples/acados_matlab_octave/control_rates/main.m
+++ b/examples/acados_matlab_octave/control_rates/main.m
@@ -168,7 +168,7 @@ function run_simulation(timeout_max_time, timeout_heuristic)
             ocp_solver.set('cost_y_ref', yref, j);
         end
         yref_e(1) = x1_ref(N_horizon+1);
-        ocp_solver.set('cost_y_ref_e', yref_e, N_horizon);
+        ocp_solver.set('cost_y_ref', yref_e, N_horizon);
 
         % solve ocp
         ocp_solver.solve();

--- a/examples/acados_matlab_octave/generic_external_cost/external_cost_example_ocp.m
+++ b/examples/acados_matlab_octave/generic_external_cost/external_cost_example_ocp.m
@@ -163,7 +163,7 @@ ocp_solver.set('init_pi', zeros(nx, N));
 %   ocp_solver.set('field', value, optional: stage_index)
 ocp_solver.set('constr_lbx', x0, 0);
 
-ocp_solver.set('p', p);
+ocp_solver.set('p', p, 0, N+1); % set parameter values for all stages at once
 
 % solve
 ocp_solver.solve();

--- a/examples/acados_matlab_octave/generic_nlp/main.m
+++ b/examples/acados_matlab_octave/generic_nlp/main.m
@@ -80,7 +80,7 @@ ocp_solver.set('init_x', init_x);
 
 % set the parameters
 p_value = [1;1];
-ocp_solver.set('p', p_value);
+ocp_solver.set('p', p_value, 0, ocp.solver_options.N_horizon+1); % set parameter values for all stages at once
 
 % solve and time
 tic

--- a/examples/acados_matlab_octave/getting_started/minimal_example_closed_loop.m
+++ b/examples/acados_matlab_octave/getting_started/minimal_example_closed_loop.m
@@ -176,7 +176,7 @@ for i=1:N_sim
         ocp_solver.set('cost_y_ref', yref, k); % last argument is the stage
     end
     yref_e(1) = p_ref(k+1); % terminal stage
-    ocp_solver.set('cost_y_ref_e', yref_e, N);
+    ocp_solver.set('cost_y_ref', yref_e, N);
 
     % solve
     ocp_solver.solve();

--- a/examples/acados_matlab_octave/getting_started/minimal_example_closed_loop.m
+++ b/examples/acados_matlab_octave/getting_started/minimal_example_closed_loop.m
@@ -133,9 +133,8 @@ ocp.constraints.x0 = x0;
 ocp_solver = AcadosOcpSolver(ocp);
 
 % set parameter for all stages
-for i = 0:N
-    ocp_solver.set('p', 1., i);
-end
+ocp_solver.set('p', 1., 0, N+1);
+
 
 %% SIM SOLVER/INTEGRATOR
 sim_solver = AcadosSimSolver(sim);

--- a/examples/acados_matlab_octave/linear_mpc/main.m
+++ b/examples/acados_matlab_octave/linear_mpc/main.m
@@ -121,7 +121,7 @@ x = x0;
 for k = 1:N_horizon-1  % intermediate stages
     ocp_solver.set('cost_y_ref', [zeros(nu,1); xr], k);
 end
-ocp_solver.set('cost_y_ref_e', xr, N_horizon);  % terminal stage
+ocp_solver.set('cost_y_ref', xr, N_horizon);  % terminal stage
 
 for isim = 1:nsim
     % set the current state

--- a/examples/acados_matlab_octave/masses_chain_model/example_ocp.m
+++ b/examples/acados_matlab_octave/masses_chain_model/example_ocp.m
@@ -232,7 +232,7 @@ ocp_solver.set('init_x', x_traj_init);
 ocp_solver.set('init_u', u_traj_init);
 
 % set parameter
-ocp_solver.set('p', T/N);
+ocp_solver.set('p', T/N, 0, N+1);
 
 % solve
 nrep = 1;

--- a/examples/acados_matlab_octave/race_cars/main.m
+++ b/examples/acados_matlab_octave/race_cars/main.m
@@ -248,7 +248,7 @@ for i = 1:Nsim
     end
     yref_N = [sref, 0, 0, 0, 0, 0];
     % yref_N=np.array([0,0,0,0,0,0])
-    ocp_solver.set('cost_y_ref_e', yref_N);
+    ocp_solver.set('cost_y_ref', yref_N, N);
 
     % solve ocp
     t = tic();

--- a/examples/acados_matlab_octave/test/param_test.m
+++ b/examples/acados_matlab_octave/test/param_test.m
@@ -46,7 +46,7 @@ ocp_solver = AcadosOcpSolver(ocp);
 ocp.solver_options.nlp_solver_max_iter = 0;
 
 %% test parameter setters and getters;
-ocp_solver.set('p', zeros(np, 1)); % TODO: this behaviour is only supported for p!
+ocp_solver.set('p', zeros(np, 1), 0, N+1);
 
 p_vals_different = reshape(1:(np*(N+1)), [np, N+1]);
 ocp_solver.set('p', p_vals_different);

--- a/examples/acados_matlab_octave/test/test_ocp_wtnx6.m
+++ b/examples/acados_matlab_octave/test/test_ocp_wtnx6.m
@@ -368,7 +368,7 @@ for ii=1:n_sim
     for jj=0:ocp_N-1
         ocp_solver.set('cost_y_ref', y_ref(:,ii+jj), jj);
     end
-    ocp_solver.set('cost_y_ref_e', y_ref(1:ny_e,ii+ocp_N));
+    ocp_solver.set('cost_y_ref', y_ref(1:ny_e,ii+ocp_N), ocp_N);
 
     % set trajectory initialization (if not, set internally using previous solution)
     ocp_solver.set('init_x', x_traj_init);

--- a/examples/acados_matlab_octave/wind_turbine_nx6/example_closed_loop.m
+++ b/examples/acados_matlab_octave/wind_turbine_nx6/example_closed_loop.m
@@ -360,7 +360,7 @@ for ii=1:n_sim
     % set x0
     ocp_solver.set('constr_x0', x_sim(:,ii));
     % set parameter
-    ocp_solver.set('p', wind0_ref(:,ii+jj), 0, ocp_N);
+    ocp_solver.set('p', wind0_ref(:,ii+jj), 0, ocp_N+1);
 
     % set reference (different at each stage)
     for jj=0:ocp_N-1

--- a/examples/acados_matlab_octave/wind_turbine_nx6/example_closed_loop.m
+++ b/examples/acados_matlab_octave/wind_turbine_nx6/example_closed_loop.m
@@ -359,8 +359,11 @@ for ii=1:n_sim
 
     % set x0
     ocp_solver.set('constr_x0', x_sim(:,ii));
+
     % set parameter
-    ocp_solver.set('p', wind0_ref(:,ii+jj), 0, ocp_N+1);
+    for jj=0:ocp_N-1
+        ocp_solver.set('p', wind0_ref(:,ii+jj), jj);
+    end
 
     % set reference (different at each stage)
     for jj=0:ocp_N-1
@@ -381,8 +384,6 @@ for ii=1:n_sim
     u = ocp_solver.get('u');
     pi = ocp_solver.get('pi');
 
-%ocp_solver.print('stat');
-%return
     % store first input
     u_sim(:,ii) = ocp_solver.get('u', 0);
 

--- a/examples/acados_matlab_octave/wind_turbine_nx6/example_closed_loop.m
+++ b/examples/acados_matlab_octave/wind_turbine_nx6/example_closed_loop.m
@@ -141,7 +141,7 @@ W(2, 2) =  0.0180;
 W(3, 3) =  0.01;
 W(4, 4) =  0.001;
 % weight matrix in mayer term
-W_e = zeros(ny_e, ny_e); 
+W_e = zeros(ny_e, ny_e);
 W_e(1, 1) =  1.5114;
 W_e(2, 1) = -0.0649;
 W_e(1, 2) = -0.0649;
@@ -360,15 +360,13 @@ for ii=1:n_sim
     % set x0
     ocp_solver.set('constr_x0', x_sim(:,ii));
     % set parameter
-    for jj=0:ocp_N-1
-        ocp_solver.set('p', wind0_ref(:,ii+jj), jj);
-    end
+    ocp_solver.set('p', wind0_ref(:,ii+jj), 0, ocp_N);
 
     % set reference (different at each stage)
     for jj=0:ocp_N-1
         ocp_solver.set('cost_y_ref', y_ref(:,ii+jj), jj);
     end
-    ocp_solver.set('cost_y_ref_e', y_ref(1:ny_e,ii+ocp_N));
+    ocp_solver.set('cost_y_ref', y_ref(1:ny_e,ii+ocp_N), ocp_N);
 
     % set trajectory initialization (if not, set internally using previous solution)
     ocp_solver.set('init_x', x_traj_init);
@@ -400,21 +398,6 @@ for ii=1:n_sim
 
     % get new state
     x_sim(:,ii+1) = sim_solver.get('xn');
-%    x_sim(:,ii+1) = x(:,2);
-
-%    (x(:,2) - sim_solver.get('xn'))'
-
-    % simulate to initialize last stage
-    % set initial state of sim
-%    sim_solver.set('x', x(:,ocp_N+1));
-    % set input in sim
-%    sim_solver.set('u', zeros(nu, 1));
-%    sim_solver.set('u', u(:,ocp_N));
-    % set parameter
-%    sim_solver.set('p', wind0_ref(:,ii+ocp_N));
-
-    % simulate state
-%    sim_solver.solve();
 
     % shift trajectory for initialization
 %    x_traj_init = [x(:,2:ocp_N+1), zeros(nx, 1)];
@@ -425,9 +408,6 @@ for ii=1:n_sim
     pi_traj_init = [pi(:,2:ocp_N), pi(:,ocp_N)];
 
     time_ext = toc;
-
-%    x(:,1)'
-%    u(:,1)'
 
     electrical_power = 0.944*97/100*x(1,1)*x(6,1);
 

--- a/examples/acados_matlab_octave/wind_turbine_nx6/example_ocp.m
+++ b/examples/acados_matlab_octave/wind_turbine_nx6/example_ocp.m
@@ -304,15 +304,12 @@ ocp_solver.set('constr_x0', x0_ref);
 
 % set parameter
 nn = 1;
-ocp_solver.set('p', wind0_ref(:,nn));
+% ocp_solver.set('p', wind0_ref(:, nn), 0, N+1);
+ocp_solver.set('p', wind0_ref(:, nn));
 
 % set reference
-% TODO use range setters when available
-for n=0:(N-1)
-    ocp_solver.set('cost_y_ref', y_ref(:,nn), n);
-end
-
-ocp_solver.set('cost_y_ref', y_ref(1:ny_e,nn), N);
+ocp_solver.set('cost_y_ref', y_ref(:, nn), 0, N);
+ocp_solver.set('cost_y_ref', y_ref(1:ny_e, nn), N);
 
 % solve
 disp('before solve')
@@ -327,7 +324,6 @@ time_ext = toc;
 
 %electrical_power = 0.944*97/100*x(1,1)*x(6,1);
 electrical_power = 0.944*97/100*x(1,:).*x(6,:);
-
 
 % statistics
 

--- a/examples/acados_matlab_octave/wind_turbine_nx6/example_ocp.m
+++ b/examples/acados_matlab_octave/wind_turbine_nx6/example_ocp.m
@@ -307,8 +307,11 @@ nn = 1;
 ocp_solver.set('p', wind0_ref(:,nn));
 
 % set reference
-ocp_solver.set('cost_y_ref', y_ref(:,nn));
-ocp_solver.set('cost_y_ref_e', y_ref(1:ny_e,nn));
+for n=0:(N-1)
+    ocp_solver.set('cost_y_ref', y_ref(:,nn), n);
+end
+
+ocp_solver.set('cost_y_ref', y_ref(1:ny_e,nn), N);
 
 % solve
 disp('before solve')
@@ -321,10 +324,8 @@ x = ocp_solver.get('x');
 
 time_ext = toc;
 
-x(:,1)'
-u(:,1)'
-%electrical_power = 0.944*97/100*x(1,1)*x(6,1)
-electrical_power = 0.944*97/100*x(1,:).*x(6,:)
+%electrical_power = 0.944*97/100*x(1,1)*x(6,1);
+electrical_power = 0.944*97/100*x(1,:).*x(6,:);
 
 
 % statistics

--- a/examples/acados_matlab_octave/wind_turbine_nx6/example_ocp.m
+++ b/examples/acados_matlab_octave/wind_turbine_nx6/example_ocp.m
@@ -307,6 +307,7 @@ nn = 1;
 ocp_solver.set('p', wind0_ref(:,nn));
 
 % set reference
+% TODO use range setters when available
 for n=0:(N-1)
     ocp_solver.set('cost_y_ref', y_ref(:,nn), n);
 end

--- a/examples/acados_matlab_octave/wind_turbine_nx6/example_ocp.m
+++ b/examples/acados_matlab_octave/wind_turbine_nx6/example_ocp.m
@@ -304,8 +304,7 @@ ocp_solver.set('constr_x0', x0_ref);
 
 % set parameter
 nn = 1;
-% ocp_solver.set('p', wind0_ref(:, nn), 0, N+1);
-ocp_solver.set('p', wind0_ref(:, nn));
+ocp_solver.set('p', wind0_ref(:, nn), 0, N+1);
 
 % set reference
 ocp_solver.set('cost_y_ref', y_ref(:, nn), 0, N);

--- a/interfaces/acados_c/ocp_nlp_interface.c
+++ b/interfaces/acados_c/ocp_nlp_interface.c
@@ -798,6 +798,10 @@ int ocp_nlp_dims_get_total_from_attr(ocp_nlp_config *config, ocp_nlp_dims *dims,
     {
         return dims->nh_total;
     }
+    else if (!strcmp(field, "yref") || !strcmp(field, "y_ref") || !strcmp(field, "ny"))
+    {
+        return dims->ny_total;
+    }
     else
     {
         printf("\nerror: ocp_nlp_dims_get_total_from_attr: field %s not available\n", field);

--- a/interfaces/acados_matlab_octave/mex_macros.h
+++ b/interfaces/acados_matlab_octave/mex_macros.h
@@ -42,7 +42,7 @@
 #define MEX_DIM_CHECK_VEC_STAGE(fun_name, field, stage, matlab_size, acados_size) {\
     if (acados_size != matlab_size)\
     {\
-        sprintf(buffer, "%s: error setting %s for all stages, wrong dimension, got %d, need %d", fun_name, field, matlab_size, acados_size);\
+        sprintf(buffer, "%s: error setting %s for stage %d, wrong dimension, got %d, need %d", fun_name, field, stage, matlab_size, acados_size);\
         mexErrMsgTxt(buffer);\
     }\
 }

--- a/interfaces/acados_matlab_octave/mex_macros.h
+++ b/interfaces/acados_matlab_octave/mex_macros.h
@@ -42,7 +42,10 @@
 #define MEX_DIM_CHECK_VEC_STAGE(fun_name, field, stage, matlab_size, acados_size) {\
     if (acados_size != matlab_size)\
     {\
-        sprintf(buffer, "%s: error setting %s for stage %d, wrong dimension, got %d, need %d", fun_name, field, stage, matlab_size, acados_size);\
+        if (stage >= 0)\
+            sprintf(buffer, "%s: error setting %s for stage %d, wrong dimension, got %d, need %d", fun_name, field, stage, matlab_size, acados_size);\
+        else\
+            sprintf(buffer, "%s: error setting %s for all stages, wrong dimension, got %d, need %d", fun_name, field, matlab_size, acados_size);\
         mexErrMsgTxt(buffer);\
     }\
 }

--- a/interfaces/acados_matlab_octave/mex_macros.h
+++ b/interfaces/acados_matlab_octave/mex_macros.h
@@ -42,10 +42,7 @@
 #define MEX_DIM_CHECK_VEC_STAGE(fun_name, field, stage, matlab_size, acados_size) {\
     if (acados_size != matlab_size)\
     {\
-        if (stage >= 0)\
-            sprintf(buffer, "%s: error setting %s for stage %d, wrong dimension, got %d, need %d", fun_name, field, stage, matlab_size, acados_size);\
-        else\
-            sprintf(buffer, "%s: error setting %s for all stages, wrong dimension, got %d, need %d", fun_name, field, matlab_size, acados_size);\
+        sprintf(buffer, "%s: error setting %s for all stages, wrong dimension, got %d, need %d", fun_name, field, matlab_size, acados_size);\
         mexErrMsgTxt(buffer);\
     }\
 }

--- a/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_mex_set.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_mex_set.in.c
@@ -395,37 +395,30 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         }
     }
     // initializations
-    else if (!strcmp(field, "init_x") || !strcmp(field, "x"))
+    else if (!strcmp(field, "init_x") || !strcmp(field, "x") ||
+             !strcmp(field, "init_u") || !strcmp(field, "u") ||
+             !strcmp(field, "init_pi")||!strcmp(field, "pi") ||
+             !strcmp(field, "init_lam")||!strcmp(field, "lam") ||
+             !strcmp(field, "init_sl")||!strcmp(field, "sl") ||
+             !strcmp(field, "init_su")||!strcmp(field, "su")
+            )
     {
 
-        extract_field_name(field, field_name, &field_name_length, &ptr_field_name);
+        // remove init_ prefix
+        if (strncmp(field, "init_", 5) == 0)
+            field = field + 5;
 
         if (nrhs == min_nrhs)
         {
-            acados_size = ocp_nlp_dims_get_total_from_attr(config, dims, out, field_name);
+            acados_size = ocp_nlp_dims_get_total_from_attr(config, dims, out, field);
             MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
-            ocp_nlp_set_all(solver, in, out, field_name, value);
+            ocp_nlp_set_all(solver, in, out, field, value);
         }
         else // (nrhs == min_nrhs + 1)
         {
-            acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, s0, field_name);
+            acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, s0, field);
             MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
-            ocp_nlp_out_set(config, dims, out, in, s0, field_name, value);
-        }
-    }
-    else if (!strcmp(field, "init_u") || !strcmp(field, "u"))
-    {
-        if (nrhs == min_nrhs)
-        {
-            acados_size = ocp_nlp_dims_get_total_from_attr(config, dims, out, "u");
-            MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
-            ocp_nlp_set_all(solver, in, out, "u", value);
-        }
-        else // (nrhs == min_nrhs + 1)
-        {
-            acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, s0, "u");
-            MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
-            ocp_nlp_out_set(config, dims, out, in, s0, "u", value);
+            ocp_nlp_out_set(config, dims, out, in, s0, field, value);
         }
     }
     else if (!strcmp(field, "init_z")||!strcmp(field, "z"))
@@ -522,66 +515,6 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
             {
                 MEX_FIELD_ONLY_SUPPORTED_FOR_SOLVER(fun_name, "init_gnsf_phi", "irk_gnsf")
             }
-        }
-    }
-    else if (!strcmp(field, "init_pi")||!strcmp(field, "pi"))
-    {
-        if (nrhs == min_nrhs)
-        {
-            acados_size = ocp_nlp_dims_get_total_from_attr(config, dims, out, "pi");
-            MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
-            ocp_nlp_set_all(solver, in, out, "pi", value);
-        }
-        else // (nrhs == min_nrhs + 1)
-        {
-            acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, s0, "pi");
-            MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
-            ocp_nlp_out_set(config, dims, out, in, s0, "pi", value);
-        }
-    }
-    else if (!strcmp(field, "init_lam")||!strcmp(field, "lam"))
-    {
-        if (nrhs == min_nrhs)
-        {
-            acados_size = ocp_nlp_dims_get_total_from_attr(config, dims, out, "lam");
-            MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
-            ocp_nlp_set_all(solver, in, out, "lam", value);
-        }
-        else //(nrhs == min_nrhs+1)
-        {
-            acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, s0, "lam");
-            MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
-            ocp_nlp_out_set(config, dims, out, in, s0, "lam", value);
-        }
-    }
-    else if (!strcmp(field, "init_sl")||!strcmp(field, "sl"))
-    {
-        if (nrhs == min_nrhs)
-        {
-            acados_size = ocp_nlp_dims_get_total_from_attr(config, dims, out, "sl");
-            MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
-            ocp_nlp_set_all(solver, in, out, "sl", value);
-        }
-        else //(nrhs == min_nrhs+1)
-        {
-            acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, s0, "sl");
-            MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
-            ocp_nlp_out_set(config, dims, out, in, s0, field, value);
-        }
-    }
-    else if (!strcmp(field, "init_su")||!strcmp(field, "su"))
-    {
-        if (nrhs == min_nrhs)
-        {
-            acados_size = ocp_nlp_dims_get_total_from_attr(config, dims, out, "su");
-            MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
-            ocp_nlp_set_all(solver, in, out, "su", value);
-        }
-        else //(nrhs == min_nrhs+1)
-        {
-            acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, s0, "su");
-            MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
-            ocp_nlp_out_set(config, dims, out, in, s0, field, value);
         }
     }
     else if (!strcmp(field, "p"))

--- a/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_mex_set.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_mex_set.in.c
@@ -687,13 +687,6 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 {% endif %}
         ocp_nlp_solver_opts_set(config, opts, "rti_phase", &rti_phase);
     }
-    else if (!strcmp(field, "qp_warm_start"))
-    {
-        acados_size = 1;
-        MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
-        int qp_warm_start = (int) value[0];
-        ocp_nlp_solver_opts_set(config, opts, "qp_warm_start", &qp_warm_start);
-    }
     else if (!strcmp(field, "qp_mu0") || !strcmp(field, "qp_solver_mu0"))
     {
         if (!(plan->ocp_qp_solver_plan.qp_solver == FULL_CONDENSING_HPIPM || plan->ocp_qp_solver_plan.qp_solver == PARTIAL_CONDENSING_HPIPM))
@@ -723,19 +716,12 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         int qp_print_level = (int) value[0];
         ocp_nlp_solver_opts_set(config, opts, "qp_print_level", &qp_print_level);
     }
-    else if (!strcmp(field, "warm_start_first_qp"))
+    else if (!strcmp(field, "qp_warm_start") || !strcmp(field, "warm_start_first_qp") || !strcmp(field, "print_level"))
     {
         acados_size = 1;
         MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
-        int warm_start_first_qp = (int) value[0];
-        ocp_nlp_solver_opts_set(config, opts, "warm_start_first_qp", &warm_start_first_qp);
-    }
-    else if (!strcmp(field, "print_level"))
-    {
-        acados_size = 1;
-        MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
-        int print_level = (int) value[0];
-        ocp_nlp_solver_opts_set(config, opts, "print_level", &print_level);
+        int int_value = (int) value[0];
+        ocp_nlp_solver_opts_set(config, opts, field, &int_value);
     }
     else if (!strcmp(field, "reset"))
     {

--- a/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_mex_set.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_mex_set.in.c
@@ -215,7 +215,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
                 {
                     if ((plan->nlp_cost[ii] == LINEAR_LS) || (plan->nlp_cost[ii] == NONLINEAR_LS) || (plan->nlp_cost[ii] == CONVEX_OVER_NONLINEAR))
                     {
-                        ocp_nlp_cost_model_set(config, dims, in, out, ii, field_name, value+offset);
+                        ocp_nlp_cost_model_set(config, dims, in, ii, field_name, value+offset);
                         tmp_int = ocp_nlp_dims_get_from_attr(config, dims, out, ii, field_name);
                         offset += tmp_int;
                     }
@@ -229,7 +229,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
                     if (acados_size != 0)
                     {
                         MEX_DIM_CHECK_VEC_STAGE(fun_name, field, ii, matlab_size, acados_size)
-                        ocp_nlp_cost_model_set(config, dims, in, out, ii, field_name, value);
+                        ocp_nlp_cost_model_set(config, dims, in, ii, field_name, value);
                     }
                 }
             }
@@ -241,7 +241,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
                 acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, s0, field_name);
                 MEX_DIM_CHECK_VEC_STAGE(fun_name, field, s0, matlab_size, acados_size)
                 if (acados_size != 0)
-                    ocp_nlp_cost_model_set(config, dims, in, out, s0, field_name, value);
+                    ocp_nlp_cost_model_set(config, dims, in, s0, field_name, value);
             }
             else
             {

--- a/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_mex_set.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_mex_set.in.c
@@ -262,7 +262,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     {
         for (ii=s0; ii<se; ii++)
         {
-            if ((plan->nlp_cost[ii] == LINEAR_LS) || (plan->nlp_cost[ii] == NONLINEAR_LS))
+            if (plan->nlp_cost[ii] == LINEAR_LS)
             {
                 int ny = ocp_nlp_dims_get_from_attr(config, dims, out, ii, "y_ref");
                 int nu = ocp_nlp_dims_get_from_attr(config, dims, out, ii, "u");
@@ -281,7 +281,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     {
         for (ii=s0; ii<se; ii++)
         {
-            if ((plan->nlp_cost[ii] == LINEAR_LS) || (plan->nlp_cost[ii] == NONLINEAR_LS))
+            if (plan->nlp_cost[ii] == LINEAR_LS)
             {
                 int ny = ocp_nlp_dims_get_from_attr(config, dims, out, ii, "y_ref");
                 int nx = ocp_nlp_dims_get_from_attr(config, dims, out, ii, "x");

--- a/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_mex_set.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_mex_set.in.c
@@ -59,7 +59,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     char field_name[128];
 
     /* RHS */
-    int min_nrhs = 3;
+    int min_nrhs = 3; // C ocp, field, value, optional: stage, second stage for range setters
 
     // C ocp
     const mxArray *C_ocp = prhs[0];
@@ -106,6 +106,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     int s0, se;
     if (nrhs == min_nrhs)
     {
+        // TODO not needed anymore?
         s0 = 0;
         se = N;
     }
@@ -118,6 +119,21 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
             mexErrMsgTxt(buffer);
         }
         se = s0 + 1;
+    }
+    else if (nrhs == min_nrhs+2)
+    {
+        s0 = mxGetScalar( prhs[3] );
+        se = mxGetScalar( prhs[4] );
+        if (s0 > N)
+        {
+            sprintf(buffer, "ocp_set: N < specified stage s0 = %d\n", s0);
+            mexErrMsgTxt(buffer);
+        }
+        if (se > N+1)
+        {
+            sprintf(buffer, "ocp_set: N + 1 < specified stage se = %d\n", se);
+            mexErrMsgTxt(buffer);
+        }
     }
     else
     {
@@ -207,30 +223,16 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         if (nrhs == min_nrhs)
         {
             acados_size = ocp_nlp_dims_get_total_from_attr(config, dims, out, "y_ref");
+            MEX_DIM_CHECK_VEC_STAGE(fun_name, field, -1, matlab_size, acados_size)
 
-            if (acados_size == matlab_size) // set flat
+            offset = 0;
+            for (ii=0; ii<=N; ii++) // TODO implement set_all
             {
-                offset = 0;
-                for (ii=0; ii<=N; ii++) // TODO implement set_all
+                if ((plan->nlp_cost[ii] == LINEAR_LS) || (plan->nlp_cost[ii] == NONLINEAR_LS) || (plan->nlp_cost[ii] == CONVEX_OVER_NONLINEAR))
                 {
-                    if ((plan->nlp_cost[ii] == LINEAR_LS) || (plan->nlp_cost[ii] == NONLINEAR_LS) || (plan->nlp_cost[ii] == CONVEX_OVER_NONLINEAR))
-                    {
-                        ocp_nlp_cost_model_set(config, dims, in, ii, "y_ref", value+offset);
-                        tmp_int = ocp_nlp_dims_get_from_attr(config, dims, out, ii, "y_ref");
-                        offset += tmp_int;
-                    }
-                }
-            }
-            else // try to set the same value for all stages for which the dimension is not 0
-            {
-                for (ii=0; ii<=N; ii++)
-                {
-                    acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, ii, "y_ref");
-                    if (acados_size != 0)
-                    {
-                        MEX_DIM_CHECK_VEC_STAGE(fun_name, field, ii, matlab_size, acados_size)
-                        ocp_nlp_cost_model_set(config, dims, in, ii, "y_ref", value);
-                    }
+                    ocp_nlp_cost_model_set(config, dims, in, ii, "y_ref", value+offset);
+                    tmp_int = ocp_nlp_dims_get_from_attr(config, dims, out, ii, "y_ref");
+                    offset += tmp_int;
                 }
             }
         }
@@ -247,7 +249,23 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
             {
                 MEX_FIELD_NOT_SUPPORTED_FOR_COST_STAGE(fun_name, field, plan->nlp_cost[ii], ii);
             }
-
+        }
+        else if (nrhs == min_nrhs + 2) // range of stages
+        {
+            for (ii=s0; ii<se; ii++)
+            {
+                if ((plan->nlp_cost[ii] == LINEAR_LS) || (plan->nlp_cost[ii] == NONLINEAR_LS) || (plan->nlp_cost[ii] == CONVEX_OVER_NONLINEAR))
+                {
+                    acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, ii, "y_ref");
+                    MEX_DIM_CHECK_VEC_STAGE(fun_name, field, ii, matlab_size, acados_size)
+                    if (acados_size != 0)
+                        ocp_nlp_cost_model_set(config, dims, in, ii, "y_ref", value);
+                }
+                else
+                {
+                    MEX_FIELD_NOT_SUPPORTED_FOR_COST_STAGE(fun_name, field, plan->nlp_cost[ii], ii);
+                }
+            }
         }
     }
     else if (!strcmp(field, "cost_y_ref_e"))

--- a/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_mex_set.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_mex_set.in.c
@@ -164,28 +164,12 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     {
         extract_field_name(field, field_name, &field_name_length, &ptr_field_name);
 
-        if (nrhs == min_nrhs) // all stages
+        if (nrhs == min_nrhs)
         {
-            acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, 0, field_name);
+            acados_size = ocp_nlp_dims_get_total_from_attr(config, dims, out, field_name);
 
-            if (acados_size == matlab_size) // set the same value for all stages for which the dimension is not 0
+            if (acados_size == matlab_size) // set flat
             {
-                for (ii=0; ii<=N; ii++)
-                {
-                    acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, ii, field_name);
-                    if (matlab_size != 0)
-                    {
-                        // NOTE: checking only stages with dimension > 0 allows this to work
-                        // also for lbu/ubu. for which dimension at terminal stage is 0
-                        MEX_DIM_CHECK_VEC_STAGE(fun_name, field, ii, matlab_size, acados_size)
-                        ocp_nlp_constraints_model_set(config, dims, in, out, ii, field_name, value);
-                    }
-                }
-            }
-            else
-            {
-                acados_size = ocp_nlp_dims_get_total_from_attr(config, dims, out, field_name);
-                MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
                 offset = 0;
                 for (ii=0; ii<=N; ii++) // TODO implement set_all
                 {
@@ -194,35 +178,81 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
                     offset += tmp_int;
                 }
             }
+            else // try to set the same value for all stages for which the dimension is not 0
+            {
+                for (ii=0; ii<=N; ii++)
+                {
+                    acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, ii, field_name);
+                    if (acados_size != 0)
+                    {
+                        // NOTE: checking only stages with dimension > 0 allows this to work
+                        // also for lbu/ubu. for which dimension at terminal stage is 0
+                        MEX_DIM_CHECK_VEC_STAGE(fun_name, field, ii, matlab_size, acados_size)
+                        ocp_nlp_constraints_model_set(config, dims, in, out, ii, field_name, value);
+                    }
+                }
+            }
         }
         else if (nrhs == min_nrhs + 1) // single stage
         {
             acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, s0, field_name);
             MEX_DIM_CHECK_VEC_STAGE(fun_name, field, s0, matlab_size, acados_size)
-            if (matlab_size != 0)
+            if (acados_size != 0)
                 ocp_nlp_constraints_model_set(config, dims, in, out, s0, field_name, value);
         }
     }
     // cost:
     else if (!strcmp(field, "cost_y_ref"))
     {
-        for (ii=s0; ii<se; ii++)
+        if (nrhs == min_nrhs)
         {
-            if ((plan->nlp_cost[ii] == LINEAR_LS) || (plan->nlp_cost[ii] == NONLINEAR_LS))
+            acados_size = ocp_nlp_dims_get_total_from_attr(config, dims, out, field_name);
+
+            if (acados_size == matlab_size) // set flat
             {
-                acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, ii, "y_ref");
-                MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
-                if (matlab_size != 0)
-                    ocp_nlp_cost_model_set(config, dims, in, ii, "y_ref", value);
+                offset = 0;
+                for (ii=0; ii<=N; ii++) // TODO implement set_all
+                {
+                    if ((plan->nlp_cost[ii] == LINEAR_LS) || (plan->nlp_cost[ii] == NONLINEAR_LS) || (plan->nlp_cost[ii] == CONVEX_OVER_NONLINEAR))
+                    {
+                        ocp_nlp_cost_model_set(config, dims, in, out, ii, field_name, value+offset);
+                        tmp_int = ocp_nlp_dims_get_from_attr(config, dims, out, ii, field_name);
+                        offset += tmp_int;
+                    }
+                }
+            }
+            else // try to set the same value for all stages for which the dimension is not 0
+            {
+                for (ii=0; ii<=N; ii++)
+                {
+                    acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, ii, field_name);
+                    if (acados_size != 0)
+                    {
+                        MEX_DIM_CHECK_VEC_STAGE(fun_name, field, ii, matlab_size, acados_size)
+                        ocp_nlp_cost_model_set(config, dims, in, out, ii, field_name, value);
+                    }
+                }
+            }
+        }
+        else if (nrhs == min_nrhs + 1) // single stage
+        {
+            if ((plan->nlp_cost[ii] == LINEAR_LS) || (plan->nlp_cost[ii] == NONLINEAR_LS) || (plan->nlp_cost[ii] == CONVEX_OVER_NONLINEAR))
+            {
+                acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, s0, field_name);
+                MEX_DIM_CHECK_VEC_STAGE(fun_name, field, s0, matlab_size, acados_size)
+                if (acados_size != 0)
+                    ocp_nlp_cost_model_set(config, dims, in, out, s0, field_name, value);
             }
             else
             {
                 MEX_FIELD_NOT_SUPPORTED_FOR_COST_STAGE(fun_name, field, plan->nlp_cost[ii], ii);
             }
+
         }
     }
     else if (!strcmp(field, "cost_y_ref_e"))
     {
+        sprintf(buffer, "ocp_set: setting cost_y_ref_e is deprecated. Use cost_y_ref at stage N instead.");
         acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, N, "y_ref");
         MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
         if (matlab_size != 0)
@@ -288,24 +318,12 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     {
         extract_field_name(field, field_name, &field_name_length, &ptr_field_name);
 
-        if (nrhs == min_nrhs) // all stages
+        if (nrhs == min_nrhs) // no stage provided
         {
-            acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, 0, field);
+            acados_size = ocp_nlp_dims_get_total_from_attr(config, dims, out, field);
 
-            if (acados_size == matlab_size) // set the same value for all stages
+            if (acados_size == matlab_size) // set flat
             {
-                for (ii=0; ii<=N; ii++)
-                {
-                    acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, ii, field);
-                    MEX_DIM_CHECK_VEC_STAGE(fun_name, field, ii, matlab_size, acados_size)
-                    if (matlab_size != 0)
-                        ocp_nlp_cost_model_set(config, dims, in, ii, field_name, value);
-                }
-            }
-            else
-            {
-                acados_size = ocp_nlp_dims_get_total_from_attr(config, dims, out, field);
-                MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
                 offset = 0;
                 for (ii=0; ii<=N; ii++) // TODO implement set_all
                 {
@@ -314,12 +332,24 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
                     offset += tmp_int;
                 }
             }
+            else // set the same value for all stages for which the dimension is not 0
+            {
+                for (ii=0; ii<=N; ii++)
+                {
+                    acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, ii, field);
+                    if (acados_size != 0)
+                    {
+                        MEX_DIM_CHECK_VEC_STAGE(fun_name, field, ii, matlab_size, acados_size)
+                        ocp_nlp_cost_model_set(config, dims, in, ii, field_name, value);
+                    }
+                }
+            }
         }
         else if (nrhs == min_nrhs + 1) // single stage
         {
             acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, s0, field);
             MEX_DIM_CHECK_VEC_STAGE(fun_name, field, s0, matlab_size, acados_size)
-            if (matlab_size != 0)
+            if (acados_size != 0)
                 ocp_nlp_cost_model_set(config, dims, in, s0, field_name, value);
         }
     }
@@ -329,26 +359,12 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 
         extract_field_name(field, field_name, &field_name_length, &ptr_field_name);
 
-        if (nrhs == min_nrhs) // all stages
+        if (nrhs == min_nrhs) // no stage provided
         {
-            acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, 0, field_name);
+            acados_size = ocp_nlp_dims_get_total_from_attr(config, dims, out, field_name);
 
-            if (acados_size == matlab_size) // set the same value for all stages
+            if (acados_size == matlab_size) // set flat
             {
-                for (ii=0; ii<=N; ii++)
-                {
-                    acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, ii, field_name);
-                    MEX_DIM_CHECK_VEC_STAGE(fun_name, field, ii, matlab_size, acados_size)
-                    if (matlab_size != 0)
-                    {
-                        ocp_nlp_cost_model_set(config, dims, in, ii, field_name, value);
-                    }
-                }
-            }
-            else
-            {
-                acados_size = ocp_nlp_dims_get_total_from_attr(config, dims, out, field_name);
-                MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
                 offset = 0;
                 for (ii=0; ii<=N; ii++)
                 {
@@ -357,12 +373,24 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
                     offset += tmp_int;
                 }
             }
+            else // set the same value for all stages for which the dimension is not 0
+            {
+                for (ii=0; ii<=N; ii++)
+                {
+                    acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, ii, field_name);
+                    if (acados_size != 0)
+                    {
+                        MEX_DIM_CHECK_VEC_STAGE(fun_name, field, ii, matlab_size, acados_size)
+                        ocp_nlp_cost_model_set(config, dims, in, ii, field_name, value);
+                    }
+                }
+            }
         }
         else if (nrhs == min_nrhs + 1) // single stage
         {
             acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, s0, field_name);
             MEX_DIM_CHECK_VEC_STAGE(fun_name, field, s0, matlab_size, acados_size)
-            if (matlab_size != 0)
+            if (acados_size != 0)
                 ocp_nlp_cost_model_set(config, dims, in, s0, field_name, value);
         }
     }
@@ -555,24 +583,26 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     }
     else if (!strcmp(field, "p"))
     {
-        if (nrhs == min_nrhs) // all stages
+        if (nrhs == min_nrhs) // no stage provided
         {
-            acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, 0, "p");
+            acados_size = ocp_nlp_dims_get_total_from_attr(config, dims, out, "p");
 
-            if (acados_size == matlab_size) // setting the same value for all stages
+            if (acados_size == matlab_size) // set flat
+            {
+                ocp_nlp_set_all(solver, in, out, "p", value);
+            }
+            else // setting the same value for all stages for which the dimension is not 0
             {
                 for (ii=0; ii<=N; ii++)
                 {
                     acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, ii, "p");
-                    MEX_DIM_CHECK_VEC_STAGE(fun_name, field, ii, matlab_size, acados_size);
-                    {{ name }}_acados_update_params(capsule, ii, value, matlab_size);
+
+                    if (acados_size != 0)
+                    {
+                        MEX_DIM_CHECK_VEC_STAGE(fun_name, field, ii, matlab_size, acados_size);
+                        {{ name }}_acados_update_params(capsule, ii, value, matlab_size);
+                    }
                 }
-            }
-            else
-            {
-                acados_size = ocp_nlp_dims_get_total_from_attr(config, dims, out, "p");
-                MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
-                ocp_nlp_set_all(solver, in, out, "p", value);
             }
         }
         else if (nrhs == min_nrhs+1) // one stage

--- a/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_mex_set.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_mex_set.in.c
@@ -397,17 +397,20 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     // initializations
     else if (!strcmp(field, "init_x") || !strcmp(field, "x"))
     {
+
+        extract_field_name(field, field_name, &field_name_length, &ptr_field_name);
+
         if (nrhs == min_nrhs)
         {
-            acados_size = ocp_nlp_dims_get_total_from_attr(config, dims, out, "x");
+            acados_size = ocp_nlp_dims_get_total_from_attr(config, dims, out, field_name);
             MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
-            ocp_nlp_set_all(solver, in, out, "x", value);
+            ocp_nlp_set_all(solver, in, out, field_name, value);
         }
         else // (nrhs == min_nrhs + 1)
         {
-            acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, s0, "x");
+            acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, s0, field_name);
             MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
-            ocp_nlp_out_set(config, dims, out, in, s0, "x", value);
+            ocp_nlp_out_set(config, dims, out, in, s0, field_name, value);
         }
     }
     else if (!strcmp(field, "init_u") || !strcmp(field, "u"))

--- a/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_mex_set.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_mex_set.in.c
@@ -153,24 +153,41 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     }
     else if (!strcmp(field, "constr_C"))
     {
-        for (ii=s0; ii<se; ii++)
+
+        if (nrhs == min_nrhs)
         {
-            int ng = ocp_nlp_dims_get_from_attr(config, dims, out, ii, "ug");
-            int nx = ocp_nlp_dims_get_from_attr(config, dims, out, ii, "x");
-            MEX_DIM_CHECK_MAT(fun_name, "constr_C", nrow, ncol, ng, nx);
-            if (matlab_size != 0)
-                ocp_nlp_constraints_model_set(config, dims, in, out, ii, "C", value);
+            sprintf(buffer, "ocp_set: set flat not implemented for constr_C.\n");
+            mexErrMsgTxt(buffer);
+        }
+        else // single stage or range of stages
+        {
+            for (ii=s0; ii<se; ii++)
+            {
+                int ng = ocp_nlp_dims_get_from_attr(config, dims, out, ii, "ug");
+                int nx = ocp_nlp_dims_get_from_attr(config, dims, out, ii, "x");
+                MEX_DIM_CHECK_MAT(fun_name, "constr_C", nrow, ncol, ng, nx);
+                if (matlab_size != 0)
+                    ocp_nlp_constraints_model_set(config, dims, in, out, ii, "C", value);
+            }
         }
     }
     else if (!strcmp(field, "constr_D"))
     {
-        for (ii=s0; ii<se; ii++)
+        if (nrhs == min_nrhs)
         {
-            int ng = ocp_nlp_dims_get_from_attr(config, dims, out, ii, "ug");
-            int nu = ocp_nlp_dims_get_from_attr(config, dims, out, ii, "u");
-            MEX_DIM_CHECK_MAT(fun_name, "constr_D", nrow, ncol, ng, nu);
-            if (matlab_size != 0)
-                ocp_nlp_constraints_model_set(config, dims, in, out, ii, "D", value);
+            sprintf(buffer, "ocp_set: set flat not implemented for constr_D.\n");
+            mexErrMsgTxt(buffer);
+        }
+        else // single stage or range of stages
+        {
+            for (ii=s0; ii<se; ii++)
+            {
+                int ng = ocp_nlp_dims_get_from_attr(config, dims, out, ii, "ug");
+                int nu = ocp_nlp_dims_get_from_attr(config, dims, out, ii, "u");
+                MEX_DIM_CHECK_MAT(fun_name, "constr_D", nrow, ncol, ng, nu);
+                if (matlab_size != 0)
+                    ocp_nlp_constraints_model_set(config, dims, in, out, ii, "D", value);
+            }
         }
     }
     else if (!strcmp(field, "constr_lbx") || !strcmp(field, "constr_ubx") ||
@@ -180,50 +197,37 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     {
         extract_field_name(field, field_name, &field_name_length, &ptr_field_name);
 
-        if (nrhs == min_nrhs)
+        if (nrhs == min_nrhs) // set flat
         {
             acados_size = ocp_nlp_dims_get_total_from_attr(config, dims, out, field_name);
+            MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size)
 
-            if (acados_size == matlab_size) // set flat
+            offset = 0;
+            for (ii=0; ii<=N; ii++) // TODO implement set_all
             {
-                offset = 0;
-                for (ii=0; ii<=N; ii++) // TODO implement set_all
-                {
-                    ocp_nlp_constraints_model_set(config, dims, in, out, ii, field_name, value+offset);
-                    tmp_int = ocp_nlp_dims_get_from_attr(config, dims, out, ii, field_name);
-                    offset += tmp_int;
-                }
-            }
-            else // try to set the same value for all stages for which the dimension is not 0
-            {
-                for (ii=0; ii<=N; ii++)
-                {
-                    acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, ii, field_name);
-                    if (acados_size != 0)
-                    {
-                        // NOTE: checking only stages with dimension > 0 allows this to work
-                        // also for lbu/ubu. for which dimension at terminal stage is 0
-                        MEX_DIM_CHECK_VEC_STAGE(fun_name, field, ii, matlab_size, acados_size)
-                        ocp_nlp_constraints_model_set(config, dims, in, out, ii, field_name, value);
-                    }
-                }
+                ocp_nlp_constraints_model_set(config, dims, in, out, ii, field_name, value+offset);
+                tmp_int = ocp_nlp_dims_get_from_attr(config, dims, out, ii, field_name);
+                offset += tmp_int;
             }
         }
-        else if (nrhs == min_nrhs + 1) // single stage
+        else if ((nrhs == min_nrhs + 1) || (nrhs == min_nrhs + 2)) // single stage or range of stages
         {
-            acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, s0, field_name);
-            MEX_DIM_CHECK_VEC_STAGE(fun_name, field, s0, matlab_size, acados_size)
-            if (acados_size != 0)
-                ocp_nlp_constraints_model_set(config, dims, in, out, s0, field_name, value);
+            for (ii=s0; ii<se; ii++)
+            {
+                acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, ii, field_name);
+                MEX_DIM_CHECK_VEC_STAGE(fun_name, field, ii, matlab_size, acados_size)
+                if (acados_size != 0)
+                    ocp_nlp_constraints_model_set(config, dims, in, out, ii, field_name, value);
+            }
         }
     }
     // cost:
     else if (!strcmp(field, "cost_y_ref"))
     {
-        if (nrhs == min_nrhs)
+        if (nrhs == min_nrhs) // set flat
         {
             acados_size = ocp_nlp_dims_get_total_from_attr(config, dims, out, "y_ref");
-            MEX_DIM_CHECK_VEC_STAGE(fun_name, field, -1, matlab_size, acados_size)
+            MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size)
 
             offset = 0;
             for (ii=0; ii<=N; ii++) // TODO implement set_all
@@ -236,21 +240,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
                 }
             }
         }
-        else if (nrhs == min_nrhs + 1) // single stage
-        {
-            if ((plan->nlp_cost[ii] == LINEAR_LS) || (plan->nlp_cost[ii] == NONLINEAR_LS) || (plan->nlp_cost[ii] == CONVEX_OVER_NONLINEAR))
-            {
-                acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, s0, "y_ref");
-                MEX_DIM_CHECK_VEC_STAGE(fun_name, field, s0, matlab_size, acados_size)
-                if (acados_size != 0)
-                    ocp_nlp_cost_model_set(config, dims, in, s0, "y_ref", value);
-            }
-            else
-            {
-                MEX_FIELD_NOT_SUPPORTED_FOR_COST_STAGE(fun_name, field, plan->nlp_cost[ii], ii);
-            }
-        }
-        else if (nrhs == min_nrhs + 2) // range of stages
+        else if ((nrhs == min_nrhs + 1) || (nrhs == min_nrhs + 2)) // single stage or range of stages
         {
             for (ii=s0; ii<se; ii++)
             {
@@ -278,57 +268,81 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     }
     else if (!strcmp(field, "cost_Vu"))
     {
-        for (ii=s0; ii<se; ii++)
+        if (nrhs == min_nrhs)
         {
-            if (plan->nlp_cost[ii] == LINEAR_LS)
+            sprintf(buffer, "ocp_set: set flat not implemented for cost_Vu\n");
+            mexErrMsgTxt(buffer);
+        }
+        else // single stage or range of stages
+        {
+            for (ii=s0; ii<se; ii++)
             {
-                int ny = ocp_nlp_dims_get_from_attr(config, dims, out, ii, "y_ref");
-                int nu = ocp_nlp_dims_get_from_attr(config, dims, out, ii, "u");
-                acados_size = ny * nu;
-                MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
-                if (matlab_size != 0)
-                    ocp_nlp_cost_model_set(config, dims, in, ii, "Vu", value);
-            }
-            else
-            {
-                MEX_FIELD_NOT_SUPPORTED_FOR_COST_STAGE(fun_name, field, plan->nlp_cost[ii], ii);
+                if (plan->nlp_cost[ii] == LINEAR_LS)
+                {
+                    int ny = ocp_nlp_dims_get_from_attr(config, dims, out, ii, "y_ref");
+                    int nu = ocp_nlp_dims_get_from_attr(config, dims, out, ii, "u");
+                    acados_size = ny * nu;
+                    MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
+                    if (matlab_size != 0)
+                        ocp_nlp_cost_model_set(config, dims, in, ii, "Vu", value);
+                }
+                else
+                {
+                    MEX_FIELD_NOT_SUPPORTED_FOR_COST_STAGE(fun_name, field, plan->nlp_cost[ii], ii);
+                }
             }
         }
     }
     else if (!strcmp(field, "cost_Vx"))
     {
-        for (ii=s0; ii<se; ii++)
+        if (nrhs == min_nrhs)
         {
-            if (plan->nlp_cost[ii] == LINEAR_LS)
+            sprintf(buffer, "ocp_set: set flat not implemented for cost_Vx\n");
+            mexErrMsgTxt(buffer);
+        }
+        else // single stage or range of stages
+        {
+            for (ii=s0; ii<se; ii++)
             {
-                int ny = ocp_nlp_dims_get_from_attr(config, dims, out, ii, "y_ref");
-                int nx = ocp_nlp_dims_get_from_attr(config, dims, out, ii, "x");
-                acados_size = ny * nx;
-                MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
-                if (matlab_size != 0)
-                    ocp_nlp_cost_model_set(config, dims, in, ii, "Vx", value);
-            }
-            else
-            {
-                MEX_FIELD_NOT_SUPPORTED_FOR_COST_STAGE(fun_name, field, plan->nlp_cost[ii], ii);
+                if (plan->nlp_cost[ii] == LINEAR_LS)
+                {
+                    int ny = ocp_nlp_dims_get_from_attr(config, dims, out, ii, "y_ref");
+                    int nx = ocp_nlp_dims_get_from_attr(config, dims, out, ii, "x");
+                    acados_size = ny * nx;
+                    MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
+                    if (matlab_size != 0)
+                        ocp_nlp_cost_model_set(config, dims, in, ii, "Vx", value);
+                }
+                else
+                {
+                    MEX_FIELD_NOT_SUPPORTED_FOR_COST_STAGE(fun_name, field, plan->nlp_cost[ii], ii);
+                }
             }
         }
     }
     else if (!strcmp(field, "cost_W"))
     {
-        for (ii=s0; ii<se; ii++)
+        if (nrhs == min_nrhs)
         {
-            if ((plan->nlp_cost[ii] == LINEAR_LS) || (plan->nlp_cost[ii] == NONLINEAR_LS))
+            sprintf(buffer, "ocp_set: set flat not implemented for cost_W\n");
+            mexErrMsgTxt(buffer);
+        }
+        else // single stage or range of stages
+        {
+            for (ii=s0; ii<se; ii++)
             {
-                int ny = ocp_nlp_dims_get_from_attr(config, dims, out, ii, "y_ref");
-                acados_size = ny * ny;
-                MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
-                if (matlab_size != 0)
-                    ocp_nlp_cost_model_set(config, dims, in, ii, "W", value);
-            }
-            else
-            {
-                MEX_FIELD_NOT_SUPPORTED_FOR_COST_STAGE(fun_name, field, plan->nlp_cost[ii], ii);
+                if ((plan->nlp_cost[ii] == LINEAR_LS) || (plan->nlp_cost[ii] == NONLINEAR_LS))
+                {
+                    int ny = ocp_nlp_dims_get_from_attr(config, dims, out, ii, "y_ref");
+                    acados_size = ny * ny;
+                    MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
+                    if (matlab_size != 0)
+                        ocp_nlp_cost_model_set(config, dims, in, ii, "W", value);
+                }
+                else
+                {
+                    MEX_FIELD_NOT_SUPPORTED_FOR_COST_STAGE(fun_name, field, plan->nlp_cost[ii], ii);
+                }
             }
         }
     }
@@ -336,39 +350,28 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     {
         extract_field_name(field, field_name, &field_name_length, &ptr_field_name);
 
-        if (nrhs == min_nrhs) // no stage provided
+        if (nrhs == min_nrhs) // set flat
         {
             acados_size = ocp_nlp_dims_get_total_from_attr(config, dims, out, field);
+            MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size)
 
-            if (acados_size == matlab_size) // set flat
+            offset = 0;
+            for (ii=0; ii<=N; ii++) // TODO implement set_all
             {
-                offset = 0;
-                for (ii=0; ii<=N; ii++) // TODO implement set_all
-                {
-                    ocp_nlp_cost_model_set(config, dims, in, ii, field_name, value+offset);
-                    tmp_int = ocp_nlp_dims_get_from_attr(config, dims, out, ii, field);
-                    offset += tmp_int;
-                }
-            }
-            else // set the same value for all stages for which the dimension is not 0
-            {
-                for (ii=0; ii<=N; ii++)
-                {
-                    acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, ii, field);
-                    if (acados_size != 0)
-                    {
-                        MEX_DIM_CHECK_VEC_STAGE(fun_name, field, ii, matlab_size, acados_size)
-                        ocp_nlp_cost_model_set(config, dims, in, ii, field_name, value);
-                    }
-                }
+                ocp_nlp_cost_model_set(config, dims, in, ii, field_name, value+offset);
+                tmp_int = ocp_nlp_dims_get_from_attr(config, dims, out, ii, field);
+                offset += tmp_int;
             }
         }
-        else if (nrhs == min_nrhs + 1) // single stage
+        else if ((nrhs == min_nrhs + 1) || (nrhs == min_nrhs + 2)) // single stage or range of stages
         {
-            acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, s0, field);
-            MEX_DIM_CHECK_VEC_STAGE(fun_name, field, s0, matlab_size, acados_size)
-            if (acados_size != 0)
-                ocp_nlp_cost_model_set(config, dims, in, s0, field_name, value);
+            for (ii=s0; ii<se; ii++)
+            {
+                acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, ii, field);
+                MEX_DIM_CHECK_VEC_STAGE(fun_name, field, ii, matlab_size, acados_size)
+                if (acados_size != 0)
+                    ocp_nlp_cost_model_set(config, dims, in, ii, field_name, value);
+            }
         }
     }
     else if (!strcmp(field, "cost_zl") || !strcmp(field, "cost_zu") ||
@@ -377,39 +380,28 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 
         extract_field_name(field, field_name, &field_name_length, &ptr_field_name);
 
-        if (nrhs == min_nrhs) // no stage provided
+        if (nrhs == min_nrhs) // set flat
         {
             acados_size = ocp_nlp_dims_get_total_from_attr(config, dims, out, field_name);
+            MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size)
 
-            if (acados_size == matlab_size) // set flat
+            offset = 0;
+            for (ii=0; ii<=N; ii++)
             {
-                offset = 0;
-                for (ii=0; ii<=N; ii++)
-                {
-                    ocp_nlp_cost_model_set(config, dims, in, ii, field_name, value+offset);
-                    tmp_int = ocp_nlp_dims_get_from_attr(config, dims, out, ii, field_name);
-                    offset += tmp_int;
-                }
-            }
-            else // set the same value for all stages for which the dimension is not 0
-            {
-                for (ii=0; ii<=N; ii++)
-                {
-                    acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, ii, field_name);
-                    if (acados_size != 0)
-                    {
-                        MEX_DIM_CHECK_VEC_STAGE(fun_name, field, ii, matlab_size, acados_size)
-                        ocp_nlp_cost_model_set(config, dims, in, ii, field_name, value);
-                    }
-                }
+                ocp_nlp_cost_model_set(config, dims, in, ii, field_name, value+offset);
+                tmp_int = ocp_nlp_dims_get_from_attr(config, dims, out, ii, field_name);
+                offset += tmp_int;
             }
         }
-        else if (nrhs == min_nrhs + 1) // single stage
+        else if ((nrhs == min_nrhs + 1) || (nrhs == min_nrhs + 2)) // single stage or range of stages
         {
-            acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, s0, field_name);
-            MEX_DIM_CHECK_VEC_STAGE(fun_name, field, s0, matlab_size, acados_size)
-            if (acados_size != 0)
-                ocp_nlp_cost_model_set(config, dims, in, s0, field_name, value);
+            for (ii=s0; ii<se; ii++)
+            {
+                acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, ii, field_name);
+                MEX_DIM_CHECK_VEC_STAGE(fun_name, field, ii, matlab_size, acados_size)
+                if (acados_size != 0)
+                    ocp_nlp_cost_model_set(config, dims, in, ii, field_name, value);
+            }
         }
     }
     // initializations
@@ -426,24 +418,28 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         if (strncmp(field, "init_", 5) == 0)
             field = field + 5;
 
-        if (nrhs == min_nrhs)
+        if (nrhs == min_nrhs) // set flat
         {
             acados_size = ocp_nlp_dims_get_total_from_attr(config, dims, out, field);
             MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
             ocp_nlp_set_all(solver, in, out, field, value);
         }
-        else // (nrhs == min_nrhs + 1)
+        else if ((nrhs == min_nrhs + 1) || (nrhs == min_nrhs + 2)) // single stage or range of stages
         {
-            acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, s0, field);
-            MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
-            ocp_nlp_out_set(config, dims, out, in, s0, field, value);
+            for (ii=s0; ii<se; ii++)
+            {
+                acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, ii, field);
+                MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
+                ocp_nlp_out_set(config, dims, out, in, ii, field, value);
+            }
         }
     }
     else if (!strcmp(field, "init_z")||!strcmp(field, "z"))
     {
         sim_solver_plan_t sim_plan = plan->sim_solver_plan[s0];
         sim_solver_t type = sim_plan.sim_solver;
-        if (nrhs == min_nrhs)
+
+        if (nrhs == min_nrhs) // set flat
         {
             {% if problem_class == "MOCP" %}
             MEX_SETTER_NO_ALL_STAGES_SUPPORT(fun_name, field)
@@ -457,13 +453,17 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
             }
             {% endif %}
         }
-        else // nrhs == min_nrhs+1)
+        else if ((nrhs == min_nrhs + 1) || (nrhs == min_nrhs + 2)) // single stage or range of stages
         {
             if (type == IRK)
             {
-                acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, s0, "z");
-                MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
-                ocp_nlp_set(solver, s0, "z_guess", value);
+                for (ii=s0; ii<se; ii++)
+                {
+                    acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, ii, "z");
+                    MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
+                    if (acados_size != 0)
+                        ocp_nlp_set(solver, ii, "z_guess", value);
+                }
             }
             else
             {
@@ -475,7 +475,8 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     {
         sim_solver_plan_t sim_plan = plan->sim_solver_plan[s0];
         sim_solver_t type = sim_plan.sim_solver;
-        if (nrhs == min_nrhs)
+
+        if (nrhs == min_nrhs) // set flat
         {
             {% if problem_class == "MOCP" %}
             MEX_SETTER_NO_ALL_STAGES_SUPPORT(fun_name, field)
@@ -489,13 +490,17 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
             }
             {% endif %}
         }
-        else // nrhs == min_nrhs+1)
+        else if ((nrhs == min_nrhs + 1) || (nrhs == min_nrhs + 2)) // single stage or range of stages
         {
             if (type == IRK)
             {
-                acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, s0, "x");
-                MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
-                ocp_nlp_set(solver, s0, "xdot_guess", value);
+                for (ii=s0; ii<se; ii++)
+                {
+                    acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, ii, "x");
+                    MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
+                    if (acados_size != 0)
+                        ocp_nlp_set(solver, ii, "xdot_guess", value);
+                }
             }
             else
             {
@@ -507,7 +512,8 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     {
         sim_solver_plan_t sim_plan = plan->sim_solver_plan[s0];
         sim_solver_t type = sim_plan.sim_solver;
-        if (nrhs == min_nrhs)
+
+        if (nrhs == min_nrhs) // set flat
         {
             {% if problem_class == "MOCP" %}
             MEX_SETTER_NO_ALL_STAGES_SUPPORT(fun_name, field)
@@ -521,13 +527,17 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
             }
             {% endif %}
         }
-        else // nrhs == min_nrhs+1)
+        else if ((nrhs == min_nrhs + 1) || (nrhs == min_nrhs + 2)) // single stage or range of stages
         {
             if (type == GNSF)
             {
-                acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, s0, "init_gnsf_phi");
-                MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
-                ocp_nlp_set(solver, s0, "gnsf_phi_guess", value);
+                for (ii=s0; ii<se; ii++)
+                {
+                    acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, ii, "init_gnsf_phi");
+                    MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
+                    if (acados_size != 0)
+                        ocp_nlp_set(solver, ii, "gnsf_phi_guess", value);
+                }
             }
             else
             {
@@ -537,33 +547,21 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     }
     else if (!strcmp(field, "p"))
     {
-        if (nrhs == min_nrhs) // no stage provided
+        if (nrhs == min_nrhs) // set flat
         {
             acados_size = ocp_nlp_dims_get_total_from_attr(config, dims, out, "p");
+            MEX_DIM_CHECK_VEC(fun_name, field, matlab_size, acados_size);
 
-            if (acados_size == matlab_size) // set flat
-            {
-                ocp_nlp_set_all(solver, in, out, "p", value);
-            }
-            else // setting the same value for all stages for which the dimension is not 0
-            {
-                for (ii=0; ii<=N; ii++)
-                {
-                    acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, ii, "p");
-
-                    if (acados_size != 0)
-                    {
-                        MEX_DIM_CHECK_VEC_STAGE(fun_name, field, ii, matlab_size, acados_size);
-                        {{ name }}_acados_update_params(capsule, ii, value, matlab_size);
-                    }
-                }
-            }
+            ocp_nlp_set_all(solver, in, out, "p", value);
         }
-        else if (nrhs == min_nrhs+1) // one stage
+        else if ((nrhs == min_nrhs + 1) || (nrhs == min_nrhs + 2)) // single stage or range of stages
         {
-            acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, s0, "p");
-            MEX_DIM_CHECK_VEC_STAGE(fun_name, field, s0, matlab_size, acados_size)
-            {{ name }}_acados_update_params(capsule, s0, value, matlab_size);
+            for (ii=s0; ii<se; ii++)
+            {
+                acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, ii, "p");
+                MEX_DIM_CHECK_VEC_STAGE(fun_name, field, ii, matlab_size, acados_size)
+                {{ name }}_acados_update_params(capsule, ii, value, matlab_size);
+            }
         }
     }
     else if (!strcmp(field, "p_global"))

--- a/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_mex_set.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_mex_set.in.c
@@ -107,6 +107,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     if (nrhs == min_nrhs)
     {
         s0 = 0; // needed for z, xdot, gnsf_phi guesses
+        se = -1; // this is not needed, just to initialize with something
     }
     else if (nrhs == min_nrhs+1)
     {

--- a/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_mex_set.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_mex_set.in.c
@@ -104,13 +104,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 
     // stage
     int s0, se;
-    if (nrhs == min_nrhs)
-    {
-        // TODO not needed anymore?
-        s0 = 0;
-        se = N;
-    }
-    else if (nrhs == min_nrhs+1)
+    if (nrhs == min_nrhs+1)
     {
         s0 = mxGetScalar( prhs[3] );
         if (s0 > N)

--- a/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_mex_set.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_mex_set.in.c
@@ -206,7 +206,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     {
         if (nrhs == min_nrhs)
         {
-            acados_size = ocp_nlp_dims_get_total_from_attr(config, dims, out, field_name);
+            acados_size = ocp_nlp_dims_get_total_from_attr(config, dims, out, "y_ref");
 
             if (acados_size == matlab_size) // set flat
             {
@@ -215,8 +215,8 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
                 {
                     if ((plan->nlp_cost[ii] == LINEAR_LS) || (plan->nlp_cost[ii] == NONLINEAR_LS) || (plan->nlp_cost[ii] == CONVEX_OVER_NONLINEAR))
                     {
-                        ocp_nlp_cost_model_set(config, dims, in, ii, field_name, value+offset);
-                        tmp_int = ocp_nlp_dims_get_from_attr(config, dims, out, ii, field_name);
+                        ocp_nlp_cost_model_set(config, dims, in, ii, "y_ref", value+offset);
+                        tmp_int = ocp_nlp_dims_get_from_attr(config, dims, out, ii, "y_ref");
                         offset += tmp_int;
                     }
                 }
@@ -225,11 +225,11 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
             {
                 for (ii=0; ii<=N; ii++)
                 {
-                    acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, ii, field_name);
+                    acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, ii, "y_ref");
                     if (acados_size != 0)
                     {
                         MEX_DIM_CHECK_VEC_STAGE(fun_name, field, ii, matlab_size, acados_size)
-                        ocp_nlp_cost_model_set(config, dims, in, ii, field_name, value);
+                        ocp_nlp_cost_model_set(config, dims, in, ii, "y_ref", value);
                     }
                 }
             }
@@ -238,10 +238,10 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         {
             if ((plan->nlp_cost[ii] == LINEAR_LS) || (plan->nlp_cost[ii] == NONLINEAR_LS) || (plan->nlp_cost[ii] == CONVEX_OVER_NONLINEAR))
             {
-                acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, s0, field_name);
+                acados_size = ocp_nlp_dims_get_from_attr(config, dims, out, s0, "y_ref");
                 MEX_DIM_CHECK_VEC_STAGE(fun_name, field, s0, matlab_size, acados_size)
                 if (acados_size != 0)
-                    ocp_nlp_cost_model_set(config, dims, in, s0, field_name, value);
+                    ocp_nlp_cost_model_set(config, dims, in, s0, "y_ref", value);
             }
             else
             {

--- a/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_mex_set.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_mex_set.in.c
@@ -104,7 +104,11 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 
     // stage
     int s0, se;
-    if (nrhs == min_nrhs+1)
+    if (nrhs == min_nrhs)
+    {
+        s0 = 0; // needed for z, xdot, gnsf_phi guesses
+    }
+    else if (nrhs == min_nrhs+1)
     {
         s0 = mxGetScalar( prhs[3] );
         if (s0 > N)


### PR DESCRIPTION
- add getter for ny_total
- add flat setter for `y_ref` in MATLAB interface
- new interface to set ranges of stages to the same value

BREAKING: MATLAB interaction with `AcadosOcpSolver`: setting the same value for all stages via `ocp_solver.set(field, value);` does not work anymore. Instead specify a range of dimensions, e.g. to get the same behavior as call above, use: `ocp_solver.set('p', p_value, 0, N_horizon+1);`.
Instead calls of the form `ocp_solver.set(field, value);` will attempt to set field for all stages and assume that value contains a flattened concatenation of the corresponding field for all stages.

This also streamlines the inconsistent behaviour of  `ocp_solver.set('cost_y_ref', value);` which previously did not set the value at the terminal node. Setting  `ocp_solver.set('cost_y_ref_e', value);` now raises a deprecation warning and should be replaced by `ocp_solver.set('cost_y_ref', value, N_horizon);`