### PR TITLE
Template: initialize numerical values for `p` and `p_global` from static const arrays

### DIFF
--- a/examples/acados_python/p_global_example/example_p_global.py
+++ b/examples/acados_python/p_global_example/example_p_global.py
@@ -244,7 +244,7 @@ def main(use_cython=False, lut=True, use_p_global=True, blazing=True, with_matla
         ocp_solver.set_p_global_and_precompute_dependencies(p_global_values)
         t_elapsed = time.time() - t_start
 
-        print(f"Precompute {t_elapsed}.")
+        print(f"Precompute: {1000*t_elapsed:.3f} ms.")
 
     timing = 0
     for i in range(20):

--- a/interfaces/acados_matlab_octave/AcadosOcpSolver.m
+++ b/interfaces/acados_matlab_octave/AcadosOcpSolver.m
@@ -159,7 +159,10 @@ classdef AcadosOcpSolver < handle
 
             %% compile problem specific shared library
             if obj.solver_creation_opts.build
+                tic;
                 obj.compile_ocp_shared_lib(code_export_directory);
+                t_elapsed = toc;
+                disp(['AcadosOcpSolver: Build completed in ' num2str(100*t_elapsed) ' ms.']);
             end
 
             %% create solver
@@ -776,10 +779,18 @@ classdef AcadosOcpSolver < handle
 
             % generate
             check_dir_and_create(obj.ocp.code_gen_opts.code_export_directory);
+            tic;
             context = obj.ocp.generate_external_functions();
+            t_elapsed = toc;
+            disp(['AcadosOcpSolver: External functions generated in ' num2str(100*t_elapsed) ' ms.']);
 
             obj.ocp.dump_to_json()
+
+            tic;
             obj.ocp.render_templates()
+            t_elapsed = toc;
+            disp(['AcadosOcpSolver: Templated solver code generated in ' num2str(100*t_elapsed) ' ms.']);
+
         end
 
         function compile_mex_interface_if_needed(obj)

--- a/interfaces/acados_matlab_octave/AcadosSimSolver.m
+++ b/interfaces/acados_matlab_octave/AcadosSimSolver.m
@@ -139,7 +139,10 @@ classdef AcadosSimSolver < handle
 
             %% compile problem specific shared library
             if obj.solver_creation_opts.build
+                tic;
                 obj.compile_sim_shared_lib(code_export_directory);
+                t_elapsed = toc;
+                disp(['AcadosSimSolver: Build completed in ' num2str(1000*(t_elapsed)) ' ms.']);
             end
 
             %% create solver
@@ -275,10 +278,19 @@ classdef AcadosSimSolver < handle
         function generate(obj)
             % generate
             check_dir_and_create(obj.sim.code_gen_opts.code_export_directory);
+            tic;
             obj.sim.generate_external_functions();
+            t_elapsed = toc;
+            disp(['AcadosSimSolver: External functions generated in ' num2str(1000*(t_elapsed)) ' ms.']);
+
 
             obj.sim.dump_to_json()
+
+            tic;
             obj.sim.render_templates()
+            t_elapsed = toc;
+            disp(['AcadosSimSolver: Templated solver code generated in  ' num2str(1000*(t_elapsed)) ' ms.']);
+
         end
 
         function compile_mex_sim_interface_if_needed(obj)

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -194,6 +194,7 @@ class AcadosOcpSolver:
         """
         code_export_dir = os.path.abspath(code_export_dir)
 
+        t0 = time.time()
         with set_directory(code_export_dir):
             if os.name == 'nt':
                 make_cmd = 'mingw32-make'
@@ -209,6 +210,11 @@ class AcadosOcpSolver:
                 else:
                     verbose_system_call([make_cmd, 'clean_ocp_shared_lib'], verbose)
                     verbose_system_call([make_cmd, 'ocp_shared_lib'], verbose)
+
+        t1 = time.time()
+
+        if verbose:
+            print(f"Build completed in {1000*(t1-t0):.3f} ms.")
 
 
     @staticmethod

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -167,9 +167,18 @@ class AcadosOcpSolver:
             print(f"NOTE: The selected QP solver {ocp.solver_options.qp_solver} does not support one-sided constraints yet.")
 
         # generate code (external functions and templated code)
+        t0 = time.time()
         ocp.generate_external_functions()
+        t1 = time.time()
+        if verbose:
+            print(f"External functions generated in {1000*(t1-t0):.3f} ms.")
         ocp.dump_to_json()
+
+        t0 = time.time()
         ocp.render_templates(cmake_builder=cmake_builder)
+        t1 = time.time()
+        if verbose:
+            print(f"Templates solver code generated in {1000*(t1-t0):.3f} ms.")
 
         # copy custom update function
         if ocp.solver_options.custom_update_filename != "" and ocp.solver_options.custom_update_copy:

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -127,7 +127,8 @@ class AcadosOcpSolver:
     def generate(ocp: Union[AcadosOcp, AcadosMultiphaseOcp],
                  json_file: str,
                  simulink_opts: Optional[dict]=None,
-                 cmake_builder: Optional[CMakeBuilder] = None, verbose=True):
+                 cmake_builder: Optional[CMakeBuilder] = None,
+                 verbose: bool = True):
         """
         Generates the code for an acados OCP solver, given the description in ocp.
 
@@ -172,13 +173,14 @@ class AcadosOcpSolver:
         t1 = time.time()
         if verbose:
             print(f"External functions generated in {1000*(t1-t0):.3f} ms.")
+
         ocp.dump_to_json()
 
         t0 = time.time()
         ocp.render_templates(cmake_builder=cmake_builder)
         t1 = time.time()
         if verbose:
-            print(f"Templates solver code generated in {1000*(t1-t0):.3f} ms.")
+            print(f"Templated solver code generated in {1000*(t1-t0):.3f} ms.")
 
         # copy custom update function
         if ocp.solver_options.custom_update_filename != "" and ocp.solver_options.custom_update_copy:

--- a/interfaces/acados_template/acados_template/acados_sim_solver.py
+++ b/interfaces/acados_template/acados_template/acados_sim_solver.py
@@ -33,6 +33,7 @@ import json
 import os
 import sys
 import warnings
+import time
 from ctypes import (POINTER, byref, c_bool, c_char_p, c_double, c_int,
                     c_void_p, cast)
 if os.name == 'nt':
@@ -90,7 +91,7 @@ class AcadosSimSolver:
         return self.__generated
 
     @staticmethod
-    def generate(acados_sim: AcadosSim, json_file='acados_sim.json', cmake_builder: CMakeBuilder = None):
+    def generate(acados_sim: AcadosSim, json_file='acados_sim.json', cmake_builder: CMakeBuilder = None, verbose: bool = True):
         """
         Generates the code for an acados sim solver, given the description in acados_sim
         """
@@ -113,15 +114,28 @@ class AcadosSimSolver:
                 detect_gnsf_structure(acados_sim.model, acados_sim.dims)
 
         # generate code for external functions
+        t0 = time.time()
         acados_sim.generate_external_functions()
+        t1 = time.time()
+        if verbose:
+            print(f"External functions generated in {1000*(t1-t0):.3f} ms.")
+
         acados_sim.dump_to_json()
+
+        t0 = time.time()
         acados_sim.render_templates(cmake_builder)
+        t1 = time.time()
+
+        if verbose:
+            print(f"Templated solver code generated in {1000*(t1-t0):.3f} ms.")
 
 
     @staticmethod
     def build(code_export_dir, with_cython=False, cmake_builder: CMakeBuilder = None, verbose: bool = True):
 
         code_export_dir = os.path.abspath(code_export_dir)
+
+        t0 = time.time()
         with set_directory(code_export_dir):
             if with_cython:
                 verbose_system_call(['make', 'clean_sim_cython'], verbose)
@@ -131,6 +145,10 @@ class AcadosSimSolver:
                     cmake_builder.exec(code_export_dir, verbose)
                 else:
                     verbose_system_call(['make', 'sim_shared_lib'], verbose)
+        t1 = time.time()
+
+        if verbose:
+            print(f"Build completed in {1000*(t1-t0):.3f} ms.")
 
 
     @staticmethod
@@ -176,7 +194,7 @@ class AcadosSimSolver:
                 print("Code reuse possible, skipping code generation.")
 
         if generate:
-            self.generate(acados_sim, json_file=json_file, cmake_builder=cmake_builder)
+            self.generate(acados_sim, json_file=json_file, cmake_builder=cmake_builder, verbose=verbose)
             self.__generated = True
         else:
             self.__generated = False

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.c
@@ -58,11 +58,15 @@
 {%- endfor %}
 {%- set np_max = np_values | sort | last %}
 
+{%- set_global sparsity_threshold = 0.1 -%}
+
 
 // standard
 #include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>
+#include <string.h> // memcpy
+
 // acados
 // #include "acados/utils/print.h"
 #include "acados_c/ocp_nlp_interface.h"
@@ -106,6 +110,23 @@
 {%- for jj in range(end=n_phases) %}
 #define NP_{{ jj }}     {{ phases_dims[jj].np }}
 {%- endfor %}
+
+
+{% if dims_0.np_global > 0 %}
+{%- set_global p_global_values_nnz = 0 -%}
+{%- for item in p_global_values -%}
+    {%- if item != 0 -%}
+        {%- set_global p_global_values_nnz = p_global_values_nnz + 1 -%}
+    {%- endif -%}
+{%- endfor -%}
+
+{% if p_global_values_nnz / dims_0.np_global > sparsity_threshold %}
+// initial value of global parameters
+static const double p_global_init[] = {
+    {%- for item in p_global_values -%}{{ item }}, {%- endfor -%}
+};
+{%- endif %}{# if p_global_values_nnz #}
+{%- endif %}{# if dims_0.np_global #}
 
 
 {{ name }}_solver_capsule * {{ name }}_acados_create_capsule(void)
@@ -839,13 +860,19 @@ void {{ name }}_acados_create_set_default_parameters({{ name }}_solver_capsule* 
     free(p);
 
 {%- if phases_dims[0].np_global > 0 %}
-    double* p_global = calloc({{ phases_dims[0].np_global }}, sizeof(double));
+
     // initialize global parameters to nominal value
+    {% if p_global_values_nnz / dims_0.np_global > sparsity_threshold %}
+    double* p_global = malloc({{ dims_0.np_global }}*sizeof(double));
+    memcpy(p_global, p_global_init, {{ dims_0.np_global }}*sizeof(double));
+    {%- else %}
+    double* p_global = calloc({{ dims_0.np_global }}, sizeof(double));
     {%- for item in p_global_values %}
         {%- if item != 0 %}
     p_global[{{ loop.index0 }}] = {{ item }};
         {%- endif %}
     {%- endfor %}
+    {%- endif %}
 
     {{ name }}_acados_set_p_global_and_precompute_dependencies(capsule, p_global, {{ phases_dims[0].np_global }});
 

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.c
@@ -111,6 +111,15 @@
 #define NP_{{ jj }}     {{ phases_dims[jj].np }}
 {%- endfor %}
 
+{%- for jj in range(end=n_phases) %}
+{% if phases_dims[jj].np > 0 %}
+// initial value of stagewise parameters
+static const double p_init_{{ jj }}[] = {
+    {%- for item in parameter_values[jj] -%}{{ item }}, {%- endfor -%}
+};
+{%- endif %}{# if phases_dims[jj].np #}
+{%- endfor %}
+
 
 {% if dims_0.np_global > 0 %}
 {%- set_global p_global_values_nnz = 0 -%}
@@ -844,14 +853,10 @@ void {{ name }}_acados_create_setup_functions({{ name }}_solver_capsule* capsule
  */
 void {{ name }}_acados_create_set_default_parameters({{ name }}_solver_capsule* capsule) {
 
-    double* p = calloc({{ np_max }}, sizeof(double));
+    double* p = malloc({{ np_max }} * sizeof(double));
     // initialize parameters to nominal value
 {%- for jj in range(end=n_phases) %}{# phases loop !#}
-    {%- for item in parameter_values[jj] %}
-        {%- if item != 0 %}
-    p[{{ loop.index0 }}] = {{ item }};
-        {%- endif %}
-    {%- endfor %}
+    memcpy(p, p_init_{{ jj }}, NP_{{ jj }}*sizeof(double));
 
     for (int i = {{ start_idx[jj] }}; i < {{ end_idx[jj] }}; i++) {
         {{ name }}_acados_update_params(capsule, i, p, NP_{{ jj }});

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.c
@@ -856,11 +856,14 @@ void {{ name }}_acados_create_set_default_parameters({{ name }}_solver_capsule* 
     double* p = malloc({{ np_max }} * sizeof(double));
     // initialize parameters to nominal value
 {%- for jj in range(end=n_phases) %}{# phases loop !#}
+
+    {%- if phases_dims[jj].np > 0 %}
     memcpy(p, p_init_{{ jj }}, NP_{{ jj }}*sizeof(double));
 
     for (int i = {{ start_idx[jj] }}; i < {{ end_idx[jj] }}; i++) {
         {{ name }}_acados_update_params(capsule, i, p, NP_{{ jj }});
     }
+    {%- endif %}
 {%- endfor %}
     free(p);
 

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.c
@@ -58,8 +58,6 @@
 {%- endfor %}
 {%- set np_max = np_values | sort | last %}
 
-{%- set_global sparsity_threshold = 0.1 -%}
-
 
 // standard
 #include <stdio.h>
@@ -122,19 +120,10 @@ static const double p_init_{{ jj }}[] = {
 
 
 {% if dims_0.np_global > 0 %}
-{%- set_global p_global_values_nnz = 0 -%}
-{%- for item in p_global_values -%}
-    {%- if item != 0 -%}
-        {%- set_global p_global_values_nnz = p_global_values_nnz + 1 -%}
-    {%- endif -%}
-{%- endfor -%}
-
-{% if p_global_values_nnz / dims_0.np_global > sparsity_threshold %}
 // initial value of global parameters
 static const double p_global_init[] = {
     {%- for item in p_global_values -%}{{ item }}, {%- endfor -%}
 };
-{%- endif %}{# if p_global_values_nnz #}
 {%- endif %}{# if dims_0.np_global #}
 
 
@@ -870,18 +859,8 @@ void {{ name }}_acados_create_set_default_parameters({{ name }}_solver_capsule* 
 {%- if phases_dims[0].np_global > 0 %}
 
     // initialize global parameters to nominal value
-    {% if p_global_values_nnz / dims_0.np_global > sparsity_threshold %}
     double* p_global = malloc({{ dims_0.np_global }}*sizeof(double));
     memcpy(p_global, p_global_init, {{ dims_0.np_global }}*sizeof(double));
-    {%- else %}
-    double* p_global = calloc({{ dims_0.np_global }}, sizeof(double));
-    {%- for item in p_global_values %}
-        {%- if item != 0 %}
-    p_global[{{ loop.index0 }}] = {{ item }};
-        {%- endif %}
-    {%- endfor %}
-    {%- endif %}
-
     {{ name }}_acados_set_p_global_and_precompute_dependencies(capsule, p_global, {{ phases_dims[0].np_global }});
 
     free(p_global);

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_sim_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_sim_solver.in.c
@@ -61,7 +61,7 @@
 
 
 {% if dims.np > 0 %}
-// initial value of stagewise parameters
+// initial value of parameters
 static const double p_init[] = {
     {%- for item in parameter_values -%}{{ item }}, {%- endfor -%}
 };

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_sim_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_sim_solver.in.c
@@ -38,6 +38,7 @@
 // standard
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h> // memcpy
 
 {%- if solver_options.with_batch_functionality %}
 // openmp
@@ -58,6 +59,13 @@
 #include "{{ model.name }}_model/{{ model.name }}_model.h"
 #include "acados_sim_solver_{{ model.name }}.h"
 
+
+{% if dims.np > 0 %}
+// initial value of stagewise parameters
+static const double p_init[] = {
+    {%- for item in parameter_values -%}{{ item }}, {%- endfor -%}
+};
+{%- endif %}{# if dims.np #}
 
 // ** solver data **
 
@@ -406,13 +414,8 @@ int {{ model.name }}_acados_sim_create({{ model.name }}_sim_solver_capsule * cap
 
 {% if dims.np > 0 %}
     /* initialize parameter values */
-    double* p = calloc(np, sizeof(double));
-    {% for item in parameter_values %}
-        {%- if item != 0 %}
-    p[{{ loop.index0 }}] = {{ item }};
-        {%- endif %}
-    {%- endfor %}
-
+    double* p = malloc(np*sizeof(double));
+    memcpy(p, p_init, np*sizeof(double));
     {{ model.name }}_acados_sim_update_params(capsule, p, np);
     free(p);
 {% endif %}{# if dims.np #}

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -117,38 +117,18 @@
 
 
 
-{%- set_global sparsity_threshold = 0.1 -%}
-
 {% if dims.np > 0 %}
-{%- set_global parameter_values_nnz = 0 -%}
-{%- for item in parameter_values -%}
-    {%- if item != 0.0 -%}
-        {%- set_global parameter_values_nnz = parameter_values_nnz + 1 -%}
-    {%- endif -%}
-{%- endfor -%}
-
-{% if parameter_values_nnz / dims.np > sparsity_threshold %}
 // initial value of stagewise parameters
 static const double p_init[] = {
     {%- for item in parameter_values -%}{{ item }}, {%- endfor -%}
 };
-{%- endif %}{# if parameter_values_nnz #}
 {%- endif %}{# if dims.np #}
 
 {% if dims.np_global > 0 %}
-{%- set_global p_global_values_nnz = 0 -%}
-{%- for item in p_global_values -%}
-    {%- if item != 0.0 -%}
-        {%- set_global p_global_values_nnz = p_global_values_nnz + 1 -%}
-    {%- endif -%}
-{%- endfor -%}
-
-{% if p_global_values_nnz / dims.np_global > sparsity_threshold %}
 // initial value of global parameters
 static const double p_global_init[] = {
     {%- for item in p_global_values -%}{{ item }}, {%- endfor -%}
 };
-{%- endif %}{# if p_global_values_nnz #}
 {%- endif %}{# if dims.np_global #}
 
 
@@ -966,17 +946,8 @@ void {{ model.name }}_acados_create_set_default_parameters({{ model.name }}_solv
 {% if dims.np > 0 %}
     const int N = capsule->nlp_solver_plan->N;
     // initialize parameters to nominal value
-    {% if parameter_values_nnz / dims.np > sparsity_threshold %}
     double* p = malloc(NP*sizeof(double));
     memcpy(p, p_init, NP*sizeof(double));
-    {%- else %}
-    double* p = calloc(NP, sizeof(double));
-    {%- for item in parameter_values %}
-        {%- if item != 0 %}
-    p[{{ loop.index0 }}] = {{ item }};
-        {%- endif %}
-    {%- endfor %}
-    {%- endif %}
     for (int i = 0; i <= N; i++) {
         {{ model.name }}_acados_update_params(capsule, i, p, NP);
     }
@@ -987,18 +958,8 @@ void {{ model.name }}_acados_create_set_default_parameters({{ model.name }}_solv
 
 {% if dims.np_global > 0 %}
     // initialize global parameters to nominal value
-    {% if p_global_values_nnz / dims.np_global > sparsity_threshold %}
     double* p_global = malloc(NP_GLOBAL*sizeof(double));
     memcpy(p_global, p_global_init, NP_GLOBAL*sizeof(double));
-    {%- else %}
-    double* p_global = calloc(NP_GLOBAL, sizeof(double));
-    {%- for item in p_global_values %}
-        {%- if item != 0 %}
-    p_global[{{ loop.index0 }}] = {{ item }};
-        {%- endif %}
-    {%- endfor %}
-    {%- endif %}
-
     {{ name }}_acados_set_p_global_and_precompute_dependencies(capsule, p_global, NP_GLOBAL);
 
     free(p_global);

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -153,6 +153,76 @@ static const double yref_e_init[] = {
 };
 {%- endif %}
 
+{%- if dims.ny_0 != 0 and cost.cost_type_0 == "LINEAR_LS" %}
+// initial value of Vx_0
+static const double Vx_0_init[] = {
+    {%- for j in range(end=dims.ny_0) -%}
+        {%- for k in range(end=dims.nx) -%}
+{{ cost.Vx_0[j][k] }}, {%- endfor -%}
+    {%- endfor -%}
+};
+
+{%- if dims.nu > 0 %}
+// initial value of Vu_0
+static const double Vu_0_init[] = {
+    {%- for j in range(end=dims.ny_0) -%}
+        {%- for k in range(end=dims.nu) -%}
+{{ cost.Vu_0[j][k] }}, {%- endfor -%}
+    {%- endfor -%}
+};
+{%- endif %}
+
+{%- if dims.nz > 0 %}
+// initial value of Vz_0
+static const double Vz_0_init[] = {
+    {%- for j in range(end=dims.ny_0) -%}
+        {%- for k in range(end=dims.nz) -%}
+{{ cost.Vz_0[j][k] }}, {%- endfor -%}
+    {%- endfor -%}
+};
+{%- endif %}
+{%- endif %}
+
+{%- if dims.ny != 0 and cost.cost_type == "LINEAR_LS" %}
+// initial value of Vx
+static const double Vx_init[] = {
+    {%- for j in range(end=dims.ny) -%}
+        {%- for k in range(end=dims.nx) -%}
+{{ cost.Vx[j][k] }}, {%- endfor -%}
+    {%- endfor -%}
+};
+
+{%- if dims.nu > 0 %}
+// initial value of Vu
+static const double Vu_init[] = {
+    {%- for j in range(end=dims.ny) -%}
+        {%- for k in range(end=dims.nu) -%}
+{{ cost.Vu[j][k] }}, {%- endfor -%}
+    {%- endfor -%}
+};
+{%- endif %}
+
+{%- if dims.nz > 0 %}
+// initial value of Vz
+static const double Vz_init[] = {
+    {%- for j in range(end=dims.ny) -%}
+        {%- for k in range(end=dims.nz) -%}
+{{ cost.Vz[j][k] }}, {%- endfor -%}
+    {%- endfor -%}
+};
+{%- endif %}
+{%- endif %}
+
+{%- if dims.ny_e != 0 and cost.cost_type_e == "LINEAR_LS" %}
+// initial value of Vx_e
+static const double Vx_e_init[] = {
+    {%- for j in range(end=dims.ny_e) -%}
+        {%- for k in range(end=dims.nx) -%}
+{{ cost.Vx_e[j][k] }}, {%- endfor -%}
+    {%- endfor -%}
+};
+{%- endif %}
+
 
 // ** solver data **
 
@@ -1171,41 +1241,20 @@ void {{ model.name }}_acados_setup_nlp_in({{ model.name }}_solver_capsule* capsu
 
   {%- if cost.cost_type_0 == "LINEAR_LS" %}
     double* Vx_0 = calloc(NY0*NX, sizeof(double));
-    // change only the non-zero elements:
-    {%- for j in range(end=dims.ny_0) %}
-        {%- for k in range(end=dims.nx) %}
-            {%- if cost.Vx_0[j][k] != 0 %}
-    Vx_0[{{ j }}+(NY0) * {{ k }}] = {{ cost.Vx_0[j][k] }};
-            {%- endif %}
-        {%- endfor %}
-    {%- endfor %}
+    memcpy(Vx_0, Vx_0_init, NY0*NX*sizeof(double));
     ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, 0, "Vx", Vx_0);
     free(Vx_0);
 
     {%- if dims.nu > 0 %}
     double* Vu_0 = calloc(NY0*NU, sizeof(double));
-    // change only the non-zero elements:
-    {%- for j in range(end=dims.ny_0) %}
-        {%- for k in range(end=dims.nu) %}
-            {%- if cost.Vu_0[j][k] != 0 %}
-    Vu_0[{{ j }}+(NY0) * {{ k }}] = {{ cost.Vu_0[j][k] }};
-            {%- endif %}
-        {%- endfor %}
-    {%- endfor %}
+    memcpy(Vu_0, Vu_0_init, NY0*NU*sizeof(double));
     ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, 0, "Vu", Vu_0);
     free(Vu_0);
     {%- endif %}
 
     {%- if dims.nz > 0 %}
     double* Vz_0 = calloc(NY0*NZ, sizeof(double));
-    // change only the non-zero elements:
-    {%- for j in range(end=dims.ny_0) %}
-        {%- for k in range(end=dims.nz) %}
-            {%- if cost.Vz_0[j][k] != 0 %}
-    Vz_0[{{ j }}+(NY0) * {{ k }}] = {{ cost.Vz_0[j][k] }};
-            {%- endif %}
-        {%- endfor %}
-    {%- endfor %}
+    memcpy(Vz_0, Vz_0_init, NY0*NZ*sizeof(double));
     ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, 0, "Vz", Vz_0);
     free(Vz_0);
     {%- endif %}{# nz > 0 #}
@@ -1242,14 +1291,7 @@ void {{ model.name }}_acados_setup_nlp_in({{ model.name }}_solver_capsule* capsu
 
   {%- if cost.cost_type == "LINEAR_LS" %}
     double* Vx = calloc(NY*NX, sizeof(double));
-    // change only the non-zero elements:
-    {%- for j in range(end=dims.ny) %}
-        {%- for k in range(end=dims.nx) %}
-            {%- if cost.Vx[j][k] != 0 %}
-    Vx[{{ j }}+(NY) * {{ k }}] = {{ cost.Vx[j][k] }};
-            {%- endif %}
-        {%- endfor %}
-    {%- endfor %}
+    memcpy(Vx, Vx_init, NY*NX*sizeof(double));
     for (int i = 1; i < N; i++)
     {
         ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, i, "Vx", Vx);
@@ -1258,15 +1300,7 @@ void {{ model.name }}_acados_setup_nlp_in({{ model.name }}_solver_capsule* capsu
 
     {% if dims.nu > 0 %}
     double* Vu = calloc(NY*NU, sizeof(double));
-    // change only the non-zero elements:
-    {%- for j in range(end=dims.ny) %}
-        {%- for k in range(end=dims.nu) %}
-            {%- if cost.Vu[j][k] != 0 %}
-    Vu[{{ j }}+(NY) * {{ k }}] = {{ cost.Vu[j][k] }};
-            {%- endif %}
-        {%- endfor %}
-    {%- endfor %}
-
+    memcpy(Vu, Vu_init, NY*NU*sizeof(double));
     for (int i = 1; i < N; i++)
     {
         ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, i, "Vu", Vu);
@@ -1276,15 +1310,7 @@ void {{ model.name }}_acados_setup_nlp_in({{ model.name }}_solver_capsule* capsu
 
     {%- if dims.nz > 0 %}
     double* Vz = calloc(NY*NZ, sizeof(double));
-    // change only the non-zero elements:
-    {%- for j in range(end=dims.ny) %}
-        {%- for k in range(end=dims.nz) %}
-            {%- if cost.Vz[j][k] != 0 %}
-    Vz[{{ j }}+(NY) * {{ k }}] = {{ cost.Vz[j][k] }};
-            {%- endif %}
-        {%- endfor %}
-    {%- endfor %}
-
+    memcpy(Vz, Vz_init, NY*NZ*sizeof(double));
     for (int i = 1; i < N; i++)
     {
         ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, i, "Vz", Vz);
@@ -1317,17 +1343,9 @@ void {{ model.name }}_acados_setup_nlp_in({{ model.name }}_solver_capsule* capsu
     free(W_e);
   {%- endif %}
 
-
   {%- if cost.cost_type_e == "LINEAR_LS" %}
     double* Vx_e = calloc(NYN*NX, sizeof(double));
-    // change only the non-zero elements:
-    {%- for j in range(end=dims.ny_e) %}
-        {%- for k in range(end=dims.nx) %}
-            {%- if cost.Vx_e[j][k] != 0 %}
-    Vx_e[{{ j }}+(NYN) * {{ k }}] = {{ cost.Vx_e[j][k] }};
-            {%- endif %}
-        {%- endfor %}
-    {%- endfor %}
+    memcpy(Vx_e, Vx_e_init, NYN*NX*sizeof(double));
     ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, N, "Vx", Vx_e);
     free(Vx_e);
   {%- endif %}

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -119,86 +119,273 @@
 // ** numerical values **
 
 {% if dims.np > 0 %}
+{%- set_global has_nonzero_parameter_values = false -%}
+{%- for item in parameter_values -%}
+    {%- if item != 0.0 -%}
+        {%- set_global has_nonzero_parameter_values = true -%}
+    {%- endif -%}
+{%- endfor -%}
+
+{% if has_nonzero_parameter_values %}
 // initial value of stagewise parameters
 static const double p_init[] = {
     {%- for item in parameter_values -%}{{ item }}, {%- endfor -%}
 };
+{%- endif %}{# if has_nonzero_parameter_values #}
 {%- endif %}{# if dims.np #}
 
 {% if dims.np_global > 0 %}
+{%- set_global has_nonzero_p_global_values = false -%}
+{%- for item in p_global_values -%}
+    {%- if item != 0.0 -%}
+        {%- set_global has_nonzero_p_global_values = true -%}
+    {%- endif -%}
+{%- endfor -%}
+
+{% if has_nonzero_p_global_values %}
 // initial value of global parameters
 static const double p_global_init[] = {
     {%- for item in p_global_values -%}{{ item }}, {%- endfor -%}
 };
+{%- endif %}{# if has_nonzero_p_global_values #}
 {%- endif %}{# if dims.np_global #}
 
 {%- if dims.ny_0 != 0 %}
+{%- set_global has_nonzero_yref_0_init = false -%}
+{%- for item in cost.yref_0 -%}
+    {%- if item != 0.0 -%}
+        {%- set_global has_nonzero_yref_0_init = true -%}
+    {%- endif -%}
+{%- endfor -%}
+
+{% if has_nonzero_yref_0_init %}
 // initial value of yref_0
 static const double yref_0_init[] = {
     {%- for item in cost.yref_0 -%}{{ item }}, {%- endfor -%}
 };
+{%- endif %}{# if has_nonzero_yref_0_init #}
 {%- endif %}
 
 {%- if dims.ny != 0 %}
+{%- set_global has_nonzero_yref_init = false -%}
+{%- for item in cost.yref -%}
+    {%- if item != 0.0 -%}
+        {%- set_global has_nonzero_yref_init = true -%}
+    {%- endif -%}
+{%- endfor -%}
+
+{% if has_nonzero_yref_init %}
 // initial value of yref
 static const double yref_init[] = {
     {%- for item in cost.yref -%}{{ item }}, {%- endfor -%}
 };
+{%- endif %}{# if has_nonzero_yref_init #}
 {%- endif %}
 
 {%- if dims.ny_e != 0 %}
+{%- set_global has_nonzero_yref_e_init = false -%}
+{%- for item in cost.yref_e -%}
+    {%- if item != 0.0 -%}
+        {%- set_global has_nonzero_yref_e_init = true -%}
+    {%- endif -%}
+{%- endfor -%}
+
+{% if has_nonzero_yref_e_init %}
 // initial value of yref_e
 static const double yref_e_init[] = {
     {%- for item in cost.yref_e -%}{{ item }}, {%- endfor -%}
 };
+{%- endif %}{# if has_nonzero_yref_e_init #}
 {%- endif %}
 
 {%- if dims.ns_0 > 0 %}
+{%- set_global has_nonzero_Zl_0_init = false -%}
+{%- for item in cost.Zl_0 -%}
+    {%- if item != 0.0 -%}
+        {%- set_global has_nonzero_Zl_0_init = true -%}
+    {%- endif -%}
+{%- endfor -%}
+{%- set_global has_nonzero_Zu_0_init = false -%}
+{%- for item in cost.Zu_0 -%}
+    {%- if item != 0.0 -%}
+        {%- set_global has_nonzero_Zu_0_init = true -%}
+    {%- endif -%}
+{%- endfor -%}
+{%- set_global has_nonzero_zl_0_init = false -%}
+{%- for item in cost.zl_0 -%}
+    {%- if item != 0.0 -%}
+        {%- set_global has_nonzero_zl_0_init = true -%}
+    {%- endif -%}
+{%- endfor -%}
+{%- set_global has_nonzero_zu_0_init = false -%}
+{%- for item in cost.zu_0 -%}
+    {%- if item != 0.0 -%}
+        {%- set_global has_nonzero_zu_0_init = true -%}
+    {%- endif -%}
+{%- endfor -%}
+
 // initial value of slacks initial: Zl_0, Zu_0, zl_0, zu_0
+{% if has_nonzero_Zl_0_init %}
 static const double Zl_0_init[] = { {%- for item in cost.Zl_0 -%}{{ item }}, {%- endfor -%} };
+{%- endif %}
+{% if has_nonzero_Zu_0_init %}
 static const double Zu_0_init[] = { {%- for item in cost.Zu_0 -%}{{ item }}, {%- endfor -%} };
+{%- endif %}
+{% if has_nonzero_zl_0_init %}
 static const double zl_0_init[] = { {%- for item in cost.zl_0 -%}{{ item }}, {%- endfor -%} };
+{%- endif %}
+{% if has_nonzero_zu_0_init %}
 static const double zu_0_init[] = { {%- for item in cost.zu_0 -%}{{ item }}, {%- endfor -%} };
+{%- endif %}
 {%- endif %}
 
 {%- if dims.ns > 0 %}
+{%- set_global has_nonzero_Zl_init = false -%}
+{%- for item in cost.Zl -%}
+    {%- if item != 0.0 -%}
+        {%- set_global has_nonzero_Zl_init = true -%}
+    {%- endif -%}
+{%- endfor -%}
+{%- set_global has_nonzero_Zu_init = false -%}
+{%- for item in cost.Zu -%}
+    {%- if item != 0.0 -%}
+        {%- set_global has_nonzero_Zu_init = true -%}
+    {%- endif -%}
+{%- endfor -%}
+{%- set_global has_nonzero_zl_init = false -%}
+{%- for item in cost.zl -%}
+    {%- if item != 0.0 -%}
+        {%- set_global has_nonzero_zl_init = true -%}
+    {%- endif -%}
+{%- endfor -%}
+{%- set_global has_nonzero_zu_init = false -%}
+{%- for item in cost.zu -%}
+    {%- if item != 0.0 -%}
+        {%- set_global has_nonzero_zu_init = true -%}
+    {%- endif -%}
+{%- endfor -%}
+
 // initial value of slacks stagewise: Zl, Zu, zl, zu
+{% if has_nonzero_Zl_init %}
 static const double Zl_init[] = { {%- for item in cost.Zl -%}{{ item }}, {%- endfor -%} };
+{%- endif %}
+{% if has_nonzero_Zu_init %}
 static const double Zu_init[] = { {%- for item in cost.Zu -%}{{ item }}, {%- endfor -%} };
+{%- endif %}
+{% if has_nonzero_zl_init %}
 static const double zl_init[] = { {%- for item in cost.zl -%}{{ item }}, {%- endfor -%} };
+{%- endif %}
+{% if has_nonzero_zu_init %}
 static const double zu_init[] = { {%- for item in cost.zu -%}{{ item }}, {%- endfor -%} };
+{%- endif %}
 {%- endif %}
 
 {%- if dims.ns_e > 0 %}
+{%- set_global has_nonzero_Zl_e_init = false -%}
+{%- for item in cost.Zl_e -%}
+    {%- if item != 0.0 -%}
+        {%- set_global has_nonzero_Zl_e_init = true -%}
+    {%- endif -%}
+{%- endfor -%}
+{%- set_global has_nonzero_Zu_e_init = false -%}
+{%- for item in cost.Zu_e -%}
+    {%- if item != 0.0 -%}
+        {%- set_global has_nonzero_Zu_e_init = true -%}
+    {%- endif -%}
+{%- endfor -%}
+{%- set_global has_nonzero_zl_e_init = false -%}
+{%- for item in cost.zl_e -%}
+    {%- if item != 0.0 -%}
+        {%- set_global has_nonzero_zl_e_init = true -%}
+    {%- endif -%}
+{%- endfor -%}
+{%- set_global has_nonzero_zu_e_init = false -%}
+{%- for item in cost.zu_e -%}
+    {%- if item != 0.0 -%}
+        {%- set_global has_nonzero_zu_e_init = true -%}
+    {%- endif -%}
+{%- endfor -%}
+
 // initial value of slacks terminal: Zl_e, Zu_e, zl_e, zu_e
+{% if has_nonzero_Zl_e_init %}
 static const double Zl_e_init[] = { {%- for item in cost.Zl_e -%}{{ item }}, {%- endfor -%} };
+{%- endif %}
+{% if has_nonzero_Zu_e_init %}
 static const double Zu_e_init[] = { {%- for item in cost.Zu_e -%}{{ item }}, {%- endfor -%} };
+{%- endif %}
+{% if has_nonzero_zl_e_init %}
 static const double zl_e_init[] = { {%- for item in cost.zl_e -%}{{ item }}, {%- endfor -%} };
+{%- endif %}
+{% if has_nonzero_zu_e_init %}
 static const double zu_e_init[] = { {%- for item in cost.zu_e -%}{{ item }}, {%- endfor -%} };
+{%- endif %}
 {%- endif %}
 
 {%- if dims.ny_0 != 0 and (cost.cost_type_0 == "NONLINEAR_LS" or cost.cost_type_0 == "LINEAR_LS") %}
+{%- set_global has_nonzero_W_0_init = false -%}
+{%- for k in range(end=dims.ny_0) -%}
+    {%- for j in range(end=dims.ny_0) -%}
+        {%- if cost.W_0[j][k] != 0.0 -%}
+            {%- set_global has_nonzero_W_0_init = true -%}
+        {%- endif -%}
+    {%- endfor -%}
+{%- endfor -%}
+
+{% if has_nonzero_W_0_init %}
 // initial value of W_0
 static const double W_0_init[] = {
     {%- for k in range(end=dims.ny_0) -%}{%- for j in range(end=dims.ny_0) -%}{{ cost.W_0[j][k] }}, {%- endfor -%}{%- endfor -%}
 };
+{%- endif %}{# if has_nonzero_W_0_init #}
 {%- endif %}
 
 {%- if dims.ny != 0 and (cost.cost_type == "NONLINEAR_LS" or cost.cost_type == "LINEAR_LS") %}
+{%- set_global has_nonzero_W_init = false -%}
+{%- for k in range(end=dims.ny) -%}
+    {%- for j in range(end=dims.ny) -%}
+        {%- if cost.W[j][k] != 0.0 -%}
+            {%- set_global has_nonzero_W_init = true -%}
+        {%- endif -%}
+    {%- endfor -%}
+{%- endfor -%}
+
+{% if has_nonzero_W_init %}
 // initial value of W
 static const double W_init[] = {
     {%- for k in range(end=dims.ny) -%}{%- for j in range(end=dims.ny) -%}{{ cost.W[j][k] }}, {%- endfor -%}{%- endfor -%}
 };
+{%- endif %}{# if has_nonzero_W_init #}
 {%- endif %}
 
 {%- if dims.ny_e != 0 and (cost.cost_type_e == "NONLINEAR_LS" or cost.cost_type_e == "LINEAR_LS") %}
+{%- set_global has_nonzero_W_e_init = false -%}
+{%- for k in range(end=dims.ny_e) -%}
+    {%- for j in range(end=dims.ny_e) -%}
+        {%- if cost.W_e[j][k] != 0.0 -%}
+            {%- set_global has_nonzero_W_e_init = true -%}
+        {%- endif -%}
+    {%- endfor -%}
+{%- endfor -%}
+
+{% if has_nonzero_W_e_init %}
 // initial value of W_e
 static const double W_e_init[] = {
     {%- for k in range(end=dims.ny_e) -%}{%- for j in range(end=dims.ny_e) -%}{{ cost.W_e[j][k] }}, {%- endfor -%}{%- endfor -%}
 };
+{%- endif %}{# if has_nonzero_W_e_init #}
 {%- endif %}
 
 {%- if dims.ny_0 != 0 and cost.cost_type_0 == "LINEAR_LS" %}
+{%- set_global has_nonzero_Vx_0_init = false -%}
+{%- for k in range(end=dims.nx) -%}
+    {%- for j in range(end=dims.ny_0) -%}
+        {%- if cost.Vx_0[j][k] != 0.0 -%}
+            {%- set_global has_nonzero_Vx_0_init = true -%}
+        {%- endif -%}
+    {%- endfor -%}
+{%- endfor -%}
+
+{% if has_nonzero_Vx_0_init %}
 // initial value of Vx_0
 static const double Vx_0_init[] = {
     {%- for k in range(end=dims.nx) -%}
@@ -206,8 +393,19 @@ static const double Vx_0_init[] = {
 {{ cost.Vx_0[j][k] }}, {%- endfor -%}
     {%- endfor -%}
 };
+{%- endif %}
 
 {%- if dims.nu > 0 %}
+{%- set_global has_nonzero_Vu_0_init = false -%}
+{%- for k in range(end=dims.nu) -%}
+    {%- for j in range(end=dims.ny_0) -%}
+        {%- if cost.Vu_0[j][k] != 0.0 -%}
+            {%- set_global has_nonzero_Vu_0_init = true -%}
+        {%- endif -%}
+    {%- endfor -%}
+{%- endfor -%}
+
+{% if has_nonzero_Vu_0_init %}
 // initial value of Vu_0
 static const double Vu_0_init[] = {
     {%- for k in range(end=dims.nu) -%}
@@ -216,8 +414,19 @@ static const double Vu_0_init[] = {
     {%- endfor -%}
 };
 {%- endif %}
+{%- endif %}
 
 {%- if dims.nz > 0 %}
+{%- set_global has_nonzero_Vz_0_init = false -%}
+{%- for k in range(end=dims.nz) -%}
+    {%- for j in range(end=dims.ny_0) -%}
+        {%- if cost.Vz_0[j][k] != 0.0 -%}
+            {%- set_global has_nonzero_Vz_0_init = true -%}
+        {%- endif -%}
+    {%- endfor -%}
+{%- endfor -%}
+
+{% if has_nonzero_Vz_0_init %}
 // initial value of Vz_0
 static const double Vz_0_init[] = {
     {%- for k in range(end=dims.nz) -%}
@@ -227,8 +436,19 @@ static const double Vz_0_init[] = {
 };
 {%- endif %}
 {%- endif %}
+{%- endif %}
 
 {%- if dims.ny != 0 and cost.cost_type == "LINEAR_LS" %}
+{%- set_global has_nonzero_Vx_init = false -%}
+{%- for k in range(end=dims.nx) -%}
+    {%- for j in range(end=dims.ny) -%}
+        {%- if cost.Vx[j][k] != 0.0 -%}
+            {%- set_global has_nonzero_Vx_init = true -%}
+        {%- endif -%}
+    {%- endfor -%}
+{%- endfor -%}
+
+{% if has_nonzero_Vx_init %}
 // initial value of Vx
 static const double Vx_init[] = {
     {%- for k in range(end=dims.nx) -%}
@@ -236,8 +456,19 @@ static const double Vx_init[] = {
 {{ cost.Vx[j][k] }}, {%- endfor -%}
     {%- endfor -%}
 };
+{%- endif %}
 
 {%- if dims.nu > 0 %}
+{%- set_global has_nonzero_Vu_init = false -%}
+{%- for k in range(end=dims.nu) -%}
+    {%- for j in range(end=dims.ny) -%}
+        {%- if cost.Vu[j][k] != 0.0 -%}
+            {%- set_global has_nonzero_Vu_init = true -%}
+        {%- endif -%}
+    {%- endfor -%}
+{%- endfor -%}
+
+{% if has_nonzero_Vu_init %}
 // initial value of Vu
 static const double Vu_init[] = {
     {%- for k in range(end=dims.nu) -%}
@@ -246,8 +477,19 @@ static const double Vu_init[] = {
     {%- endfor -%}
 };
 {%- endif %}
+{%- endif %}
 
 {%- if dims.nz > 0 %}
+{%- set_global has_nonzero_Vz_init = false -%}
+{%- for k in range(end=dims.nz) -%}
+    {%- for j in range(end=dims.ny) -%}
+        {%- if cost.Vz[j][k] != 0.0 -%}
+            {%- set_global has_nonzero_Vz_init = true -%}
+        {%- endif -%}
+    {%- endfor -%}
+{%- endfor -%}
+
+{% if has_nonzero_Vz_init %}
 // initial value of Vz
 static const double Vz_init[] = {
     {%- for k in range(end=dims.nz) -%}
@@ -257,8 +499,19 @@ static const double Vz_init[] = {
 };
 {%- endif %}
 {%- endif %}
+{%- endif %}
 
 {%- if dims.ny_e != 0 and cost.cost_type_e == "LINEAR_LS" %}
+{%- set_global has_nonzero_Vx_e_init = false -%}
+{%- for k in range(end=dims.nx) -%}
+    {%- for j in range(end=dims.ny_e) -%}
+        {%- if cost.Vx_e[j][k] != 0.0 -%}
+            {%- set_global has_nonzero_Vx_e_init = true -%}
+        {%- endif -%}
+    {%- endfor -%}
+{%- endfor -%}
+
+{% if has_nonzero_Vx_e_init %}
 // initial value of Vx_e
 static const double Vx_e_init[] = {
     {%- for k in range(end=dims.nx) -%}
@@ -266,6 +519,7 @@ static const double Vx_e_init[] = {
 {{ cost.Vx_e[j][k] }}, {%- endfor -%}
     {%- endfor -%}
 };
+{%- endif %}
 {%- endif %}
 
 
@@ -1083,8 +1337,9 @@ void {{ model.name }}_acados_create_set_default_parameters({{ model.name }}_solv
     const int N = capsule->nlp_solver_plan->N;
     // initialize parameters to nominal value
     double* p = calloc(NP, sizeof(double));
+    {% if has_nonzero_parameter_values %}
     memcpy(p, p_init, NP*sizeof(double));
-
+    {%- endif %}
     for (int i = 0; i <= N; i++) {
         {{ model.name }}_acados_update_params(capsule, i, p, NP);
     }
@@ -1096,7 +1351,9 @@ void {{ model.name }}_acados_create_set_default_parameters({{ model.name }}_solv
 {% if dims.np_global > 0 %}
     // initialize global parameters to nominal value
     double* p_global = calloc(NP_GLOBAL, sizeof(double));
+    {% if has_nonzero_p_global_values %}
     memcpy(p_global, p_global_init, NP_GLOBAL*sizeof(double));
+    {%- endif %}
 
     {{ name }}_acados_set_p_global_and_precompute_dependencies(capsule, p_global, NP_GLOBAL);
 
@@ -1266,33 +1523,43 @@ void {{ model.name }}_acados_setup_nlp_in({{ model.name }}_solver_capsule* capsu
 
 {%- if dims.ny_0 != 0 %}
     double* yref_0 = calloc(NY0, sizeof(double));
+    {% if has_nonzero_yref_0_init %}
     memcpy(yref_0, yref_0_init, NY0*sizeof(double));
+    {%- endif %}
     ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, 0, "yref", yref_0);
     free(yref_0);
   {%- if cost.cost_type_0 == "NONLINEAR_LS" or cost.cost_type_0 == "LINEAR_LS" %}
 
    double* W_0 = calloc(NY0*NY0, sizeof(double));
+    {% if has_nonzero_W_0_init %}
     memcpy(W_0, W_0_init, NY0*NY0*sizeof(double));
+    {%- endif %}
     ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, 0, "W", W_0);
     free(W_0);
   {%- endif %}
 
   {%- if cost.cost_type_0 == "LINEAR_LS" %}
     double* Vx_0 = calloc(NY0*NX, sizeof(double));
+        {% if has_nonzero_Vx_0_init %}
     memcpy(Vx_0, Vx_0_init, NY0*NX*sizeof(double));
+        {%- endif %}
     ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, 0, "Vx", Vx_0);
     free(Vx_0);
 
     {%- if dims.nu > 0 %}
     double* Vu_0 = calloc(NY0*NU, sizeof(double));
+        {% if has_nonzero_Vu_0_init %}
     memcpy(Vu_0, Vu_0_init, NY0*NU*sizeof(double));
+        {%- endif %}
     ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, 0, "Vu", Vu_0);
     free(Vu_0);
     {%- endif %}
 
     {%- if dims.nz > 0 %}
     double* Vz_0 = calloc(NY0*NZ, sizeof(double));
+        {% if has_nonzero_Vz_0_init %}
     memcpy(Vz_0, Vz_0_init, NY0*NZ*sizeof(double));
+        {%- endif %}
     ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, 0, "Vz", Vz_0);
     free(Vz_0);
     {%- endif %}{# nz > 0 #}
@@ -1302,7 +1569,9 @@ void {{ model.name }}_acados_setup_nlp_in({{ model.name }}_solver_capsule* capsu
 
 {%- if dims.ny != 0 %}
     double* yref = calloc(NY, sizeof(double));
+    {% if has_nonzero_yref_init %}
     memcpy(yref, yref_init, NY*sizeof(double));
+    {%- endif %}
     for (int i = 1; i < N; i++)
     {
         ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, i, "yref", yref);
@@ -1310,7 +1579,9 @@ void {{ model.name }}_acados_setup_nlp_in({{ model.name }}_solver_capsule* capsu
     free(yref);
   {%- if cost.cost_type == "NONLINEAR_LS" or cost.cost_type == "LINEAR_LS" %}
     double* W = calloc(NY*NY, sizeof(double));
+        {% if has_nonzero_W_init %}
     memcpy(W, W_init, NY*NY*sizeof(double));
+        {%- endif %}
     for (int i = 1; i < N; i++)
     {
         ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, i, "W", W);
@@ -1320,7 +1591,9 @@ void {{ model.name }}_acados_setup_nlp_in({{ model.name }}_solver_capsule* capsu
 
   {%- if cost.cost_type == "LINEAR_LS" %}
     double* Vx = calloc(NY*NX, sizeof(double));
+        {% if has_nonzero_Vx_init %}
     memcpy(Vx, Vx_init, NY*NX*sizeof(double));
+        {%- endif %}
     for (int i = 1; i < N; i++)
     {
         ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, i, "Vx", Vx);
@@ -1329,7 +1602,9 @@ void {{ model.name }}_acados_setup_nlp_in({{ model.name }}_solver_capsule* capsu
 
     {% if dims.nu > 0 %}
     double* Vu = calloc(NY*NU, sizeof(double));
+    {% if has_nonzero_Vu_init %}
     memcpy(Vu, Vu_init, NY*NU*sizeof(double));
+    {%- endif %}
     for (int i = 1; i < N; i++)
     {
         ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, i, "Vu", Vu);
@@ -1339,7 +1614,9 @@ void {{ model.name }}_acados_setup_nlp_in({{ model.name }}_solver_capsule* capsu
 
     {%- if dims.nz > 0 %}
     double* Vz = calloc(NY*NZ, sizeof(double));
+    {% if has_nonzero_Vz_init %}
     memcpy(Vz, Vz_init, NY*NZ*sizeof(double));
+    {%- endif %}
     for (int i = 1; i < N; i++)
     {
         ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, i, "Vz", Vz);
@@ -1353,20 +1630,26 @@ void {{ model.name }}_acados_setup_nlp_in({{ model.name }}_solver_capsule* capsu
 
 {%- if dims.ny_e != 0 %}
     double* yref_e = calloc(NYN, sizeof(double));
+        {% if has_nonzero_yref_e_init %}
     memcpy(yref_e, yref_e_init, NYN*sizeof(double));
+        {%- endif %}
     ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, N, "yref", yref_e);
     free(yref_e);
 
   {%- if cost.cost_type_e == "NONLINEAR_LS" or cost.cost_type_e == "LINEAR_LS" %}
     double* W_e = calloc(NYN*NYN, sizeof(double));
+        {% if has_nonzero_W_e_init %}
     memcpy(W_e, W_e_init, NYN*NYN*sizeof(double));
+        {%- endif %}
     ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, N, "W", W_e);
     free(W_e);
   {%- endif %}
 
   {%- if cost.cost_type_e == "LINEAR_LS" %}
     double* Vx_e = calloc(NYN*NX, sizeof(double));
+        {% if has_nonzero_Vx_e_init %}
     memcpy(Vx_e, Vx_e_init, NYN*NX*sizeof(double));
+        {%- endif %}
     ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, N, "Vx", Vx_e);
     free(Vx_e);
   {%- endif %}
@@ -1458,10 +1741,18 @@ void {{ model.name }}_acados_setup_nlp_in({{ model.name }}_solver_capsule* capsu
     double* zl_0 = zlu0_mem+NS0*2;
     double* zu_0 = zlu0_mem+NS0*3;
 
+    {% if has_nonzero_Zl_0_init %}
     memcpy(Zl_0, Zl_0_init, NS0*sizeof(double));
+    {%- endif %}
+    {% if has_nonzero_Zu_0_init %}
     memcpy(Zu_0, Zu_0_init, NS0*sizeof(double));
+    {%- endif %}
+    {% if has_nonzero_zl_0_init %}
     memcpy(zl_0, zl_0_init, NS0*sizeof(double));
+    {%- endif %}
+    {% if has_nonzero_zu_0_init %}
     memcpy(zu_0, zu_0_init, NS0*sizeof(double));
+    {%- endif %}
 
     ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, 0, "Zl", Zl_0);
     ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, 0, "Zu", Zu_0);
@@ -1478,10 +1769,18 @@ void {{ model.name }}_acados_setup_nlp_in({{ model.name }}_solver_capsule* capsu
     double* Zu = zlumem+NS*1;
     double* zl = zlumem+NS*2;
     double* zu = zlumem+NS*3;
+    {% if has_nonzero_Zl_init %}
     memcpy(Zl, Zl_init, NS*sizeof(double));
+    {%- endif %}
+    {% if has_nonzero_Zu_init %}
     memcpy(Zu, Zu_init, NS*sizeof(double));
+    {%- endif %}
+    {% if has_nonzero_zl_init %}
     memcpy(zl, zl_init, NS*sizeof(double));
+    {%- endif %}
+    {% if has_nonzero_zu_init %}
     memcpy(zu, zu_init, NS*sizeof(double));
+    {%- endif %}
 
     for (int i = 1; i < N; i++)
     {
@@ -1502,10 +1801,18 @@ void {{ model.name }}_acados_setup_nlp_in({{ model.name }}_solver_capsule* capsu
     double* zl_e = zluemem+NSN*2;
     double* zu_e = zluemem+NSN*3;
 
+    {% if has_nonzero_Zl_e_init %}
     memcpy(Zl_e, Zl_e_init, NSN*sizeof(double));
+    {%- endif %}
+    {% if has_nonzero_Zu_e_init %}
     memcpy(Zu_e, Zu_e_init, NSN*sizeof(double));
+    {%- endif %}
+    {% if has_nonzero_zl_e_init %}
     memcpy(zl_e, zl_e_init, NSN*sizeof(double));
+    {%- endif %}
+    {% if has_nonzero_zu_e_init %}
     memcpy(zu_e, zu_e_init, NSN*sizeof(double));
+    {%- endif %}
 
     ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, N, "Zl", Zl_e);
     ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, N, "Zu", Zu_e);

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -117,37 +117,38 @@
 
 
 // ** numerical values **
+{%- set_global sparsity_threshold = 0.1 -%}
 
 {% if dims.np > 0 %}
-{%- set_global has_nonzero_parameter_values = false -%}
+{%- set_global parameter_values_nnz = 0 -%}
 {%- for item in parameter_values -%}
     {%- if item != 0.0 -%}
-        {%- set_global has_nonzero_parameter_values = true -%}
+        {%- set_global parameter_values_nnz = parameter_values_nnz + 1 -%}
     {%- endif -%}
 {%- endfor -%}
 
-{% if has_nonzero_parameter_values %}
+{% if parameter_values_nnz / dims.np > sparsity_threshold %}
 // initial value of stagewise parameters
 static const double p_init[] = {
     {%- for item in parameter_values -%}{{ item }}, {%- endfor -%}
 };
-{%- endif %}{# if has_nonzero_parameter_values #}
+{%- endif %}{# if parameter_values_nnz #}
 {%- endif %}{# if dims.np #}
 
 {% if dims.np_global > 0 %}
-{%- set_global has_nonzero_p_global_values = false -%}
+{%- set_global p_global_values_nnz = 0 -%}
 {%- for item in p_global_values -%}
     {%- if item != 0.0 -%}
-        {%- set_global has_nonzero_p_global_values = true -%}
+        {%- set_global p_global_values_nnz = p_global_values_nnz + 1 -%}
     {%- endif -%}
 {%- endfor -%}
 
-{% if has_nonzero_p_global_values %}
+{% if p_global_values_nnz / dims.np_global > sparsity_threshold %}
 // initial value of global parameters
 static const double p_global_init[] = {
     {%- for item in p_global_values -%}{{ item }}, {%- endfor -%}
 };
-{%- endif %}{# if has_nonzero_p_global_values #}
+{%- endif %}{# if p_global_values_nnz #}
 {%- endif %}{# if dims.np_global #}
 
 {%- if dims.ny_0 != 0 %}
@@ -1335,13 +1336,17 @@ void {{ model.name }}_acados_create_set_default_parameters({{ model.name }}_solv
 {
 {% if dims.np > 0 %}
     const int N = capsule->nlp_solver_plan->N;
-    {% if has_nonzero_parameter_values %}
     // initialize parameters to nominal value
+    {% if parameter_values_nnz %}
     double* p = malloc(NP*sizeof(double));
     memcpy(p, p_init, NP*sizeof(double));
     {%- else %}
-    // initialize parameters to zero
     double* p = calloc(NP, sizeof(double));
+    {%- for item in parameter_values %}
+        {%- if item != 0 %}
+    p[{{ loop.index0 }}] = {{ item }};
+        {%- endif %}
+    {%- endfor %}
     {%- endif %}
     for (int i = 0; i <= N; i++) {
         {{ model.name }}_acados_update_params(capsule, i, p, NP);
@@ -1352,13 +1357,17 @@ void {{ model.name }}_acados_create_set_default_parameters({{ model.name }}_solv
 {%- endif %}{# if dims.np #}
 
 {% if dims.np_global > 0 %}
-    {% if has_nonzero_p_global_values %}
     // initialize global parameters to nominal value
+    {% if p_global_values_nnz / dims.np_global > sparsity_threshold %}
     double* p_global = malloc(NP_GLOBAL*sizeof(double));
     memcpy(p_global, p_global_init, NP_GLOBAL*sizeof(double));
     {%- else %}
-    // initialize global parameters to zero
     double* p_global = calloc(NP_GLOBAL, sizeof(double));
+    {%- for item in p_global_values %}
+        {%- if item != 0.0 %}
+    p_global[{{ loop.index0 }}] = {{ item }};
+        {%- endif %}
+    {%- endfor %}
     {%- endif %}
 
     {{ name }}_acados_set_p_global_and_precompute_dependencies(capsule, p_global, NP_GLOBAL);

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -180,29 +180,29 @@ static const double zu_e_init[] = { {%- for item in cost.zu_e -%}{{ item }}, {%-
 {%- if dims.ny_0 != 0 and (cost.cost_type_0 == "NONLINEAR_LS" or cost.cost_type_0 == "LINEAR_LS") %}
 // initial value of W_0
 static const double W_0_init[] = {
-    {%- for j in range(end=dims.ny_0) -%}{%- for k in range(end=dims.ny_0) -%}{{ cost.W_0[j][k] }}, {%- endfor -%}{%- endfor -%}
+    {%- for k in range(end=dims.ny_0) -%}{%- for j in range(end=dims.ny_0) -%}{{ cost.W_0[j][k] }}, {%- endfor -%}{%- endfor -%}
 };
 {%- endif %}
 
 {%- if dims.ny != 0 and (cost.cost_type == "NONLINEAR_LS" or cost.cost_type == "LINEAR_LS") %}
 // initial value of W
 static const double W_init[] = {
-    {%- for j in range(end=dims.ny) -%}{%- for k in range(end=dims.ny) -%}{{ cost.W[j][k] }}, {%- endfor -%}{%- endfor -%}
+    {%- for k in range(end=dims.ny) -%}{%- for j in range(end=dims.ny) -%}{{ cost.W[j][k] }}, {%- endfor -%}{%- endfor -%}
 };
 {%- endif %}
 
 {%- if dims.ny_e != 0 and (cost.cost_type_e == "NONLINEAR_LS" or cost.cost_type_e == "LINEAR_LS") %}
 // initial value of W_e
 static const double W_e_init[] = {
-    {%- for j in range(end=dims.ny_e) -%}{%- for k in range(end=dims.ny_e) -%}{{ cost.W_e[j][k] }}, {%- endfor -%}{%- endfor -%}
+    {%- for k in range(end=dims.ny_e) -%}{%- for j in range(end=dims.ny_e) -%}{{ cost.W_e[j][k] }}, {%- endfor -%}{%- endfor -%}
 };
 {%- endif %}
 
 {%- if dims.ny_0 != 0 and cost.cost_type_0 == "LINEAR_LS" %}
 // initial value of Vx_0
 static const double Vx_0_init[] = {
+    {%- for k in range(end=dims.nx) -%}
     {%- for j in range(end=dims.ny_0) -%}
-        {%- for k in range(end=dims.nx) -%}
 {{ cost.Vx_0[j][k] }}, {%- endfor -%}
     {%- endfor -%}
 };
@@ -210,8 +210,8 @@ static const double Vx_0_init[] = {
 {%- if dims.nu > 0 %}
 // initial value of Vu_0
 static const double Vu_0_init[] = {
+    {%- for k in range(end=dims.nu) -%}
     {%- for j in range(end=dims.ny_0) -%}
-        {%- for k in range(end=dims.nu) -%}
 {{ cost.Vu_0[j][k] }}, {%- endfor -%}
     {%- endfor -%}
 };
@@ -220,8 +220,8 @@ static const double Vu_0_init[] = {
 {%- if dims.nz > 0 %}
 // initial value of Vz_0
 static const double Vz_0_init[] = {
+    {%- for k in range(end=dims.nz) -%}
     {%- for j in range(end=dims.ny_0) -%}
-        {%- for k in range(end=dims.nz) -%}
 {{ cost.Vz_0[j][k] }}, {%- endfor -%}
     {%- endfor -%}
 };
@@ -231,8 +231,8 @@ static const double Vz_0_init[] = {
 {%- if dims.ny != 0 and cost.cost_type == "LINEAR_LS" %}
 // initial value of Vx
 static const double Vx_init[] = {
+    {%- for k in range(end=dims.nx) -%}
     {%- for j in range(end=dims.ny) -%}
-        {%- for k in range(end=dims.nx) -%}
 {{ cost.Vx[j][k] }}, {%- endfor -%}
     {%- endfor -%}
 };
@@ -240,8 +240,8 @@ static const double Vx_init[] = {
 {%- if dims.nu > 0 %}
 // initial value of Vu
 static const double Vu_init[] = {
+    {%- for k in range(end=dims.nu) -%}
     {%- for j in range(end=dims.ny) -%}
-        {%- for k in range(end=dims.nu) -%}
 {{ cost.Vu[j][k] }}, {%- endfor -%}
     {%- endfor -%}
 };
@@ -250,8 +250,8 @@ static const double Vu_init[] = {
 {%- if dims.nz > 0 %}
 // initial value of Vz
 static const double Vz_init[] = {
+    {%- for k in range(end=dims.nz) -%}
     {%- for j in range(end=dims.ny) -%}
-        {%- for k in range(end=dims.nz) -%}
 {{ cost.Vz[j][k] }}, {%- endfor -%}
     {%- endfor -%}
 };
@@ -261,8 +261,8 @@ static const double Vz_init[] = {
 {%- if dims.ny_e != 0 and cost.cost_type_e == "LINEAR_LS" %}
 // initial value of Vx_e
 static const double Vx_e_init[] = {
+    {%- for k in range(end=dims.nx) -%}
     {%- for j in range(end=dims.ny_e) -%}
-        {%- for k in range(end=dims.nx) -%}
 {{ cost.Vx_e[j][k] }}, {%- endfor -%}
     {%- endfor -%}
 };

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -118,12 +118,40 @@
 
 // ** numerical values **
 
+{% if dims.np > 0 %}
+// initial value of stagewise parameters
+static const double p_init[] = {
+    {%- for item in parameter_values -%}{{ item }}, {%- endfor -%}
+};
+{%- endif %}{# if dims.np #}
+
 {% if dims.np_global > 0 %}
 // initial value of global parameters
 static const double p_global_init[] = {
     {%- for item in p_global_values -%}{{ item }}, {%- endfor -%}
 };
 {%- endif %}{# if dims.np_global #}
+
+{%- if dims.ny_0 != 0 %}
+// initial value of yref_0
+static const double yref_0_init[] = {
+    {%- for item in cost.yref_0 -%}{{ item }}, {%- endfor -%}
+};
+{%- endif %}
+
+{%- if dims.ny != 0 %}
+// initial value of yref
+static const double yref_init[] = {
+    {%- for item in cost.yref -%}{{ item }}, {%- endfor -%}
+};
+{%- endif %}
+
+{%- if dims.ny_e != 0 %}
+// initial value of yref_e
+static const double yref_e_init[] = {
+    {%- for item in cost.yref_e -%}{{ item }}, {%- endfor -%}
+};
+{%- endif %}
 
 
 // ** solver data **
@@ -940,11 +968,7 @@ void {{ model.name }}_acados_create_set_default_parameters({{ model.name }}_solv
     const int N = capsule->nlp_solver_plan->N;
     // initialize parameters to nominal value
     double* p = calloc(NP, sizeof(double));
-    {%- for item in parameter_values %}
-        {%- if item != 0 %}
-    p[{{ loop.index0 }}] = {{ item }};
-        {%- endif %}
-    {%- endfor %}
+    memcpy(p, p_init, NP*sizeof(double));
 
     for (int i = 0; i <= N; i++) {
         {{ model.name }}_acados_update_params(capsule, i, p, NP);
@@ -1127,12 +1151,7 @@ void {{ model.name }}_acados_setup_nlp_in({{ model.name }}_solver_capsule* capsu
 
 {%- if dims.ny_0 != 0 %}
     double* yref_0 = calloc(NY0, sizeof(double));
-    // change only the non-zero elements:
-    {%- for j in range(end=dims.ny_0) %}
-        {%- if cost.yref_0[j] != 0 %}
-    yref_0[{{ j }}] = {{ cost.yref_0[j] }};
-        {%- endif %}
-    {%- endfor %}
+    memcpy(yref_0, yref_0_init, NY0*sizeof(double));
     ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, 0, "yref", yref_0);
     free(yref_0);
   {%- if cost.cost_type_0 == "NONLINEAR_LS" or cost.cost_type_0 == "LINEAR_LS" %}
@@ -1196,12 +1215,7 @@ void {{ model.name }}_acados_setup_nlp_in({{ model.name }}_solver_capsule* capsu
 
 {%- if dims.ny != 0 %}
     double* yref = calloc(NY, sizeof(double));
-    // change only the non-zero elements:
-    {%- for j in range(end=dims.ny) %}
-        {%- if cost.yref[j] != 0 %}
-    yref[{{ j }}] = {{ cost.yref[j] }};
-        {%- endif %}
-    {%- endfor %}
+    memcpy(yref, yref_init, NY*sizeof(double));
 
     for (int i = 1; i < N; i++)
     {
@@ -1284,12 +1298,7 @@ void {{ model.name }}_acados_setup_nlp_in({{ model.name }}_solver_capsule* capsu
 
 {%- if dims.ny_e != 0 %}
     double* yref_e = calloc(NYN, sizeof(double));
-    // change only the non-zero elements:
-    {%- for j in range(end=dims.ny_e) %}
-        {%- if cost.yref_e[j] != 0 %}
-    yref_e[{{ j }}] = {{ cost.yref_e[j] }};
-        {%- endif %}
-    {%- endfor %}
+    memcpy(yref_e, yref_e_init, NYN*sizeof(double));
     ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, N, "yref", yref_e);
     free(yref_e);
 

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -116,7 +116,7 @@
 #define NSBXN  {{ model.name | upper }}_NSBXN
 
 
-// ** numerical values **
+
 {%- set_global sparsity_threshold = 0.1 -%}
 
 {% if dims.np > 0 %}
@@ -151,377 +151,6 @@ static const double p_global_init[] = {
 {%- endif %}{# if p_global_values_nnz #}
 {%- endif %}{# if dims.np_global #}
 
-{%- if dims.ny_0 != 0 %}
-{%- set_global has_nonzero_yref_0_init = false -%}
-{%- for item in cost.yref_0 -%}
-    {%- if item != 0.0 -%}
-        {%- set_global has_nonzero_yref_0_init = true -%}
-    {%- endif -%}
-{%- endfor -%}
-
-{% if has_nonzero_yref_0_init %}
-// initial value of yref_0
-static const double yref_0_init[] = {
-    {%- for item in cost.yref_0 -%}{{ item }}, {%- endfor -%}
-};
-{%- endif %}{# if has_nonzero_yref_0_init #}
-{%- endif %}
-
-{%- if dims.ny != 0 %}
-{%- set_global has_nonzero_yref_init = false -%}
-{%- for item in cost.yref -%}
-    {%- if item != 0.0 -%}
-        {%- set_global has_nonzero_yref_init = true -%}
-    {%- endif -%}
-{%- endfor -%}
-
-{% if has_nonzero_yref_init %}
-// initial value of yref
-static const double yref_init[] = {
-    {%- for item in cost.yref -%}{{ item }}, {%- endfor -%}
-};
-{%- endif %}{# if has_nonzero_yref_init #}
-{%- endif %}
-
-{%- if dims.ny_e != 0 %}
-{%- set_global has_nonzero_yref_e_init = false -%}
-{%- for item in cost.yref_e -%}
-    {%- if item != 0.0 -%}
-        {%- set_global has_nonzero_yref_e_init = true -%}
-    {%- endif -%}
-{%- endfor -%}
-
-{% if has_nonzero_yref_e_init %}
-// initial value of yref_e
-static const double yref_e_init[] = {
-    {%- for item in cost.yref_e -%}{{ item }}, {%- endfor -%}
-};
-{%- endif %}{# if has_nonzero_yref_e_init #}
-{%- endif %}
-
-{%- if dims.ns_0 > 0 %}
-{%- set_global has_nonzero_Zl_0_init = false -%}
-{%- for item in cost.Zl_0 -%}
-    {%- if item != 0.0 -%}
-        {%- set_global has_nonzero_Zl_0_init = true -%}
-    {%- endif -%}
-{%- endfor -%}
-{%- set_global has_nonzero_Zu_0_init = false -%}
-{%- for item in cost.Zu_0 -%}
-    {%- if item != 0.0 -%}
-        {%- set_global has_nonzero_Zu_0_init = true -%}
-    {%- endif -%}
-{%- endfor -%}
-{%- set_global has_nonzero_zl_0_init = false -%}
-{%- for item in cost.zl_0 -%}
-    {%- if item != 0.0 -%}
-        {%- set_global has_nonzero_zl_0_init = true -%}
-    {%- endif -%}
-{%- endfor -%}
-{%- set_global has_nonzero_zu_0_init = false -%}
-{%- for item in cost.zu_0 -%}
-    {%- if item != 0.0 -%}
-        {%- set_global has_nonzero_zu_0_init = true -%}
-    {%- endif -%}
-{%- endfor -%}
-
-// initial value of slacks initial: Zl_0, Zu_0, zl_0, zu_0
-{% if has_nonzero_Zl_0_init %}
-static const double Zl_0_init[] = { {%- for item in cost.Zl_0 -%}{{ item }}, {%- endfor -%} };
-{%- endif %}
-{% if has_nonzero_Zu_0_init %}
-static const double Zu_0_init[] = { {%- for item in cost.Zu_0 -%}{{ item }}, {%- endfor -%} };
-{%- endif %}
-{% if has_nonzero_zl_0_init %}
-static const double zl_0_init[] = { {%- for item in cost.zl_0 -%}{{ item }}, {%- endfor -%} };
-{%- endif %}
-{% if has_nonzero_zu_0_init %}
-static const double zu_0_init[] = { {%- for item in cost.zu_0 -%}{{ item }}, {%- endfor -%} };
-{%- endif %}
-{%- endif %}
-
-{%- if dims.ns > 0 %}
-{%- set_global has_nonzero_Zl_init = false -%}
-{%- for item in cost.Zl -%}
-    {%- if item != 0.0 -%}
-        {%- set_global has_nonzero_Zl_init = true -%}
-    {%- endif -%}
-{%- endfor -%}
-{%- set_global has_nonzero_Zu_init = false -%}
-{%- for item in cost.Zu -%}
-    {%- if item != 0.0 -%}
-        {%- set_global has_nonzero_Zu_init = true -%}
-    {%- endif -%}
-{%- endfor -%}
-{%- set_global has_nonzero_zl_init = false -%}
-{%- for item in cost.zl -%}
-    {%- if item != 0.0 -%}
-        {%- set_global has_nonzero_zl_init = true -%}
-    {%- endif -%}
-{%- endfor -%}
-{%- set_global has_nonzero_zu_init = false -%}
-{%- for item in cost.zu -%}
-    {%- if item != 0.0 -%}
-        {%- set_global has_nonzero_zu_init = true -%}
-    {%- endif -%}
-{%- endfor -%}
-
-// initial value of slacks stagewise: Zl, Zu, zl, zu
-{% if has_nonzero_Zl_init %}
-static const double Zl_init[] = { {%- for item in cost.Zl -%}{{ item }}, {%- endfor -%} };
-{%- endif %}
-{% if has_nonzero_Zu_init %}
-static const double Zu_init[] = { {%- for item in cost.Zu -%}{{ item }}, {%- endfor -%} };
-{%- endif %}
-{% if has_nonzero_zl_init %}
-static const double zl_init[] = { {%- for item in cost.zl -%}{{ item }}, {%- endfor -%} };
-{%- endif %}
-{% if has_nonzero_zu_init %}
-static const double zu_init[] = { {%- for item in cost.zu -%}{{ item }}, {%- endfor -%} };
-{%- endif %}
-{%- endif %}
-
-{%- if dims.ns_e > 0 %}
-{%- set_global has_nonzero_Zl_e_init = false -%}
-{%- for item in cost.Zl_e -%}
-    {%- if item != 0.0 -%}
-        {%- set_global has_nonzero_Zl_e_init = true -%}
-    {%- endif -%}
-{%- endfor -%}
-{%- set_global has_nonzero_Zu_e_init = false -%}
-{%- for item in cost.Zu_e -%}
-    {%- if item != 0.0 -%}
-        {%- set_global has_nonzero_Zu_e_init = true -%}
-    {%- endif -%}
-{%- endfor -%}
-{%- set_global has_nonzero_zl_e_init = false -%}
-{%- for item in cost.zl_e -%}
-    {%- if item != 0.0 -%}
-        {%- set_global has_nonzero_zl_e_init = true -%}
-    {%- endif -%}
-{%- endfor -%}
-{%- set_global has_nonzero_zu_e_init = false -%}
-{%- for item in cost.zu_e -%}
-    {%- if item != 0.0 -%}
-        {%- set_global has_nonzero_zu_e_init = true -%}
-    {%- endif -%}
-{%- endfor -%}
-
-// initial value of slacks terminal: Zl_e, Zu_e, zl_e, zu_e
-{% if has_nonzero_Zl_e_init %}
-static const double Zl_e_init[] = { {%- for item in cost.Zl_e -%}{{ item }}, {%- endfor -%} };
-{%- endif %}
-{% if has_nonzero_Zu_e_init %}
-static const double Zu_e_init[] = { {%- for item in cost.Zu_e -%}{{ item }}, {%- endfor -%} };
-{%- endif %}
-{% if has_nonzero_zl_e_init %}
-static const double zl_e_init[] = { {%- for item in cost.zl_e -%}{{ item }}, {%- endfor -%} };
-{%- endif %}
-{% if has_nonzero_zu_e_init %}
-static const double zu_e_init[] = { {%- for item in cost.zu_e -%}{{ item }}, {%- endfor -%} };
-{%- endif %}
-{%- endif %}
-
-{%- if dims.ny_0 != 0 and (cost.cost_type_0 == "NONLINEAR_LS" or cost.cost_type_0 == "LINEAR_LS") %}
-{%- set_global has_nonzero_W_0_init = false -%}
-{%- for k in range(end=dims.ny_0) -%}
-    {%- for j in range(end=dims.ny_0) -%}
-        {%- if cost.W_0[j][k] != 0.0 -%}
-            {%- set_global has_nonzero_W_0_init = true -%}
-        {%- endif -%}
-    {%- endfor -%}
-{%- endfor -%}
-
-{% if has_nonzero_W_0_init %}
-// initial value of W_0
-static const double W_0_init[] = {
-    {%- for k in range(end=dims.ny_0) -%}{%- for j in range(end=dims.ny_0) -%}{{ cost.W_0[j][k] }}, {%- endfor -%}{%- endfor -%}
-};
-{%- endif %}{# if has_nonzero_W_0_init #}
-{%- endif %}
-
-{%- if dims.ny != 0 and (cost.cost_type == "NONLINEAR_LS" or cost.cost_type == "LINEAR_LS") %}
-{%- set_global has_nonzero_W_init = false -%}
-{%- for k in range(end=dims.ny) -%}
-    {%- for j in range(end=dims.ny) -%}
-        {%- if cost.W[j][k] != 0.0 -%}
-            {%- set_global has_nonzero_W_init = true -%}
-        {%- endif -%}
-    {%- endfor -%}
-{%- endfor -%}
-
-{% if has_nonzero_W_init %}
-// initial value of W
-static const double W_init[] = {
-    {%- for k in range(end=dims.ny) -%}{%- for j in range(end=dims.ny) -%}{{ cost.W[j][k] }}, {%- endfor -%}{%- endfor -%}
-};
-{%- endif %}{# if has_nonzero_W_init #}
-{%- endif %}
-
-{%- if dims.ny_e != 0 and (cost.cost_type_e == "NONLINEAR_LS" or cost.cost_type_e == "LINEAR_LS") %}
-{%- set_global has_nonzero_W_e_init = false -%}
-{%- for k in range(end=dims.ny_e) -%}
-    {%- for j in range(end=dims.ny_e) -%}
-        {%- if cost.W_e[j][k] != 0.0 -%}
-            {%- set_global has_nonzero_W_e_init = true -%}
-        {%- endif -%}
-    {%- endfor -%}
-{%- endfor -%}
-
-{% if has_nonzero_W_e_init %}
-// initial value of W_e
-static const double W_e_init[] = {
-    {%- for k in range(end=dims.ny_e) -%}{%- for j in range(end=dims.ny_e) -%}{{ cost.W_e[j][k] }}, {%- endfor -%}{%- endfor -%}
-};
-{%- endif %}{# if has_nonzero_W_e_init #}
-{%- endif %}
-
-{%- if dims.ny_0 != 0 and cost.cost_type_0 == "LINEAR_LS" %}
-{%- set_global has_nonzero_Vx_0_init = false -%}
-{%- for k in range(end=dims.nx) -%}
-    {%- for j in range(end=dims.ny_0) -%}
-        {%- if cost.Vx_0[j][k] != 0.0 -%}
-            {%- set_global has_nonzero_Vx_0_init = true -%}
-        {%- endif -%}
-    {%- endfor -%}
-{%- endfor -%}
-
-{% if has_nonzero_Vx_0_init %}
-// initial value of Vx_0
-static const double Vx_0_init[] = {
-    {%- for k in range(end=dims.nx) -%}
-    {%- for j in range(end=dims.ny_0) -%}
-{{ cost.Vx_0[j][k] }}, {%- endfor -%}
-    {%- endfor -%}
-};
-{%- endif %}
-
-{%- if dims.nu > 0 %}
-{%- set_global has_nonzero_Vu_0_init = false -%}
-{%- for k in range(end=dims.nu) -%}
-    {%- for j in range(end=dims.ny_0) -%}
-        {%- if cost.Vu_0[j][k] != 0.0 -%}
-            {%- set_global has_nonzero_Vu_0_init = true -%}
-        {%- endif -%}
-    {%- endfor -%}
-{%- endfor -%}
-
-{% if has_nonzero_Vu_0_init %}
-// initial value of Vu_0
-static const double Vu_0_init[] = {
-    {%- for k in range(end=dims.nu) -%}
-    {%- for j in range(end=dims.ny_0) -%}
-{{ cost.Vu_0[j][k] }}, {%- endfor -%}
-    {%- endfor -%}
-};
-{%- endif %}
-{%- endif %}
-
-{%- if dims.nz > 0 %}
-{%- set_global has_nonzero_Vz_0_init = false -%}
-{%- for k in range(end=dims.nz) -%}
-    {%- for j in range(end=dims.ny_0) -%}
-        {%- if cost.Vz_0[j][k] != 0.0 -%}
-            {%- set_global has_nonzero_Vz_0_init = true -%}
-        {%- endif -%}
-    {%- endfor -%}
-{%- endfor -%}
-
-{% if has_nonzero_Vz_0_init %}
-// initial value of Vz_0
-static const double Vz_0_init[] = {
-    {%- for k in range(end=dims.nz) -%}
-    {%- for j in range(end=dims.ny_0) -%}
-{{ cost.Vz_0[j][k] }}, {%- endfor -%}
-    {%- endfor -%}
-};
-{%- endif %}
-{%- endif %}
-{%- endif %}
-
-{%- if dims.ny != 0 and cost.cost_type == "LINEAR_LS" %}
-{%- set_global has_nonzero_Vx_init = false -%}
-{%- for k in range(end=dims.nx) -%}
-    {%- for j in range(end=dims.ny) -%}
-        {%- if cost.Vx[j][k] != 0.0 -%}
-            {%- set_global has_nonzero_Vx_init = true -%}
-        {%- endif -%}
-    {%- endfor -%}
-{%- endfor -%}
-
-{% if has_nonzero_Vx_init %}
-// initial value of Vx
-static const double Vx_init[] = {
-    {%- for k in range(end=dims.nx) -%}
-    {%- for j in range(end=dims.ny) -%}
-{{ cost.Vx[j][k] }}, {%- endfor -%}
-    {%- endfor -%}
-};
-{%- endif %}
-
-{%- if dims.nu > 0 %}
-{%- set_global has_nonzero_Vu_init = false -%}
-{%- for k in range(end=dims.nu) -%}
-    {%- for j in range(end=dims.ny) -%}
-        {%- if cost.Vu[j][k] != 0.0 -%}
-            {%- set_global has_nonzero_Vu_init = true -%}
-        {%- endif -%}
-    {%- endfor -%}
-{%- endfor -%}
-
-{% if has_nonzero_Vu_init %}
-// initial value of Vu
-static const double Vu_init[] = {
-    {%- for k in range(end=dims.nu) -%}
-    {%- for j in range(end=dims.ny) -%}
-{{ cost.Vu[j][k] }}, {%- endfor -%}
-    {%- endfor -%}
-};
-{%- endif %}
-{%- endif %}
-
-{%- if dims.nz > 0 %}
-{%- set_global has_nonzero_Vz_init = false -%}
-{%- for k in range(end=dims.nz) -%}
-    {%- for j in range(end=dims.ny) -%}
-        {%- if cost.Vz[j][k] != 0.0 -%}
-            {%- set_global has_nonzero_Vz_init = true -%}
-        {%- endif -%}
-    {%- endfor -%}
-{%- endfor -%}
-
-{% if has_nonzero_Vz_init %}
-// initial value of Vz
-static const double Vz_init[] = {
-    {%- for k in range(end=dims.nz) -%}
-    {%- for j in range(end=dims.ny) -%}
-{{ cost.Vz[j][k] }}, {%- endfor -%}
-    {%- endfor -%}
-};
-{%- endif %}
-{%- endif %}
-{%- endif %}
-
-{%- if dims.ny_e != 0 and cost.cost_type_e == "LINEAR_LS" %}
-{%- set_global has_nonzero_Vx_e_init = false -%}
-{%- for k in range(end=dims.nx) -%}
-    {%- for j in range(end=dims.ny_e) -%}
-        {%- if cost.Vx_e[j][k] != 0.0 -%}
-            {%- set_global has_nonzero_Vx_e_init = true -%}
-        {%- endif -%}
-    {%- endfor -%}
-{%- endfor -%}
-
-{% if has_nonzero_Vx_e_init %}
-// initial value of Vx_e
-static const double Vx_e_init[] = {
-    {%- for k in range(end=dims.nx) -%}
-    {%- for j in range(end=dims.ny_e) -%}
-{{ cost.Vx_e[j][k] }}, {%- endfor -%}
-    {%- endfor -%}
-};
-{%- endif %}
-{%- endif %}
 
 
 // ** solver data **
@@ -1337,7 +966,7 @@ void {{ model.name }}_acados_create_set_default_parameters({{ model.name }}_solv
 {% if dims.np > 0 %}
     const int N = capsule->nlp_solver_plan->N;
     // initialize parameters to nominal value
-    {% if parameter_values_nnz %}
+    {% if parameter_values_nnz / dims.np > sparsity_threshold %}
     double* p = malloc(NP*sizeof(double));
     memcpy(p, p_init, NP*sizeof(double));
     {%- else %}
@@ -1364,7 +993,7 @@ void {{ model.name }}_acados_create_set_default_parameters({{ model.name }}_solv
     {%- else %}
     double* p_global = calloc(NP_GLOBAL, sizeof(double));
     {%- for item in p_global_values %}
-        {%- if item != 0.0 %}
+        {%- if item != 0 %}
     p_global[{{ loop.index0 }}] = {{ item }};
         {%- endif %}
     {%- endfor %}
@@ -1537,54 +1166,67 @@ void {{ model.name }}_acados_setup_nlp_in({{ model.name }}_solver_capsule* capsu
     /**** Cost ****/
 
 {%- if dims.ny_0 != 0 %}
-    {% if has_nonzero_yref_0_init %}
-    double* yref_0 = malloc(NY0*sizeof(double));
-    memcpy(yref_0, yref_0_init, NY0*sizeof(double));
-    {%- else %}
     double* yref_0 = calloc(NY0, sizeof(double));
-    {%- endif %}
+    // change only the non-zero elements:
+    {%- for j in range(end=dims.ny_0) %}
+        {%- if cost.yref_0[j] != 0 %}
+    yref_0[{{ j }}] = {{ cost.yref_0[j] }};
+        {%- endif %}
+    {%- endfor %}
     ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, 0, "yref", yref_0);
     free(yref_0);
   {%- if cost.cost_type_0 == "NONLINEAR_LS" or cost.cost_type_0 == "LINEAR_LS" %}
 
-    {% if has_nonzero_W_0_init %}
-   double* W_0 = malloc(NY0*NY0*sizeof(double));
-    memcpy(W_0, W_0_init, NY0*NY0*sizeof(double));
-    {%- else %}
    double* W_0 = calloc(NY0*NY0, sizeof(double));
-    {%- endif %}
+    // change only the non-zero elements:
+    {%- for j in range(end=dims.ny_0) %}
+        {%- for k in range(end=dims.ny_0) %}
+            {%- if cost.W_0[j][k] != 0 %}
+    W_0[{{ j }}+(NY0) * {{ k }}] = {{ cost.W_0[j][k] }};
+            {%- endif %}
+        {%- endfor %}
+    {%- endfor %}
     ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, 0, "W", W_0);
     free(W_0);
   {%- endif %}
 
   {%- if cost.cost_type_0 == "LINEAR_LS" %}
-    {% if has_nonzero_Vx_0_init %}
-    double* Vx_0 = malloc(NY0*NX*sizeof(double));
-    memcpy(Vx_0, Vx_0_init, NY0*NX*sizeof(double));
-    {%- else %}
     double* Vx_0 = calloc(NY0*NX, sizeof(double));
-    {%- endif %}
+        // change only the non-zero elements:
+    {%- for j in range(end=dims.ny_0) %}
+        {%- for k in range(end=dims.nx) %}
+            {%- if cost.Vx_0[j][k] != 0 %}
+    Vx_0[{{ j }}+(NY0) * {{ k }}] = {{ cost.Vx_0[j][k] }};
+            {%- endif %}
+        {%- endfor %}
+    {%- endfor %}
     ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, 0, "Vx", Vx_0);
     free(Vx_0);
 
     {%- if dims.nu > 0 %}
-    {% if has_nonzero_Vu_0_init %}
-    double* Vu_0 = malloc(NY0*NU*sizeof(double));
-    memcpy(Vu_0, Vu_0_init, NY0*NU*sizeof(double));
-    {%- else %}
     double* Vu_0 = calloc(NY0*NU, sizeof(double));
-    {%- endif %}
+    // change only the non-zero elements:
+    {%- for j in range(end=dims.ny_0) %}
+        {%- for k in range(end=dims.nu) %}
+            {%- if cost.Vu_0[j][k] != 0 %}
+    Vu_0[{{ j }}+(NY0) * {{ k }}] = {{ cost.Vu_0[j][k] }};
+            {%- endif %}
+        {%- endfor %}
+    {%- endfor %}
     ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, 0, "Vu", Vu_0);
     free(Vu_0);
     {%- endif %}
 
     {%- if dims.nz > 0 %}
-    {% if has_nonzero_Vz_0_init %}
-    double* Vz_0 = malloc(NY0*NZ*sizeof(double));
-    memcpy(Vz_0, Vz_0_init, NY0*NZ*sizeof(double));
-    {%- else %}
     double* Vz_0 = calloc(NY0*NZ, sizeof(double));
-    {%- endif %}
+    // change only the non-zero elements:
+    {%- for j in range(end=dims.ny_0) %}
+        {%- for k in range(end=dims.nz) %}
+            {%- if cost.Vz_0[j][k] != 0 %}
+    Vz_0[{{ j }}+(NY0) * {{ k }}] = {{ cost.Vz_0[j][k] }};
+            {%- endif %}
+        {%- endfor %}
+    {%- endfor %}
     ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, 0, "Vz", Vz_0);
     free(Vz_0);
     {%- endif %}{# nz > 0 #}
@@ -1593,24 +1235,30 @@ void {{ model.name }}_acados_setup_nlp_in({{ model.name }}_solver_capsule* capsu
 
 
 {%- if dims.ny != 0 %}
-    {% if has_nonzero_yref_init %}
-    double* yref = malloc(NY*sizeof(double));
-    memcpy(yref, yref_init, NY*sizeof(double));
-    {%- else %}
     double* yref = calloc(NY, sizeof(double));
-    {%- endif %}
+    // change only the non-zero elements:
+    {%- for j in range(end=dims.ny) %}
+        {%- if cost.yref[j] != 0 %}
+    yref[{{ j }}] = {{ cost.yref[j] }};
+        {%- endif %}
+    {%- endfor %}
+
     for (int i = 1; i < N; i++)
     {
         ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, i, "yref", yref);
     }
     free(yref);
   {%- if cost.cost_type == "NONLINEAR_LS" or cost.cost_type == "LINEAR_LS" %}
-    {% if has_nonzero_W_init %}
-    double* W = malloc(NY*NY*sizeof(double));
-    memcpy(W, W_init, NY*NY*sizeof(double));
-    {%- else %}
     double* W = calloc(NY*NY, sizeof(double));
-    {%- endif %}
+    // change only the non-zero elements:
+    {%- for j in range(end=dims.ny) %}
+        {%- for k in range(end=dims.ny) %}
+            {%- if cost.W[j][k] != 0 %}
+    W[{{ j }}+(NY) * {{ k }}] = {{ cost.W[j][k] }};
+            {%- endif %}
+        {%- endfor %}
+    {%- endfor %}
+
     for (int i = 1; i < N; i++)
     {
         ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, i, "W", W);
@@ -1619,12 +1267,15 @@ void {{ model.name }}_acados_setup_nlp_in({{ model.name }}_solver_capsule* capsu
   {%- endif %}
 
   {%- if cost.cost_type == "LINEAR_LS" %}
-    {% if has_nonzero_Vx_init %}
-    double* Vx = malloc(NY*NX*sizeof(double));
-    memcpy(Vx, Vx_init, NY*NX*sizeof(double));
-    {%- else %}
     double* Vx = calloc(NY*NX, sizeof(double));
-    {%- endif %}
+    // change only the non-zero elements:
+    {%- for j in range(end=dims.ny) %}
+        {%- for k in range(end=dims.nx) %}
+            {%- if cost.Vx[j][k] != 0 %}
+    Vx[{{ j }}+(NY) * {{ k }}] = {{ cost.Vx[j][k] }};
+            {%- endif %}
+        {%- endfor %}
+    {%- endfor %}
     for (int i = 1; i < N; i++)
     {
         ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, i, "Vx", Vx);
@@ -1632,12 +1283,16 @@ void {{ model.name }}_acados_setup_nlp_in({{ model.name }}_solver_capsule* capsu
     free(Vx);
 
     {% if dims.nu > 0 %}
-    {% if has_nonzero_Vu_init %}
-    double* Vu = malloc(NY*NU*sizeof(double));
-    memcpy(Vu, Vu_init, NY*NU*sizeof(double));
-    {%- else %}
     double* Vu = calloc(NY*NU, sizeof(double));
-    {%- endif %}
+    // change only the non-zero elements:
+    {%- for j in range(end=dims.ny) %}
+        {%- for k in range(end=dims.nu) %}
+            {%- if cost.Vu[j][k] != 0 %}
+    Vu[{{ j }}+(NY) * {{ k }}] = {{ cost.Vu[j][k] }};
+            {%- endif %}
+        {%- endfor %}
+    {%- endfor %}
+
     for (int i = 1; i < N; i++)
     {
         ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, i, "Vu", Vu);
@@ -1646,12 +1301,16 @@ void {{ model.name }}_acados_setup_nlp_in({{ model.name }}_solver_capsule* capsu
     {%- endif %}
 
     {%- if dims.nz > 0 %}
-    {% if has_nonzero_Vz_init %}
-    double* Vz = malloc(NY*NZ*sizeof(double));
-    memcpy(Vz, Vz_init, NY*NZ*sizeof(double));
-    {%- else %}
     double* Vz = calloc(NY*NZ, sizeof(double));
-    {%- endif %}
+    // change only the non-zero elements:
+    {%- for j in range(end=dims.ny) %}
+        {%- for k in range(end=dims.nz) %}
+            {%- if cost.Vz[j][k] != 0 %}
+    Vz[{{ j }}+(NY) * {{ k }}] = {{ cost.Vz[j][k] }};
+            {%- endif %}
+        {%- endfor %}
+    {%- endfor %}
+
     for (int i = 1; i < N; i++)
     {
         ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, i, "Vz", Vz);
@@ -1664,33 +1323,42 @@ void {{ model.name }}_acados_setup_nlp_in({{ model.name }}_solver_capsule* capsu
 
 
 {%- if dims.ny_e != 0 %}
-    {% if has_nonzero_yref_e_init %}
-    double* yref_e = malloc(NYN*sizeof(double));
-    memcpy(yref_e, yref_e_init, NYN*sizeof(double));
-    {%- else %}
     double* yref_e = calloc(NYN, sizeof(double));
-    {%- endif %}
+    // change only the non-zero elements:
+    {%- for j in range(end=dims.ny_e) %}
+        {%- if cost.yref_e[j] != 0 %}
+    yref_e[{{ j }}] = {{ cost.yref_e[j] }};
+        {%- endif %}
+    {%- endfor %}
     ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, N, "yref", yref_e);
     free(yref_e);
 
   {%- if cost.cost_type_e == "NONLINEAR_LS" or cost.cost_type_e == "LINEAR_LS" %}
-    {% if has_nonzero_W_e_init %}
-    double* W_e = malloc(NYN*NYN*sizeof(double));
-    memcpy(W_e, W_e_init, NYN*NYN*sizeof(double));
-    {%- else %}
+
     double* W_e = calloc(NYN*NYN, sizeof(double));
-    {%- endif %}
+    // change only the non-zero elements:
+    {%- for j in range(end=dims.ny_e) %}
+        {%- for k in range(end=dims.ny_e) %}
+            {%- if cost.W_e[j][k] != 0 %}
+    W_e[{{ j }}+(NYN) * {{ k }}] = {{ cost.W_e[j][k] }};
+            {%- endif %}
+        {%- endfor %}
+    {%- endfor %}
     ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, N, "W", W_e);
     free(W_e);
   {%- endif %}
 
+
   {%- if cost.cost_type_e == "LINEAR_LS" %}
-    {% if has_nonzero_Vx_e_init %}
-    double* Vx_e = malloc(NYN*NX*sizeof(double));
-    memcpy(Vx_e, Vx_e_init, NYN*NX*sizeof(double));
-    {%- else %}
     double* Vx_e = calloc(NYN*NX, sizeof(double));
-    {%- endif %}
+    // change only the non-zero elements:
+    {%- for j in range(end=dims.ny_e) %}
+        {%- for k in range(end=dims.nx) %}
+            {%- if cost.Vx_e[j][k] != 0 %}
+    Vx_e[{{ j }}+(NYN) * {{ k }}] = {{ cost.Vx_e[j][k] }};
+            {%- endif %}
+        {%- endfor %}
+    {%- endfor %}
     ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, N, "Vx", Vx_e);
     free(Vx_e);
   {%- endif %}
@@ -1782,18 +1450,30 @@ void {{ model.name }}_acados_setup_nlp_in({{ model.name }}_solver_capsule* capsu
     double* zl_0 = zlu0_mem+NS0*2;
     double* zu_0 = zlu0_mem+NS0*3;
 
-    {% if has_nonzero_Zl_0_init %}
-    memcpy(Zl_0, Zl_0_init, NS0*sizeof(double));
-    {%- endif %}
-    {% if has_nonzero_Zu_0_init %}
-    memcpy(Zu_0, Zu_0_init, NS0*sizeof(double));
-    {%- endif %}
-    {% if has_nonzero_zl_0_init %}
-    memcpy(zl_0, zl_0_init, NS0*sizeof(double));
-    {%- endif %}
-    {% if has_nonzero_zu_0_init %}
-    memcpy(zu_0, zu_0_init, NS0*sizeof(double));
-    {%- endif %}
+    // change only the non-zero elements:
+    {%- for j in range(end=dims.ns_0) %}
+        {%- if cost.Zl_0[j] != 0 %}
+    Zl_0[{{ j }}] = {{ cost.Zl_0[j] }};
+        {%- endif %}
+    {%- endfor %}
+
+    {%- for j in range(end=dims.ns_0) %}
+        {%- if cost.Zu_0[j] != 0 %}
+    Zu_0[{{ j }}] = {{ cost.Zu_0[j] }};
+        {%- endif %}
+    {%- endfor %}
+
+    {%- for j in range(end=dims.ns_0) %}
+        {%- if cost.zl_0[j] != 0 %}
+    zl_0[{{ j }}] = {{ cost.zl_0[j] }};
+        {%- endif %}
+    {%- endfor %}
+
+    {%- for j in range(end=dims.ns_0) %}
+        {%- if cost.zu_0[j] != 0 %}
+    zu_0[{{ j }}] = {{ cost.zu_0[j] }};
+        {%- endif %}
+    {%- endfor %}
 
     ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, 0, "Zl", Zl_0);
     ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, 0, "Zu", Zu_0);
@@ -1810,18 +1490,30 @@ void {{ model.name }}_acados_setup_nlp_in({{ model.name }}_solver_capsule* capsu
     double* Zu = zlumem+NS*1;
     double* zl = zlumem+NS*2;
     double* zu = zlumem+NS*3;
-    {% if has_nonzero_Zl_init %}
-    memcpy(Zl, Zl_init, NS*sizeof(double));
-    {%- endif %}
-    {% if has_nonzero_Zu_init %}
-    memcpy(Zu, Zu_init, NS*sizeof(double));
-    {%- endif %}
-    {% if has_nonzero_zl_init %}
-    memcpy(zl, zl_init, NS*sizeof(double));
-    {%- endif %}
-    {% if has_nonzero_zu_init %}
-    memcpy(zu, zu_init, NS*sizeof(double));
-    {%- endif %}
+    // change only the non-zero elements:
+    {%- for j in range(end=dims.ns) %}
+        {%- if cost.Zl[j] != 0 %}
+    Zl[{{ j }}] = {{ cost.Zl[j] }};
+        {%- endif %}
+    {%- endfor %}
+
+    {%- for j in range(end=dims.ns) %}
+        {%- if cost.Zu[j] != 0 %}
+    Zu[{{ j }}] = {{ cost.Zu[j] }};
+        {%- endif %}
+    {%- endfor %}
+
+    {%- for j in range(end=dims.ns) %}
+        {%- if cost.zl[j] != 0 %}
+    zl[{{ j }}] = {{ cost.zl[j] }};
+        {%- endif %}
+    {%- endfor %}
+
+    {%- for j in range(end=dims.ns) %}
+        {%- if cost.zu[j] != 0 %}
+    zu[{{ j }}] = {{ cost.zu[j] }};
+        {%- endif %}
+    {%- endfor %}
 
     for (int i = 1; i < N; i++)
     {
@@ -1842,18 +1534,30 @@ void {{ model.name }}_acados_setup_nlp_in({{ model.name }}_solver_capsule* capsu
     double* zl_e = zluemem+NSN*2;
     double* zu_e = zluemem+NSN*3;
 
-    {% if has_nonzero_Zl_e_init %}
-    memcpy(Zl_e, Zl_e_init, NSN*sizeof(double));
-    {%- endif %}
-    {% if has_nonzero_Zu_e_init %}
-    memcpy(Zu_e, Zu_e_init, NSN*sizeof(double));
-    {%- endif %}
-    {% if has_nonzero_zl_e_init %}
-    memcpy(zl_e, zl_e_init, NSN*sizeof(double));
-    {%- endif %}
-    {% if has_nonzero_zu_e_init %}
-    memcpy(zu_e, zu_e_init, NSN*sizeof(double));
-    {%- endif %}
+    // change only the non-zero elements:
+    {%- for j in range(end=dims.ns_e) %}
+        {%- if cost.Zl_e[j] != 0 %}
+    Zl_e[{{ j }}] = {{ cost.Zl_e[j] }};
+        {%- endif %}
+    {%- endfor %}
+
+    {%- for j in range(end=dims.ns_e) %}
+        {%- if cost.Zu_e[j] != 0 %}
+    Zu_e[{{ j }}] = {{ cost.Zu_e[j] }};
+        {%- endif %}
+    {%- endfor %}
+
+    {%- for j in range(end=dims.ns_e) %}
+        {%- if cost.zl_e[j] != 0 %}
+    zl_e[{{ j }}] = {{ cost.zl_e[j] }};
+        {%- endif %}
+    {%- endfor %}
+
+    {%- for j in range(end=dims.ns_e) %}
+        {%- if cost.zu_e[j] != 0 %}
+    zu_e[{{ j }}] = {{ cost.zu_e[j] }};
+        {%- endif %}
+    {%- endfor %}
 
     ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, N, "Zl", Zl_e);
     ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, N, "Zu", Zu_e);

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -153,6 +153,27 @@ static const double yref_e_init[] = {
 };
 {%- endif %}
 
+{%- if dims.ny_0 != 0 and (cost.cost_type_0 == "NONLINEAR_LS" or cost.cost_type_0 == "LINEAR_LS") %}
+// initial value of W_0
+static const double W_0_init[] = {
+    {%- for j in range(end=dims.ny_0) -%}{%- for k in range(end=dims.ny_0) -%}{{ cost.W_0[j][k] }}, {%- endfor -%}{%- endfor -%}
+};
+{%- endif %}
+
+{%- if dims.ny != 0 and (cost.cost_type == "NONLINEAR_LS" or cost.cost_type == "LINEAR_LS") %}
+// initial value of W
+static const double W_init[] = {
+    {%- for j in range(end=dims.ny) -%}{%- for k in range(end=dims.ny) -%}{{ cost.W[j][k] }}, {%- endfor -%}{%- endfor -%}
+};
+{%- endif %}
+
+{%- if dims.ny_e != 0 and (cost.cost_type_e == "NONLINEAR_LS" or cost.cost_type_e == "LINEAR_LS") %}
+// initial value of W_e
+static const double W_e_init[] = {
+    {%- for j in range(end=dims.ny_e) -%}{%- for k in range(end=dims.ny_e) -%}{{ cost.W_e[j][k] }}, {%- endfor -%}{%- endfor -%}
+};
+{%- endif %}
+
 {%- if dims.ny_0 != 0 and cost.cost_type_0 == "LINEAR_LS" %}
 // initial value of Vx_0
 static const double Vx_0_init[] = {
@@ -1227,14 +1248,7 @@ void {{ model.name }}_acados_setup_nlp_in({{ model.name }}_solver_capsule* capsu
   {%- if cost.cost_type_0 == "NONLINEAR_LS" or cost.cost_type_0 == "LINEAR_LS" %}
 
    double* W_0 = calloc(NY0*NY0, sizeof(double));
-    // change only the non-zero elements:
-    {%- for j in range(end=dims.ny_0) %}
-        {%- for k in range(end=dims.ny_0) %}
-            {%- if cost.W_0[j][k] != 0 %}
-    W_0[{{ j }}+(NY0) * {{ k }}] = {{ cost.W_0[j][k] }};
-            {%- endif %}
-        {%- endfor %}
-    {%- endfor %}
+    memcpy(W_0, W_0_init, NY0*NY0*sizeof(double));
     ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, 0, "W", W_0);
     free(W_0);
   {%- endif %}
@@ -1273,14 +1287,7 @@ void {{ model.name }}_acados_setup_nlp_in({{ model.name }}_solver_capsule* capsu
     free(yref);
   {%- if cost.cost_type == "NONLINEAR_LS" or cost.cost_type == "LINEAR_LS" %}
     double* W = calloc(NY*NY, sizeof(double));
-    // change only the non-zero elements:
-    {%- for j in range(end=dims.ny) %}
-        {%- for k in range(end=dims.ny) %}
-            {%- if cost.W[j][k] != 0 %}
-    W[{{ j }}+(NY) * {{ k }}] = {{ cost.W[j][k] }};
-            {%- endif %}
-        {%- endfor %}
-    {%- endfor %}
+    memcpy(W, W_init, NY*NY*sizeof(double));
 
     for (int i = 1; i < N; i++)
     {
@@ -1331,14 +1338,7 @@ void {{ model.name }}_acados_setup_nlp_in({{ model.name }}_solver_capsule* capsu
   {%- if cost.cost_type_e == "NONLINEAR_LS" or cost.cost_type_e == "LINEAR_LS" %}
 
     double* W_e = calloc(NYN*NYN, sizeof(double));
-    // change only the non-zero elements:
-    {%- for j in range(end=dims.ny_e) %}
-        {%- for k in range(end=dims.ny_e) %}
-            {%- if cost.W_e[j][k] != 0 %}
-    W_e[{{ j }}+(NYN) * {{ k }}] = {{ cost.W_e[j][k] }};
-            {%- endif %}
-        {%- endfor %}
-    {%- endfor %}
+    memcpy(W_e, W_e_init, NYN*NYN*sizeof(double));
     ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, N, "W", W_e);
     free(W_e);
   {%- endif %}

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -1335,10 +1335,13 @@ void {{ model.name }}_acados_create_set_default_parameters({{ model.name }}_solv
 {
 {% if dims.np > 0 %}
     const int N = capsule->nlp_solver_plan->N;
-    // initialize parameters to nominal value
-    double* p = calloc(NP, sizeof(double));
     {% if has_nonzero_parameter_values %}
+    // initialize parameters to nominal value
+    double* p = malloc(NP*sizeof(double));
     memcpy(p, p_init, NP*sizeof(double));
+    {%- else %}
+    // initialize parameters to zero
+    double* p = calloc(NP, sizeof(double));
     {%- endif %}
     for (int i = 0; i <= N; i++) {
         {{ model.name }}_acados_update_params(capsule, i, p, NP);
@@ -1349,10 +1352,13 @@ void {{ model.name }}_acados_create_set_default_parameters({{ model.name }}_solv
 {%- endif %}{# if dims.np #}
 
 {% if dims.np_global > 0 %}
-    // initialize global parameters to nominal value
-    double* p_global = calloc(NP_GLOBAL, sizeof(double));
     {% if has_nonzero_p_global_values %}
+    // initialize global parameters to nominal value
+    double* p_global = malloc(NP_GLOBAL*sizeof(double));
     memcpy(p_global, p_global_init, NP_GLOBAL*sizeof(double));
+    {%- else %}
+    // initialize global parameters to zero
+    double* p_global = calloc(NP_GLOBAL, sizeof(double));
     {%- endif %}
 
     {{ name }}_acados_set_p_global_and_precompute_dependencies(capsule, p_global, NP_GLOBAL);
@@ -1522,44 +1528,54 @@ void {{ model.name }}_acados_setup_nlp_in({{ model.name }}_solver_capsule* capsu
     /**** Cost ****/
 
 {%- if dims.ny_0 != 0 %}
-    double* yref_0 = calloc(NY0, sizeof(double));
     {% if has_nonzero_yref_0_init %}
+    double* yref_0 = malloc(NY0*sizeof(double));
     memcpy(yref_0, yref_0_init, NY0*sizeof(double));
+    {%- else %}
+    double* yref_0 = calloc(NY0, sizeof(double));
     {%- endif %}
     ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, 0, "yref", yref_0);
     free(yref_0);
   {%- if cost.cost_type_0 == "NONLINEAR_LS" or cost.cost_type_0 == "LINEAR_LS" %}
 
-   double* W_0 = calloc(NY0*NY0, sizeof(double));
     {% if has_nonzero_W_0_init %}
+   double* W_0 = malloc(NY0*NY0*sizeof(double));
     memcpy(W_0, W_0_init, NY0*NY0*sizeof(double));
+    {%- else %}
+   double* W_0 = calloc(NY0*NY0, sizeof(double));
     {%- endif %}
     ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, 0, "W", W_0);
     free(W_0);
   {%- endif %}
 
   {%- if cost.cost_type_0 == "LINEAR_LS" %}
-    double* Vx_0 = calloc(NY0*NX, sizeof(double));
-        {% if has_nonzero_Vx_0_init %}
+    {% if has_nonzero_Vx_0_init %}
+    double* Vx_0 = malloc(NY0*NX*sizeof(double));
     memcpy(Vx_0, Vx_0_init, NY0*NX*sizeof(double));
-        {%- endif %}
+    {%- else %}
+    double* Vx_0 = calloc(NY0*NX, sizeof(double));
+    {%- endif %}
     ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, 0, "Vx", Vx_0);
     free(Vx_0);
 
     {%- if dims.nu > 0 %}
-    double* Vu_0 = calloc(NY0*NU, sizeof(double));
-        {% if has_nonzero_Vu_0_init %}
+    {% if has_nonzero_Vu_0_init %}
+    double* Vu_0 = malloc(NY0*NU*sizeof(double));
     memcpy(Vu_0, Vu_0_init, NY0*NU*sizeof(double));
-        {%- endif %}
+    {%- else %}
+    double* Vu_0 = calloc(NY0*NU, sizeof(double));
+    {%- endif %}
     ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, 0, "Vu", Vu_0);
     free(Vu_0);
     {%- endif %}
 
     {%- if dims.nz > 0 %}
-    double* Vz_0 = calloc(NY0*NZ, sizeof(double));
-        {% if has_nonzero_Vz_0_init %}
+    {% if has_nonzero_Vz_0_init %}
+    double* Vz_0 = malloc(NY0*NZ*sizeof(double));
     memcpy(Vz_0, Vz_0_init, NY0*NZ*sizeof(double));
-        {%- endif %}
+    {%- else %}
+    double* Vz_0 = calloc(NY0*NZ, sizeof(double));
+    {%- endif %}
     ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, 0, "Vz", Vz_0);
     free(Vz_0);
     {%- endif %}{# nz > 0 #}
@@ -1568,9 +1584,11 @@ void {{ model.name }}_acados_setup_nlp_in({{ model.name }}_solver_capsule* capsu
 
 
 {%- if dims.ny != 0 %}
-    double* yref = calloc(NY, sizeof(double));
     {% if has_nonzero_yref_init %}
+    double* yref = malloc(NY*sizeof(double));
     memcpy(yref, yref_init, NY*sizeof(double));
+    {%- else %}
+    double* yref = calloc(NY, sizeof(double));
     {%- endif %}
     for (int i = 1; i < N; i++)
     {
@@ -1578,10 +1596,12 @@ void {{ model.name }}_acados_setup_nlp_in({{ model.name }}_solver_capsule* capsu
     }
     free(yref);
   {%- if cost.cost_type == "NONLINEAR_LS" or cost.cost_type == "LINEAR_LS" %}
-    double* W = calloc(NY*NY, sizeof(double));
-        {% if has_nonzero_W_init %}
+    {% if has_nonzero_W_init %}
+    double* W = malloc(NY*NY*sizeof(double));
     memcpy(W, W_init, NY*NY*sizeof(double));
-        {%- endif %}
+    {%- else %}
+    double* W = calloc(NY*NY, sizeof(double));
+    {%- endif %}
     for (int i = 1; i < N; i++)
     {
         ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, i, "W", W);
@@ -1590,10 +1610,12 @@ void {{ model.name }}_acados_setup_nlp_in({{ model.name }}_solver_capsule* capsu
   {%- endif %}
 
   {%- if cost.cost_type == "LINEAR_LS" %}
-    double* Vx = calloc(NY*NX, sizeof(double));
-        {% if has_nonzero_Vx_init %}
+    {% if has_nonzero_Vx_init %}
+    double* Vx = malloc(NY*NX*sizeof(double));
     memcpy(Vx, Vx_init, NY*NX*sizeof(double));
-        {%- endif %}
+    {%- else %}
+    double* Vx = calloc(NY*NX, sizeof(double));
+    {%- endif %}
     for (int i = 1; i < N; i++)
     {
         ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, i, "Vx", Vx);
@@ -1601,9 +1623,11 @@ void {{ model.name }}_acados_setup_nlp_in({{ model.name }}_solver_capsule* capsu
     free(Vx);
 
     {% if dims.nu > 0 %}
-    double* Vu = calloc(NY*NU, sizeof(double));
     {% if has_nonzero_Vu_init %}
+    double* Vu = malloc(NY*NU*sizeof(double));
     memcpy(Vu, Vu_init, NY*NU*sizeof(double));
+    {%- else %}
+    double* Vu = calloc(NY*NU, sizeof(double));
     {%- endif %}
     for (int i = 1; i < N; i++)
     {
@@ -1613,9 +1637,11 @@ void {{ model.name }}_acados_setup_nlp_in({{ model.name }}_solver_capsule* capsu
     {%- endif %}
 
     {%- if dims.nz > 0 %}
-    double* Vz = calloc(NY*NZ, sizeof(double));
     {% if has_nonzero_Vz_init %}
+    double* Vz = malloc(NY*NZ*sizeof(double));
     memcpy(Vz, Vz_init, NY*NZ*sizeof(double));
+    {%- else %}
+    double* Vz = calloc(NY*NZ, sizeof(double));
     {%- endif %}
     for (int i = 1; i < N; i++)
     {
@@ -1629,27 +1655,33 @@ void {{ model.name }}_acados_setup_nlp_in({{ model.name }}_solver_capsule* capsu
 
 
 {%- if dims.ny_e != 0 %}
-    double* yref_e = calloc(NYN, sizeof(double));
-        {% if has_nonzero_yref_e_init %}
+    {% if has_nonzero_yref_e_init %}
+    double* yref_e = malloc(NYN*sizeof(double));
     memcpy(yref_e, yref_e_init, NYN*sizeof(double));
-        {%- endif %}
+    {%- else %}
+    double* yref_e = calloc(NYN, sizeof(double));
+    {%- endif %}
     ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, N, "yref", yref_e);
     free(yref_e);
 
   {%- if cost.cost_type_e == "NONLINEAR_LS" or cost.cost_type_e == "LINEAR_LS" %}
-    double* W_e = calloc(NYN*NYN, sizeof(double));
-        {% if has_nonzero_W_e_init %}
+    {% if has_nonzero_W_e_init %}
+    double* W_e = malloc(NYN*NYN*sizeof(double));
     memcpy(W_e, W_e_init, NYN*NYN*sizeof(double));
-        {%- endif %}
+    {%- else %}
+    double* W_e = calloc(NYN*NYN, sizeof(double));
+    {%- endif %}
     ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, N, "W", W_e);
     free(W_e);
   {%- endif %}
 
   {%- if cost.cost_type_e == "LINEAR_LS" %}
-    double* Vx_e = calloc(NYN*NX, sizeof(double));
-        {% if has_nonzero_Vx_e_init %}
+    {% if has_nonzero_Vx_e_init %}
+    double* Vx_e = malloc(NYN*NX*sizeof(double));
     memcpy(Vx_e, Vx_e_init, NYN*NX*sizeof(double));
-        {%- endif %}
+    {%- else %}
+    double* Vx_e = calloc(NYN*NX, sizeof(double));
+    {%- endif %}
     ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, N, "Vx", Vx_e);
     free(Vx_e);
   {%- endif %}

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -153,6 +153,30 @@ static const double yref_e_init[] = {
 };
 {%- endif %}
 
+{%- if dims.ns_0 > 0 %}
+// initial value of slacks initial: Zl_0, Zu_0, zl_0, zu_0
+static const double Zl_0_init[] = { {%- for item in cost.Zl_0 -%}{{ item }}, {%- endfor -%} };
+static const double Zu_0_init[] = { {%- for item in cost.Zu_0 -%}{{ item }}, {%- endfor -%} };
+static const double zl_0_init[] = { {%- for item in cost.zl_0 -%}{{ item }}, {%- endfor -%} };
+static const double zu_0_init[] = { {%- for item in cost.zu_0 -%}{{ item }}, {%- endfor -%} };
+{%- endif %}
+
+{%- if dims.ns > 0 %}
+// initial value of slacks stagewise: Zl, Zu, zl, zu
+static const double Zl_init[] = { {%- for item in cost.Zl -%}{{ item }}, {%- endfor -%} };
+static const double Zu_init[] = { {%- for item in cost.Zu -%}{{ item }}, {%- endfor -%} };
+static const double zl_init[] = { {%- for item in cost.zl -%}{{ item }}, {%- endfor -%} };
+static const double zu_init[] = { {%- for item in cost.zu -%}{{ item }}, {%- endfor -%} };
+{%- endif %}
+
+{%- if dims.ns_e > 0 %}
+// initial value of slacks terminal: Zl_e, Zu_e, zl_e, zu_e
+static const double Zl_e_init[] = { {%- for item in cost.Zl_e -%}{{ item }}, {%- endfor -%} };
+static const double Zu_e_init[] = { {%- for item in cost.Zu_e -%}{{ item }}, {%- endfor -%} };
+static const double zl_e_init[] = { {%- for item in cost.zl_e -%}{{ item }}, {%- endfor -%} };
+static const double zu_e_init[] = { {%- for item in cost.zu_e -%}{{ item }}, {%- endfor -%} };
+{%- endif %}
+
 {%- if dims.ny_0 != 0 and (cost.cost_type_0 == "NONLINEAR_LS" or cost.cost_type_0 == "LINEAR_LS") %}
 // initial value of W_0
 static const double W_0_init[] = {
@@ -1279,7 +1303,6 @@ void {{ model.name }}_acados_setup_nlp_in({{ model.name }}_solver_capsule* capsu
 {%- if dims.ny != 0 %}
     double* yref = calloc(NY, sizeof(double));
     memcpy(yref, yref_init, NY*sizeof(double));
-
     for (int i = 1; i < N; i++)
     {
         ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, i, "yref", yref);
@@ -1288,7 +1311,6 @@ void {{ model.name }}_acados_setup_nlp_in({{ model.name }}_solver_capsule* capsu
   {%- if cost.cost_type == "NONLINEAR_LS" or cost.cost_type == "LINEAR_LS" %}
     double* W = calloc(NY*NY, sizeof(double));
     memcpy(W, W_init, NY*NY*sizeof(double));
-
     for (int i = 1; i < N; i++)
     {
         ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, i, "W", W);
@@ -1336,7 +1358,6 @@ void {{ model.name }}_acados_setup_nlp_in({{ model.name }}_solver_capsule* capsu
     free(yref_e);
 
   {%- if cost.cost_type_e == "NONLINEAR_LS" or cost.cost_type_e == "LINEAR_LS" %}
-
     double* W_e = calloc(NYN*NYN, sizeof(double));
     memcpy(W_e, W_e_init, NYN*NYN*sizeof(double));
     ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, N, "W", W_e);
@@ -1437,30 +1458,10 @@ void {{ model.name }}_acados_setup_nlp_in({{ model.name }}_solver_capsule* capsu
     double* zl_0 = zlu0_mem+NS0*2;
     double* zu_0 = zlu0_mem+NS0*3;
 
-    // change only the non-zero elements:
-    {%- for j in range(end=dims.ns_0) %}
-        {%- if cost.Zl_0[j] != 0 %}
-    Zl_0[{{ j }}] = {{ cost.Zl_0[j] }};
-        {%- endif %}
-    {%- endfor %}
-
-    {%- for j in range(end=dims.ns_0) %}
-        {%- if cost.Zu_0[j] != 0 %}
-    Zu_0[{{ j }}] = {{ cost.Zu_0[j] }};
-        {%- endif %}
-    {%- endfor %}
-
-    {%- for j in range(end=dims.ns_0) %}
-        {%- if cost.zl_0[j] != 0 %}
-    zl_0[{{ j }}] = {{ cost.zl_0[j] }};
-        {%- endif %}
-    {%- endfor %}
-
-    {%- for j in range(end=dims.ns_0) %}
-        {%- if cost.zu_0[j] != 0 %}
-    zu_0[{{ j }}] = {{ cost.zu_0[j] }};
-        {%- endif %}
-    {%- endfor %}
+    memcpy(Zl_0, Zl_0_init, NS0*sizeof(double));
+    memcpy(Zu_0, Zu_0_init, NS0*sizeof(double));
+    memcpy(zl_0, zl_0_init, NS0*sizeof(double));
+    memcpy(zu_0, zu_0_init, NS0*sizeof(double));
 
     ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, 0, "Zl", Zl_0);
     ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, 0, "Zu", Zu_0);
@@ -1477,30 +1478,10 @@ void {{ model.name }}_acados_setup_nlp_in({{ model.name }}_solver_capsule* capsu
     double* Zu = zlumem+NS*1;
     double* zl = zlumem+NS*2;
     double* zu = zlumem+NS*3;
-    // change only the non-zero elements:
-    {%- for j in range(end=dims.ns) %}
-        {%- if cost.Zl[j] != 0 %}
-    Zl[{{ j }}] = {{ cost.Zl[j] }};
-        {%- endif %}
-    {%- endfor %}
-
-    {%- for j in range(end=dims.ns) %}
-        {%- if cost.Zu[j] != 0 %}
-    Zu[{{ j }}] = {{ cost.Zu[j] }};
-        {%- endif %}
-    {%- endfor %}
-
-    {%- for j in range(end=dims.ns) %}
-        {%- if cost.zl[j] != 0 %}
-    zl[{{ j }}] = {{ cost.zl[j] }};
-        {%- endif %}
-    {%- endfor %}
-
-    {%- for j in range(end=dims.ns) %}
-        {%- if cost.zu[j] != 0 %}
-    zu[{{ j }}] = {{ cost.zu[j] }};
-        {%- endif %}
-    {%- endfor %}
+    memcpy(Zl, Zl_init, NS*sizeof(double));
+    memcpy(Zu, Zu_init, NS*sizeof(double));
+    memcpy(zl, zl_init, NS*sizeof(double));
+    memcpy(zu, zu_init, NS*sizeof(double));
 
     for (int i = 1; i < N; i++)
     {
@@ -1521,30 +1502,10 @@ void {{ model.name }}_acados_setup_nlp_in({{ model.name }}_solver_capsule* capsu
     double* zl_e = zluemem+NSN*2;
     double* zu_e = zluemem+NSN*3;
 
-    // change only the non-zero elements:
-    {%- for j in range(end=dims.ns_e) %}
-        {%- if cost.Zl_e[j] != 0 %}
-    Zl_e[{{ j }}] = {{ cost.Zl_e[j] }};
-        {%- endif %}
-    {%- endfor %}
-
-    {%- for j in range(end=dims.ns_e) %}
-        {%- if cost.Zu_e[j] != 0 %}
-    Zu_e[{{ j }}] = {{ cost.Zu_e[j] }};
-        {%- endif %}
-    {%- endfor %}
-
-    {%- for j in range(end=dims.ns_e) %}
-        {%- if cost.zl_e[j] != 0 %}
-    zl_e[{{ j }}] = {{ cost.zl_e[j] }};
-        {%- endif %}
-    {%- endfor %}
-
-    {%- for j in range(end=dims.ns_e) %}
-        {%- if cost.zu_e[j] != 0 %}
-    zu_e[{{ j }}] = {{ cost.zu_e[j] }};
-        {%- endif %}
-    {%- endfor %}
+    memcpy(Zl_e, Zl_e_init, NSN*sizeof(double));
+    memcpy(Zu_e, Zu_e_init, NSN*sizeof(double));
+    memcpy(zl_e, zl_e_init, NSN*sizeof(double));
+    memcpy(zu_e, zu_e_init, NSN*sizeof(double));
 
     ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, N, "Zl", Zl_e);
     ocp_nlp_cost_model_set(nlp_config, nlp_dims, nlp_in, N, "Zu", Zu_e);

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -121,9 +121,7 @@
 {% if dims.np_global > 0 %}
 // initial value of global parameters
 static const double p_global_init[] = {
-    {%- for item in p_global_values %}
-    {{ item }},
-    {%- endfor %}
+    {%- for item in p_global_values -%}{{ item }}, {%- endfor -%}
 };
 {%- endif %}{# if dims.np_global #}
 

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -32,6 +32,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>
+#include <string.h> // memcpy
 // acados
 // #include "acados/utils/print.h"
 #include "acados_c/ocp_nlp_interface.h"
@@ -114,6 +115,17 @@
 #define NSGN   {{ model.name | upper }}_NSGN
 #define NSBXN  {{ model.name | upper }}_NSBXN
 
+
+// ** numerical values **
+
+{% if dims.np_global > 0 %}
+// initial value of global parameters
+static const double p_global_init[] = {
+    {%- for item in p_global_values %}
+    {{ item }},
+    {%- endfor %}
+};
+{%- endif %}{# if dims.np_global #}
 
 
 // ** solver data **
@@ -947,11 +959,7 @@ void {{ model.name }}_acados_create_set_default_parameters({{ model.name }}_solv
 {% if dims.np_global > 0 %}
     // initialize global parameters to nominal value
     double* p_global = calloc(NP_GLOBAL, sizeof(double));
-    {%- for item in p_global_values %}
-        {%- if item != 0 %}
-    p_global[{{ loop.index0 }}] = {{ item }};
-        {%- endif %}
-    {%- endfor %}
+    memcpy(p_global, p_global_init, NP_GLOBAL*sizeof(double));
 
     {{ name }}_acados_set_p_global_and_precompute_dependencies(capsule, p_global, NP_GLOBAL);
 


### PR DESCRIPTION
In the ocp and sim solver template, numerical data for `p` and `p_global` is initialized from a static const array instead of assigning each nonzero value individually.

This change significantly reduces compile time for problems with lots of (global) parameters.
In the example `example_p_global.py` with `LARGE_SCALE = True`, this reduces compile time by a factor > 10.

Other
* print timings for external function generation, templated code generation, compilation (if verbose)