### PR TITLE
Python/MATLAB: add check for dynamics expressions, based on the integrator type

### DIFF
--- a/interfaces/acados_matlab_octave/AcadosOcp.m
+++ b/interfaces/acados_matlab_octave/AcadosOcp.m
@@ -998,14 +998,14 @@ classdef AcadosOcp < handle
 
             % integrator: num_stages
             if ~isempty(opts.sim_method_num_stages)
-                if(strcmp(opts.integrator_type, "ERK"))
+                if (strcmp(opts.integrator_type, "ERK"))
                     if (any(opts.sim_method_num_stages < 1) || any(opts.sim_method_num_stages > 4))
                         error(['ERK: num_stages = ', num2str(opts.sim_method_num_stages) ' not available. Only number of stages = {1,2,3,4} implemented!']);
                     end
                 end
             end
 
-            %% options sanity checks
+            % options sanity checks
             if length(opts.sim_method_num_steps) == 1
                 opts.sim_method_num_steps = opts.sim_method_num_steps * ones(1, opts.N_horizon);
             elseif length(opts.sim_method_num_steps) ~= opts.N_horizon
@@ -1022,6 +1022,17 @@ classdef AcadosOcp < handle
                 error('sim_method_jac_reuse must be a scalar or a vector of length N');
             end
 
+            % check dynamics expression for the specified integrator type
+            switch opts.integrator_type
+                case 'ERK'
+                    assert(~isempty(self.model.f_expl_expr), 'For the ERK integrator, AcadosModel.f_expl_expr should be provided.')
+                case {'IRK', 'LIFTED_IRK', 'GNSF'}
+                    assert(~isempty(self.model.f_impl_expr), ['For the ', opts.integrator_type, ' integrator, AcadosModel.f_impl_expr should be provided.'])
+                case 'DISCRETE'
+                    assert(~isempty(self.model.disc_dyn_expr), 'For the DISCRETE integrator, AcadosModel.disc_dyn_expr should be provided.')
+                otherwise
+                    error('Integrator type not recognized.')
+            end
 
         end
 

--- a/interfaces/acados_template/acados_template/acados_ocp.py
+++ b/interfaces/acados_template/acados_template/acados_ocp.py
@@ -1023,6 +1023,14 @@ class AcadosOcp:
         else:
             raise ValueError("Wrong value for sim_method_jac_reuse. Should be either int or array of ints of shape (N,).")
 
+        # check expression for the specified integrator type
+        if opts.integrator_type == 'ERK':
+            assert not is_empty(self.model.f_expl_expr), "For the ERK integrator, AcadosModel.f_expl_expr should be provided."
+        elif opts.integrator_type in {'IRK', 'LIFTED_IRK', 'GNSF'}:
+            assert not is_empty(self.model.f_impl_expr), f"For the {opts.integrator_type} integrator, AcadosModel.f_impl_expr should be provided."
+        elif opts.integrator_type == 'DISCRETE':
+            assert not is_empty(self.model.disc_dyn_expr), "For the DISCRETE integrator, AcadosModel.disc_dyn_expr should be provided."
+
 
     def make_consistent(self, mocp_info: Optional[dict]=None, verbose: bool=True) -> None:
         """


### PR DESCRIPTION
If this is ok, I can add the checks in [MATLAB](https://github.com/acados/acados/blob/dc6668f8538e49831f03a36ddf755de6e92d38ea/interfaces/acados_matlab_octave/AcadosOcp.m#L986) as well