### PR TITLE
Template: add sparsity check for p/p_global initialization

### DIFF
--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.c
@@ -105,25 +105,52 @@
 
 #define {{ name | upper }}_N      {{ N_horizon }}
 
+{%- set_global sparsity_threshold = 0.1 -%}
+
 {%- for jj in range(end=n_phases) %}
 #define NP_{{ jj }}     {{ phases_dims[jj].np }}
 {%- endfor %}
 
+{%- set_global parameter_values_nnz = [] -%}
+
+{%- for jj in range(end=n_phases) %}
+    {%- set_global nnz = 0 -%}
+    {%- for item in parameter_values[jj] -%}
+        {%- if item != 0.0 -%}
+            {%- set_global nnz = nnz + 1 -%}
+        {%- endif -%}
+    {%- endfor -%}
+    {%- set_global parameter_values_nnz = parameter_values_nnz | concat(with=(nnz)) %}
+{%- endfor %}
+
 {%- for jj in range(end=n_phases) %}
 {% if phases_dims[jj].np > 0 %}
+{% if parameter_values_nnz[jj] / phases_dims[jj].np > sparsity_threshold %}
+
 // initial value of stagewise parameters
 static const double p_init_{{ jj }}[] = {
     {%- for item in parameter_values[jj] -%}{{ item }}, {%- endfor -%}
 };
+{%- endif %}
 {%- endif %}{# if phases_dims[jj].np #}
 {%- endfor %}
 
 
 {% if dims_0.np_global > 0 %}
+
+{%- set_global p_global_values_nnz = 0 -%}
+{%- for item in p_global_values -%}
+    {%- if item != 0.0 -%}
+        {%- set_global p_global_values_nnz = p_global_values_nnz + 1 -%}
+    {%- endif -%}
+{%- endfor -%}
+
+{% if p_global_values_nnz / dims_0.np_global > sparsity_threshold %}
 // initial value of global parameters
 static const double p_global_init[] = {
     {%- for item in p_global_values -%}{{ item }}, {%- endfor -%}
 };
+{%- endif %}
 {%- endif %}{# if dims_0.np_global #}
 
 
@@ -842,25 +869,46 @@ void {{ name }}_acados_create_setup_functions({{ name }}_solver_capsule* capsule
  */
 void {{ name }}_acados_create_set_default_parameters({{ name }}_solver_capsule* capsule) {
 
-    double* p = malloc({{ np_max }} * sizeof(double));
     // initialize parameters to nominal value
-{%- for jj in range(end=n_phases) %}{# phases loop !#}
+    double* p = calloc({{ np_max }}, sizeof(double));
+    {%- for jj in range(end=n_phases) %}{# phases loop !#}
 
-    {%- if phases_dims[jj].np > 0 %}
+    {% if phases_dims[jj].np > 0 %}
+
+    {% if parameter_values_nnz[jj] / phases_dims[jj].np > sparsity_threshold %}
     memcpy(p, p_init_{{ jj }}, NP_{{ jj }}*sizeof(double));
+    {%- else %}
+    {%- for item in parameter_values[jj] %}
+        {%- if item != 0 %}
+    p[{{ loop.index0 }}] = {{ item }};
+        {%- endif %}
+    {%- endfor %}
+    {%- endif %}
 
     for (int i = {{ start_idx[jj] }}; i < {{ end_idx[jj] }}; i++) {
         {{ name }}_acados_update_params(capsule, i, p, NP_{{ jj }});
     }
-    {%- endif %}
+    {%- endif %}{# if phases_dims[jj].np #}
 {%- endfor %}
     free(p);
 
 {%- if phases_dims[0].np_global > 0 %}
 
     // initialize global parameters to nominal value
+    {%- if p_global_values_nnz / phases_dims[0].np_global > sparsity_threshold %}
+
     double* p_global = malloc({{ dims_0.np_global }}*sizeof(double));
     memcpy(p_global, p_global_init, {{ dims_0.np_global }}*sizeof(double));
+    {%- else %}
+    double* p_global = calloc(dims_0.np_global, sizeof(double));
+    {%- for item in p_global_values %}
+        {%- if item != 0 %}
+    p_global[{{ loop.index0 }}] = {{ item }};
+        {%- endif %}
+    {%- endfor %}
+
+    {%- endif %}
+
     {{ name }}_acados_set_p_global_and_precompute_dependencies(capsule, p_global, {{ phases_dims[0].np_global }});
 
     free(p_global);

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_sim_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_sim_solver.in.c
@@ -60,11 +60,23 @@
 #include "acados_sim_solver_{{ model.name }}.h"
 
 
+{%- set_global sparsity_threshold = 0.1 -%}
+
 {% if dims.np > 0 %}
-// initial value of parameters
+
+{%- set_global parameter_values_nnz = 0 -%}
+{%- for item in parameter_values -%}
+    {%- if item != 0.0 -%}
+        {%- set_global parameter_values_nnz = parameter_values_nnz + 1 -%}
+    {%- endif -%}
+{%- endfor -%}
+
+{% if parameter_values_nnz / dims.np > sparsity_threshold %}
+// initial value of stagewise parameters
 static const double p_init[] = {
     {%- for item in parameter_values -%}{{ item }}, {%- endfor -%}
 };
+{%- endif %}
 {%- endif %}{# if dims.np #}
 
 // ** solver data **
@@ -414,8 +426,17 @@ int {{ model.name }}_acados_sim_create({{ model.name }}_sim_solver_capsule * cap
 
 {% if dims.np > 0 %}
     /* initialize parameter values */
+    {% if parameter_values_nnz / dims.np > sparsity_threshold %}
     double* p = malloc(np*sizeof(double));
     memcpy(p, p_init, np*sizeof(double));
+    {%- else %}
+    double* p = calloc(np, sizeof(double));
+    {%- for item in parameter_values %}
+        {%- if item != 0 %}
+    p[{{ loop.index0 }}] = {{ item }};
+        {%- endif %}
+    {%- endfor %}
+    {%- endif %}
     {{ model.name }}_acados_sim_update_params(capsule, p, np);
     free(p);
 {% endif %}{# if dims.np #}

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -144,6 +144,7 @@ static const double p_init[] = {
     {%- endif -%}
 {%- endfor -%}
 
+
 {% if global_parameter_values_nnz / dims.np_global > sparsity_threshold %}
 // initial value of global parameters
 static const double p_global_init[] = {
@@ -995,7 +996,7 @@ void {{ model.name }}_acados_create_set_default_parameters({{ model.name }}_solv
     memcpy(p_global, p_global_init, NP_GLOBAL*sizeof(double));
     {%- else %}
     double* p_global = calloc(NP_GLOBAL, sizeof(double));
-    {%- for item in global_parameter_values %}
+    {%- for item in p_global_values %}
         {%- if item != 0 %}
     p_global[{{ loop.index0 }}] = {{ item }};
         {%- endif %}

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -116,19 +116,40 @@
 #define NSBXN  {{ model.name | upper }}_NSBXN
 
 
+{%- set_global sparsity_threshold = 0.1 -%}
 
 {% if dims.np > 0 %}
+
+{%- set_global parameter_values_nnz = 0 -%}
+{%- for item in parameter_values -%}
+    {%- if item != 0.0 -%}
+        {%- set_global parameter_values_nnz = parameter_values_nnz + 1 -%}
+    {%- endif -%}
+{%- endfor -%}
+
+{% if parameter_values_nnz / dims.np > sparsity_threshold %}
 // initial value of stagewise parameters
 static const double p_init[] = {
     {%- for item in parameter_values -%}{{ item }}, {%- endfor -%}
 };
+{%- endif %}
 {%- endif %}{# if dims.np #}
 
 {% if dims.np_global > 0 %}
+
+{%- set_global global_parameter_values_nnz = 0 -%}
+{%- for item in p_global_values -%}
+    {%- if item != 0.0 -%}
+        {%- set_global global_parameter_values_nnz = global_parameter_values_nnz + 1 -%}
+    {%- endif -%}
+{%- endfor -%}
+
+{% if global_parameter_values_nnz / dims.np_global > sparsity_threshold %}
 // initial value of global parameters
 static const double p_global_init[] = {
     {%- for item in p_global_values -%}{{ item }}, {%- endfor -%}
 };
+{%- endif %}
 {%- endif %}{# if dims.np_global #}
 
 
@@ -945,9 +966,20 @@ void {{ model.name }}_acados_create_set_default_parameters({{ model.name }}_solv
 {
 {% if dims.np > 0 %}
     const int N = capsule->nlp_solver_plan->N;
-    // initialize parameters to nominal value
+
+    // initialize parameters to initial value
+    {% if parameter_values_nnz / dims.np > sparsity_threshold %}
     double* p = malloc(NP*sizeof(double));
     memcpy(p, p_init, NP*sizeof(double));
+    {%- else %}
+    double* p = calloc(NP, sizeof(double));
+    {%- for item in parameter_values %}
+        {%- if item != 0 %}
+    p[{{ loop.index0 }}] = {{ item }};
+        {%- endif %}
+    {%- endfor %}
+    {%- endif %}
+
     for (int i = 0; i <= N; i++) {
         {{ model.name }}_acados_update_params(capsule, i, p, NP);
     }
@@ -957,9 +989,19 @@ void {{ model.name }}_acados_create_set_default_parameters({{ model.name }}_solv
 {%- endif %}{# if dims.np #}
 
 {% if dims.np_global > 0 %}
-    // initialize global parameters to nominal value
+    // initialize global parameters to initial value
+    {% if global_parameter_values_nnz / dims.np_global > sparsity_threshold %}
     double* p_global = malloc(NP_GLOBAL*sizeof(double));
     memcpy(p_global, p_global_init, NP_GLOBAL*sizeof(double));
+    {%- else %}
+    double* p_global = calloc(NP_GLOBAL, sizeof(double));
+    {%- for item in global_parameter_values %}
+        {%- if item != 0 %}
+    p_global[{{ loop.index0 }}] = {{ item }};
+        {%- endif %}
+    {%- endfor %}
+    {%- endif %}
+
     {{ name }}_acados_set_p_global_and_precompute_dependencies(capsule, p_global, NP_GLOBAL);
 
     free(p_global);

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -137,15 +137,15 @@ static const double p_init[] = {
 
 {% if dims.np_global > 0 %}
 
-{%- set_global global_parameter_values_nnz = 0 -%}
+{%- set_global p_global_values_nnz = 0 -%}
 {%- for item in p_global_values -%}
     {%- if item != 0.0 -%}
-        {%- set_global global_parameter_values_nnz = global_parameter_values_nnz + 1 -%}
+        {%- set_global p_global_values_nnz = p_global_values_nnz + 1 -%}
     {%- endif -%}
 {%- endfor -%}
 
 
-{% if global_parameter_values_nnz / dims.np_global > sparsity_threshold %}
+{% if p_global_values_nnz / dims.np_global > sparsity_threshold %}
 // initial value of global parameters
 static const double p_global_init[] = {
     {%- for item in p_global_values -%}{{ item }}, {%- endfor -%}
@@ -991,7 +991,7 @@ void {{ model.name }}_acados_create_set_default_parameters({{ model.name }}_solv
 
 {% if dims.np_global > 0 %}
     // initialize global parameters to initial value
-    {% if global_parameter_values_nnz / dims.np_global > sparsity_threshold %}
+    {% if p_global_values_nnz / dims.np_global > sparsity_threshold %}
     double* p_global = malloc(NP_GLOBAL*sizeof(double));
     memcpy(p_global, p_global_init, NP_GLOBAL*sizeof(double));
     {%- else %}


### PR DESCRIPTION
follow up to https://github.com/acados/acados/pull/1838

check sparsity of initial values of (global) parameters to avoid excessive memory usage if initial values are zero