### PR TITLE
AcadosOcpSolver: do not load formulation from json

### DIFF
--- a/.github/linux/install_new_casadi_matlab.sh
+++ b/.github/linux/install_new_casadi_matlab.sh
@@ -30,7 +30,7 @@
 #
 
 
-CASADI_MATLAB_URL="https://github.com/casadi/casadi/releases/download/3.7.0/casadi-3.7.0-linux64-matlab2018b.zip";
+CASADI_MATLAB_URL="https://github.com/casadi/casadi/releases/download/3.7.2/casadi-3.7.2-linux64-matlab2018b.zip";
 
 wget -O casadi-linux-matlab.zip "${CASADI_MATLAB_URL}";
 mkdir -p casadi-matlab;

--- a/.github/linux/install_new_casadi_octave.sh
+++ b/.github/linux/install_new_casadi_octave.sh
@@ -30,7 +30,7 @@
 #
 
 echo "Installing CasADi for Octave";
-CASADI_OCTAVE_URL="https://github.com/casadi/casadi/releases/download/3.7.0/casadi-3.7.0-linux64-octave7.3.0.zip";
+CASADI_OCTAVE_URL="https://github.com/casadi/casadi/releases/download/3.7.2/casadi-3.7.2-linux64-octave7.3.0.zip";
 
 wget -O casadi-linux-octave.zip "${CASADI_OCTAVE_URL}";
 mkdir -p casadi-octave;

--- a/examples/acados_matlab_octave/test/create_ocp_solver_code_reuse.m
+++ b/examples/acados_matlab_octave/test/create_ocp_solver_code_reuse.m
@@ -37,7 +37,7 @@ function ocp_solver = create_ocp_solver_code_reuse(creation_mode)
         disp('Standard creation mode');
     elseif strcmp(creation_mode, 'ocp_from_json')
         disp('OCP from JSON creation mode');
-    elseif strcmp(creation_mode, 'precompiled') || strcmp(creation_mode, 'no_ocp')
+    elseif strcmp(creation_mode, 'precompiled')
         solver_creation_opts.generate = false;
         solver_creation_opts.build = false;
         solver_creation_opts.compile_mex_wrapper = false;
@@ -50,9 +50,7 @@ function ocp_solver = create_ocp_solver_code_reuse(creation_mode)
         error('Invalid creation mode')
     end
 
-    if strcmp(creation_mode, 'no_ocp')
-        ocp = [];
-    elseif strcmp(creation_mode, 'ocp_from_json')
+    if strcmp(creation_mode, 'ocp_from_json')
         ocp = AcadosOcp.from_json(json_file);
     else
         ocp = create_pendulum_ocp();
@@ -61,7 +59,7 @@ function ocp_solver = create_ocp_solver_code_reuse(creation_mode)
     % create solver
     ocp_solver = AcadosOcpSolver(ocp, solver_creation_opts);
 
-    if strcmp(creation_mode, 'precompiled') || strcmp(creation_mode, 'force_precompiled') || strcmp(creation_mode, 'no_ocp')
+    if strcmp(creation_mode, 'precompiled') || strcmp(creation_mode, 'force_precompiled')
         % check if code reuse worked
         if ocp_solver.solver_creation_opts.generate || ocp_solver.solver_creation_opts.build
             error("Code reuse failed, solver was regenerated or rebuilt.");

--- a/examples/acados_matlab_octave/test/test_code_reuse.m
+++ b/examples/acados_matlab_octave/test/test_code_reuse.m
@@ -30,9 +30,7 @@
 import casadi.*
 
 check_acados_requirements()
-creation_modes = {'standard', 'precompiled', 'force_precompiled', 'ocp_from_json', 'no_ocp'};
-
-% NOTE: no_ocp creation mode is not recommended and might be deprecated in the future.
+creation_modes = {'standard', 'precompiled', 'force_precompiled', 'ocp_from_json'};
 
 for i = 1:length(creation_modes)
     disp(['testing creation mode ', creation_modes{i}]);

--- a/examples/acados_python/crane/time_optimal_example.py
+++ b/examples/acados_python/crane/time_optimal_example.py
@@ -99,7 +99,7 @@ def setup_solver_and_integrator(x0: np.ndarray, xf: np.ndarray, N: int, creation
     ocp.cost.cost_type_e = 'EXTERNAL'
 
     ocp.model.cost_expr_ext_cost = dt
-    ocp.model.cost_expr_ext_cost_e = 0
+    ocp.model.cost_expr_ext_cost_e = SX.zeros(1)
 
     ocp.model.cost_expr_ext_cost_custom_hess = diag(vertcat(SX.zeros(1, 1), 1./(dt), SX.zeros(model.x.rows(), 1)))
 
@@ -135,8 +135,10 @@ def setup_solver_and_integrator(x0: np.ndarray, xf: np.ndarray, N: int, creation
     elif creation_mode == 'ctypes_precompiled':
         ## Note: skip generate and build assuming this is done before (in cython run)
         ocp_solver = AcadosOcpSolver(ocp, json_file=ocp_json_file, build=False, generate=False)
-    elif creation_mode == 'ctypes_precompiled_no_ocp':
-        ocp_solver = AcadosOcpSolver(None, json_file=ocp_json_file, build=False, generate=False)
+    elif creation_mode == 'ctypes_precompiled_load_ocp':
+        ocp = AcadosOcp.from_json(ocp_json_file)
+        breakpoint()
+        ocp_solver = AcadosOcpSolver(ocp, build=False, generate=False)
     elif creation_mode == 'ctypes':
         ocp_solver = AcadosOcpSolver(ocp, json_file=ocp_json_file)
     else:
@@ -156,7 +158,8 @@ def setup_solver_and_integrator(x0: np.ndarray, xf: np.ndarray, N: int, creation
 
     return ocp_solver, integrator
 
-def main(creation_mode=True):
+def main(creation_mode, plot=False):
+    print(f"\nrunning with creation mode {creation_mode}\n")
 
     nu = 2
     nx = 4
@@ -231,11 +234,12 @@ def main(creation_mode=True):
 
             k += 1
 
-    plot_crane_trajectories(ts_fine, simX_fine, simU_fine)
+    if plot:
+        plot_crane_trajectories(ts_fine, simX_fine, simU_fine)
 
-CREATION_MODES = ['cython', 'ctypes_precompiled', 'ctypes', 'ctypes_precompiled_no_ocp']
+CREATION_MODES = ['cython', 'ctypes_precompiled', 'ctypes', 'ctypes_precompiled_load_ocp']
 
 if __name__ == "__main__":
-    for creation_mode in ['cython', 'ctypes_precompiled_no_ocp', 'ctypes_precompiled']:
-        main(creation_mode=creation_mode)
+    for creation_mode in ['ctypes', 'ctypes_precompiled_load_ocp', 'ctypes_precompiled']:
+        main(creation_mode=creation_mode, plot=False)
 

--- a/examples/acados_python/crane/time_optimal_example.py
+++ b/examples/acados_python/crane/time_optimal_example.py
@@ -137,7 +137,6 @@ def setup_solver_and_integrator(x0: np.ndarray, xf: np.ndarray, N: int, creation
         ocp_solver = AcadosOcpSolver(ocp, json_file=ocp_json_file, build=False, generate=False)
     elif creation_mode == 'ctypes_precompiled_load_ocp':
         ocp = AcadosOcp.from_json(ocp_json_file)
-        breakpoint()
         ocp_solver = AcadosOcpSolver(ocp, build=False, generate=False)
     elif creation_mode == 'ctypes':
         ocp_solver = AcadosOcpSolver(ocp, json_file=ocp_json_file)

--- a/examples/acados_python/p_global_example/code_reuse_py2matlab.m
+++ b/examples/acados_python/p_global_example/code_reuse_py2matlab.m
@@ -42,7 +42,12 @@ for i = 1:length(json_files)
     solver_creation_opts.generate = false;
     solver_creation_opts.build = false;
     solver_creation_opts.compile_mex_wrapper = true;
-    ocp = [];
+
+    if ~isempty(strfind(json_file, 'multi'))
+        ocp = AcadosMultiphaseOcp.from_json(json_file);
+    else
+        ocp = AcadosOcp.from_json(json_file);
+    end
 
     % create solver
     ocp_solver = AcadosOcpSolver(ocp, solver_creation_opts);

--- a/examples/acados_python/p_global_example/example_p_global.py
+++ b/examples/acados_python/p_global_example/example_p_global.py
@@ -228,6 +228,7 @@ def main(use_cython=False, lut=True, use_p_global=True, blazing=True, with_matla
     # create ocp solver
     print(f"Creating ocp solver with p_global = {ocp.model.p_global}, p = {ocp.model.p}")
     if with_matlab_templates:
+        # TODO: proper multi-phase options.
         ocp.simulink_opts = get_simulink_default_opts()
     solver_json = 'acados_ocp_' + ocp.model.name + '.json'
     if use_cython:
@@ -371,8 +372,9 @@ if __name__ == "__main__":
     np.testing.assert_almost_equal(ref_nolut, res_mocp_nolut_p)
     np.testing.assert_almost_equal(ref_nolut, res_mocp_nolut_p_global)
 
+    with_matlab_templates = False # TODO: set this to True, when multiphase simulink is done properly in python.
     res_mocp_lut_p, _, mocp_json_file = main_mocp(use_p_global=False, lut=True)
-    res_mocp_lut_p_global, _, mocp_json_file = main_mocp(use_p_global=True, lut=True, with_matlab_templates=True)
+    res_mocp_lut_p_global, _, mocp_json_file = main_mocp(use_p_global=True, lut=True, with_matlab_templates=with_matlab_templates)
     res_mocp_load, _ = main_mocp_json_load(mocp_json_file)
 
     np.testing.assert_almost_equal(res_mocp_load, res_mocp_lut_p_global)
@@ -383,4 +385,4 @@ if __name__ == "__main__":
         np.testing.assert_almost_equal(ref_lut, ref_nolut)
 
     # to test transfer to MATLAB/Octave
-    res_lut, t_lin_lut = main(use_cython=False, use_p_global=True, lut=True, with_matlab_templates=True, code_export_directory='c_generated_code_single_phase')
+    res_lut, t_lin_lut = main(use_cython=False, use_p_global=True, lut=True, with_matlab_templates=with_matlab_templates, code_export_directory='c_generated_code_single_phase')

--- a/examples/acados_python/pendulum_on_cart/ocp/nonuniform_discretization_example.py
+++ b/examples/acados_python/pendulum_on_cart/ocp/nonuniform_discretization_example.py
@@ -140,7 +140,8 @@ def main(discretization='shooting_nodes'):
 
     # Set additional options for Simulink interface:
     simulink_opts = get_simulink_default_opts()
-    ocp_solver = AcadosOcpSolver(ocp, json_file = 'acados_ocp.json', simulink_opts = simulink_opts, verbose=False)
+    ocp.simulink_opts = simulink_opts
+    ocp_solver = AcadosOcpSolver(ocp, json_file = 'acados_ocp.json', verbose=False)
 
     simX = np.zeros((N+1, nx))
     simU = np.zeros((N, nu))

--- a/examples/acados_python/pendulum_on_cart/ocp/simulink_example.py
+++ b/examples/acados_python/pendulum_on_cart/ocp/simulink_example.py
@@ -84,10 +84,10 @@ def main():
     ocp.solver_options.tf = Tf
 
     # to generate Simulink wrapper for solver
-    simulink_opts = get_simulink_default_opts() # modify those options, if you like.
+    ocp.simulink_opts = get_simulink_default_opts() # modify those options, if you like.
 
     # create solver
-    ocp_solver = AcadosOcpSolver(ocp, json_file = 'acados_ocp.json', simulink_opts=simulink_opts)
+    ocp_solver = AcadosOcpSolver(ocp, json_file = 'acados_ocp.json')
 
     simX = np.zeros((N+1, nx))
     simU = np.zeros((N, nu))

--- a/examples/acados_python/tests/test_rti_sqp_residuals.py
+++ b/examples/acados_python/tests/test_rti_sqp_residuals.py
@@ -31,7 +31,7 @@
 import sys, json, os
 sys.path.insert(0, '../pendulum_on_cart/common')
 
-from acados_template import AcadosOcp, AcadosOcpSolver, acados_dae_model_json_dump, get_acados_path, get_simulink_default_opts
+from acados_template import AcadosOcp, AcadosOcpSolver
 from pendulum_model import export_pendulum_ode_model
 import numpy as np
 import scipy.linalg

--- a/examples/acados_python/zoRO_example/pendulum_on_cart/minimal_example_zoro.py
+++ b/examples/acados_python/zoRO_example/pendulum_on_cart/minimal_example_zoro.py
@@ -141,6 +141,7 @@ def main():
     simulink_opts['inputs']['ubx'] = 0
     simulink_opts['inputs']['lbx_e'] = 0
     simulink_opts['inputs']['ubx_e'] = 0
+    ocp.simulink_opts = simulink_opts
 
     ocp_solver = AcadosOcpSolver(ocp, json_file = 'acados_ocp.json', simulink_opts=simulink_opts)
 

--- a/examples/acados_python/zoRO_example/pendulum_on_cart/minimal_example_zoro.py
+++ b/examples/acados_python/zoRO_example/pendulum_on_cart/minimal_example_zoro.py
@@ -143,7 +143,7 @@ def main():
     simulink_opts['inputs']['ubx_e'] = 0
     ocp.simulink_opts = simulink_opts
 
-    ocp_solver = AcadosOcpSolver(ocp, json_file = 'acados_ocp.json', simulink_opts=simulink_opts)
+    ocp_solver = AcadosOcpSolver(ocp, json_file = 'acados_ocp.json')
 
     Nsim = 100
     simX = np.zeros((Nsim+1, nx))

--- a/interfaces/acados_matlab_octave/AcadosOcpSolver.m
+++ b/interfaces/acados_matlab_octave/AcadosOcpSolver.m
@@ -41,13 +41,11 @@ classdef AcadosOcpSolver < handle
         qp_gettable_fields = {'qp_Q', 'qp_R', 'qp_S', 'qp_q', 'qp_r', 'qp_A', 'qp_B', 'qp_b', 'qp_C', 'qp_D', 'qp_lg', 'qp_ug', 'qp_lbx', 'qp_ubx', 'qp_lbu', 'qp_ubu', 'qp_zl', 'qp_zu', 'qp_Zl', 'qp_Zu'}
         t_ocp % templated solver
 
-        % required info loaded from json
+        % solver-relevant information from the OCP formulation
         N_horizon
-        solver_options
         problem_class
         name
         has_x0
-        nsbu_0
         nbxe_0
     end
     methods
@@ -67,6 +65,13 @@ classdef AcadosOcpSolver < handle
             % - compile_mex_wrapper: boolean, if true, the mex wrapper is compiled
             % - compile_interface: can be [], true or false. If [], the interface is compiled if it does not exist.
             % - output_dir: path to the directory where the MEX interface is compiled
+            if isempty(ocp)
+                error(['AcadosOcpSolver: Creating an AcadosOcpSolver without providing the `ocp` formulation (ocp=[]) is deprecated. ', ...
+                       'AcadosOcp/AcadosMultiphaseOcp objects can be loaded using AcadosOcp.from_json() / AcadosMultiphaseOcp.from_json().']);
+            end
+            if ~(isa(ocp, 'AcadosOcp') || isa(ocp, 'AcadosMultiphaseOcp'))
+                error('AcadosOcpSolver: ocp should be of type AcadosOcp or AcadosMultiphaseOcp.');
+            end
             obj.ocp = ocp;
 
             % optional arguments
@@ -93,33 +98,20 @@ classdef AcadosOcpSolver < handle
             end
             obj.solver_creation_opts = solver_creation_opts;
 
-            if isempty(ocp) && isempty(solver_creation_opts.json_file)
-                error('AcadosOcpSolver: provide either an OCP object or a json file');
+            if ~isempty(ocp.solver_options.compile_interface) && ~isempty(obj.solver_creation_opts.compile_interface)
+                error('AcadosOcpSolver: provide either compile_interface in OCP object or obj.solver_creation_opts');
             end
-
-            if isempty(ocp)
-                json_file = obj.solver_creation_opts.json_file;
-                if obj.solver_creation_opts.generate
-                    disp('AcadosOcpSolver: OCP not provided, cannot generate code, setting generate to false');
-                    obj.solver_creation_opts.generate = false;
-                end
-                obj.solver_creation_opts.check_reuse_possible = false;
-            else
-                % formulation provided
-                if ~isempty(ocp.solver_options.compile_interface) && ~isempty(obj.solver_creation_opts.compile_interface)
-                    error('AcadosOcpSolver: provide either compile_interface in OCP object or obj.solver_creation_opts');
-                end
-                if ~isempty(ocp.solver_options.compile_interface)
-                    obj.solver_creation_opts.compile_interface = ocp.solver_options.compile_interface;
-                end
-                if ~isempty(obj.solver_creation_opts.json_file)
-                    ocp.code_gen_options.json_file = obj.solver_creation_opts.json_file;
-                end
-                % make consistent
-                ocp.make_consistent();
-
-                json_file = ocp.code_gen_options.json_file;
+            if ~isempty(ocp.solver_options.compile_interface)
+                obj.solver_creation_opts.compile_interface = ocp.solver_options.compile_interface;
             end
+            if ~isempty(obj.solver_creation_opts.json_file)
+                ocp.code_gen_options.json_file = obj.solver_creation_opts.json_file;
+            end
+            % make consistent
+            ocp.make_consistent();
+
+            json_file = ocp.code_gen_options.json_file;
+            obj.ocp = ocp;
 
             %% compile mex interface if needed
             obj.compile_mex_interface_if_needed();
@@ -142,23 +134,22 @@ classdef AcadosOcpSolver < handle
                 obj.generate();
             end
 
-            %% load json, store options in object
-            acados_ocp_struct = loadjson(fileread(json_file), 'SimplifyCell', 0);
-            obj.problem_class = acados_ocp_struct.problem_class;
-            obj.solver_options = acados_ocp_struct.solver_options;
-            obj.N_horizon = acados_ocp_struct.solver_options.N_horizon;
-            obj.name = acados_ocp_struct.name;
+            %% store solver-relevant information directly from the OCP formulation object
+            if isa(ocp, 'AcadosMultiphaseOcp')
+                obj.problem_class = 'MOCP';
+            else
+                obj.problem_class = 'OCP';
+            end
+            obj.name = ocp.name;
 
             if strcmp(obj.problem_class, "OCP")
-                obj.has_x0 = acados_ocp_struct.constraints.has_x0;
-                obj.nsbu_0 = acados_ocp_struct.dims.nsbu;
-                obj.nbxe_0 = acados_ocp_struct.dims.nbxe_0;
+                obj.has_x0 = ocp.constraints.has_x0;
+                obj.nbxe_0 = ocp.dims.nbxe_0;
             elseif strcmp(obj.problem_class, "MOCP")
-                obj.has_x0 = acados_ocp_struct.constraints{1}.has_x0;
-                obj.nsbu_0 = acados_ocp_struct.phases_dims{1}.nsbu;
-                obj.nbxe_0 = acados_ocp_struct.phases_dims{1}.nbxe_0;
+                obj.has_x0 = ocp.constraints{1}.has_x0;
+                obj.nbxe_0 = ocp.phases_dims{1}.nbxe_0;
             end
-            code_export_directory = acados_ocp_struct.code_gen_options.code_export_directory;
+            code_export_directory = ocp.code_gen_options.code_export_directory;
 
             %% compile problem specific shared library
             if obj.solver_creation_opts.build
@@ -294,7 +285,7 @@ classdef AcadosOcpSolver < handle
             % all indices are zero -based.
             ineq_fun = obj.evaluate_constraints_and_get_violation();
             if nargin < 2
-                tol = obj.solver_options.nlp_solver_tol_ineq;
+                tol = obj.ocp.solver_options.nlp_solver_tol_ineq;
             end
             violation_idx = [];
             for i=1:length(ineq_fun)
@@ -312,7 +303,7 @@ classdef AcadosOcpSolver < handle
         end
 
         function value = get_qp_scaling_constraints(obj, stage)
-            if strcmp(obj.solver_options.qpscaling_scale_constraints, 'NO_CONSTRAINT_SCALING')
+            if strcmp(obj.ocp.solver_options.qpscaling_scale_constraints, 'NO_CONSTRAINT_SCALING')
                 error("QP scaling constraints are not enabled.");
             end
             % returns the qp scaling constraints for the given stage
@@ -321,7 +312,7 @@ classdef AcadosOcpSolver < handle
 
         function value = get_qp_scaling_objective(obj)
             % returns the qp scaling objective
-            if strcmp(obj.solver_options.qpscaling_scale_objective, 'NO_OBJECTIVE_SCALING')
+            if strcmp(obj.ocp.solver_options.qpscaling_scale_objective, 'NO_OBJECTIVE_SCALING')
                 error("QP scaling objective is not enabled.");
             end
             value = obj.t_ocp.get('qpscaling_obj');
@@ -330,19 +321,19 @@ classdef AcadosOcpSolver < handle
         function value = get(obj, field, varargin)
             if strcmp('qp_iter_all', field)
                 full_stats = obj.t_ocp.get('stat');
-                if strcmp(obj.solver_options.nlp_solver_type, 'SQP')
+                if strcmp(obj.ocp.solver_options.nlp_solver_type, 'SQP')
                     value = full_stats(:, 7);
                     return;
-                elseif strcmp(obj.solver_options.nlp_solver_type, 'SQP_RTI')
+                elseif strcmp(obj.ocp.solver_options.nlp_solver_type, 'SQP_RTI')
                     value = full_stats(:, 3);
                     return;
                 else
-                    error("qp_iter is not available for nlp_solver_type %s.", obj.solver_options.nlp_solver_type);
+                    error("qp_iter is not available for nlp_solver_type %s.", obj.ocp.solver_options.nlp_solver_type);
                 end
             end
 
             if strcmp('res_all', field)
-                if ~strcmp(obj.solver_options.nlp_solver_type, 'SQP')
+                if ~strcmp(obj.ocp.solver_options.nlp_solver_type, 'SQP')
                     error("res_all is only available for nlp_solver_type SQP.");
                 end
                 full_stats = obj.t_ocp.get('stat');
@@ -355,7 +346,7 @@ classdef AcadosOcpSolver < handle
                 if length(varargin) > 0
                     n = varargin{1};
 
-                    if n < obj.solver_options.N_horizon
+                    if n < obj.ocp.solver_options.N_horizon
                         Q = obj.get('qp_Q', n);
                         R = obj.get('qp_R', n);
                         S = obj.get('qp_S', n);
@@ -367,20 +358,20 @@ classdef AcadosOcpSolver < handle
 
                     return;
                 else
-                    value = cell(obj.solver_options.N_horizon, 1);
-                    for n=0:(obj.solver_options.N_horizon-1)
+                    value = cell(obj.ocp.solver_options.N_horizon, 1);
+                    for n=0:(obj.ocp.solver_options.N_horizon-1)
                         Q = obj.get('qp_Q', n);
                         R = obj.get('qp_R', n);
                         S = obj.get('qp_S', n);
 
                         value{n+1} = [R, S; S', Q];
                     end
-                    value{end+1} = obj.get('qp_Q', obj.solver_options.N_horizon);
+                    value{end+1} = obj.get('qp_Q', obj.ocp.solver_options.N_horizon);
                     return;
                 end
             elseif strcmp('pc_hess_block', field)
 
-                if ~strncmp(obj.solver_options.qp_solver, 'PARTIAL_CONDENSING', length('PARTIAL_CONDENSING'))
+                if ~strncmp(obj.ocp.solver_options.qp_solver, 'PARTIAL_CONDENSING', length('PARTIAL_CONDENSING'))
                     error("Getting hessian block of partially condensed QP only works for PARTIAL_CONDENSING QP solvers");
                 end
                 if length(varargin) > 0
@@ -448,13 +439,13 @@ classdef AcadosOcpSolver < handle
 
             % get iterate:
             solution = struct();
-            for i=0:obj.N_horizon
+            for i=0:obj.ocp.solver_options.N_horizon
                 solution.(['x_' num2str(i)]) = obj.get('x', i);
                 solution.(['lam_' num2str(i)]) = obj.get('lam', i);
                 solution.(['sl_' num2str(i)]) = obj.get('sl', i);
                 solution.(['su_' num2str(i)]) = obj.get('su', i);
             end
-            for i=0:obj.N_horizon-1
+            for i=0:obj.ocp.solver_options.N_horizon-1
                 solution.(['z_' num2str(i)]) = obj.get('z', i);
                 solution.(['u_' num2str(i)]) = obj.get('u', i);
                 solution.(['pi_' num2str(i)]) = obj.get('pi', i);
@@ -525,13 +516,13 @@ classdef AcadosOcpSolver < handle
                 error('set_iterate: iterate needs to be of type AcadosOcpIterate');
             end
 
-            for i = 1:obj.solver_options.N_horizon + 1
+            for i = 1:obj.ocp.solver_options.N_horizon + 1
                 obj.t_ocp.set('x', iterate.x{i, 1}, i-1);
                 obj.t_ocp.set('sl', iterate.sl{i, 1}, i-1);
                 obj.t_ocp.set('su', iterate.su{i, 1}, i-1);
                 obj.t_ocp.set('lam', iterate.lam{i, 1}, i-1);
             end
-            for i = 1:obj.solver_options.N_horizon
+            for i = 1:obj.ocp.solver_options.N_horizon
                 obj.t_ocp.set('u', iterate.u{i, 1}, i-1);
                 obj.t_ocp.set('pi', iterate.pi{i, 1}, i-1);
                 if ~isempty(iterate.z{i, 1})
@@ -548,11 +539,11 @@ classdef AcadosOcpSolver < handle
                 error("iteration needs to be nonnegative and <= nlp_iter.");
             end
 
-            if ~get_last_iterate && ~obj.solver_options.store_iterates
+            if ~get_last_iterate && ~obj.ocp.solver_options.store_iterates
                 error("get_iterate: the solver option store_iterates needs to be true in order to get intermediate iterates.");
             end
 
-            if ~get_last_iterate && strcmp(obj.solver_options.nlp_solver_type, 'SQP_RTI')
+            if ~get_last_iterate && strcmp(obj.ocp.solver_options.nlp_solver_type, 'SQP_RTI')
                 error("get_iterate: SQP_RTI not supported.");
             end
 
@@ -561,8 +552,8 @@ classdef AcadosOcpSolver < handle
             for fi = 1:length(fields)
                 field = fields{fi};
                 traj = {};
-                for n = 0:obj.solver_options.N_horizon
-                    if n < obj.solver_options.N_horizon || ~ismember(field, {'u','pi','z'})
+                for n = 0:obj.ocp.solver_options.N_horizon
+                    if n < obj.ocp.solver_options.N_horizon || ~ismember(field, {'u','pi','z'})
 
                         if get_last_iterate
                             val = obj.get(field, n);
@@ -621,15 +612,15 @@ classdef AcadosOcpSolver < handle
                                 'idxe'};
 
             % Format for zero-padding stage numbers
-            lN = length(num2str(obj.N_horizon));
+            lN = length(num2str(obj.ocp.solver_options.N_horizon));
 
             % Get cost and constraint fields (for stages 0 to N)
             all_other_fields = [qp_cost_fields, qp_constraint_fields, qp_dynamics_fields];
             for i = 1:length(all_other_fields)
                 field = all_other_fields{i};
-                k_last = obj.N_horizon;
+                k_last = obj.ocp.solver_options.N_horizon;
                 if ismember(field, qp_dynamics_fields)
-                    k_last = obj.N_horizon - 1; % dynamics only up to N-1
+                    k_last = obj.ocp.solver_options.N_horizon - 1; % dynamics only up to N-1
                 end
                 for stage = 0:k_last
                     field_name = sprintf('%s_%0*d', field, lN, stage);
@@ -742,9 +733,9 @@ classdef AcadosOcpSolver < handle
             end
 
             if partially_condensed_qp
-                num_blocks = obj.solver_options.qp_solver_cond_N + 1;
+                num_blocks = obj.ocp.solver_options.qp_solver_cond_N + 1;
             else
-                num_blocks = obj.N_horizon + 1;
+                num_blocks = obj.ocp.solver_options.N_horizon + 1;
             end
             result = struct();
             result.min_eigv_stage = zeros(num_blocks, 1);
@@ -773,7 +764,7 @@ classdef AcadosOcpSolver < handle
                 result.condition_number_stage(n) = max(eigvals) / min(eigvals);
             end
             % Zl, Zu don't change in partial condensing.
-            for n=1:obj.N_horizon+1
+            for n=1:obj.ocp.solver_options.N_horizon+1
                 max_abs_hess_val = max(max_abs_hess_val, max(abs(obj.get('qp_Zl', n-1))));
                 max_abs_hess_val = max(max_abs_hess_val, max(abs(obj.get('qp_Zu', n-1))));
             end
@@ -954,4 +945,3 @@ classdef AcadosOcpSolver < handle
     end % private methods
 
 end % class
-

--- a/interfaces/acados_matlab_octave/AcadosOcpSolver.m
+++ b/interfaces/acados_matlab_octave/AcadosOcpSolver.m
@@ -99,9 +99,10 @@ classdef AcadosOcpSolver < handle
             obj.solver_creation_opts = solver_creation_opts;
 
             if ~isempty(ocp.solver_options.compile_interface) && ~isempty(obj.solver_creation_opts.compile_interface)
-                error('AcadosOcpSolver: provide either compile_interface in OCP object or obj.solver_creation_opts');
+                error('AcadosOcpSolver: provide either compile_interface in ocp.solver_options or solver_creation_opts');
             end
             if ~isempty(ocp.solver_options.compile_interface)
+                warning('AcadosOcpSolver: provide compile_interface in solver_creation_opts, setting it in ocp.solver_options will be deprecated after acados v0.5.5.')
                 obj.solver_creation_opts.compile_interface = ocp.solver_options.compile_interface;
             end
             if ~isempty(obj.solver_creation_opts.json_file)

--- a/interfaces/acados_template/acados_template/acados_model.py
+++ b/interfaces/acados_template/acados_template/acados_model.py
@@ -51,6 +51,8 @@ class AcadosModel():
     b) all CasADi variables/expressions needed in the CasADi function generation process.
     """
     def __init__(self):
+
+        self.__non_expression_properties = ["name", "dyn_ext_fun_type", "dyn_generic_source", "gnsf_model", "nu_original", "t0", "x_labels", "u_labels", "t_label"]
         ## common for OCP and Integrator
         self.__name = None
         self.__x = []
@@ -1077,7 +1079,7 @@ class AcadosModel():
 
         model = cls()
 
-        expression_names =  model_dict.get('expression_names')
+        expression_names = model_dict.get('expression_names')
         serialized_expressions = model_dict.get('serialized_expressions')
 
         if expression_names is None or serialized_expressions is None:
@@ -1089,7 +1091,7 @@ class AcadosModel():
             value = model_dict.get(attr)
 
             # expressions are expected to be None
-            if value is None and attr not in expression_names:
+            if value is None and attr in model.__non_expression_properties:
                 warnings.warn(f"Attribute {attr} not in dictionary.")
             else:
                 try:

--- a/interfaces/acados_template/acados_template/acados_model.py
+++ b/interfaces/acados_template/acados_template/acados_model.py
@@ -1091,8 +1091,11 @@ class AcadosModel():
             value = model_dict.get(attr)
 
             if attr == 'gnsf_model' and value is not None:
-                gnsf_model = GnsfModel.from_dict(value)
-                setattr(model, attr, gnsf_model)
+                try:
+                    gnsf_model = GnsfModel.from_dict(value)
+                    setattr(model, attr, gnsf_model)
+                except Exception as e:
+                    print("Failed to load gnsf_model from dictionary. If formulation objects are exchanged between MATLAB/Octave and Python, this is a known issue, not loading gnsf_model.\n Got error:\n" + repr(e))
             # expressions are expected to be None
             elif value is None and attr in model.__non_expression_properties:
                 warnings.warn(f"Attribute {attr} not in dictionary.")
@@ -1101,7 +1104,7 @@ class AcadosModel():
                     if not (isinstance(value, list) and not value) and not attr in expression_names:
                         setattr(model, attr, value)
                 except Exception as e:
-                    Exception("Failed to load attribute {attr} from dictionary:\n" + repr(e))
+                    Exception(f"Failed to load attribute {attr} from dictionary:\n" + repr(e))
 
         model.deserialize(model_dict['serialized_expressions'], model_dict['expression_names'])
 

--- a/interfaces/acados_template/acados_template/acados_model.py
+++ b/interfaces/acados_template/acados_template/acados_model.py
@@ -1090,15 +1090,14 @@ class AcadosModel():
 
             value = model_dict.get(attr)
 
+            if attr == 'gnsf_model' and value is not None:
+                gnsf_model = GnsfModel.from_dict(value)
+                setattr(model, attr, gnsf_model)
             # expressions are expected to be None
-            if value is None and attr in model.__non_expression_properties:
+            elif value is None and attr in model.__non_expression_properties:
                 warnings.warn(f"Attribute {attr} not in dictionary.")
             else:
                 try:
-                    # check whether value is not the empty list and not a CasADi symbol/expression
-                    if attr == 'gnsf_model' and value is not None:
-                        gnsf_model = GnsfModel.from_dict(value)
-                        setattr(model, attr, gnsf_model)
                     if not (isinstance(value, list) and not value) and not attr in expression_names:
                         setattr(model, attr, value)
                 except Exception as e:

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -2576,7 +2576,7 @@ class AcadosOcpSolver:
 
         if (field_ == 'max_iter' or field_ == 'nlp_solver_max_iter') and value_ > self.ocp.solver_options.nlp_solver_max_iter:
             raise ValueError('AcadosOcpSolver.options_set() cannot increase nlp_solver_max_iter' \
-                    f' above initial value {self.__nlp_solver_max_iter} (you have {value_})')
+                    f' above initial value {self.ocp.solver_options.nlp_solver_max_iter} (you have {value_})')
 
         if field_ == 'rti_phase':
             if value_ < 0 or value_ > 2:

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -630,7 +630,7 @@ class AcadosOcpSolver:
 
         This is only implemented for HPIPM QP solver without condensing.
         """
-        if self.__ocp.solver_options.qp_solver not in ['PARTIAL_CONDENSING_HPIPM', 'FULL_CONDENSING_HPIPM']:
+        if self.ocp.solver_options.qp_solver not in ['PARTIAL_CONDENSING_HPIPM', 'FULL_CONDENSING_HPIPM']:
             raise NotImplementedError('This function is only implemented for PARTIAL_CONDENSING_HPIPM and FULL_CONDENSING_HPIPM!')
 
         self._status = getattr(self.shared_lib, f"{self.name}_acados_setup_qp_matrices_and_factorize")(self.capsule)
@@ -702,14 +702,14 @@ class AcadosOcpSolver:
             raise RuntimeError('Solver was not yet created!')
 
         # check if time steps really changed in value
-        if np.array_equal(self.__ocp.solver_options.time_steps, new_time_steps):
+        if np.array_equal(self.ocp.solver_options.time_steps, new_time_steps):
             return
 
         N = new_time_steps.size
         new_time_steps_data = cast(new_time_steps.ctypes.data, POINTER(c_double))
 
         # check if recreation of acados is necessary (no need to recreate acados if sizes are identical)
-        if len(self.__ocp.solver_options.time_steps) == N:
+        if len(self.ocp.solver_options.time_steps) == N:
             assert getattr(self.shared_lib, f"{self.name}_acados_update_time_steps")(self.capsule, N, new_time_steps_data) == 0
         else:  # recreate the solver with the new time steps
             self.solver_created = False
@@ -726,9 +726,9 @@ class AcadosOcpSolver:
             self.__get_pointers_solver()
 
         # store time_steps, N
-        self.__ocp.solver_options.time_steps = new_time_steps
+        self.ocp.solver_options.time_steps = new_time_steps
         self.__N = N
-        self.__ocp.solver_options.Tsim = self.__ocp.solver_options.time_steps[0]
+        self.ocp.solver_options.Tsim = self.ocp.solver_options.time_steps[0]
 
 
     def update_qp_solver_cond_N(self, qp_solver_cond_N: int):
@@ -753,14 +753,14 @@ class AcadosOcpSolver:
             raise RuntimeError('Solver was not yet created!')
         if self.N < qp_solver_cond_N:
             raise ValueError('Setting qp_solver_cond_N to be larger than N does not work!')
-        if self.__ocp.solver_options.qp_solver_cond_N != qp_solver_cond_N:
+        if self.ocp.solver_options.qp_solver_cond_N != qp_solver_cond_N:
             self.solver_created = False
 
             # recreate the solver
             assert getattr(self.shared_lib, f'{self.name}_acados_update_qp_solver_cond_N')(self.capsule, qp_solver_cond_N) == 0
 
             # store the new value
-            self.__ocp.solver_options.qp_solver_cond_N = qp_solver_cond_N
+            self.ocp.solver_options.qp_solver_cond_N = qp_solver_cond_N
             self.solver_created = True
 
             # get pointers solver
@@ -890,7 +890,7 @@ class AcadosOcpSolver:
         if self.__problem_class == "MOCP":
             raise ValueError("Solution sensitivities are not implemented for multiphase OCPs.")
 
-        self.__ocp.ensure_solution_sensitivities_available(parametric=parametric)
+        self.ocp.ensure_solution_sensitivities_available(parametric=parametric)
 
 
     def eval_solution_sensitivity(self,
@@ -1308,7 +1308,7 @@ class AcadosOcpSolver:
         """
         stat = self.get_stats("statistics")
 
-        if self.__ocp.solver_options.nlp_solver_type == 'SQP':
+        if self.ocp.solver_options.nlp_solver_type == 'SQP':
             print('\niter\tres_stat\tres_eq\t\tres_ineq\tres_comp\tqp_stat\tqp_iter\talpha')
             if stat.shape[0]>8:
                 print('\tqp_res_stat\tqp_res_eq\tqp_res_ineq\tqp_res_comp')
@@ -1319,26 +1319,26 @@ class AcadosOcpSolver:
                     print('\t{:e}\t{:e}\t{:e}\t{:e}'.format( \
                         stat[8][jj], stat[9][jj], stat[10][jj], stat[11][jj]))
             print('\n')
-        elif self.__ocp.solver_options.nlp_solver_type == 'SQP_RTI':
+        elif self.ocp.solver_options.nlp_solver_type == 'SQP_RTI':
             header = '\niter\tqp_stat\tqp_iter'
-            if self.__ocp.solver_options.nlp_solver_ext_qp_res == 1:
+            if self.ocp.solver_options.nlp_solver_ext_qp_res == 1:
                 header += '\tqp_res_stat\tqp_res_eq\tqp_res_ineq\tqp_res_comp'
-            if self.__ocp.solver_options.rti_log_residuals == 1:
+            if self.ocp.solver_options.rti_log_residuals == 1:
                 header += '\tres_stat\tres_eq\t\tres_ineq\tres_comp'
             print(header)
             for jj in range(stat.shape[1]):
                 line = '{:d}\t{:d}\t{:d}'.format( int(stat[0][jj]), int(stat[1][jj]), int(stat[2][jj]))
                 offset = 2
-                if self.__ocp.solver_options.nlp_solver_ext_qp_res == 1:
+                if self.ocp.solver_options.nlp_solver_ext_qp_res == 1:
                     line += '\t{:e}\t{:e}\t{:e}\t{:e}'.format( \
                          stat[offset+1][jj], stat[offset+2][jj], stat[offset+3][jj], stat[offset+4][jj])
                     offset += 4
-                if self.__ocp.solver_options.rti_log_residuals == 1:
+                if self.ocp.solver_options.rti_log_residuals == 1:
                     line += '\t{:e}\t{:e}\t{:e}\t{:e}'.format( \
                          stat[offset+1][jj], stat[offset+2][jj], stat[offset+3][jj], stat[offset+4][jj])
                 print(line)
             print('\n')
-        elif self.__ocp.solver_options.nlp_solver_type == 'DDP':
+        elif self.ocp.solver_options.nlp_solver_type == 'DDP':
             for jj in range(stat.shape[1]):
                 if jj % 10 == 0:
                     print(("{iter:>6} | {obj:>10} | {inf:>10} | {stat:>10} | "
@@ -1362,7 +1362,7 @@ class AcadosOcpSolver:
                      qp_iter=int(stat[6][jj]),
                      alpha=stat[7][jj]))
             print('\n')
-        elif self.__ocp.solver_options.nlp_solver_type == 'SQP_WITH_FEASIBLE_QP':
+        elif self.ocp.solver_options.nlp_solver_type == 'SQP_WITH_FEASIBLE_QP':
             print(("{iter:>5}   {stat:>10}   {res_eq:>10}   "
                    "{res_ineq:>10}   {res_comp:>10}   {qp1_status:>8}   {qp1_iter:>6}   "
                    "{qp2_status:>8}   {qp2_iter:>6}   {qp3_status:>8}   {qp3_iter:>6}   "
@@ -1815,27 +1815,27 @@ class AcadosOcpSolver:
 
         elif field_ == 'qp_stat':
             full_stats = self.get_stats('statistics')
-            if self.__ocp.solver_options.nlp_solver_type == 'SQP':
+            if self.ocp.solver_options.nlp_solver_type == 'SQP':
                 return full_stats[5, :]
-            elif self.__ocp.solver_options.nlp_solver_type == 'SQP_RTI':
+            elif self.ocp.solver_options.nlp_solver_type == 'SQP_RTI':
                 return full_stats[1, :]
 
         elif field_ == 'qp_iter':
             full_stats = self.get_stats('statistics')
-            if self.__ocp.solver_options.nlp_solver_type == 'SQP':
+            if self.ocp.solver_options.nlp_solver_type == 'SQP':
                 return full_stats[6, :]
-            elif self.__ocp.solver_options.nlp_solver_type == 'SQP_RTI':
+            elif self.ocp.solver_options.nlp_solver_type == 'SQP_RTI':
                 return full_stats[2, :]
-            elif self.__ocp.solver_options.nlp_solver_type == 'SQP_WITH_FEASIBLE_QP':
+            elif self.ocp.solver_options.nlp_solver_type == 'SQP_WITH_FEASIBLE_QP':
                 return full_stats[6, :] + full_stats[8, :] + full_stats[10, :]
             else:
-                raise ValueError(f"qp_iter is not available for nlp_solver_type {self.__ocp.solver_options.nlp_solver_type}.")
+                raise ValueError(f"qp_iter is not available for nlp_solver_type {self.ocp.solver_options.nlp_solver_type}.")
 
         elif field_ == "qp_res_ineq":
-            if not self.__ocp.solver_options.nlp_solver_ext_qp_res:
+            if not self.ocp.solver_options.nlp_solver_ext_qp_res:
                 raise ValueError("qp_res_ineq only supported if nlp_solver_ext_qp_res is enabled.")
             full_stats = self.get_stats('statistics')
-            if self.__ocp.solver_options.nlp_solver_type == 'SQP':
+            if self.ocp.solver_options.nlp_solver_type == 'SQP':
                 return full_stats[10, :]
             else:
                 raise ValueError("qp_res_ineq only supported for SQP solver.")
@@ -1843,19 +1843,19 @@ class AcadosOcpSolver:
 
         elif field_ == 'alpha':
             full_stats = self.get_stats('statistics')
-            if self.__ocp.solver_options.nlp_solver_type == 'SQP':
+            if self.ocp.solver_options.nlp_solver_type == 'SQP':
                 return full_stats[7, :]
-            else: # self.__ocp.solver_options.nlp_solver_type == 'SQP_RTI':
+            else: # self.ocp.solver_options.nlp_solver_type == 'SQP_RTI':
                 raise ValueError("alpha values are not available for SQP_RTI")
 
         elif field_ == 'residuals':
             return self.get_residuals()
 
         elif field_ == 'qp_residuals':
-            if self.__ocp.solver_options.nlp_solver_ext_qp_res != 1 or self.__ocp.solver_options.nlp_solver_type != 'SQP':
+            if self.ocp.solver_options.nlp_solver_ext_qp_res != 1 or self.ocp.solver_options.nlp_solver_type != 'SQP':
                 raise ValueError("qp_residuals only supported if nlp_solver_ext_qp_res is enabled and nlp_solver_type is SQP.")
             full_stats = self.get_stats('statistics')
-            if self.__ocp.solver_options.nlp_solver_type == 'SQP':
+            if self.ocp.solver_options.nlp_solver_type == 'SQP':
                 res_stat = full_stats[8, -1]
                 res_eq = full_stats[9, -1]
                 res_ineq = full_stats[10, -1]
@@ -1864,51 +1864,51 @@ class AcadosOcpSolver:
 
         elif field_ == 'res_eq_all':
             full_stats = self.get_stats('statistics')
-            if self.__ocp.solver_options.nlp_solver_type == 'SQP':
+            if self.ocp.solver_options.nlp_solver_type == 'SQP':
                 return full_stats[2, :]
-            elif self.__ocp.solver_options.nlp_solver_type == 'SQP_RTI':
-                if self.__ocp.solver_options.rti_log_residuals == 1:
+            elif self.ocp.solver_options.nlp_solver_type == 'SQP_RTI':
+                if self.ocp.solver_options.rti_log_residuals == 1:
                     return full_stats[4, :]
                 else:
                     raise ValueError("res_eq_all is not available for SQP_RTI if rti_log_residuals is not enabled.")
             else:
-                raise KeyError(f"res_eq_all is not available for nlp_solver_type {self.__ocp.solver_options.nlp_solver_type}.")
+                raise KeyError(f"res_eq_all is not available for nlp_solver_type {self.ocp.solver_options.nlp_solver_type}.")
 
         elif field_ == 'res_stat_all':
             full_stats = self.get_stats('statistics')
-            if self.__ocp.solver_options.nlp_solver_type == 'SQP':
+            if self.ocp.solver_options.nlp_solver_type == 'SQP':
                 return full_stats[1, :]
-            elif self.__ocp.solver_options.nlp_solver_type == 'SQP_RTI':
-                if self.__ocp.solver_options.rti_log_residuals == 1:
+            elif self.ocp.solver_options.nlp_solver_type == 'SQP_RTI':
+                if self.ocp.solver_options.rti_log_residuals == 1:
                     return full_stats[3, :]
                 else:
                     raise ValueError("res_stat_all is not available for SQP_RTI if rti_log_residuals is not enabled.")
             else:
-                raise ValueError(f"res_stat_all is not available for nlp_solver_type {self.__ocp.solver_options.nlp_solver_type}.")
+                raise ValueError(f"res_stat_all is not available for nlp_solver_type {self.ocp.solver_options.nlp_solver_type}.")
 
         elif field_ == 'res_ineq_all':
             full_stats = self.get_stats('statistics')
-            if self.__ocp.solver_options.nlp_solver_type == 'SQP':
+            if self.ocp.solver_options.nlp_solver_type == 'SQP':
                 return full_stats[3, :]
-            elif self.__ocp.solver_options.nlp_solver_type == 'SQP_RTI':
-                if self.__ocp.solver_options.rti_log_residuals == 1:
+            elif self.ocp.solver_options.nlp_solver_type == 'SQP_RTI':
+                if self.ocp.solver_options.rti_log_residuals == 1:
                     return full_stats[5, :]
                 else:
                     raise ValueError("res_ineq_all is not available for SQP_RTI if rti_log_residuals is not enabled.")
             else:
-                raise KeyError(f"res_ineq_all is not available for nlp_solver_type {self.__ocp.solver_options.nlp_solver_type}.")
+                raise KeyError(f"res_ineq_all is not available for nlp_solver_type {self.ocp.solver_options.nlp_solver_type}.")
 
         elif field_ == 'res_comp_all':
             full_stats = self.get_stats('statistics')
-            if self.__ocp.solver_options.nlp_solver_type == 'SQP':
+            if self.ocp.solver_options.nlp_solver_type == 'SQP':
                 return full_stats[4, :]
-            elif self.__ocp.solver_options.nlp_solver_type == 'SQP_RTI':
-                if self.__ocp.solver_options.rti_log_residuals == 1:
+            elif self.ocp.solver_options.nlp_solver_type == 'SQP_RTI':
+                if self.ocp.solver_options.rti_log_residuals == 1:
                     return full_stats[6, :]
                 else:
                     raise ValueError("res_comp_all is not available for SQP_RTI if rti_log_residuals is not enabled.")
             else:
-                raise KeyError(f"res_comp_all is not available for nlp_solver_type {self.__ocp.solver_options.nlp_solver_type}.")
+                raise KeyError(f"res_comp_all is not available for nlp_solver_type {self.ocp.solver_options.nlp_solver_type}.")
 
         elif field_ == 'res_all':
             return np.concatenate((np.atleast_2d(self.get_stats('res_stat_all')),
@@ -1955,7 +1955,7 @@ class AcadosOcpSolver:
         """
         # compute residuals if RTI
         if recompute:
-            if self.__ocp.solver_options.nlp_solver_type == 'SQP_RTI':
+            if self.ocp.solver_options.nlp_solver_type == 'SQP_RTI':
                 as_rti_level = self.options_get('as_rti_level')
                 if as_rti_level != 4: # not standard RTI
                     warnings.warn(f"Calling get_residuals() with recompute==True for AS-RTI can overwrite previous problem linearization in memory which are needed for AS-RTI to work properly!")
@@ -1989,15 +1989,15 @@ class AcadosOcpSolver:
         Residuals: residuals of initial iterate in previous solver call
         """
         full_stats = self.get_stats('statistics')
-        if self.__ocp.solver_options.nlp_solver_type == 'SQP':
+        if self.ocp.solver_options.nlp_solver_type == 'SQP':
             return full_stats[1:5, 0]
-        elif self.__ocp.solver_options.nlp_solver_type == 'SQP_RTI':
-            if self.__ocp.solver_options.rti_log_residuals == 1:
+        elif self.ocp.solver_options.nlp_solver_type == 'SQP_RTI':
+            if self.ocp.solver_options.rti_log_residuals == 1:
                 return full_stats[3:7, 0]
             else:
                 raise ValueError("initial_residuals is only available for SQP_RTI if rti_log_residuals is enabled, for efficiency the rti_log_only_available_residuals option is recommended.")
         else:
-            raise ValueError(f"initial_residuals is not available for nlp_solver_type {self.__ocp.solver_options.nlp_solver_type}.")
+            raise ValueError(f"initial_residuals is not available for nlp_solver_type {self.ocp.solver_options.nlp_solver_type}.")
 
     # Note: this function should not be used anymore, better use cost_set, constraints_set
     def set(self, stage_: int, field_: str, value_: np.ndarray):
@@ -2330,23 +2330,23 @@ class AcadosOcpSolver:
         if field_ not in self.__all_qp_fields | self.__all_relaxed_qp_fields:
             raise ValueError(f"field {field_} not supported.")
         if field_ in self.__qp_pc_hpipm_fields:
-            if self.__ocp.solver_options.qp_solver != "PARTIAL_CONDENSING_HPIPM" or self.__ocp.solver_options.qp_solver_cond_N != self.N:
+            if self.ocp.solver_options.qp_solver != "PARTIAL_CONDENSING_HPIPM" or self.ocp.solver_options.qp_solver_cond_N != self.N:
                 raise ValueError(f"field {field_} only works for PARTIAL_CONDENSING_HPIPM QP solver with qp_solver_cond_N == N.")
             if field_ in ["P", "K", "p"] and stage_ == 0 and self.__nbxe_0 > 0:
                 raise ValueError(f"getting field {field_} at stage 0 only works without x0 elimination (see nbxe_0).")
         if field_ in self.__qp_pc_fields:
-            if not self.__ocp.solver_options.qp_solver.startswith("PARTIAL_CONDENSING"):
+            if not self.ocp.solver_options.qp_solver.startswith("PARTIAL_CONDENSING"):
                 raise ValueError(f"field {field_} only works for PARTIAL_CONDENSING QP solvers.")
-            if field_.split("_", 1)[1] in self.__qp_dynamics_fields and stage_ >= self.__ocp.solver_options.qp_solver_cond_N:
+            if field_.split("_", 1)[1] in self.__qp_dynamics_fields and stage_ >= self.ocp.solver_options.qp_solver_cond_N:
                 raise ValueError(f"dynamics field {field_} not available at last stage of partial condensing")
-            elif stage_ > self.__ocp.solver_options.qp_solver_cond_N:
+            elif stage_ > self.ocp.solver_options.qp_solver_cond_N:
                 raise ValueError(f"stage should be <= qp_solver_cond_N for partial condensing fields")
-        elif field_ in self.__all_relaxed_qp_fields and not self.__ocp.solver_options.nlp_solver_type == "SQP_WITH_FEASIBLE_QP":
+        elif field_ in self.__all_relaxed_qp_fields and not self.ocp.solver_options.nlp_solver_type == "SQP_WITH_FEASIBLE_QP":
             raise ValueError(f"field {field_} only works for SQP_WITH_FEASIBLE_QP nlp_solver_type.")
         elif field_ in self.__qp_fc_fields:
             if stage_ != 0:
                 raise ValueError(f"field {field_} only works for stage 0.")
-            if not self.__ocp.solver_options.qp_solver.startswith("FULL_CONDENSING"):
+            if not self.ocp.solver_options.qp_solver.startswith("FULL_CONDENSING"):
                 raise ValueError(f"field {field_} only works for FULL_CONDENSING QP solvers.")
 
         field = field_.encode('utf-8')
@@ -2385,7 +2385,7 @@ class AcadosOcpSolver:
         Bounds are not scaled, so the dimension is ng + nh + nphi.
         Only available if qpscaling_scale_constraints != NO_CONSTRAINT_SCALING.
         """
-        if self.__ocp.solver_options.qpscaling_scale_constraints == "NO_CONSTRAINT_SCALING":
+        if self.ocp.solver_options.qpscaling_scale_constraints == "NO_CONSTRAINT_SCALING":
             raise ValueError(f"get_qp_scaling_constraints: only works if qpscaling_scale_constraints != NO_CONSTRAINT_SCALING.")
 
         # call getter
@@ -2405,7 +2405,7 @@ class AcadosOcpSolver:
         Returns the cost scaling value corresponding to the previous QP solution.
         Only available if qpscaling_scale_objective != NO_OBJECTIVE_SCALING.
         """
-        if self.__ocp.solver_options.qpscaling_scale_objective == "NO_OBJECTIVE_SCALING":
+        if self.ocp.solver_options.qpscaling_scale_objective == "NO_OBJECTIVE_SCALING":
             raise ValueError("get_qp_scaling_objective: only works for QP solvers with qpscaling_scale_objective != NO_OBJECTIVE_SCALING.")
 
         # create output array
@@ -2443,10 +2443,10 @@ class AcadosOcpSolver:
         if not get_final_iterate and (iteration > nlp_iter or iteration < 0):
             raise ValueError("get_iterate: iteration needs to be nonnegative and <= nlp_iter or -1.")
 
-        if not get_final_iterate and not self.__ocp.solver_options.store_iterates:
+        if not get_final_iterate and not self.ocp.solver_options.store_iterates:
             raise ValueError("get_iterate: the solver option store_iterates needs to be true in order to get intermediate iterates.")
 
-        if not get_final_iterate and self.__ocp.solver_options.nlp_solver_type == "SQP_RTI":
+        if not get_final_iterate and self.ocp.solver_options.nlp_solver_type == "SQP_RTI":
             raise NotImplementedError("get_iterate: SQP_RTI not supported.")
 
         d = {}
@@ -2574,7 +2574,7 @@ class AcadosOcpSolver:
                 f' Possible values are {fields}.')
 
 
-        if (field_ == 'max_iter' or field_ == 'nlp_solver_max_iter') and value_ > self.__ocp.solver_options.nlp_solver_max_iter:
+        if (field_ == 'max_iter' or field_ == 'nlp_solver_max_iter') and value_ > self.ocp.solver_options.nlp_solver_max_iter:
             raise ValueError('AcadosOcpSolver.options_set() cannot increase nlp_solver_max_iter' \
                     f' above initial value {self.__nlp_solver_max_iter} (you have {value_})')
 
@@ -2582,10 +2582,10 @@ class AcadosOcpSolver:
             if value_ < 0 or value_ > 2:
                 raise ValueError('AcadosOcpSolver.options_set(): argument \'rti_phase\' can '
                     'take only values 0, 1, 2 for SQP-RTI-type solvers')
-            if self.__ocp.solver_options.nlp_solver_type != 'SQP_RTI' and value_ > 0:
+            if self.ocp.solver_options.nlp_solver_type != 'SQP_RTI' and value_ > 0:
                 raise ValueError('AcadosOcpSolver.options_set(): argument \'rti_phase\' can '
                     'take only value 0 for SQP-type solvers')
-            if self.__ocp.solver_options.nlp_solver_type == 'SQP_RTI' and self.__ocp.solver_options.as_rti_level != 4 and value_ == 0:
+            if self.ocp.solver_options.nlp_solver_type == 'SQP_RTI' and self.ocp.solver_options.as_rti_level != 4 and value_ == 0:
                 raise ValueError('AcadosOcpSolver.options_set(): argument \'rti_phase\' can '
                     'take only values 1, 2 for AS-RTI.')
 
@@ -2611,7 +2611,7 @@ class AcadosOcpSolver:
         """
         int_fields = ['as_rti_level']
         if field_ == 'as_rti_level':
-            if self.__ocp.solver_options.nlp_solver_type != "SQP_RTI":
+            if self.ocp.solver_options.nlp_solver_type != "SQP_RTI":
                 raise ValueError("as_rti_level only available for SQP_RTI")
 
         if field_ in int_fields:

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -678,8 +678,7 @@ class AcadosOcpSolver:
         NOTE: First, the numerical values are reset, then x is set to x0_bar.
         """
 
-        if reset_x_to_x0_bar and ((isinstance(self.ocp, AcadosOcp) and not self.ocp.constraints.has_x0) or
-                                  (isinstance(self.ocp, AcadosMultiphaseOcp) and not self.ocp.constraints[0].has_x0)):
+        if reset_x_to_x0_bar and not self.__has_x0:
             raise ValueError('reset_x_to_x0_bar can only be used if there is an initial state constraint!')
         getattr(self.shared_lib, f"{self.name}_acados_reset")(self.capsule, reset_qp_solver_mem, reset_numerical_values, reset_solver_options, reset_x_to_x0_bar)
 

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -55,7 +55,8 @@ from .acados_multiphase_ocp import AcadosMultiphaseOcp
 from .gnsf import detect_gnsf_structure
 from .utils import (get_shared_lib_ext, get_shared_lib_prefix, get_shared_lib_dir, get_shared_lib,
                     make_object_json_dumpable, set_up_imported_gnsf_model, verbose_system_call,
-                    acados_lib_is_compiled_with_openmp, set_directory, status_to_str, hash_class_instance, compare_ocp_formulations)
+                    acados_lib_is_compiled_with_openmp, set_directory, status_to_str, hash_class_instance,
+                    compare_ocp_formulations)
 from .acados_ocp_iterate import AcadosOcpIterate, AcadosOcpIterates, AcadosOcpFlattenedIterate
 
 
@@ -269,31 +270,29 @@ class AcadosOcpSolver:
         return self.__name
 
     def __init__(self, ocp: Union[AcadosOcp, AcadosMultiphaseOcp, None], json_file=None, simulink_opts=None, build=True, generate=True, cmake_builder: CMakeBuilder = None, verbose=True, save_p_global=False, check_reuse_possible=True,
-                 tol_code_reuse: float = 1e-13):
+                tol_code_reuse: float = 1e-13):
 
         self.solver_created = False
-        self.__save_p_global = save_p_global
-        if save_p_global:
-            self.__p_global_values = ocp.p_global_values
-        else:
-            self.__p_global_values = np.array([])
 
-        if not (isinstance(ocp, (AcadosOcp, AcadosMultiphaseOcp)) or ocp is None):
-            raise TypeError('ocp should be of type AcadosOcp or AcadosMultiphaseOcp.')
         if ocp is None:
-            if json_file is None:
-                raise ValueError('json_file should be provided if ocp is None.')
-            if generate or build:
-                raise ValueError('generate and build should be False if ocp is None.')
-            if not os.path.exists(json_file):
-                raise FileNotFoundError(f'json_file {json_file} does not exist.')
-            check_reuse_possible = False
-        else:
-            # formulation provided
-            if json_file is not None:
-                ocp.code_gen_options.json_file = json_file
-            ocp.make_consistent(verbose=verbose)
-            json_file = ocp.code_gen_options.json_file
+            raise TypeError(
+                "Creating an AcadosOcpSolver without providing the `ocp` formulation (ocp=None) is deprecated. "
+                "AcadosOcp/AcadosMultiphaseOcp objects can be loaded using Acados[Multiphase]Ocp.from_json()."
+            )
+        if not isinstance(ocp, (AcadosOcp, AcadosMultiphaseOcp)):
+            raise TypeError('ocp should be of type AcadosOcp or AcadosMultiphaseOcp.')
+
+        # formulation provided (or reconstructed above)
+        if json_file is not None:
+            ocp.code_gen_options.json_file = json_file
+        ocp.make_consistent(verbose=verbose)
+        json_file = ocp.code_gen_options.json_file
+
+        # Store a reference to the OCP formulation instead of re-loading its data from json.
+        self.__ocp = ocp
+
+        self.__save_p_global = save_p_global
+        self.__p_global_values = ocp.p_global_values if save_p_global else np.array([])
 
         if check_reuse_possible and (not generate or not build):
             # Check if existing code can be reused
@@ -312,25 +311,20 @@ class AcadosOcpSolver:
         else:
             self.__generated = False
 
-        # load json, store options in object
-        with open(json_file, 'r') as f:
-            ocp_json = json.load(f)
-        self.__problem_class = ocp_json['problem_class']
-        self.__solver_options = ocp_json['solver_options']
-        self.__N = ocp_json['solver_options']['N_horizon']
-        self.__name = ocp_json['name']
+        # store solver-relevant information directly from the OCP formulation object
+        self.__problem_class = "OCP" if isinstance(ocp, AcadosOcp) else "MOCP"
+        self.__N = ocp.solver_options.N_horizon
+        self.__name = ocp.name
 
         if self.__problem_class == "OCP":
-            self.__has_x0 = ocp_json['constraints']['has_x0']
-            self.__nsbu_0 = ocp_json['dims']['nsbu']
-            self.__nbxe_0 = ocp_json['dims']['nbxe_0']
+            self.__has_x0 = ocp.constraints.has_x0
+            self.__nbxe_0 = ocp.dims.nbxe_0
         elif self.__problem_class == "MOCP":
-            self.__has_x0 = ocp_json['constraints'][0]['has_x0']
-            self.__nsbu_0 = ocp_json['phases_dims'][0]['nsbu']
-            self.__nbxe_0 = ocp_json['phases_dims'][0]['nbxe_0']
+            self.__has_x0 = ocp.constraints[0].has_x0
+            self.__nbxe_0 = ocp.phases_dims[0].nbxe_0
 
-        acados_lib_path = ocp_json['code_gen_options']['acados_lib_path']
-        code_export_directory = ocp_json['code_gen_options']['code_export_directory']
+        acados_lib_path = ocp.code_gen_options.acados_lib_path
+        code_export_directory = ocp.code_gen_options.code_export_directory
 
         if build:
             self.build(code_export_directory, with_cython=False, cmake_builder=cmake_builder, verbose=verbose)
@@ -367,8 +361,6 @@ class AcadosOcpSolver:
         getattr(self.__shared_lib, f"{self.name}_acados_create").restype = c_int
         assert getattr(self.__shared_lib, f"{self.name}_acados_create")(self.capsule)==0
         self.solver_created = True
-
-        self.__ocp = ocp
 
         # get pointers solver
         self.__get_pointers_solver()
@@ -478,7 +470,7 @@ class AcadosOcpSolver:
 
         # zoRO getter (only present for zoRO builds)
         self.__zoro_getter = None
-        if ocp_json.get('zoro_description'):
+        if self.__problem_class == "OCP" and ocp.zoro_description is not None:
             self.__zoro_getter = getattr(self.__shared_lib, f"{self.name}_acados_get_zoRO_Pk_matrices")
             self.__zoro_getter.argtypes = [c_void_p, POINTER(c_double), c_int]
             self.__zoro_getter.restype  = c_int
@@ -628,7 +620,7 @@ class AcadosOcpSolver:
 
         This is only implemented for HPIPM QP solver without condensing.
         """
-        if self.__solver_options["qp_solver"] not in ['PARTIAL_CONDENSING_HPIPM', 'FULL_CONDENSING_HPIPM']:
+        if self.__ocp.solver_options.qp_solver not in ['PARTIAL_CONDENSING_HPIPM', 'FULL_CONDENSING_HPIPM']:
             raise NotImplementedError('This function is only implemented for PARTIAL_CONDENSING_HPIPM and FULL_CONDENSING_HPIPM!')
 
         self._status = getattr(self.shared_lib, f"{self.name}_acados_setup_qp_matrices_and_factorize")(self.capsule)
@@ -701,14 +693,14 @@ class AcadosOcpSolver:
             raise RuntimeError('Solver was not yet created!')
 
         # check if time steps really changed in value
-        if np.array_equal(self.__solver_options['time_steps'], new_time_steps):
+        if np.array_equal(self.__ocp.solver_options.time_steps, new_time_steps):
             return
 
         N = new_time_steps.size
         new_time_steps_data = cast(new_time_steps.ctypes.data, POINTER(c_double))
 
         # check if recreation of acados is necessary (no need to recreate acados if sizes are identical)
-        if len(self.__solver_options['time_steps']) == N:
+        if len(self.__ocp.solver_options.time_steps) == N:
             assert getattr(self.shared_lib, f"{self.name}_acados_update_time_steps")(self.capsule, N, new_time_steps_data) == 0
         else:  # recreate the solver with the new time steps
             self.solver_created = False
@@ -725,9 +717,9 @@ class AcadosOcpSolver:
             self.__get_pointers_solver()
 
         # store time_steps, N
-        self.__solver_options['time_steps'] = new_time_steps
+        self.__ocp.solver_options.time_steps = new_time_steps
         self.__N = N
-        self.__solver_options['Tsim'] = self.__solver_options['time_steps'][0]
+        self.__ocp.solver_options.Tsim = self.__ocp.solver_options.time_steps[0]
 
 
     def update_qp_solver_cond_N(self, qp_solver_cond_N: int):
@@ -752,14 +744,14 @@ class AcadosOcpSolver:
             raise RuntimeError('Solver was not yet created!')
         if self.N < qp_solver_cond_N:
             raise ValueError('Setting qp_solver_cond_N to be larger than N does not work!')
-        if self.__solver_options['qp_solver_cond_N'] != qp_solver_cond_N:
+        if self.__ocp.solver_options.qp_solver_cond_N != qp_solver_cond_N:
             self.solver_created = False
 
             # recreate the solver
             assert getattr(self.shared_lib, f'{self.name}_acados_update_qp_solver_cond_N')(self.capsule, qp_solver_cond_N) == 0
 
             # store the new value
-            self.__solver_options['qp_solver_cond_N'] = qp_solver_cond_N
+            self.__ocp.solver_options.qp_solver_cond_N = qp_solver_cond_N
             self.solver_created = True
 
             # get pointers solver
@@ -780,6 +772,7 @@ class AcadosOcpSolver:
         - for field `initial_control`, the gradient is the Lagrange multiplier of the initial control constraint.
         The gradient computation consists of adding the Lagrange multipliers corresponding to the upper and lower bound of the initial control.
         This requires the OCP to have control bounds with lbu = ubu at the first stage, i.e. the gradient of the state-action value function or Q-function is computed.
+        NOTE: requires non-slacked nbu constraints.
 
         - for field `p_global`, the gradient of the Lagrange function w.r.t. the global parameters is computed.
 
@@ -805,7 +798,7 @@ class AcadosOcpSolver:
             lbu = self.get_from_qp_in(0, 'lbu')
             ubu = self.get_from_qp_in(0, 'ubu')
 
-            if not (nbu == nu and np.all(lbu == ubu) and self.__nsbu_0 == 0):
+            if not (nbu == nu and np.all(lbu == ubu)):
                 raise ValueError("OCP does not have an equality constraint on the initial control.")
 
             lam = self.get(0, 'lam')
@@ -1306,7 +1299,7 @@ class AcadosOcpSolver:
         """
         stat = self.get_stats("statistics")
 
-        if self.__solver_options['nlp_solver_type'] == 'SQP':
+        if self.__ocp.solver_options.nlp_solver_type == 'SQP':
             print('\niter\tres_stat\tres_eq\t\tres_ineq\tres_comp\tqp_stat\tqp_iter\talpha')
             if stat.shape[0]>8:
                 print('\tqp_res_stat\tqp_res_eq\tqp_res_ineq\tqp_res_comp')
@@ -1317,26 +1310,26 @@ class AcadosOcpSolver:
                     print('\t{:e}\t{:e}\t{:e}\t{:e}'.format( \
                         stat[8][jj], stat[9][jj], stat[10][jj], stat[11][jj]))
             print('\n')
-        elif self.__solver_options['nlp_solver_type'] == 'SQP_RTI':
+        elif self.__ocp.solver_options.nlp_solver_type == 'SQP_RTI':
             header = '\niter\tqp_stat\tqp_iter'
-            if self.__solver_options['nlp_solver_ext_qp_res'] == 1:
+            if self.__ocp.solver_options.nlp_solver_ext_qp_res == 1:
                 header += '\tqp_res_stat\tqp_res_eq\tqp_res_ineq\tqp_res_comp'
-            if self.__solver_options['rti_log_residuals'] == 1:
+            if self.__ocp.solver_options.rti_log_residuals == 1:
                 header += '\tres_stat\tres_eq\t\tres_ineq\tres_comp'
             print(header)
             for jj in range(stat.shape[1]):
                 line = '{:d}\t{:d}\t{:d}'.format( int(stat[0][jj]), int(stat[1][jj]), int(stat[2][jj]))
                 offset = 2
-                if self.__solver_options['nlp_solver_ext_qp_res'] == 1:
+                if self.__ocp.solver_options.nlp_solver_ext_qp_res == 1:
                     line += '\t{:e}\t{:e}\t{:e}\t{:e}'.format( \
                          stat[offset+1][jj], stat[offset+2][jj], stat[offset+3][jj], stat[offset+4][jj])
                     offset += 4
-                if self.__solver_options['rti_log_residuals'] == 1:
+                if self.__ocp.solver_options.rti_log_residuals == 1:
                     line += '\t{:e}\t{:e}\t{:e}\t{:e}'.format( \
                          stat[offset+1][jj], stat[offset+2][jj], stat[offset+3][jj], stat[offset+4][jj])
                 print(line)
             print('\n')
-        elif self.__solver_options['nlp_solver_type'] == 'DDP':
+        elif self.__ocp.solver_options.nlp_solver_type == 'DDP':
             for jj in range(stat.shape[1]):
                 if jj % 10 == 0:
                     print(("{iter:>6} | {obj:>10} | {inf:>10} | {stat:>10} | "
@@ -1360,7 +1353,7 @@ class AcadosOcpSolver:
                      qp_iter=int(stat[6][jj]),
                      alpha=stat[7][jj]))
             print('\n')
-        elif self.__solver_options['nlp_solver_type'] == 'SQP_WITH_FEASIBLE_QP':
+        elif self.__ocp.solver_options.nlp_solver_type == 'SQP_WITH_FEASIBLE_QP':
             print(("{iter:>5}   {stat:>10}   {res_eq:>10}   "
                    "{res_ineq:>10}   {res_comp:>10}   {qp1_status:>8}   {qp1_iter:>6}   "
                    "{qp2_status:>8}   {qp2_iter:>6}   {qp3_status:>8}   {qp3_iter:>6}   "
@@ -1813,27 +1806,27 @@ class AcadosOcpSolver:
 
         elif field_ == 'qp_stat':
             full_stats = self.get_stats('statistics')
-            if self.__solver_options['nlp_solver_type'] == 'SQP':
+            if self.__ocp.solver_options.nlp_solver_type == 'SQP':
                 return full_stats[5, :]
-            elif self.__solver_options['nlp_solver_type'] == 'SQP_RTI':
+            elif self.__ocp.solver_options.nlp_solver_type == 'SQP_RTI':
                 return full_stats[1, :]
 
         elif field_ == 'qp_iter':
             full_stats = self.get_stats('statistics')
-            if self.__solver_options['nlp_solver_type'] == 'SQP':
+            if self.__ocp.solver_options.nlp_solver_type == 'SQP':
                 return full_stats[6, :]
-            elif self.__solver_options['nlp_solver_type'] == 'SQP_RTI':
+            elif self.__ocp.solver_options.nlp_solver_type == 'SQP_RTI':
                 return full_stats[2, :]
-            elif self.__solver_options['nlp_solver_type'] == 'SQP_WITH_FEASIBLE_QP':
+            elif self.__ocp.solver_options.nlp_solver_type == 'SQP_WITH_FEASIBLE_QP':
                 return full_stats[6, :] + full_stats[8, :] + full_stats[10, :]
             else:
-                raise ValueError(f"qp_iter is not available for nlp_solver_type {self.__solver_options['nlp_solver_type']}.")
+                raise ValueError(f"qp_iter is not available for nlp_solver_type {self.__ocp.solver_options.nlp_solver_type}.")
 
         elif field_ == "qp_res_ineq":
-            if not self.__solver_options['nlp_solver_ext_qp_res']:
+            if not self.__ocp.solver_options.nlp_solver_ext_qp_res:
                 raise ValueError("qp_res_ineq only supported if nlp_solver_ext_qp_res is enabled.")
             full_stats = self.get_stats('statistics')
-            if self.__solver_options['nlp_solver_type'] == 'SQP':
+            if self.__ocp.solver_options.nlp_solver_type == 'SQP':
                 return full_stats[10, :]
             else:
                 raise ValueError("qp_res_ineq only supported for SQP solver.")
@@ -1841,19 +1834,19 @@ class AcadosOcpSolver:
 
         elif field_ == 'alpha':
             full_stats = self.get_stats('statistics')
-            if self.__solver_options['nlp_solver_type'] == 'SQP':
+            if self.__ocp.solver_options.nlp_solver_type == 'SQP':
                 return full_stats[7, :]
-            else: # self.__solver_options['nlp_solver_type'] == 'SQP_RTI':
+            else: # self.__ocp.solver_options.nlp_solver_type == 'SQP_RTI':
                 raise ValueError("alpha values are not available for SQP_RTI")
 
         elif field_ == 'residuals':
             return self.get_residuals()
 
         elif field_ == 'qp_residuals':
-            if self.__solver_options['nlp_solver_ext_qp_res'] != 1 or self.__solver_options['nlp_solver_type'] != 'SQP':
+            if self.__ocp.solver_options.nlp_solver_ext_qp_res != 1 or self.__ocp.solver_options.nlp_solver_type != 'SQP':
                 raise ValueError("qp_residuals only supported if nlp_solver_ext_qp_res is enabled and nlp_solver_type is SQP.")
             full_stats = self.get_stats('statistics')
-            if self.__solver_options['nlp_solver_type'] == 'SQP':
+            if self.__ocp.solver_options.nlp_solver_type == 'SQP':
                 res_stat = full_stats[8, -1]
                 res_eq = full_stats[9, -1]
                 res_ineq = full_stats[10, -1]
@@ -1862,51 +1855,51 @@ class AcadosOcpSolver:
 
         elif field_ == 'res_eq_all':
             full_stats = self.get_stats('statistics')
-            if self.__solver_options['nlp_solver_type'] == 'SQP':
+            if self.__ocp.solver_options.nlp_solver_type == 'SQP':
                 return full_stats[2, :]
-            elif self.__solver_options['nlp_solver_type'] == 'SQP_RTI':
-                if self.__solver_options['rti_log_residuals'] == 1:
+            elif self.__ocp.solver_options.nlp_solver_type == 'SQP_RTI':
+                if self.__ocp.solver_options.rti_log_residuals == 1:
                     return full_stats[4, :]
                 else:
                     raise ValueError("res_eq_all is not available for SQP_RTI if rti_log_residuals is not enabled.")
             else:
-                raise KeyError(f"res_eq_all is not available for nlp_solver_type {self.__solver_options['nlp_solver_type']}.")
+                raise KeyError(f"res_eq_all is not available for nlp_solver_type {self.__ocp.solver_options.nlp_solver_type}.")
 
         elif field_ == 'res_stat_all':
             full_stats = self.get_stats('statistics')
-            if self.__solver_options['nlp_solver_type'] == 'SQP':
+            if self.__ocp.solver_options.nlp_solver_type == 'SQP':
                 return full_stats[1, :]
-            elif self.__solver_options['nlp_solver_type'] == 'SQP_RTI':
-                if self.__solver_options['rti_log_residuals'] == 1:
+            elif self.__ocp.solver_options.nlp_solver_type == 'SQP_RTI':
+                if self.__ocp.solver_options.rti_log_residuals == 1:
                     return full_stats[3, :]
                 else:
                     raise ValueError("res_stat_all is not available for SQP_RTI if rti_log_residuals is not enabled.")
             else:
-                raise ValueError(f"res_stat_all is not available for nlp_solver_type {self.__solver_options['nlp_solver_type']}.")
+                raise ValueError(f"res_stat_all is not available for nlp_solver_type {self.__ocp.solver_options.nlp_solver_type}.")
 
         elif field_ == 'res_ineq_all':
             full_stats = self.get_stats('statistics')
-            if self.__solver_options['nlp_solver_type'] == 'SQP':
+            if self.__ocp.solver_options.nlp_solver_type == 'SQP':
                 return full_stats[3, :]
-            elif self.__solver_options['nlp_solver_type'] == 'SQP_RTI':
-                if self.__solver_options['rti_log_residuals'] == 1:
+            elif self.__ocp.solver_options.nlp_solver_type == 'SQP_RTI':
+                if self.__ocp.solver_options.rti_log_residuals == 1:
                     return full_stats[5, :]
                 else:
                     raise ValueError("res_ineq_all is not available for SQP_RTI if rti_log_residuals is not enabled.")
             else:
-                raise KeyError(f"res_ineq_all is not available for nlp_solver_type {self.__solver_options['nlp_solver_type']}.")
+                raise KeyError(f"res_ineq_all is not available for nlp_solver_type {self.__ocp.solver_options.nlp_solver_type}.")
 
         elif field_ == 'res_comp_all':
             full_stats = self.get_stats('statistics')
-            if self.__solver_options['nlp_solver_type'] == 'SQP':
+            if self.__ocp.solver_options.nlp_solver_type == 'SQP':
                 return full_stats[4, :]
-            elif self.__solver_options['nlp_solver_type'] == 'SQP_RTI':
-                if self.__solver_options['rti_log_residuals'] == 1:
+            elif self.__ocp.solver_options.nlp_solver_type == 'SQP_RTI':
+                if self.__ocp.solver_options.rti_log_residuals == 1:
                     return full_stats[6, :]
                 else:
                     raise ValueError("res_comp_all is not available for SQP_RTI if rti_log_residuals is not enabled.")
             else:
-                raise KeyError(f"res_comp_all is not available for nlp_solver_type {self.__solver_options['nlp_solver_type']}.")
+                raise KeyError(f"res_comp_all is not available for nlp_solver_type {self.__ocp.solver_options.nlp_solver_type}.")
 
         elif field_ == 'res_all':
             return np.concatenate((np.atleast_2d(self.get_stats('res_stat_all')),
@@ -1953,7 +1946,7 @@ class AcadosOcpSolver:
         """
         # compute residuals if RTI
         if recompute:
-            if self.__solver_options['nlp_solver_type'] == 'SQP_RTI':
+            if self.__ocp.solver_options.nlp_solver_type == 'SQP_RTI':
                 as_rti_level = self.options_get('as_rti_level')
                 if as_rti_level != 4: # not standard RTI
                     warnings.warn(f"Calling get_residuals() with recompute==True for AS-RTI can overwrite previous problem linearization in memory which are needed for AS-RTI to work properly!")
@@ -1987,15 +1980,15 @@ class AcadosOcpSolver:
         Residuals: residuals of initial iterate in previous solver call
         """
         full_stats = self.get_stats('statistics')
-        if self.__solver_options['nlp_solver_type'] == 'SQP':
+        if self.__ocp.solver_options.nlp_solver_type == 'SQP':
             return full_stats[1:5, 0]
-        elif self.__solver_options['nlp_solver_type'] == 'SQP_RTI':
-            if self.__solver_options['rti_log_residuals'] == 1:
+        elif self.__ocp.solver_options.nlp_solver_type == 'SQP_RTI':
+            if self.__ocp.solver_options.rti_log_residuals == 1:
                 return full_stats[3:7, 0]
             else:
                 raise ValueError("initial_residuals is only available for SQP_RTI if rti_log_residuals is enabled, for efficiency the rti_log_only_available_residuals option is recommended.")
         else:
-            raise ValueError(f"initial_residuals is not available for nlp_solver_type {self.__solver_options['nlp_solver_type']}.")
+            raise ValueError(f"initial_residuals is not available for nlp_solver_type {self.__ocp.solver_options.nlp_solver_type}.")
 
     # Note: this function should not be used anymore, better use cost_set, constraints_set
     def set(self, stage_: int, field_: str, value_: np.ndarray):
@@ -2328,23 +2321,23 @@ class AcadosOcpSolver:
         if field_ not in self.__all_qp_fields | self.__all_relaxed_qp_fields:
             raise ValueError(f"field {field_} not supported.")
         if field_ in self.__qp_pc_hpipm_fields:
-            if self.__solver_options["qp_solver"] != "PARTIAL_CONDENSING_HPIPM" or self.__solver_options["qp_solver_cond_N"] != self.N:
+            if self.__ocp.solver_options.qp_solver != "PARTIAL_CONDENSING_HPIPM" or self.__ocp.solver_options.qp_solver_cond_N != self.N:
                 raise ValueError(f"field {field_} only works for PARTIAL_CONDENSING_HPIPM QP solver with qp_solver_cond_N == N.")
             if field_ in ["P", "K", "p"] and stage_ == 0 and self.__nbxe_0 > 0:
                 raise ValueError(f"getting field {field_} at stage 0 only works without x0 elimination (see nbxe_0).")
         if field_ in self.__qp_pc_fields:
-            if not self.__solver_options["qp_solver"].startswith("PARTIAL_CONDENSING"):
+            if not self.__ocp.solver_options.qp_solver.startswith("PARTIAL_CONDENSING"):
                 raise ValueError(f"field {field_} only works for PARTIAL_CONDENSING QP solvers.")
-            if field_.split("_", 1)[1] in self.__qp_dynamics_fields and stage_ >= self.__solver_options["qp_solver_cond_N"]:
+            if field_.split("_", 1)[1] in self.__qp_dynamics_fields and stage_ >= self.__ocp.solver_options.qp_solver_cond_N:
                 raise ValueError(f"dynamics field {field_} not available at last stage of partial condensing")
-            elif stage_ > self.__solver_options["qp_solver_cond_N"]:
+            elif stage_ > self.__ocp.solver_options.qp_solver_cond_N:
                 raise ValueError(f"stage should be <= qp_solver_cond_N for partial condensing fields")
-        elif field_ in self.__all_relaxed_qp_fields and not self.__solver_options["nlp_solver_type"] == "SQP_WITH_FEASIBLE_QP":
+        elif field_ in self.__all_relaxed_qp_fields and not self.__ocp.solver_options.nlp_solver_type == "SQP_WITH_FEASIBLE_QP":
             raise ValueError(f"field {field_} only works for SQP_WITH_FEASIBLE_QP nlp_solver_type.")
         elif field_ in self.__qp_fc_fields:
             if stage_ != 0:
                 raise ValueError(f"field {field_} only works for stage 0.")
-            if not self.__solver_options["qp_solver"].startswith("FULL_CONDENSING"):
+            if not self.__ocp.solver_options.qp_solver.startswith("FULL_CONDENSING"):
                 raise ValueError(f"field {field_} only works for FULL_CONDENSING QP solvers.")
 
         field = field_.encode('utf-8')
@@ -2383,7 +2376,7 @@ class AcadosOcpSolver:
         Bounds are not scaled, so the dimension is ng + nh + nphi.
         Only available if qpscaling_scale_constraints != NO_CONSTRAINT_SCALING.
         """
-        if self.__solver_options["qpscaling_scale_constraints"] == "NO_CONSTRAINT_SCALING":
+        if self.__ocp.solver_options.qpscaling_scale_constraints == "NO_CONSTRAINT_SCALING":
             raise ValueError(f"get_qp_scaling_constraints: only works if qpscaling_scale_constraints != NO_CONSTRAINT_SCALING.")
 
         # call getter
@@ -2403,7 +2396,7 @@ class AcadosOcpSolver:
         Returns the cost scaling value corresponding to the previous QP solution.
         Only available if qpscaling_scale_objective != NO_OBJECTIVE_SCALING.
         """
-        if self.__solver_options["qpscaling_scale_objective"] == "NO_OBJECTIVE_SCALING":
+        if self.__ocp.solver_options.qpscaling_scale_objective == "NO_OBJECTIVE_SCALING":
             raise ValueError("get_qp_scaling_objective: only works for QP solvers with qpscaling_scale_objective != NO_OBJECTIVE_SCALING.")
 
         # create output array
@@ -2441,10 +2434,10 @@ class AcadosOcpSolver:
         if not get_final_iterate and (iteration > nlp_iter or iteration < 0):
             raise ValueError("get_iterate: iteration needs to be nonnegative and <= nlp_iter or -1.")
 
-        if not get_final_iterate and not self.__solver_options["store_iterates"]:
+        if not get_final_iterate and not self.__ocp.solver_options.store_iterates:
             raise ValueError("get_iterate: the solver option store_iterates needs to be true in order to get intermediate iterates.")
 
-        if not get_final_iterate and self.__solver_options["nlp_solver_type"] == "SQP_RTI":
+        if not get_final_iterate and self.__ocp.solver_options.nlp_solver_type == "SQP_RTI":
             raise NotImplementedError("get_iterate: SQP_RTI not supported.")
 
         d = {}
@@ -2572,7 +2565,7 @@ class AcadosOcpSolver:
                 f' Possible values are {fields}.')
 
 
-        if (field_ == 'max_iter' or field_ == 'nlp_solver_max_iter') and value_ > self.__solver_options['nlp_solver_max_iter']:
+        if (field_ == 'max_iter' or field_ == 'nlp_solver_max_iter') and value_ > self.__ocp.solver_options.nlp_solver_max_iter:
             raise ValueError('AcadosOcpSolver.options_set() cannot increase nlp_solver_max_iter' \
                     f' above initial value {self.__nlp_solver_max_iter} (you have {value_})')
 
@@ -2580,10 +2573,10 @@ class AcadosOcpSolver:
             if value_ < 0 or value_ > 2:
                 raise ValueError('AcadosOcpSolver.options_set(): argument \'rti_phase\' can '
                     'take only values 0, 1, 2 for SQP-RTI-type solvers')
-            if self.__solver_options['nlp_solver_type'] != 'SQP_RTI' and value_ > 0:
+            if self.__ocp.solver_options.nlp_solver_type != 'SQP_RTI' and value_ > 0:
                 raise ValueError('AcadosOcpSolver.options_set(): argument \'rti_phase\' can '
                     'take only value 0 for SQP-type solvers')
-            if self.__solver_options['nlp_solver_type'] == 'SQP_RTI' and self.__solver_options['as_rti_level'] != 4 and value_ == 0:
+            if self.__ocp.solver_options.nlp_solver_type == 'SQP_RTI' and self.__ocp.solver_options.as_rti_level != 4 and value_ == 0:
                 raise ValueError('AcadosOcpSolver.options_set(): argument \'rti_phase\' can '
                     'take only values 1, 2 for AS-RTI.')
 
@@ -2609,7 +2602,7 @@ class AcadosOcpSolver:
         """
         int_fields = ['as_rti_level']
         if field_ == 'as_rti_level':
-            if self.__solver_options['nlp_solver_type'] != "SQP_RTI":
+            if self.__ocp.solver_options.nlp_solver_type != "SQP_RTI":
                 raise ValueError("as_rti_level only available for SQP_RTI")
 
         if field_ in int_fields:

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -316,7 +316,7 @@ class AcadosOcpSolver:
                 print("Code reuse possible, skipping code generation.")
 
         if generate:
-            self.generate(ocp, json_file=ocp.code_gen_options.json_file, cmake_builder=cmake_builder, verbose=verbose)
+            self.generate(ocp, json_file=ocp.code_gen_options.json_file, simulink_opts=simulink_opts, cmake_builder=cmake_builder, verbose=verbose)
             self.__generated = True
         else:
             self.__generated = False

--- a/interfaces/acados_template/acados_template/acados_ocp_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_solver.py
@@ -66,8 +66,8 @@ class AcadosOcpSolver:
 
     :param ocp: type :py:class:`~acados_template.acados_ocp.AcadosOcp` or
         :py:class:`~acados_template.acados_multiphase_ocp.AcadosMultiphaseOcp` (description of the OCP for acados)
-    :param json_file: name for the json file used to render the templated code
-        (default: ``acados_ocp_nlp.json``)
+    :param json_file: name for the json file used to render the templated code (default: ``acados_ocp_nlp.json``)
+    :param simulink_opts: *DEPRECATED (v0.5.5)*: set simulink_opts in AcadosOcp / AcadosMultiphaseOcp instead, default: `None`.
     """
     if os.name == 'nt':
         dlclose = DllLoader('kernel32', use_last_error=True).FreeLibrary
@@ -135,8 +135,7 @@ class AcadosOcpSolver:
 
         :param ocp: type Union[AcadosOcp, AcadosMultiphaseOcp] - description of the OCP for acados
         :param json_file: name for the json file used to render the templated code - default: `acados_ocp_nlp.json`
-        :param simulink_opts: Options to configure Simulink S-function blocks, mainly to activate possible inputs and
-               outputs; default: `None`
+        :param simulink_opts: *DEPRECATED (v0.5.5)*: set simulink_opts in AcadosOcp / AcadosMultiphaseOcp instead, default: `None`.
         :param cmake_builder: type :py:class:`~acados_template.builders.CMakeBuilder` generate a `CMakeLists.txt` and use
                the `CMake` pipeline instead of a `Makefile` (`CMake` seems to be the better option in conjunction with
                `MS Visual Studio`); default: `None`
@@ -150,6 +149,11 @@ class AcadosOcpSolver:
                 raise RuntimeError('simulink_opts are already set in ocp.')
             else:
                 ocp.simulink_opts = simulink_opts
+                warnings.warn(
+                    "Passing simulink_opts in generate() is deprecated, set simulink_opts in AcadosOcp / AcadosMultiphaseOcp instead.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
 
         # make consistent
         ocp.make_consistent(verbose=verbose)
@@ -272,6 +276,12 @@ class AcadosOcpSolver:
     def __init__(self, ocp: Union[AcadosOcp, AcadosMultiphaseOcp, None], json_file=None, simulink_opts=None, build=True, generate=True, cmake_builder: CMakeBuilder = None, verbose=True, save_p_global=False, check_reuse_possible=True,
                 tol_code_reuse: float = 1e-13):
 
+        if simulink_opts is not None:
+            warnings.warn(
+                    "Passing simulink_opts in AcadosOcpSolver is deprecated, set simulink_opts in AcadosOcp / AcadosMultiphaseOcp instead.",
+                    DeprecationWarning,
+                    stacklevel=2,
+            )
         self.solver_created = False
 
         if ocp is None:
@@ -306,7 +316,7 @@ class AcadosOcpSolver:
                 print("Code reuse possible, skipping code generation.")
 
         if generate:
-            self.generate(ocp, json_file=ocp.code_gen_options.json_file, simulink_opts=simulink_opts, cmake_builder=cmake_builder, verbose=verbose)
+            self.generate(ocp, json_file=ocp.code_gen_options.json_file, cmake_builder=cmake_builder, verbose=verbose)
             self.__generated = True
         else:
             self.__generated = False


### PR DESCRIPTION
- Cleanup solver internal dict/struct.
- Breaking: `ocp` can not be None / empty in `AcadosOcpSolver`, instead load the problem formulation from json.
- Enabled by #1854
- Python: Deprecate passing `simulink_opts` to `AcadosOcpSolver`, must be set in `AcadosOcp` / `AcadosMultiphaseOcp`