### PR TITLE
Refactor reset

### DIFF
--- a/acados/ocp_nlp/ocp_nlp_dynamics_common.h
+++ b/acados/ocp_nlp/ocp_nlp_dynamics_common.h
@@ -109,6 +109,7 @@ typedef struct
     void (*compute_adj_p)(void *config, void *dims, void *model, void *opts, void *memory, struct blasfeo_dvec *out);
     void (*compute_fun_and_adj)(void *config_, void *dims, void *model_, void *opts_, void *mem_, void *work_);
     int (*precompute)(void *config_, void *dims, void *model_, void *opts_, void *mem_, void *work_);
+    void (*reset)(void *config_, void *dims_, void *model_, void *opts_, void *mem_, void *work_);
     int stage;
 } ocp_nlp_dynamics_config;
 

--- a/acados/ocp_nlp/ocp_nlp_dynamics_cont.c
+++ b/acados/ocp_nlp/ocp_nlp_dynamics_cont.c
@@ -1093,8 +1093,7 @@ int ocp_nlp_dynamics_cont_precompute(void *config_, void *dims_, void *model_, v
     int status = config->sim_solver->precompute(config->sim_solver, work->sim_in, work->sim_out,
                                    opts->sim_solver, mem->sim_solver, work->sim_solver);
 
-    config->sim_solver->memory_set_to_zero(config->sim_solver, work->sim_in->dims,
-                                    opts->sim_solver, mem->sim_solver, "guesses");
+    config->sim_solver->memory_set_to_zero(config->sim_solver, work->sim_in->dims, opts->sim_solver, mem->sim_solver);
 
     return status;
 }
@@ -1122,7 +1121,7 @@ void ocp_nlp_dynamics_cont_reset(void *config_, void *dims_, void *model_, void 
     ocp_nlp_dynamics_cont_workspace *work = work_;
 
     // reset integrator memory
-    config->sim_solver->memory_set_to_zero(config->sim_solver, work->sim_in->dims, opts->sim_solver, mem->sim_solver, "guesses");
+    config->sim_solver->memory_set_to_zero(config->sim_solver, work->sim_in->dims, opts->sim_solver, mem->sim_solver);
 }
 
 

--- a/acados/ocp_nlp/ocp_nlp_dynamics_cont.c
+++ b/acados/ocp_nlp/ocp_nlp_dynamics_cont.c
@@ -1112,6 +1112,23 @@ void ocp_nlp_dynamics_cont_compute_adj_p(void* config_, void *dims_, void *model
     exit(1);
 }
 
+void ocp_nlp_dynamics_cont_reset(void *config_, void *dims_, void *model_, void *opts_, void *mem_, void *work_)
+{
+    ocp_nlp_dynamics_config *config = config_;
+    ocp_nlp_dynamics_cont_dims *dims = dims_;
+    ocp_nlp_dynamics_cont_opts *opts = opts_;
+    ocp_nlp_dynamics_cont_memory *mem = mem_;
+
+    mem->workspace_size = ocp_nlp_dynamics_cont_workspace_calculate_size(config, dims_, opts_);
+    mem->sim_workspace_size = config->sim_solver->workspace_calculate_size(config->sim_solver, dims->sim, opts->sim_solver);
+
+    ocp_nlp_dynamics_cont_cast_workspace(config_, dims_, opts_, work_, mem_);
+    ocp_nlp_dynamics_cont_workspace *work = work_;
+
+    // reset integrator memory
+    config->sim_solver->memory_set_to_zero(config->sim_solver, work->sim_in->dims, opts->sim_solver, mem->sim_solver, "guesses");
+}
+
 
 size_t ocp_nlp_dynamics_cont_get_external_fun_workspace_requirement(void *config_, void *dims_, void *opts_, void *model_)
 {
@@ -1179,6 +1196,7 @@ void ocp_nlp_dynamics_cont_config_initialize_default(void *config_, int stage)
     config->precompute = &ocp_nlp_dynamics_cont_precompute;
     config->config_initialize_default = &ocp_nlp_dynamics_cont_config_initialize_default;
     config->compute_jac_hess_p = &ocp_nlp_dynamics_cont_compute_jac_hess_p;
+    config->reset = &ocp_nlp_dynamics_cont_reset;
     config->stage = stage;
 
     return;

--- a/acados/ocp_nlp/ocp_nlp_dynamics_cont.c
+++ b/acados/ocp_nlp/ocp_nlp_dynamics_cont.c
@@ -1115,15 +1115,13 @@ void ocp_nlp_dynamics_cont_compute_adj_p(void* config_, void *dims_, void *model
 void ocp_nlp_dynamics_cont_reset(void *config_, void *dims_, void *model_, void *opts_, void *mem_, void *work_)
 {
     ocp_nlp_dynamics_config *config = config_;
-    ocp_nlp_dynamics_cont_dims *dims = dims_;
+    ocp_nlp_dynamics_cont_model *model = model_;
     ocp_nlp_dynamics_cont_opts *opts = opts_;
     ocp_nlp_dynamics_cont_memory *mem = mem_;
 
-    mem->workspace_size = ocp_nlp_dynamics_cont_workspace_calculate_size(config, dims_, opts_);
-    mem->sim_workspace_size = config->sim_solver->workspace_calculate_size(config->sim_solver, dims->sim, opts->sim_solver);
-
     ocp_nlp_dynamics_cont_cast_workspace(config_, dims_, opts_, work_, mem_);
     ocp_nlp_dynamics_cont_workspace *work = work_;
+    work->sim_in->model = model->sim_model;
 
     // reset integrator memory
     config->sim_solver->memory_set_to_zero(config->sim_solver, work->sim_in->dims, opts->sim_solver, mem->sim_solver, "guesses");

--- a/acados/ocp_nlp/ocp_nlp_dynamics_cont.c
+++ b/acados/ocp_nlp/ocp_nlp_dynamics_cont.c
@@ -1114,14 +1114,12 @@ void ocp_nlp_dynamics_cont_compute_adj_p(void* config_, void *dims_, void *model
 
 void ocp_nlp_dynamics_cont_reset(void *config_, void *dims_, void *model_, void *opts_, void *mem_, void *work_)
 {
+    ocp_nlp_dynamics_cont_cast_workspace(config_, dims_, opts_, work_, mem_);
+
     ocp_nlp_dynamics_config *config = config_;
-    ocp_nlp_dynamics_cont_model *model = model_;
     ocp_nlp_dynamics_cont_opts *opts = opts_;
     ocp_nlp_dynamics_cont_memory *mem = mem_;
-
-    ocp_nlp_dynamics_cont_cast_workspace(config_, dims_, opts_, work_, mem_);
     ocp_nlp_dynamics_cont_workspace *work = work_;
-    work->sim_in->model = model->sim_model;
 
     // reset integrator memory
     config->sim_solver->memory_set_to_zero(config->sim_solver, work->sim_in->dims, opts->sim_solver, mem->sim_solver, "guesses");

--- a/acados/ocp_nlp/ocp_nlp_dynamics_cont.h
+++ b/acados/ocp_nlp/ocp_nlp_dynamics_cont.h
@@ -203,6 +203,8 @@ int ocp_nlp_dynamics_cont_precompute(void *config_, void *dims, void *model_, vo
 void ocp_nlp_dynamics_cont_compute_jac_hess_p(void *config_, void *dims, void *model_, void *opts, void *mem, void *work_);
 //
 void ocp_nlp_dynamics_cont_compute_adj_p(void* config_, void *dims_, void *model_, void *opts_, void *mem_, struct blasfeo_dvec *out);
+//
+void ocp_nlp_dynamics_cont_reset(void *config_, void *dims_, void *model_, void *opts_, void *mem_, void *work_);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/acados/ocp_nlp/ocp_nlp_dynamics_disc.c
+++ b/acados/ocp_nlp/ocp_nlp_dynamics_disc.c
@@ -978,6 +978,12 @@ void ocp_nlp_dynamics_disc_set_external_fun_workspaces(void *config_, void *dims
 }
 
 
+void ocp_nlp_dynamics_disc_reset(void *config_, void *dims_, void *model_, void *opts_, void *mem_, void *work_)
+{
+    // no internal memory to reset for discrete dynamics
+    return;
+}
+
 void ocp_nlp_dynamics_disc_config_initialize_default(void *config_, int stage)
 {
     ocp_nlp_dynamics_config *config = config_;
@@ -1021,6 +1027,7 @@ void ocp_nlp_dynamics_disc_config_initialize_default(void *config_, int stage)
     config->compute_adj_p = &ocp_nlp_dynamics_disc_compute_adj_p;
     config->precompute = &ocp_nlp_dynamics_disc_precompute;
     config->config_initialize_default = &ocp_nlp_dynamics_disc_config_initialize_default;
+    config->reset = &ocp_nlp_dynamics_disc_reset;
     config->stage = stage;
 
     return;

--- a/acados/ocp_nlp/ocp_nlp_dynamics_disc.h
+++ b/acados/ocp_nlp/ocp_nlp_dynamics_disc.h
@@ -187,6 +187,8 @@ void ocp_nlp_dynamics_disc_compute_fun(void *config_, void *dims, void *model_, 
 void ocp_nlp_dynamics_disc_compute_jac_hess_p(void *config_, void *dims, void *model_, void *opts, void *mem, void *work_);
 //
 void ocp_nlp_dynamics_disc_compute_adj_p(void* config_, void *dims_, void *model_, void *opts_, void *mem_, struct blasfeo_dvec *out);
+//
+void ocp_nlp_dynamics_disc_reset(void *config_, void *dims_, void *model_, void *opts_, void *mem_, void *work_);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/acados/sim/sim_common.h
+++ b/acados/sim/sim_common.h
@@ -174,7 +174,7 @@ typedef struct
     acados_size_t (*memory_calculate_size)(void *config, void *dims, void *opts);
     void *(*memory_assign)(void *config, void *dims, void *opts, void *raw_memory);
     int (*memory_set)(void *config, void *dims, void *mem, const char *field, void *value);
-    int (*memory_set_to_zero)(void *config, void *dims, void *opts, void *mem, const char *field);
+    int (*memory_set_to_zero)(void *config, void *dims, void *opts, void *mem);
     void (*memory_get)(void *config, void *dims, void *mem, const char *field, void *value);
     // work
     acados_size_t (*workspace_calculate_size)(void *config, void *dims, void *opts);

--- a/acados/sim/sim_erk_integrator.c
+++ b/acados/sim/sim_erk_integrator.c
@@ -381,19 +381,11 @@ int sim_erk_memory_set(void *config_, void *dims_, void *mem_, const char *field
 
 
 
-int sim_erk_memory_set_to_zero(void *config_, void * dims_, void *opts_, void *mem_, const char *field)
+int sim_erk_memory_set_to_zero(void *config_, void * dims_, void *opts_, void *mem_)
 {
     int status = ACADOS_SUCCESS;
 
-    if (!strcmp(field, "guesses"))
-    {
-        // no guesses/initialization in ERK
-    }
-    else
-    {
-        printf("sim_erk_memory_set_to_zero field %s is not supported! \n", field);
-        exit(1);
-    }
+    // no memory to set to zero in ERK
 
     return status;
 }

--- a/acados/sim/sim_gnsf.c
+++ b/acados/sim/sim_gnsf.c
@@ -1453,23 +1453,15 @@ int sim_gnsf_memory_set(void *config_, void *dims_, void *mem_, const char *fiel
 
 
 
-int sim_gnsf_memory_set_to_zero(void *config_, void * dims_, void *opts_, void *mem_, const char *field)
+int sim_gnsf_memory_set_to_zero(void *config_, void * dims_, void *opts_, void *mem_)
 {
     sim_gnsf_memory *mem = (sim_gnsf_memory *) mem_;
     sim_gnsf_dims *dims = (sim_gnsf_dims *) dims_;
 
     int status = ACADOS_SUCCESS;
 
-    if (!strcmp(field, "guesses"))
-    {
-        for (int ii=0; ii < dims->n_out; ii++)
-            mem->phi_guess[ii] = 0.0;
-    }
-    else
-    {
-        printf("sim_gnsf_memory_set_to_zero field %s is not supported! \n", field);
-        exit(1);
-    }
+    for (int ii=0; ii < dims->n_out; ii++)
+        mem->phi_guess[ii] = 0.0;
 
     return status;
 }

--- a/acados/sim/sim_irk_integrator.c
+++ b/acados/sim/sim_irk_integrator.c
@@ -550,28 +550,21 @@ int sim_irk_memory_set(void *config_, void *dims_, void *mem_, const char *field
 
 
 
-int sim_irk_memory_set_to_zero(void *config_, void * dims_, void *opts_, void *mem_, const char *field)
+int sim_irk_memory_set_to_zero(void *config_, void * dims_, void *opts_, void *mem_)
 {
     sim_config *config = config_;
     sim_irk_memory *mem = (sim_irk_memory *) mem_;
 
     int status = ACADOS_SUCCESS;
 
-    if (!strcmp(field, "guesses"))
-    {
-        int nx, nz;
-        config->dims_get(config_, dims_, "nz", &nz);
-        config->dims_get(config_, dims_, "nx", &nx);
-        for (int ii=0; ii < nz; ii++)
-            mem->z[ii] = 0.0;
-        for (int ii=0; ii < nx; ii++)
-            mem->xdot[ii] = 0.0;
-    }
-    else
-    {
-        printf("sim_irk_memory_set: field %s is not supported! \n", field);
-        exit(1);
-    }
+    int nx, nz;
+    config->dims_get(config_, dims_, "nz", &nz);
+    config->dims_get(config_, dims_, "nx", &nx);
+
+    for (int ii=0; ii < nz; ii++)
+        mem->z[ii] = 0.0;
+    for (int ii=0; ii < nx; ii++)
+        mem->xdot[ii] = 0.0;
 
     return status;
 }

--- a/acados/sim/sim_lifted_irk_integrator.c
+++ b/acados/sim/sim_lifted_irk_integrator.c
@@ -466,7 +466,7 @@ int sim_lifted_irk_memory_set(void *config_, void *dims_, void *mem_, const char
 
 
 
-int sim_lifted_irk_memory_set_to_zero(void *config_, void * dims_, void *opts_, void *mem_, const char *field)
+int sim_lifted_irk_memory_set_to_zero(void *config_, void * dims_, void *opts_, void *mem_)
 {
     sim_config *config = config_;
     sim_lifted_irk_memory *mem = (sim_lifted_irk_memory *) mem_;
@@ -474,20 +474,10 @@ int sim_lifted_irk_memory_set_to_zero(void *config_, void * dims_, void *opts_, 
 
     int status = ACADOS_SUCCESS;
 
-    if (!strcmp(field, "guesses"))
-    {
-        int nx;
-        config->dims_get(config_, dims_, "nx", &nx);
-        for (int i = 0; i < opts->num_steps; i++)
-        {
-            blasfeo_dvecse(nx * opts->ns, 0.0, &mem->K[i], 0);
-        }
-    }
-    else
-    {
-        printf("sim_lifted_irk_memory_set_to_zero field %s is not supported! \n", field);
-        exit(1);
-    }
+    int nx;
+    config->dims_get(config_, dims_, "nx", &nx);
+    for (int i = 0; i < opts->num_steps; i++)
+        blasfeo_dvecse(nx * opts->ns, 0.0, &mem->K[i], 0);
 
     return status;
 }

--- a/interfaces/acados_c/ocp_nlp_interface.c
+++ b/interfaces/acados_c/ocp_nlp_interface.c
@@ -1403,13 +1403,18 @@ void ocp_nlp_solver_reset_qp_memory(ocp_nlp_solver *solver, ocp_nlp_in *nlp_in, 
 
 void ocp_nlp_solver_reset_integrator_memory(ocp_nlp_solver *solver, ocp_nlp_in *nlp_in, ocp_nlp_out *nlp_out)
 {
+    ocp_nlp_config *config = solver->config;
+    ocp_nlp_memory *nlp_mem;
+    ocp_nlp_opts *nlp_opts;
+    ocp_nlp_workspace *nlp_work;
+    config->get(config, solver->dims, solver->mem, "nlp_mem", &nlp_mem);
+    config->opts_get(config, solver->opts, "nlp_opts", &nlp_opts);
+    config->work_get(config, solver->dims, solver->work, "nlp_work", &nlp_work);
 
     for (int i = 0; i < solver->dims->N; i++)
     {
-        printf("Resetting integrator memory for stage %d\n", i);
-        solver->config->dynamics[i]->reset(solver->config->dynamics[i], solver->dims->dynamics[i], nlp_in->dynamics[i], solver->opts, solver->mem, solver->work);
+        solver->config->dynamics[i]->reset(solver->config->dynamics[i], solver->dims->dynamics[i], nlp_in->dynamics[i], nlp_opts->dynamics[i], nlp_mem->dynamics[i], nlp_work->dynamics[i]);
     }
-    printf("Done\n");
 }
 
 

--- a/interfaces/acados_c/ocp_nlp_interface.c
+++ b/interfaces/acados_c/ocp_nlp_interface.c
@@ -1401,6 +1401,17 @@ void ocp_nlp_solver_reset_qp_memory(ocp_nlp_solver *solver, ocp_nlp_in *nlp_in, 
                                     solver->opts, solver->mem, solver->work);
 }
 
+void ocp_nlp_solver_reset_integrator_memory(ocp_nlp_solver *solver, ocp_nlp_in *nlp_in, ocp_nlp_out *nlp_out)
+{
+
+    for (int i = 0; i < solver->dims->N; i++)
+    {
+        printf("Resetting integrator memory for stage %d\n", i);
+        solver->config->dynamics[i]->reset(solver->config->dynamics[i], solver->dims->dynamics[i], nlp_in->dynamics[i], solver->opts, solver->mem, solver->work);
+    }
+    printf("Done\n");
+}
+
 
 int ocp_nlp_solve(ocp_nlp_solver *solver, ocp_nlp_in *nlp_in, ocp_nlp_out *nlp_out)
 {

--- a/interfaces/acados_c/ocp_nlp_interface.h
+++ b/interfaces/acados_c/ocp_nlp_interface.h
@@ -403,6 +403,14 @@ ACADOS_SYMBOL_EXPORT int ocp_nlp_setup_qp_matrices_and_factorize(ocp_nlp_solver 
 ACADOS_SYMBOL_EXPORT void ocp_nlp_solver_reset_qp_memory(ocp_nlp_solver *solver, ocp_nlp_in *nlp_in, ocp_nlp_out *nlp_out);
 
 
+// Resets the memory of the integrators
+///
+/// \param solver The solver struct.
+/// \param nlp_in The inputs struct.
+/// \param nlp_out The output struct.
+ACADOS_SYMBOL_EXPORT void ocp_nlp_solver_reset_integrator_memory(ocp_nlp_solver *solver, ocp_nlp_in *nlp_in, ocp_nlp_out *nlp_out);
+
+
 /// Performs precomputations for the solver. Needs to be called before
 /// ocp_nlp_solve (TBC).
 ///

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.c
@@ -2932,26 +2932,11 @@ int {{ name }}_acados_reset({{ name }}_solver_capsule* capsule, int reset_qp_sol
     // sets primal and dual iterates to zero
     ocp_nlp_out_set_values_to_zero(nlp_config, nlp_dims, nlp_out);
 
-    double* buffer = calloc({{ nx_max + nz_max }}, sizeof(double));
-
-    // TODO the following should be implemented via a intgrator reset functionality
-{%- for jj in range(end=n_phases) %}{# phases loop !#}
-    // Reset stage {{ jj }}
-    for (int i = {{ start_idx[jj] }}; i < {{ end_idx[jj] }}; i++)
+    // reset integrator
+    for (int i = 0; i < N; i++)
     {
-        if (i<N)
-        {
-        {%- if mocp_opts.integrator_type[jj] == "IRK" %}
-            ocp_nlp_set(nlp_solver, i, "xdot_guess", buffer);
-            ocp_nlp_set(nlp_solver, i, "z_guess", buffer);
-        {%- elif mocp_opts.integrator_type[jj] == "LIFTED_IRK" %}
-            ocp_nlp_set(nlp_solver, i, "xdot_guess", buffer);
-        {%- elif mocp_opts.integrator_type[jj] == "GNSF" %}
-            ocp_nlp_set(nlp_solver, i, "gnsf_phi_guess", buffer);
-        {%- endif %}
-        }
+        nlp_config->dynamics[i]->reset(nlp_config->dynamics[i], nlp_dims->dynamics[i], nlp_in->dynamics[i], nlp_opts->dynamics[i], nlp_mem->dynamics[i], nlp_work->dynamics[i]);
     }
-{%- endfor %}
 
 {%- if solver_options.qp_solver == 'PARTIAL_CONDENSING_HPIPM' %}
     // get qp_status: if NaN -> reset memory
@@ -2962,7 +2947,7 @@ int {{ name }}_acados_reset({{ name }}_solver_capsule* capsule, int reset_qp_sol
         // printf("\nin reset qp_status %d -> resetting QP memory\n", qp_status);
         ocp_nlp_solver_reset_qp_memory(nlp_solver, nlp_in, nlp_out);
     }
-{%- endif %}
+    {%- endif %}
 
     if (reset_numerical_values)
     {
@@ -2982,17 +2967,17 @@ int {{ name }}_acados_reset({{ name }}_solver_capsule* capsule, int reset_qp_sol
     if (reset_x_to_x0_bar)
     {
         {%- if constraints_0.has_x0 -%}
+        double* buffer = calloc({{ nx_max }}, sizeof(double));
         ocp_nlp_constraints_model_get(nlp_config, nlp_dims, nlp_in, 0, "lbx", buffer);
         for (int i=0; i<N+1; i++)
         {
             ocp_nlp_out_set(nlp_config, nlp_dims, nlp_out, nlp_in, i, "x", buffer);
         }
+        free(buffer);
         {%- else %}
         // no x0 constraint, cannot reset x to x0_bar
         {%- endif %}
     }
-
-    free(buffer);
     return 0;
 }
 

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.c
@@ -2932,11 +2932,8 @@ int {{ name }}_acados_reset({{ name }}_solver_capsule* capsule, int reset_qp_sol
     // sets primal and dual iterates to zero
     ocp_nlp_out_set_values_to_zero(nlp_config, nlp_dims, nlp_out);
 
-    // reset integrator
-    for (int i = 0; i < N; i++)
-    {
-        nlp_config->dynamics[i]->reset(nlp_config->dynamics[i], nlp_dims->dynamics[i], nlp_in->dynamics[i], nlp_opts->dynamics[i], nlp_mem->dynamics[i], nlp_work->dynamics[i]);
-    }
+    // reset integrator memory
+    ocp_nlp_solver_reset_integrator_memory(nlp_solver, nlp_in, nlp_out);
 
 {%- if solver_options.qp_solver == 'PARTIAL_CONDENSING_HPIPM' %}
     // get qp_status: if NaN -> reset memory

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -3018,7 +3018,7 @@ int {{ model.name }}_acados_update_qp_solver_cond_N({{ model.name }}_solver_caps
 
 int {{ model.name }}_acados_reset({{ model.name }}_solver_capsule* capsule, int reset_qp_solver_mem, int reset_numerical_values, int reset_solver_options, int reset_x_to_x0_bar)
 {
-
+    // TODO this function should be moved to acados_c_interface
     // set initialization to all zeros
     const int N = capsule->nlp_solver_plan->N;
     ocp_nlp_config* nlp_config = capsule->nlp_config;
@@ -3030,18 +3030,10 @@ int {{ model.name }}_acados_reset({{ model.name }}_solver_capsule* capsule, int 
     // sets primal and dual iterates to zero
     ocp_nlp_out_set_values_to_zero(nlp_config, nlp_dims, nlp_out);
 
-    // TODO this should be implemented using blasfeo_dvecse
-    double* buffer = calloc(NX+NZ, sizeof(double));
+    // reset integrator memory
     for (int i=0; i<N; i++)
     {
-        {%- if solver_options.integrator_type == "IRK" %}
-            ocp_nlp_set(nlp_solver, i, "xdot_guess", buffer);
-            ocp_nlp_set(nlp_solver, i, "z_guess", buffer);
-        {%- elif solver_options.integrator_type == "LIFTED_IRK" %}
-            ocp_nlp_set(nlp_solver, i, "xdot_guess", buffer);
-        {%- elif solver_options.integrator_type == "GNSF" %}
-            ocp_nlp_set(nlp_solver, i, "gnsf_phi_guess", buffer);
-        {%- endif %}
+        nlp_config->dynamics[i]->reset(nlp_config->dynamics[i], nlp_dims->dynamics[i], nlp_in->dynamics[i], nlp_opts->dynamics[i], nlp_mem->dynamics[i], nlp_work->dynamics[i]);
     }
 
     {%- if solver_options.qp_solver == 'PARTIAL_CONDENSING_HPIPM' %}
@@ -3073,17 +3065,17 @@ int {{ model.name }}_acados_reset({{ model.name }}_solver_capsule* capsule, int 
     if (reset_x_to_x0_bar)
     {
         {%- if constraints.has_x0 -%}
+        double* buffer = calloc(NX, sizeof(double));
         ocp_nlp_constraints_model_get(nlp_config, nlp_dims, nlp_in, 0, "lbx", buffer);
         for (int i=0; i<N+1; i++)
         {
             ocp_nlp_out_set(nlp_config, nlp_dims, nlp_out, nlp_in, i, "x", buffer);
         }
+        free(buffer);
         {%- else %}
         // no x0 constraint, cannot reset x to x0_bar
         {%- endif %}
     }
-
-    free(buffer);
     return 0;
 }
 

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -3018,7 +3018,6 @@ int {{ model.name }}_acados_update_qp_solver_cond_N({{ model.name }}_solver_caps
 
 int {{ model.name }}_acados_reset({{ model.name }}_solver_capsule* capsule, int reset_qp_solver_mem, int reset_numerical_values, int reset_solver_options, int reset_x_to_x0_bar)
 {
-    // TODO this function should be moved to acados_c_interface
     // set initialization to all zeros
     const int N = capsule->nlp_solver_plan->N;
     ocp_nlp_config* nlp_config = capsule->nlp_config;

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -3031,10 +3031,7 @@ int {{ model.name }}_acados_reset({{ model.name }}_solver_capsule* capsule, int 
     ocp_nlp_out_set_values_to_zero(nlp_config, nlp_dims, nlp_out);
 
     // reset integrator memory
-    for (int i=0; i<N; i++)
-    {
-        nlp_config->dynamics[i]->reset(nlp_config->dynamics[i], nlp_dims->dynamics[i], nlp_in->dynamics[i], nlp_opts->dynamics[i], nlp_mem->dynamics[i], nlp_work->dynamics[i]);
-    }
+    ocp_nlp_solver_reset_integrator_memory(nlp_solver, nlp_in, nlp_out);
 
     {%- if solver_options.qp_solver == 'PARTIAL_CONDENSING_HPIPM' %}
     // get qp_status: if NaN -> reset memory


### PR DESCRIPTION
This PR add the function `ocp_nlp_solver_reset_integrator_memory` to the acados c interface. It is called within the templated solver reset to reset the integrator memory.