### PR TITLE
S-functions: allocate buffer dynamically

### DIFF
--- a/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_sim_solver_sfun.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_sim_solver_sfun.in.c
@@ -49,7 +49,7 @@
 
 typedef struct {
     {{ model.name }}_sim_solver_capsule *capsule;
-    real_t* buffer;
+    double* buffer;
 } AcadosSimData;
 
 
@@ -145,7 +145,7 @@ static void mdlStart(SimStruct *S)
     // local buffer
     {% set input_sizes = [dims.nx, dims.nu, dims.np] %}
     {%- set buffer_size =  input_sizes | sort | last %}
-    sim_data->buffer = malloc({{ buffer_size}} * sizeof(real_t));
+    sim_data->buffer = malloc({{ buffer_size}} * sizeof(double));
 
     ssSetUserData(S, (void*) sim_data);
 }
@@ -154,7 +154,7 @@ static void mdlOutputs(SimStruct *S, int_T tid)
 {
     AcadosSimData *sim_data = ssGetUserData(S);
     {{ model.name }}_sim_solver_capsule *capsule = sim_data->capsule;
-    real_t* buffer = sim_data->buffer;
+    double* buffer = sim_data->buffer;
 
     sim_config *acados_sim_config = {{ model.name }}_acados_get_sim_config(capsule);
     sim_in *acados_sim_in = {{ model.name }}_acados_get_sim_in(capsule);
@@ -211,7 +211,7 @@ static void mdlOutputs(SimStruct *S, int_T tid)
 
 
     /* set outputs */
-    real_t *out_x = ssGetOutputPortRealSignal(S, 0);
+    double *out_x = ssGetOutputPortRealSignal(S, 0);
 
     // get simulated state
     sim_out_get(acados_sim_config, acados_sim_dims, acados_sim_out,
@@ -228,7 +228,7 @@ static void mdlTerminate(SimStruct *S)
 {
     AcadosSimData *sim_data = ssGetUserData(S);
     {{ model.name }}_sim_solver_capsule *capsule = sim_data->capsule;
-    real_t* buffer = sim_data->buffer;
+    double* buffer = sim_data->buffer;
 
     {{ model.name }}_acados_sim_free(capsule);
     {{ model.name }}_acados_sim_solver_free_capsule(capsule);

--- a/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_sim_solver_sfun.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_sim_solver_sfun.in.c
@@ -47,6 +47,12 @@
 #define SAMPLINGTIME {{ solver_options.Tsim }}
 
 
+typedef struct {
+    {{ model.name }}_sim_solver_capsule *capsule;
+    real_t* buffer;
+} AcadosSimData;
+
+
 static void mdlInitializeSizes (SimStruct *S)
 {
     // specify the number of continuous and discrete states
@@ -130,15 +136,25 @@ static void mdlInitializeSampleTimes(SimStruct *S)
 
 static void mdlStart(SimStruct *S)
 {
-    {{ model.name }}_sim_solver_capsule *capsule = {{ model.name }}_acados_sim_solver_create_capsule();
-    {{ model.name }}_acados_sim_create(capsule);
+    AcadosSimData *sim_data = malloc(sizeof(*sim_data));
 
-    ssSetUserData(S, (void*)capsule);
+    // capsule
+    sim_data->capsule = {{ model.name }}_acados_sim_solver_create_capsule();
+    {{ model.name }}_acados_sim_create(sim_data->capsule);
+
+    // local buffer
+    {% set input_sizes = [dims.nx, dims.nu, dims.np] %}
+    {%- set buffer_size =  input_sizes | sort | last %}
+    sim_data->buffer = malloc({{ buffer_size}} * sizeof(real_t));
+
+    ssSetUserData(S, (void*) sim_data);
 }
 
 static void mdlOutputs(SimStruct *S, int_T tid)
 {
-    {{ model.name }}_sim_solver_capsule *capsule = ssGetUserData(S);
+    AcadosSimData *sim_data = ssGetUserData(S);
+    {{ model.name }}_sim_solver_capsule *capsule = sim_data->capsule;
+    real_t* buffer = sim_data->buffer;
 
     sim_config *acados_sim_config = {{ model.name }}_acados_get_sim_config(capsule);
     sim_in *acados_sim_in = {{ model.name }}_acados_get_sim_in(capsule);
@@ -148,12 +164,6 @@ static void mdlOutputs(SimStruct *S, int_T tid)
     // sim_solver * {{ model.name }}_acados_get_sim_solver(capsule);
 
     InputRealPtrsType in_sign;
-    {% set input_sizes = [dims.nx, dims.nu, dims.np] %}
-
-    // local buffer
-    {%- set buffer_size =  input_sizes | sort | last %}
-    real_t buffer[{{ buffer_size }}];
-
 
     /* go through inputs */
     {%- set i_input = 0 %}
@@ -216,10 +226,14 @@ static void mdlOutputs(SimStruct *S, int_T tid)
 
 static void mdlTerminate(SimStruct *S)
 {
-    {{ model.name }}_sim_solver_capsule *capsule = ssGetUserData(S);
+    AcadosSimData *sim_data = ssGetUserData(S);
+    {{ model.name }}_sim_solver_capsule *capsule = sim_data->capsule;
+    real_t* buffer = sim_data->buffer;
 
     {{ model.name }}_acados_sim_free(capsule);
     {{ model.name }}_acados_sim_solver_free_capsule(capsule);
+    free(buffer);
+    free(sim_data);
 }
 
 

--- a/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_solver_sfun.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_solver_sfun.in.c
@@ -147,6 +147,11 @@
   {%- set ns_max = ns_values | sort | last %}
 {%- endif %}
 
+typedef struct {
+    {{ name }}_solver_capsule *capsule;
+    real_t* buffer;
+} AcadosOcpData;
+
 
 static void mdlInitializeSizes (SimStruct *S)
 {
@@ -779,26 +784,13 @@ static void mdlInitializeSampleTimes(SimStruct *S)
 
 static void mdlStart(SimStruct *S)
 {
-    {{ name }}_solver_capsule *capsule = {{ name }}_acados_create_capsule();
-    {{ name }}_acados_create(capsule);
+    AcadosOcpData *ocp_data = malloc(sizeof(*ocp_data));
 
-    ssSetUserData(S, (void*)capsule);
-}
+    // capsule
+    ocp_data->capsule = {{ name }}_acados_create_capsule();
+    {{ name }}_acados_create(ocp_data->capsule);
 
-
-static void mdlOutputs(SimStruct *S, int_T tid)
-{
-    {{ name }}_solver_capsule *capsule = ssGetUserData(S);
-    ocp_nlp_config *nlp_config = {{ name }}_acados_get_nlp_config(capsule);
-    ocp_nlp_dims *nlp_dims = {{ name }}_acados_get_nlp_dims(capsule);
-    ocp_nlp_in *nlp_in = {{ name }}_acados_get_nlp_in(capsule);
-    ocp_nlp_out *nlp_out = {{ name }}_acados_get_nlp_out(capsule);
-    ocp_nlp_solver *nlp_solver = {{ name }}_acados_get_nlp_solver(capsule);
-
-    InputRealPtrsType in_sign;
-
-    int N = {{ solver_options.N_horizon }};
-
+    // buffer
     {%- set buffer_sizes = [nx_total, nu_total, dims_0.nbx_0, np_total, dims_0.nbx, dims_e.nbx_e, dims_0.nbu, dims_0.ng, dims_0.nh, dims_0.nh_0, dims_e.ng_e, dims_e.nh_e, ns_total] -%}
 
   {%- if dims_0.ny_0 > 0 and simulink_opts.inputs.y_ref_0 %}  {# y_ref_0 #}
@@ -830,7 +822,29 @@ static void mdlOutputs(SimStruct *S, int_T tid)
 
     // local buffer
     {%- set buffer_size = buffer_sizes | sort | last %}
-    double buffer[{{ buffer_size }}];
+
+    ocp_data->buffer = malloc({{ buffer_size}} * sizeof(real_t));
+
+    ssSetUserData(S, (void*)ocp_data);
+}
+
+
+static void mdlOutputs(SimStruct *S, int_T tid)
+{
+    AcadosOcpData *ocp_data = ssGetUserData(S);
+    {{ name }}_solver_capsule *capsule = ocp_data->capsule;
+    real_t* buffer = ocp_data->buffer;
+
+    ocp_nlp_config *nlp_config = {{ name }}_acados_get_nlp_config(capsule);
+    ocp_nlp_dims *nlp_dims = {{ name }}_acados_get_nlp_dims(capsule);
+    ocp_nlp_in *nlp_in = {{ name }}_acados_get_nlp_in(capsule);
+    ocp_nlp_out *nlp_out = {{ name }}_acados_get_nlp_out(capsule);
+    ocp_nlp_solver *nlp_solver = {{ name }}_acados_get_nlp_solver(capsule);
+
+    InputRealPtrsType in_sign;
+
+    int N = {{ solver_options.N_horizon }};
+
     double tmp_double;
     int tmp_offset, tmp_int;
     {#- NOTE: buffer is necessary as ssGetInputPortRealSignalPtrs does not return double pointer #}
@@ -1548,10 +1562,14 @@ static void mdlOutputs(SimStruct *S, int_T tid)
 
 static void mdlTerminate(SimStruct *S)
 {
-    {{ name }}_solver_capsule *capsule = ssGetUserData(S);
+    AcadosOcpData *ocp_data = ssGetUserData(S);
+    {{ name }}_solver_capsule *capsule = ocp_data->capsule;
+    real_t* buffer = ocp_data->buffer;
 
     {{ name }}_acados_free(capsule);
     {{ name }}_acados_free_capsule(capsule);
+    free(buffer);
+    free(ocp_data);
 }
 
 

--- a/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_solver_sfun.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_solver_sfun.in.c
@@ -149,7 +149,7 @@
 
 typedef struct {
     {{ name }}_solver_capsule *capsule;
-    real_t* buffer;
+    double* buffer;
 } AcadosOcpData;
 
 
@@ -823,7 +823,7 @@ static void mdlStart(SimStruct *S)
     // local buffer
     {%- set buffer_size = buffer_sizes | sort | last %}
 
-    ocp_data->buffer = malloc({{ buffer_size}} * sizeof(real_t));
+    ocp_data->buffer = malloc({{ buffer_size}} * sizeof(double));
 
     ssSetUserData(S, (void*)ocp_data);
 }
@@ -833,7 +833,7 @@ static void mdlOutputs(SimStruct *S, int_T tid)
 {
     AcadosOcpData *ocp_data = ssGetUserData(S);
     {{ name }}_solver_capsule *capsule = ocp_data->capsule;
-    real_t* buffer = ocp_data->buffer;
+    double* buffer = ocp_data->buffer;
 
     ocp_nlp_config *nlp_config = {{ name }}_acados_get_nlp_config(capsule);
     ocp_nlp_dims *nlp_dims = {{ name }}_acados_get_nlp_dims(capsule);
@@ -1564,7 +1564,7 @@ static void mdlTerminate(SimStruct *S)
 {
     AcadosOcpData *ocp_data = ssGetUserData(S);
     {{ name }}_solver_capsule *capsule = ocp_data->capsule;
-    real_t* buffer = ocp_data->buffer;
+    double* buffer = ocp_data->buffer;
 
     {{ name }}_acados_free(capsule);
     {{ name }}_acados_free_capsule(capsule);

--- a/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_solver_sfun.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/matlab_templates/acados_solver_sfun.in.c
@@ -41,7 +41,6 @@
 // example specific
 #include "acados_solver_{{ name }}.h"
 
-
 {%- if not solver_options.custom_update_filename %}
     {%- set custom_update_filename = "" %}
 {% else %}


### PR DESCRIPTION
In S-functions, move buffer and data to separate struct to enable buffer allocation on heap.