### PR TITLE
Fix include paths in MATLAB sim_compile_interface

### DIFF
--- a/interfaces/acados_matlab_octave/sim_compile_interface.m
+++ b/interfaces/acados_matlab_octave/sim_compile_interface.m
@@ -37,8 +37,11 @@ function sim_compile_interface(output_dir)
 
     % set paths
     acados_mex_folder = fullfile(acados_folder, 'interfaces', 'acados_matlab_octave');
-    acados_include = ['-I' acados_folder];
+    acados_include = ['-I' fullfile(acados_folder, 'include')];
     acados_interfaces_include = ['-I' fullfile(acados_folder, 'interfaces')];
+    external_include = ['-I' fullfile(acados_folder, 'external')];
+    blasfeo_include = ['-I' fullfile(acados_folder, 'include', 'blasfeo', 'include')];
+    hpipm_include = ['-I' fullfile(acados_folder, 'include', 'hpipm', 'include')];
     acados_lib_path = ['-L' fullfile(acados_folder, 'lib')];
 
     mex_names = { ...
@@ -78,11 +81,11 @@ function sim_compile_interface(output_dir)
         disp(['compiling ', mex_files{ii}])
         if is_octave()
     %        mkoctfile -p CFLAGS
-            mex(acados_include, acados_interfaces_include, acados_lib_path,...
+            mex(acados_include, acados_interfaces_include, external_include, blasfeo_include, hpipm_include, acados_lib_path,...
                 '-lacados', '-lhpipm', '-lblasfeo', mex_files{ii})
         else
             FLAGS = 'CFLAGS=$CFLAGS -std=c99';
-            mex(mex_flags, FLAGS, acados_include, acados_interfaces_include, acados_lib_path, ...
+            mex(mex_flags, FLAGS, acados_include, acados_interfaces_include, external_include, blasfeo_include, hpipm_include, acados_lib_path, ...
                 '-lacados', '-lhpipm', '-lblasfeo', mex_files{ii}, '-outdir', output_dir)
         end
     end


### PR DESCRIPTION
### Why

Building an `AcadosSimSolver` from the MATLAB interface can fail while compiling the sim MEX interface with

```
fatal error: 'acados/sim/sim_common.h' file not found
```

on some systems, while `AcadosOcpSolver` builds fine on the same install. The cause is that `sim_compile_interface.m` points the compiler at `-I<acados_dir>` instead of `-I<acados_dir>/include`, and does not pass the `external` / `blasfeo` / `hpipm` include directories that `sim_common.h` pulls in transitively. The sibling `ocp_compile_interface.m` already uses the correct include paths — it looks like `sim_compile_interface.m` was simply not updated in parallel.

Resolves #1867. As @FreyJo noted in the issue, this does not reproduce on every system (CI and the maintainer's machine are unaffected), but the include paths here are objectively inconsistent with the working OCP interface, so aligning them is harmless where it already works and fixes the build where it does not.

### Change

Minimal, mirrors `ocp_compile_interface.m`:

```diff
-    acados_include = ['-I' acados_folder];
+    acados_include = ['-I' fullfile(acados_folder, 'include')];
     acados_interfaces_include = ['-I' fullfile(acados_folder, 'interfaces')];
+    external_include = ['-I' fullfile(acados_folder, 'external')];
+    blasfeo_include = ['-I' fullfile(acados_folder, 'include', 'blasfeo', 'include')];
+    hpipm_include = ['-I' fullfile(acados_folder, 'include', 'hpipm', 'include')];
     acados_lib_path = ['-L' fullfile(acados_folder, 'lib')];
```

and the three new include dirs are added to both `mex(...)` invocations (Octave and MATLAB branches).

### Testing

Verified on macOS (Apple Silicon, MATLAB R2026a): before the change `AcadosSimSolver` fails to compile as above; after it, `sim_solve.c` / `sim_get.c` compile and the solver builds and runs end-to-end (IRK integrator on a pendulum-on-cart model). No other files needed changes.

This is a build-script include-path fix, not readily covered by a new unit test; the existing MATLAB/Octave sim examples already exercise the interface on CI.
