### PR TITLE
Interfaces: warn in `verify_weighting_matrices` instead of error

### DIFF
--- a/examples/acados_matlab_octave/test/test_conl_cost.m
+++ b/examples/acados_matlab_octave/test/test_conl_cost.m
@@ -105,7 +105,7 @@ for i = 1:2
         ocp.model.cost_psi_expr_e = 0.5 * r_e' * W_e * r_e;
     else
         % NONLINEAR_LS cost setup (equivalent to CONVEX_OVER_NONLINEAR with quadratic psi)
-        ocp.cost.W = W;
+        ocp.cost.W = -W; % just to test that we dont fail if a negative definite matrix is set
         ocp.cost.W_e = W_e;
     end
 
@@ -124,6 +124,14 @@ for i = 1:2
 
     % Create solver and solve
     solver = AcadosOcpSolver(ocp);
+
+    if strcmp(cost_type, 'NONLINEAR_LS')
+
+        % set weighting matrix to positive definite value
+        for n = 0:N-1
+            solver.set('cost_W', W, n);
+        end
+    end
     solver.solve();
     status = solver.get('status');
 

--- a/interfaces/acados_matlab_octave/verify_weighting_matrix.m
+++ b/interfaces/acados_matlab_octave/verify_weighting_matrix.m
@@ -47,18 +47,23 @@ function [] = verify_weighting_matrix(A, name, tol)
         error('Matrix %s is not square.', name);
     end
     if norm(A - A.', inf) > tol
-        error('Matrix %s is not symmetric.', name);
-    end
-
-    if isequal(A, diag(diag(A)))
-        if any(diag(A) < 0)
-            error('Diagonal weighting matrix %s is not positive semidefinite.', name);
-        end
+        warning('Matrix %s is not symmetric.', name);
     else
-        E = eig(A);
-        result = all(E > tol);
-        if ~result
-            error('Matrix %s is not positive definite. Eigenvalues: %s', name, mat2str(E));
+        if isequal(A, diag(diag(A)))
+            if any(diag(A) < 0)
+                warning('Diagonal weighting matrix %s is not positive semidefinite.', name);
+            end
+        else
+            try
+                E = eig(A);
+                result = all(E > tol);
+            catch
+                warning('Eigenvalue decomposition of %s failed, matrix might not be positive definite.', name)
+                result = true;
+            end
+            if ~result
+                warning('Matrix %s is not positive definite. Eigenvalues: %s', name, mat2str(E));
+            end
         end
     end
 end

--- a/interfaces/acados_template/acados_template/utils.py
+++ b/interfaces/acados_template/acados_template/utils.py
@@ -779,13 +779,16 @@ def verify_weighting_matrix(A, name, tol=1e-10):
     if A.shape[0] != A.shape[1]:
         raise ValueError(f"Weighting matrix {name} is not square.")
     if not np.allclose(A, A.T, atol=tol):
-        raise ValueError(f"Weighting matrix {name} is not symmetric.")
-
-    # check whether A is diagonal
-    if np.all(np.abs(A - np.diag(np.diag(A))) < tol):
-        if np.any(np.diag(A) < 0):
-            raise ValueError(f"Diagonal weighting matrix {name} is not positive semi-definite.")
+        raise warnings.warn(f"Weighting matrix {name} is not symmetric.")
     else:
-        E = np.linalg.eigvalsh(A)
-        if not np.all(E > tol):
-            raise ValueError(f"Weighting matrix {name} is not positive definite.")
+        # check whether A is diagonal
+        if np.all(np.abs(A - np.diag(np.diag(A))) < tol):
+            if np.any(np.diag(A) < 0):
+                raise warnings.warn(f"Diagonal weighting matrix {name} is not positive semi-definite.")
+        else:
+            try:
+                E = np.linalg.eigvalsh(A)
+            except:
+                raise warnings.warn(f"Eigenvalue decomposition of weighting matrix {name} failed, the matrix might not be positive definite.")
+            if not np.all(E > tol):
+                raise warnings.warn(f"Weighting matrix {name} is not positive definite.")


### PR DESCRIPTION
This allows expert users to set default values that are not positive semidefinite without getting errors in `make_consistent`