### PR TITLE
Support timeout for SQP_WITH_FEASIBLE_QP

### DIFF
--- a/acados/ocp_nlp/ocp_nlp_sqp_with_feasible_qp.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp_with_feasible_qp.c
@@ -109,6 +109,8 @@ void ocp_nlp_sqp_wfqp_opts_initialize_default(void *config_, void *dims_, void *
 
     // SQP opts
     opts->nlp_opts->max_iter = 20;
+    opts->timeout_heuristic = ZERO;
+    opts->timeout_max_time = 0; // corresponds to no timeout
 
     opts->nlp_opts->eval_residual_at_max_iter = true;
     opts->use_QP_l1_inf_from_slacks = false; // if manual calculation used, results seem more accurate and solver performs better!
@@ -169,7 +171,17 @@ void ocp_nlp_sqp_wfqp_opts_set(void *config_, void *opts_, const char *field, vo
     }
     else // nlp opts
     {
-        if (!strcmp(field, "use_constraint_hessian_in_feas_qp"))
+        if (!strcmp(field, "timeout_max_time"))
+        {
+            double* timeout_max_time = (double *) value;
+            opts->timeout_max_time = *timeout_max_time;
+        }
+        else if (!strcmp(field, "timeout_heuristic"))
+        {
+            ocp_nlp_timeout_heuristic_t* timeout_heuristic = (ocp_nlp_timeout_heuristic_t *) value;
+            opts->timeout_heuristic = *timeout_heuristic;
+        }
+        else if (!strcmp(field, "use_constraint_hessian_in_feas_qp"))
         {
             bool* use_constraint_hessian_in_feas_qp = (bool *) value;
             opts->use_constraint_hessian_in_feas_qp = *use_constraint_hessian_in_feas_qp;
@@ -417,6 +429,7 @@ void *ocp_nlp_sqp_wfqp_memory_assign(void *config_, void *dims_, void *opts_, vo
     }
 
     mem->nlp_mem->status = ACADOS_READY;
+    mem->timeout_estimated_per_iteration_time = 0;
     assign_and_advance_char(MAX_STR_LEN, &mem->search_direction_type, &c_ptr);
 
     // blasfeo_mem align
@@ -590,6 +603,15 @@ static bool check_termination(int n_iter, ocp_nlp_dims *dims, ocp_nlp_res *nlp_r
         return true;
     }
 
+    // Check timeout
+    if (opts->timeout_max_time > 0)
+    {
+        if (opts->timeout_max_time <= mem->nlp_mem->nlp_timings->time_tot + mem->timeout_estimated_per_iteration_time)
+        {
+            mem->nlp_mem->status = ACADOS_TIMEOUT;
+            return true;
+        }
+    }
     return false;
 }
 
@@ -1567,6 +1589,9 @@ int ocp_nlp_sqp_wfqp(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
     mem->l1_infeasibility = -1.0; // default, cannot be negative
     nlp_opts->ext_qp_res = 0; // logging not supported yet.
 
+    if (opts->timeout_heuristic != MAX_OVERALL)
+        mem->timeout_estimated_per_iteration_time = 0;
+
 #if defined(ACADOS_WITH_OPENMP)
     // backup number of threads
     int num_threads_bkp = omp_get_num_threads();
@@ -1585,6 +1610,9 @@ int ocp_nlp_sqp_wfqp(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
     nlp_mem->iter = 0;
     double prev_levenberg_marquardt = 0.0;
     int search_direction_status = 0;
+
+    double timeout_previous_time_tot = 0.;
+    double timeout_time_prev_iter = 0.;
 
     if (nlp_opts->print_level > 1)
     {
@@ -1651,6 +1679,46 @@ int ocp_nlp_sqp_wfqp(void *config_, void *dims_, void *nlp_in_, void *nlp_out_,
             print_iteration(nlp_mem->iter, config, nlp_res, mem, nlp_opts, prev_levenberg_marquardt, qp_status, qp_iter);
         }
         prev_levenberg_marquardt = nlp_opts->levenberg_marquardt;
+
+        // update timeout memory based on chosen heuristic
+        if (opts->timeout_max_time > 0.)
+        {
+            nlp_timings->time_tot = acados_toc(&timer_tot);
+
+            if (nlp_mem->iter > 0)
+            {
+                timeout_time_prev_iter = nlp_timings->time_tot - timeout_previous_time_tot;
+
+                switch (opts->timeout_heuristic)
+                {
+                    case LAST:
+                        mem->timeout_estimated_per_iteration_time = timeout_time_prev_iter;
+                        break;
+                    case MAX_CALL:
+                    case MAX_OVERALL:
+                        mem->timeout_estimated_per_iteration_time = timeout_time_prev_iter > mem->timeout_estimated_per_iteration_time ? timeout_time_prev_iter : mem->timeout_estimated_per_iteration_time;
+                        break;
+                    case AVERAGE:
+                        if (nlp_mem->iter == 0)
+                        {
+                            mem->timeout_estimated_per_iteration_time = timeout_time_prev_iter;
+                        }
+                        else
+                        {
+                            // TODO make weighting a parameter?
+                            mem->timeout_estimated_per_iteration_time = 0.5*timeout_time_prev_iter + 0.5*mem->timeout_estimated_per_iteration_time;
+                        }
+                        break;
+                    case ZERO: // predicted per iteration time is zero as initialized
+                        break;
+                    default:
+                        printf("Unknown timeout heuristic.\n");
+                        exit(1);
+                }
+            }
+
+            timeout_previous_time_tot = nlp_timings->time_tot;
+        }
 
         /* Termination */
         if (check_termination(nlp_mem->iter, dims, nlp_res, mem, opts))

--- a/acados/ocp_nlp/ocp_nlp_sqp_with_feasible_qp.h
+++ b/acados/ocp_nlp/ocp_nlp_sqp_with_feasible_qp.h
@@ -54,6 +54,8 @@ extern "C" {
 typedef struct
 {
     ocp_nlp_opts *nlp_opts;
+    double timeout_max_time; // maximum time the solve may require before timeout is triggered. No timeout if 0.
+    ocp_nlp_timeout_heuristic_t timeout_heuristic; // type of heuristic used to predict solve time of next QP
     bool log_pi_norm_inf; // compute and log the max norm of the pi multipliers
     bool log_lam_norm_inf; // compute and log the max norm of the lam multipliers
     bool use_constraint_hessian_in_feas_qp; // Either use exact Hessian or identity matrix in feasibility QP
@@ -101,6 +103,7 @@ typedef struct
     int stat_n;
 
     double step_norm;
+    double timeout_estimated_per_iteration_time;
     double norm_inf_pi;
     double norm_inf_lam;
 

--- a/examples/acados_python/linear_mass_model/sqp_wfqp_test.py
+++ b/examples/acados_python/linear_mass_model/sqp_wfqp_test.py
@@ -101,7 +101,8 @@ def feasible_qp_index_test(soften_obstacle, soften_terminal, soften_controls, N,
             # We slack the obstacle constraint and the terminal constraints
             assert np.allclose(idxs, np.arange(dims.nh_e + dims.nbx_e)), f"i=N+1: Everything should be slacked"
 
-def create_solver_opts(N=4, Tf=2, nlp_solver_type = 'SQP_WITH_FEASIBLE_QP', allow_switching_modes=True):
+def create_solver_opts(N=4, Tf=2, nlp_solver_type = 'SQP_WITH_FEASIBLE_QP', allow_switching_modes=True,
+                       timeout_max_time=0.0):
 
     solver_options = AcadosOcpOptions()
 
@@ -122,6 +123,7 @@ def create_solver_opts(N=4, Tf=2, nlp_solver_type = 'SQP_WITH_FEASIBLE_QP', allo
     solver_options.print_level = 1
     solver_options.nlp_solver_max_iter = 20
     solver_options.use_constraint_hessian_in_feas_qp = False
+    solver_options.timeout_max_time = timeout_max_time
 
     if not allow_switching_modes:
         solver_options.search_direction_mode = 'BYRD_OMOJOKUN'
@@ -134,7 +136,7 @@ def create_solver_opts(N=4, Tf=2, nlp_solver_type = 'SQP_WITH_FEASIBLE_QP', allo
 
 def create_solver(solver_name: str, soften_obstacle: bool, soften_terminal: bool,
                   soften_controls: bool, nlp_solver_type: str = 'SQP_WITH_FEASIBLE_QP',
-                  allow_switching_modes: bool = True):
+                  allow_switching_modes: bool = True, timeout_max_time: float = 0.0):
 
     # create ocp object to formulate the OCP
     ocp = AcadosOcp()
@@ -235,7 +237,8 @@ def create_solver(solver_name: str, soften_obstacle: bool, soften_terminal: bool
         ocp.cost.Zu_e = np.concatenate((ocp.cost.Zu_e, Zh))
 
     # load options
-    ocp.solver_options = create_solver_opts(N, Tf, nlp_solver_type, allow_switching_modes)
+    ocp.solver_options = create_solver_opts(N, Tf, nlp_solver_type, allow_switching_modes,
+                                            timeout_max_time)
 
     # create ocp solver
     ocp_solver = AcadosOcpSolver(ocp, json_file=f'{model.name}_{solver_name}_ocp.json', verbose=False)
@@ -305,6 +308,14 @@ def test_same_behavior_sqp_and_sqp_wfqp():
 
     print(f"\n\n----------------------\n")
 
+def test_timeout():
+    _, ocp_solver = create_solver("timeout", True, False, True, timeout_max_time=1e-12)
+    status = ocp_solver.solve()
+
+    assert status == 7, f"Expected ACADOS_TIMEOUT, got status {status}."
+
+    print(f"\n\n----------------------\n")
+
 def sqp_wfqp_test_same_matrices():
     # # SETTINGS:
     soften_controls = False
@@ -356,4 +367,5 @@ def main_test():
 if __name__ == '__main__':
     main_test()
     test_same_behavior_sqp_and_sqp_wfqp()
+    test_timeout()
     sqp_wfqp_test_same_matrices()

--- a/interfaces/acados_template/acados_template/acados_ocp_options.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_options.py
@@ -1426,7 +1426,7 @@ class AcadosOcpOptions:
         ``current_time_tot + predicted_per_iteration_time > timeout_max_time``
         is satisfied at the end of an SQP iteration.
         The value of ``predicted_per_iteration_time`` is estimated using ``timeout_heuristic``.
-        Currently implemented for SQP only.
+        Currently implemented for SQP and SQP_WITH_FEASIBLE_QP.
         Default: 0.
         """
         return self.__timeout_max_time
@@ -1461,7 +1461,7 @@ class AcadosOcpOptions:
         LAST: Use the time required by the last iteration as estimate.
         AVERAGE: Use an exponential moving average of the previous per iteration times as estimate (weight is currently fixed at 0.5).
         ZERO: Use 0 as estimate.
-        Currently implemented for SQP only.
+        Currently implemented for SQP and SQP_WITH_FEASIBLE_QP.
         Default: ZERO.
         """
         return self.__timeout_heuristic

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_multi_solver.in.c
@@ -2644,7 +2644,7 @@ ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "allow_direction_mode_switch_to_no
     double nlp_qp_tol_min_comp = {{ solver_options.nlp_qp_tol_min_comp }};
     ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "nlp_qp_tol_min_comp", &nlp_qp_tol_min_comp);
 
-{%- if solver_options.nlp_solver_type == "SQP" and solver_options.timeout_max_time > 0 %}
+{%- if solver_options.nlp_solver_type in ["SQP", "SQP_WITH_FEASIBLE_QP"] and solver_options.timeout_max_time > 0 %}
     double timeout_max_time = {{ solver_options.timeout_max_time }};
     ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "timeout_max_time", &timeout_max_time);
 

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -2861,7 +2861,7 @@ static void {{ model.name }}_acados_create_set_opts({{ model.name }}_solver_caps
     double nlp_qp_tol_min_comp = {{ solver_options.nlp_qp_tol_min_comp }};
     ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "nlp_qp_tol_min_comp", &nlp_qp_tol_min_comp);
 
-{%- if solver_options.nlp_solver_type == "SQP" and solver_options.timeout_max_time > 0 %}
+{%- if solver_options.nlp_solver_type in ["SQP", "SQP_WITH_FEASIBLE_QP"] and solver_options.timeout_max_time > 0 %}
     double timeout_max_time = {{ solver_options.timeout_max_time }};
     ocp_nlp_solver_opts_set(nlp_config, nlp_opts, "timeout_max_time", &timeout_max_time);
 


### PR DESCRIPTION
First of all: Thank you for developing and maintaining acados! We use it in our open-source [trajectory optimizer for automated driving](https://github.com/openads-project/trajectory_optimization) and greatly appreciate its performance and flexibility.

To better manage the available computation time, this PR extends the existing `timeout_max_time` and `timeout_heuristic` options to `SQP_WITH_FEASIBLE_QP`.

The implementation mirrors the existing SQP timeout behavior:

- adds the timeout options and timing state to the solver
- evaluates the timeout between outer SQP iterations
- returns `ACADOS_TIMEOUT` when the time limit is reached
- enables the options in the single- and multi-solver templates
- updates the Python documentation
- adds a regression test to the existing CI-covered SQP-WFQP test

### Testing

- `make -j2 static_library`
- `make -j2 shared_library`
- `python examples/acados_python/linear_mass_model/sqp_wfqp_test.py`
- `git diff --check`