### PR TITLE
`AcadosSimBatchSolver`: refactor specification of number of threads and batches to match `AcadosOcpBatchSolver`

### DIFF
--- a/.github/workflows/full_build.yml
+++ b/.github/workflows/full_build.yml
@@ -671,7 +671,7 @@ jobs:
         cd ${{ github.workspace }}/examples/acados_python/chain_mass/
         python solution_sensitivity_example.py
 
-    - name: Python Furuta pendulum timeout test
+    - name: Python Furuta pendulum timeout test, minimal batch examples
       if: always()
       working-directory: ${{ github.workspace }}/build
       shell: bash
@@ -680,6 +680,11 @@ jobs:
         cd ${{ github.workspace }}/examples/acados_python/furuta_pendulum
         python main_closed_loop.py
         python anderson_convergence_experiment.py
+        cd ${{ github.workspace }}/examples/acados_python/pendulum_on_cart/ocp
+        python minimal_example_batch_ocp_solver.py
+        cd ${{ github.workspace }}/examples/acados_python/pendulum_on_cart/sim
+        python minimal_example_batch_sim_solver.py
+
 
     - name: Python evaluator test
       if: always()

--- a/interfaces/acados_template/acados_template/acados_sim.py
+++ b/interfaces/acados_template/acados_template/acados_sim.py
@@ -86,10 +86,6 @@ class AcadosSimOptions:
         self.__sens_forw_p = False
 
 
-        # TODO: check whether this is still needed? has no setter/getter
-        self.__num_threads_in_batch_solve: int = 1
-
-
     @property
     def integrator_type(self):
         """Integrator type. Default: 'ERK'."""

--- a/interfaces/acados_template/acados_template/acados_sim_batch_solver.py
+++ b/interfaces/acados_template/acados_template/acados_sim_batch_solver.py
@@ -30,7 +30,7 @@
 
 from .acados_sim_solver import AcadosSimSolver
 from .acados_sim import AcadosSim
-from typing import List, Union
+from typing import List
 from ctypes import (POINTER, c_int, c_void_p)
 import warnings
 
@@ -41,6 +41,7 @@ class AcadosSimBatchSolver():
 
         :param sim: type :py:class:`~acados_template.acados_sim.AcadosSim`
         :param N_batch: batch size, positive integer
+        :param num_threads_in_batch_solve: number of threads used for parallelizing the batch methods. Default: 1
         :param json_file: Default: 'acados_sim.json'
         :param build: Flag indicating whether solver should be (re)compiled. If False an attempt is made to load an already compiled shared library for the solver. Default: True
         :param generate: Flag indicating whether problem functions should be code generated. Default: True
@@ -49,13 +50,10 @@ class AcadosSimBatchSolver():
 
     __sim_solvers : List[AcadosSimSolver]
 
-    def __init__(self, sim: AcadosSim, N_batch: int, num_threads_in_batch_solve: Union[int, None] = None , json_file: str = 'acados_sim.json', build: bool = True, generate: bool = True, verbose: bool=True):
+    def __init__(self, sim: AcadosSim, N_batch: int, num_threads_in_batch_solve: int = 1, json_file: str = 'acados_sim.json', build: bool = True, generate: bool = True, verbose: bool=True):
 
         if not isinstance(N_batch, int) or N_batch <= 0:
             raise ValueError("AcadosSimBatchSolver: argument N_batch should be a positive integer.")
-        if num_threads_in_batch_solve is None:
-            num_threads_in_batch_solve = sim.solver_options.num_threads_in_batch_solve
-            warnings.warn(f"num_threads_in_batch_solve is None. Using value {num_threads_in_batch_solve} set in sim.solver_options instead. In the future, it should be passed explicitly in the AcadosSimBatchSolver constructor.")
         if not isinstance(num_threads_in_batch_solve, int) or num_threads_in_batch_solve <= 0:
             raise ValueError("AcadosSimBatchSolver: argument num_threads_in_batch_solve should be a positive integer.")
         if not sim.solver_options.with_batch_functionality:
@@ -111,4 +109,3 @@ class AcadosSimBatchSolver():
     @num_threads_in_batch_solve.setter
     def num_threads_in_batch_solve(self, num_threads_in_batch_solve):
         self.__num_threads_in_batch_solve = num_threads_in_batch_solve
-

--- a/interfaces/acados_template/acados_template/acados_sim_batch_solver.py
+++ b/interfaces/acados_template/acados_template/acados_sim_batch_solver.py
@@ -40,7 +40,7 @@ class AcadosSimBatchSolver():
     Batch Integrator for parallel integration.
 
         :param sim: type :py:class:`~acados_template.acados_sim.AcadosSim`
-        :param N_batch: batch size, positive integer
+        :param N_batch_init: initial batch size, positive integer
         :param num_threads_in_batch_solve: number of threads used for parallelizing the batch methods. Default: 1
         :param json_file: Default: 'acados_sim.json'
         :param build: Flag indicating whether solver should be (re)compiled. If False an attempt is made to load an already compiled shared library for the solver. Default: True
@@ -50,10 +50,15 @@ class AcadosSimBatchSolver():
 
     __sim_solvers : List[AcadosSimSolver]
 
-    def __init__(self, sim: AcadosSim, N_batch: int, num_threads_in_batch_solve: int = 1, json_file: str = 'acados_sim.json', build: bool = True, generate: bool = True, verbose: bool=True):
+    def __init__(self, sim: AcadosSim,
+                 N_batch_init: int, num_threads_in_batch_solve: int = 1,
+                 json_file: str = 'acados_sim.json',
+                 build: bool = True,
+                 generate: bool = True,
+                 verbose: bool=True):
 
-        if not isinstance(N_batch, int) or N_batch <= 0:
-            raise ValueError("AcadosSimBatchSolver: argument N_batch should be a positive integer.")
+        if not isinstance(N_batch_init, int) or N_batch_init <= 0:
+            raise ValueError("AcadosSimBatchSolver: argument N_batch_init should be a positive integer.")
         if not isinstance(num_threads_in_batch_solve, int) or num_threads_in_batch_solve <= 0:
             raise ValueError("AcadosSimBatchSolver: argument num_threads_in_batch_solve should be a positive integer.")
         if not sim.solver_options.with_batch_functionality:
@@ -61,20 +66,20 @@ class AcadosSimBatchSolver():
             sim.solver_options.with_batch_functionality = True
 
         self.__num_threads_in_batch_solve = num_threads_in_batch_solve
-        self.__N_batch = N_batch
+        self.__n_batch_current = N_batch_init
         self.__sim_solvers = [AcadosSimSolver(sim,
                                               json_file=json_file,
                                               build=n==0 if build else False,
                                               generate=n==0 if generate else False,
                                               verbose=verbose if n==0 else False,
                                               )
-                              for n in range(self.N_batch)]
+                              for n in range(self.n_batch_current)]
 
         self.__shared_lib = self.sim_solvers[0].shared_lib
         self.__model_name = self.sim_solvers[0].model_name
-        self.__sim_solvers_pointer = (c_void_p * self.N_batch)()
+        self.__sim_solvers_pointer = (c_void_p * self.n_batch_current)()
 
-        for i in range(self.N_batch):
+        for i in range(self.n_batch_current):
             self.__sim_solvers_pointer[i] = self.sim_solvers[i].capsule
 
         getattr(self.__shared_lib, f"{self.__model_name}_acados_sim_batch_solve").argtypes = [POINTER(c_void_p), c_int, c_int]
@@ -84,11 +89,19 @@ class AcadosSimBatchSolver():
             warnings.warn("Please compile the acados shared library with openmp and the number of threads set to 1, i.e. with the flags -DACADOS_WITH_OPENMP=ON -DACADOS_NUM_THREADS=1.")
 
 
-    def solve(self):
+    def solve(self, n_batch: int = None) -> None:
         """
-        Solve the simulation problem with current input for all `N_batch` integrators.
+        Solve the simulation problem with current input for the first `n_batch` integrators.
+        Or `n_batch_current` if `n_batch` is None.
         """
-        getattr(self.__shared_lib, f"{self.__model_name}_acados_sim_batch_solve")(self.__sim_solvers_pointer, self.__N_batch, self.__num_threads_in_batch_solve)
+        if n_batch is None:
+            n_batch = self.n_batch_current
+        elif n_batch <= self.n_batch_current:
+            self.__n_batch_current = n_batch
+        else:
+            raise ValueError("You are attempting to solve more problem instances than what have been initialized so far.")
+
+        getattr(self.__shared_lib, f"{self.__model_name}_acados_sim_batch_solve")(self.__sim_solvers_pointer, n_batch, self.__num_threads_in_batch_solve)
 
 
     @property
@@ -97,10 +110,10 @@ class AcadosSimBatchSolver():
         return self.__sim_solvers
 
     @property
-    def N_batch(self):
-        """Batch size."""
-        return self.__N_batch
-    
+    def n_batch_current(self):
+        """The current default batch size which depends on the previous batch method call."""
+        return self.__n_batch_current
+
     @property
     def num_threads_in_batch_solve(self):
         """Number of threads used for parallelizing the batch methods."""

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_sim_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_sim_solver.in.c
@@ -494,7 +494,7 @@ void {{ model.name }}_acados_sim_batch_solve({{ model.name }}_sim_solver_capsule
     int num_threads_bkp;
     if (num_threads_in_batch_solve > 1){
         num_threads_bkp = omp_get_num_threads();
-        omp_set_num_threads({{ solver_options.num_threads_in_batch_solve }});
+        omp_set_num_threads(num_threads_in_batch_solve);
     }
 
     #pragma omp parallel for


### PR DESCRIPTION
- number of threads is specified via `num_threads_in_batch_solve` keyword argument and removed from `AcadosSimOptions`.
- number of batches can be updated on the fly dynamically and is initialized via `N_batch_init`.