### PR TITLE
Add batch set functionality, modify example to vary dimensions easily.

### DIFF
--- a/examples/acados_python/solution_sensitivities_convex_example/batch_adjoint_solution_sensitivity_example.py
+++ b/examples/acados_python/solution_sensitivities_convex_example/batch_adjoint_solution_sensitivity_example.py
@@ -134,7 +134,7 @@ def main_batch(Xinit, simU, param_vals, adjoints_ref, tol, nx: int, nu: int, num
 
     # eval adjoint
     t0 = time.time()
-    sens_adj = batch_solver.eval_adjoint_solution_sensitivity([(1, np.ones((N_batch, ocp.dims.nx, 1)))], [(1, np.ones((N_batch, ocp.dims.nu, 1)))])
+    sens_adj = batch_solver.eval_adjoint_solution_sensitivity([(1, np.ones((N_batch, ocp.dims.nx, 1)))], [(1, np.ones((N_batch, ocp.dims.nu, 1)))], sanity_checks=False)
     t_elapsed = 1e3 * (time.time() - t0)
 
     print(f"main_batch: with {num_threads_in_batch_solve} threads, adjoint solution sens: {t_elapsed:.3f} ms\n")

--- a/examples/acados_python/solution_sensitivities_convex_example/batch_adjoint_solution_sensitivity_example.py
+++ b/examples/acados_python/solution_sensitivities_convex_example/batch_adjoint_solution_sensitivity_example.py
@@ -29,29 +29,32 @@
 #
 
 import numpy as np
-from acados_template import AcadosOcpBatchSolver, AcadosOcpSolver
-from setup_parametric_ocp import PARAM_VALUE_DICT, export_parametric_ocp
+from acados_template import AcadosOcpBatchSolver, AcadosOcpSolver, AcadosCasadiOcpSolver
+from setup_parametric_ocp import get_default_param_values, export_parametric_ocp
 import time
 
 
-def main_sequential(x0, N_sim):
+def main_sequential(x0, N_sim, nx: int, nu: int):
 
     learnable_params = ["A", "Q", "b"]
-    ocp = export_parametric_ocp(PARAM_VALUE_DICT, learnable_params=learnable_params)
+    ocp = export_parametric_ocp(nx, nu, learnable_params=learnable_params)
     ocp.code_gen_options.with_solution_sens_wrt_params_adj = True
     ocp.solver_options.qp_solver_ric_alg = 0
+    ocp.solver_options.nlp_solver_ext_qp_res = 1
 
     solver = AcadosOcpSolver(ocp, verbose=False)
-
-    nx = ocp.dims.nx
-    nu = ocp.dims.nu
 
     simU = np.zeros((N_sim, nu))
     simX = np.zeros((N_sim+1, nx))
     simX[0,:] = x0
 
-    adjoints = []
-    param_vals = []
+    n_p_global = ocp.p_global_values.shape[0]
+    adjoints = np.zeros((N_sim, 1, n_p_global))
+    param_vals = np.zeros((N_sim, n_p_global))
+    nlp_iter = np.zeros((N_sim,))
+    qp_iter = np.zeros((N_sim,))
+    status_solve = np.zeros((N_sim,))
+    status_sens = np.zeros((N_sim,))
 
     t0 = time.time()
     for i in range(N_sim):
@@ -62,27 +65,42 @@ def main_sequential(x0, N_sim):
         param[i % param.shape[0]] += 0.05
         solver.set_p_global_and_precompute_dependencies(param)
 
-        simU[i,:] = solver.solve_for_x0(x0_bar=simX[i, :])
+        simU[i,:] = solver.solve_for_x0(x0_bar=simX[i, :], fail_on_nonzero_status=False)
         simX[i+1,:] = solver.get(1, "x")
+        status_solve[i] = solver.status
 
         solver.setup_qp_matrices_and_factorize()
         sens_adj = solver.eval_adjoint_solution_sensitivity([(1, np.ones((ocp.dims.nx, 1)))], [(1, np.ones((ocp.dims.nu, 1)))])
-        adjoints.append(sens_adj)
-        param_vals.append(param)
+        adjoints[i] = sens_adj
+        param_vals[i] = param
+        nlp_iter[i] = solver.get_stats('nlp_iter')
+        qp_iter[i] = np.sum(solver.get_stats('qp_iter'))
+        status_sens[i] = solver.status
 
     t_elapsed = 1e3 * (time.time() - t0)
-    print("main_sequential, reset, set p_global, solve, adjoints and get:", f"{t_elapsed:.3f} ms\n")
+    print("main_sequential, reset, set p_global, solve, adjoints and get:", f"{t_elapsed:.3f} ms")
+    print(f"  stats: nlp_iter: max {int(np.max(nlp_iter))}, avg {np.mean(nlp_iter):.1f}, qp_iter: max {int(np.max(qp_iter))}, avg {np.mean(qp_iter):.1f}")
+
+    if all(status_solve == 0):
+        print("  all problems solved successfully")
+    else:
+        failing = np.where(status_solve != 0)[0]
+        print(f"  got {len(failing)} failing solve instances at indices {failing}, status: {status_solve[failing].astype(int)}")
+    if not all(status_sens == 0):
+        failing = np.where(status_sens != 0)[0]
+        print(f"  got {len(failing)} failing sens instances at indices {failing}, status: {status_sens[failing].astype(int)}")
+    print("")
 
     return simX, simU, param_vals, adjoints
 
 
-def main_batch(Xinit, simU, param_vals, adjoints_ref, tol, num_threads_in_batch_solve=1):
+def main_batch(Xinit, simU, param_vals, adjoints_ref, tol, nx: int, nu: int, num_threads_in_batch_solve=1):
 
     N_batch = Xinit.shape[0] - 1
 
     learnable_params = ["A", "Q", "b"]
-    ocp = export_parametric_ocp(PARAM_VALUE_DICT, learnable_params=learnable_params)
-    ocp.code_gen_options.with_solution_sens_wrt_params = True
+    ocp = export_parametric_ocp(nx, nu, learnable_params=learnable_params)
+    ocp.code_gen_options.with_solution_sens_wrt_params_adj = True
     ocp.solver_options.qp_solver_ric_alg = 0
 
     batch_solver = AcadosOcpBatchSolver(ocp, N_batch, num_threads_in_batch_solve=num_threads_in_batch_solve, verbose=False)
@@ -126,12 +144,12 @@ def main_batch(Xinit, simU, param_vals, adjoints_ref, tol, num_threads_in_batch_
         if not diff < tol:
             raise Exception(f"solution should match sequential call up to {tol} got error {diff} for {n}th batch solve")
 
-def dynamic_batch_size(Xinit, simU, param_vals, adjoints_ref, tol, num_threads_in_batch_solve=1):
+def dynamic_batch_size(Xinit, simU, param_vals, adjoints_ref, tol, nx: int, nu: int, num_threads_in_batch_solve=1):
     N_batch = Xinit.shape[0] - 1
 
     learnable_params = ["A", "Q", "b"]
-    ocp = export_parametric_ocp(PARAM_VALUE_DICT, learnable_params=learnable_params)
-    ocp.code_gen_options.with_solution_sens_wrt_params = True
+    ocp = export_parametric_ocp(nx, nu, learnable_params=learnable_params)
+    ocp.code_gen_options.with_solution_sens_wrt_params_adj = True
     ocp.solver_options.qp_solver_ric_alg = 0
 
     batch_solver = AcadosOcpBatchSolver(ocp, 2, num_threads_in_batch_solve=num_threads_in_batch_solve, verbose=False)
@@ -158,6 +176,7 @@ def dynamic_batch_size(Xinit, simU, param_vals, adjoints_ref, tol, num_threads_i
     # actually not needed for convex problem but we want to test it
     batch_solver.setup_qp_matrices_and_factorize(N_batch)
 
+    t0 = time.time()
     sens_adj = batch_solver.eval_adjoint_solution_sensitivity([(1, np.ones((N_batch, ocp.dims.nx, 1)))], [(1, np.ones((N_batch, ocp.dims.nu, 1)))])
     t_elapsed = 1e3 * (time.time() - t0)
 
@@ -168,16 +187,34 @@ def dynamic_batch_size(Xinit, simU, param_vals, adjoints_ref, tol, num_threads_i
         if not diff < tol:
             raise Exception(f"solution should match sequential call up to {tol} got error {diff} for {n}th batch solve")
 
-if __name__ == "__main__":
 
-    tol = 1e-12
-    N_batch = 128
-    x0 = np.array([0.1, -0.2])
+def main_benchmark():
+    nx, nu = 12, 8
+    tol = 1e-8
+    N_batch = 1024
+    x0 = 0.1 * (-1) ** np.arange(nx)
 
     print("main sequential")
-    simX, simU, param_vals, adjoints = main_sequential(x0=x0, N_sim=N_batch)
+    simX, simU, param_vals, adjoints = main_sequential(x0=x0, N_sim=N_batch, nx=nx, nu=nu)
 
     print("main batch")
-    main_batch(Xinit=simX, simU=simU, param_vals=param_vals, adjoints_ref=adjoints, tol=tol, num_threads_in_batch_solve=1)
-    main_batch(Xinit=simX, simU=simU, param_vals=param_vals, adjoints_ref=adjoints, tol=tol, num_threads_in_batch_solve=4)
-    dynamic_batch_size(Xinit=simX, simU=simU, param_vals=param_vals, adjoints_ref=adjoints, tol=tol, num_threads_in_batch_solve=4)
+    main_batch(Xinit=simX, simU=simU, param_vals=param_vals, adjoints_ref=adjoints, tol=tol, nx=nx, nu=nu, num_threads_in_batch_solve=1)
+    main_batch(Xinit=simX, simU=simU, param_vals=param_vals, adjoints_ref=adjoints, tol=tol, nx=nx, nu=nu, num_threads_in_batch_solve=4)
+    # main_batch(Xinit=simX, simU=simU, param_vals=param_vals, adjoints_ref=adjoints, tol=tol, nx=nx, nu=nu, num_threads_in_batch_solve=8)
+
+def main_testing():
+    nx, nu = 12, 8
+    tol = 1e-8
+    N_batch = 128
+    x0 = 0.1 * (-1) ** np.arange(nx)
+
+    print("main sequential")
+    simX, simU, param_vals, adjoints = main_sequential(x0=x0, N_sim=N_batch, nx=nx, nu=nu)
+
+    print("main batch")
+    main_batch(Xinit=simX, simU=simU, param_vals=param_vals, adjoints_ref=adjoints, tol=tol, nx=nx, nu=nu, num_threads_in_batch_solve=2)
+    dynamic_batch_size(Xinit=simX, simU=simU, param_vals=param_vals, adjoints_ref=adjoints, tol=tol, nx=nx, nu=nu, num_threads_in_batch_solve=4)
+
+if __name__ == "__main__":
+    # main_benchmark()
+    main_testing()

--- a/examples/acados_python/solution_sensitivities_convex_example/setup_parametric_ocp.py
+++ b/examples/acados_python/solution_sensitivities_convex_example/setup_parametric_ocp.py
@@ -33,7 +33,7 @@ from casadi.tools import entry, struct_symMX, struct_symSX
 import casadi as ca
 from typing import Optional
 
-USE_MX = True
+USE_MX = False
 
 def get_default_param_values(nx: int, nu: int) -> dict:
     """Return default parameter values for a stable LTI system of size nx, nu.

--- a/examples/acados_python/solution_sensitivities_convex_example/setup_parametric_ocp.py
+++ b/examples/acados_python/solution_sensitivities_convex_example/setup_parametric_ocp.py
@@ -33,17 +33,34 @@ from casadi.tools import entry, struct_symMX, struct_symSX
 import casadi as ca
 from typing import Optional
 
-PARAM_VALUE_DICT = {
-    "A": np.array([[1.0, 0.25], [0.0, 1.0]]),
-    "B": np.array([[0.03125], [0.25]]),
-    "Q": np.identity(2),
-    "R": np.identity(1),
-    "b": np.array([[0.2], [0.2]]),
-    "f": np.array([[0.0], [0.0], [0.0]]),
-    "V_0": np.array([1e-3]),
-}
-
 USE_MX = True
+
+def get_default_param_values(nx: int, nu: int) -> dict:
+    """Return default parameter values for a stable LTI system of size nx, nu.
+
+    A is Schur-stable with small subdiagonal coupling (non-identity).
+    B maps each input to its corresponding state.
+    """
+    # stable A
+    A = 0.99 * np.eye(nx) + 0.1 * np.diag(np.ones(nx - 1), -1)
+    # B: each input directly drives one state, scaled so the system is well-conditioned
+    B = np.zeros((nx, nu))
+    for i in range(min(nx, nu)):
+        B[i, i] = 1.0
+    if nx > nu:
+        # remaining states driven by last input with smaller gain
+        for i in range(nu, nx):
+            B[i, nu - 1] += 0.2 + 0.01 * i
+    return {
+        "A": A,
+        "B": B,
+        "Q": np.eye(nx),
+        "R": np.eye(nu),
+        "b": 0.001 * np.ones((nx, 1)),
+        "f": np.zeros((nx + nu, 1)),
+        "V_0": np.array([1e-3]),
+    }
+
 
 def find_param_in_p_or_p_global(param_name: list[str], model: AcadosModel) -> list:
     if model.p == []:
@@ -86,13 +103,18 @@ def cost_expr_ext_cost_e(model: AcadosModel):
 
 
 def export_parametric_ocp(
-    param: dict[str, np.ndarray],
+    nx: int,
+    nu: int,
+    param: Optional[dict[str, np.ndarray]] = None,
     name: str = "lti",
     learnable_params: Optional[list[str]] = None,
 ) -> AcadosOcp:
 
     if learnable_params is None:
         learnable_params = []
+
+    if param is None:
+        param = get_default_param_values(nx, nu)
 
     ocp = AcadosOcp()
 
@@ -105,15 +127,15 @@ def export_parametric_ocp(
         symbol = ca.SX.sym
         struct_sym = struct_symSX
 
-    nx = 2
     ocp.model.x = symbol("x", nx)
-    ocp.model.u = symbol("u", 1)
+    ocp.model.u = symbol("u", nu)
 
-    ocp.solver_options.N_horizon = 4
+    ocp.solver_options.N_horizon = 20
     ocp.solver_options.tf = 8
     ocp.solver_options.integrator_type = 'DISCRETE'
     ocp.solver_options.hessian_approx = 'EXACT'
     ocp.solver_options.nlp_solver_type = "SQP"
+    ocp.solver_options.with_batch_functionality = True
 
     # Add learnable parameters to p_global
     if len(learnable_params) != 0:
@@ -148,23 +170,19 @@ def export_parametric_ocp(
     ocp.cost.cost_type_e = "EXTERNAL"
     ocp.model.cost_expr_ext_cost_e = cost_expr_ext_cost_e(ocp.model)
 
-    ocp.constraints.idxbx_0 = np.arange(nx)
-    ocp.constraints.lbx_0 = -1 * np.ones((nx,))
-    ocp.constraints.ubx_0 = 1 * np.ones((nx,))
+    # initial state dummy equality
+    ocp.constraints.x0 = np.ones(nx)
 
-    ocp.constraints.idxbx = np.array([0, 1])
-    ocp.constraints.lbx = np.array([-0.0, -1.0])
-    ocp.constraints.ubx = np.array([+1.0, +1.0])
+    # # path state bounds
+    # ocp.constraints.idxbx = np.arange(nx)
+    # ocp.constraints.lbx = -np.ones(nx)
+    # ocp.constraints.ubx = np.ones(nx)
 
-    ocp.constraints.idxsbx = np.array([0])
-    ocp.cost.zl = np.array([1e2])
-    ocp.cost.zu = np.array([1e2])
-    ocp.cost.Zl = np.diag([0])
-    ocp.cost.Zu = np.diag([0])
-
-    ocp.constraints.idxbu = np.array([0])
-    ocp.constraints.lbu = np.array([-1.0])
-    ocp.constraints.ubu = np.array([+1.0])
+    # Control bounds
+    umax = 1e0
+    ocp.constraints.idxbu = np.arange(nu)
+    ocp.constraints.lbu = -umax * np.ones(nu)
+    ocp.constraints.ubu = umax * np.ones(nu)
 
     if isinstance(ocp.model.p, (struct_symMX, struct_symSX)):
         ocp.model.p = ocp.model.p.cat if ocp.model.p is not None else []

--- a/examples/acados_python/solution_sensitivities_convex_example/value_gradient_example_linear.py
+++ b/examples/acados_python/solution_sensitivities_convex_example/value_gradient_example_linear.py
@@ -33,16 +33,16 @@ sys.path.insert(0, '../pendulum_on_cart/solution_sensitivities')
 import numpy as np
 from sensitivity_utils import plot_cost_gradient_results
 from acados_template import AcadosOcpSolver
-from setup_parametric_ocp import PARAM_VALUE_DICT, export_parametric_ocp
+from setup_parametric_ocp import get_default_param_values, export_parametric_ocp
 
 
-def main():
+def main(nx: int, nu: int, x0: np.ndarray):
 
     learnable_params = ["A", "Q", "b"]
-    x0 = np.array([0.1, -0.2])
 
     delta_p = 0.005
-    p_nominal = np.concatenate([PARAM_VALUE_DICT[k].flatten() for k in learnable_params]).flatten()
+    param = get_default_param_values(nx, nu)
+    p_nominal = np.concatenate([param[k].flatten() for k in learnable_params]).flatten()
 
     p_test = np.arange(0.0, 1.0, delta_p)
     np_test = p_test.shape[0]
@@ -57,8 +57,8 @@ def main():
     dp[8] = -0.2
     dp[9] = -0.2
 
-    ocp = export_parametric_ocp(PARAM_VALUE_DICT, learnable_params = learnable_params)
-    ocp.code_gen_options.with_value_sens_wrt_params = True
+    ocp = export_parametric_ocp(nx, nu, learnable_params=learnable_params)
+    ocp.solver_options.with_value_sens_wrt_params = True
     acados_ocp_solver = AcadosOcpSolver(ocp)
 
     optimal_value_grad = np.zeros((np_test,))
@@ -95,4 +95,6 @@ def main():
     assert median_diff <= test_tol
 
 if __name__ == "__main__":
-    main()
+    nx, nu = 2, 1
+    x0 = 0.1 * (-1) ** np.arange(nx)
+    main(nx, nu, x0)

--- a/interfaces/acados_template/acados_template/acados_ocp_batch_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_batch_solver.py
@@ -115,6 +115,9 @@ class AcadosOcpBatchSolver():
         getattr(self.__shared_lib, f"{self.__name}_acados_batch_set").argtypes = [POINTER(c_void_p), c_char_p, c_int, POINTER(c_double), c_int, c_int, c_int]
         getattr(self.__shared_lib, f"{self.__name}_acados_batch_set").restype = c_void_p
 
+        getattr(self.__shared_lib, f"{self.__name}_acados_batch_reset_sens_out").argtypes = [POINTER(c_void_p), c_int, c_int]
+        getattr(self.__shared_lib, f"{self.__name}_acados_batch_reset_sens_out").restype = c_void_p
+
         if self.ocp_solvers[0].acados_lib_uses_omp:
             msg = "Note: Please make sure that the acados shared library is compiled with the number of threads set to 1,\n"
         else:
@@ -326,9 +329,9 @@ class AcadosOcpBatchSolver():
 
 
     def _reset_sens_out(self, n_batch: int) -> None:
-        # TODO batch this
-        for n in range(n_batch):
-            self.__acados_lib.ocp_nlp_out_set_values_to_zero(self.__ocp_solvers[n].nlp_config, self.__ocp_solvers[n].nlp_dims, self.__ocp_solvers[n].sens_out)
+        getattr(self.__shared_lib, f"{self.__name}_acados_batch_reset_sens_out")(
+            self.__ocp_solvers_pointer, c_int(n_batch), c_int(self.__num_threads_in_batch_solve)
+        )
 
 
     def set_flat(self, field_: str, value_: np.ndarray) -> None:

--- a/interfaces/acados_template/acados_template/acados_ocp_batch_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_batch_solver.py
@@ -112,6 +112,9 @@ class AcadosOcpBatchSolver():
         getattr(self.__shared_lib, f"{self.__name}_acados_batch_get_flat").argtypes = [POINTER(c_void_p), c_char_p, POINTER(c_double), c_int, c_int, c_int]
         getattr(self.__shared_lib, f"{self.__name}_acados_batch_get_flat").restype = c_void_p
 
+        getattr(self.__shared_lib, f"{self.__name}_acados_batch_set").argtypes = [POINTER(c_void_p), c_char_p, c_int, POINTER(c_double), c_int, c_int, c_int]
+        getattr(self.__shared_lib, f"{self.__name}_acados_batch_set").restype = c_void_p
+
         if self.ocp_solvers[0].acados_lib_uses_omp:
             msg = "Note: Please make sure that the acados shared library is compiled with the number of threads set to 1,\n"
         else:
@@ -295,12 +298,10 @@ class AcadosOcpBatchSolver():
                 # set seed:
                 self._reset_sens_out(n_batch)
 
-                # TODO this could be a batch_set
-                for m in range(n_batch):
-                    for (stage, sx) in seed_x:
-                        self.ocp_solvers[m].set(stage, 'sens_x', sx[m, :, i_seed])
-                    for (stage, su) in seed_u:
-                        self.ocp_solvers[m].set(stage, 'sens_u', su[m, :, i_seed])
+                for (stage, sx) in seed_x:
+                    self.set(stage, 'sens_x', sx[:n_batch, :, i_seed])
+                for (stage, su) in seed_u:
+                    self.set(stage, 'sens_u', su[:n_batch, :, i_seed])
 
                 c_grad_p = cast(grad_p[0, i_seed].ctypes.data, POINTER(c_double))
 
@@ -519,10 +520,10 @@ class AcadosOcpBatchSolver():
 
     def set(self,  stage_: int, field_: str, data_: np.ndarray):
         """
-        Set numerical data inside the solvers.
+        Set numerical data inside the solvers using a parallelized batch C call.
 
         :param stage: integer corresponding to shooting node
-        :param field: string in ['x', 'u', 'pi', 'lam', 'p', 'xdot_guess', 'z_guess', 'sens_x', 'sens_u']
+        :param field: string in ['x', 'u', 'pi', 'lam', 'z', 'sl', 'su', 'p', 'xdot_guess', 'z_guess', 'sens_x', 'sens_u']
         :param data: the data of shape (n_batch, field_dim).
 
         .. note:: regarding lam: \n
@@ -536,6 +537,11 @@ class AcadosOcpBatchSolver():
                       sl: slack variables of soft lower inequality constraints \n
                       su: slack variables of soft upper inequality constraints \n
         """
+        valid_fields = ['x', 'u', 'pi', 'lam', 'z', 'sl', 'su', 'p', 'xdot_guess', 'z_guess', 'sens_x', 'sens_u']
+        if field_ not in valid_fields:
+            raise ValueError(f"AcadosOcpBatchSolver.set(): '{field_}' is not a valid argument.\n"
+                             f" Possible values are {valid_fields}.")
+
         n_batch = data_.shape[0]
 
         if data_.ndim < 2:
@@ -547,5 +553,11 @@ class AcadosOcpBatchSolver():
             self.__n_batch_current = n_batch
             self._create_missing_solvers(n_batch)
 
-        for i, solver in enumerate(self.ocp_solvers[:n_batch]):
-            solver.set(stage_, field_, data_[i])
+        field = field_.encode('utf-8')
+        data_ = np.ascontiguousarray(data_, dtype=np.float64)
+        N_data = data_.size
+        data_p = cast(data_.ctypes.data, POINTER(c_double))
+
+        getattr(self.__shared_lib, f"{self.__name}_acados_batch_set")(
+            self.__ocp_solvers_pointer, field, c_int(stage_), data_p, c_int(N_data), c_int(n_batch), c_int(self.__num_threads_in_batch_solve)
+        )

--- a/interfaces/acados_template/acados_template/acados_ocp_batch_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_batch_solver.py
@@ -220,7 +220,7 @@ class AcadosOcpBatchSolver():
             :param seed_u : Sequence of tuples of the form (stage: int, seed_vec: np.ndarray).
                     The stage is the stage at which the seed_vec is applied, and seed_vec is the seed for the controls at that stage with shape (n_batch, nu, n_seeds)
             :param with_respect_to : string in ["p_global"]
-            :param sanity_checks : bool - whether to perform sanity checks, turn off for minimal overhead, default: True
+            :param sanity_checks : bool - whether to perform sanity checks on solver settings, turn off for minimal overhead, default: True
             :returns : np.ndarray of shape (n_batch, n_seeds, np_global)
         """
 

--- a/interfaces/acados_template/acados_template/acados_ocp_batch_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_batch_solver.py
@@ -224,6 +224,7 @@ class AcadosOcpBatchSolver():
             :returns : np.ndarray of shape (n_batch, n_seeds, np_global)
         """
 
+        t0 = time.time()
         if seed_x is None:
             seed_x = []
         elif not isinstance(seed_x, Sequence):
@@ -296,18 +297,26 @@ class AcadosOcpBatchSolver():
 
             for i_seed in range(n_seeds):
                 # set seed:
+                t0 = time.time()
                 self._reset_sens_out(n_batch)
+                t_elapsed = 1e3 * (time.time() - t0)
+                print(f"time reset {t_elapsed:.3f} ms")
 
                 for (stage, sx) in seed_x:
                     self.set(stage, 'sens_x', sx[:n_batch, :, i_seed])
                 for (stage, su) in seed_u:
                     self.set(stage, 'sens_u', su[:n_batch, :, i_seed])
 
+                t_elapsed = 1e3 * (time.time() - t0)
+                print(f"time reset + set seed {t_elapsed:.3f} ms")
                 c_grad_p = cast(grad_p[0, i_seed].ctypes.data, POINTER(c_double))
+
+                t0 = time.time()
 
                 # solve adjoint sensitivities
                 getattr(self.__shared_lib, f"{self.__name}_acados_batch_eval_solution_sens_adj_p")(
                     self.__ocp_solvers_pointer, field, 0, c_grad_p, offset, n_batch, self.__num_threads_in_batch_solve)
+                print(f"time C adj solve {1e3*(time.time() - t0):.3f} ms")
 
             self.time_solution_sens_solve = time.time() - t1
 

--- a/interfaces/acados_template/acados_template/acados_ocp_batch_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_batch_solver.py
@@ -227,7 +227,6 @@ class AcadosOcpBatchSolver():
             :returns : np.ndarray of shape (n_batch, n_seeds, np_global)
         """
 
-        t0 = time.time()
         if seed_x is None:
             seed_x = []
         elif not isinstance(seed_x, Sequence):
@@ -300,26 +299,18 @@ class AcadosOcpBatchSolver():
 
             for i_seed in range(n_seeds):
                 # set seed:
-                t0 = time.time()
                 self._reset_sens_out(n_batch)
-                t_elapsed = 1e3 * (time.time() - t0)
-                print(f"time reset {t_elapsed:.3f} ms")
 
                 for (stage, sx) in seed_x:
                     self.set(stage, 'sens_x', sx[:n_batch, :, i_seed])
                 for (stage, su) in seed_u:
                     self.set(stage, 'sens_u', su[:n_batch, :, i_seed])
 
-                t_elapsed = 1e3 * (time.time() - t0)
-                print(f"time reset + set seed {t_elapsed:.3f} ms")
                 c_grad_p = cast(grad_p[0, i_seed].ctypes.data, POINTER(c_double))
-
-                t0 = time.time()
 
                 # solve adjoint sensitivities
                 getattr(self.__shared_lib, f"{self.__name}_acados_batch_eval_solution_sens_adj_p")(
                     self.__ocp_solvers_pointer, field, 0, c_grad_p, offset, n_batch, self.__num_threads_in_batch_solve)
-                print(f"time C adj solve {1e3*(time.time() - t0):.3f} ms")
 
             self.time_solution_sens_solve = time.time() - t1
 

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -3375,6 +3375,29 @@ void {{ model.name }}_acados_batch_get_flat({{ model.name }}_solver_capsule ** c
 }
 
 
+void {{ model.name }}_acados_batch_reset_sens_out({{ model.name }}_solver_capsule ** capsules, int N_batch, int num_threads_in_batch_solve)
+{
+    int num_threads_bkp;
+    if (num_threads_in_batch_solve > 1)
+    {
+        num_threads_bkp = omp_get_num_threads();
+        omp_set_num_threads(num_threads_in_batch_solve);
+    }
+
+    #pragma omp parallel for
+    for (int i = 0; i < N_batch; i++)
+    {
+        ocp_nlp_out_set_values_to_zero(capsules[i]->nlp_config, capsules[i]->nlp_dims, capsules[i]->sens_out);
+    }
+
+    if (num_threads_in_batch_solve > 1)
+    {
+        omp_set_num_threads( num_threads_bkp );
+    }
+    return;
+}
+
+
 void {{ model.name }}_acados_batch_set({{ model.name }}_solver_capsule ** capsules, const char *field, int stage, double *data, int N_data, int N_batch, int num_threads_in_batch_solve)
 {
     // get dimension at the given stage for the requested field.

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -3373,6 +3373,91 @@ void {{ model.name }}_acados_batch_get_flat({{ model.name }}_solver_capsule ** c
     }
     return;
 }
+
+
+void {{ model.name }}_acados_batch_set({{ model.name }}_solver_capsule ** capsules, const char *field, int stage, double *data, int N_data, int N_batch, int num_threads_in_batch_solve)
+{
+    // get dimension at the given stage for the requested field.
+    // sens_x and sens_u are aliases for x and u in sens_out.
+    int dim;
+    if (!strcmp(field, "sens_x"))
+        dim = ocp_nlp_dims_get_from_attr(capsules[0]->nlp_config, capsules[0]->nlp_dims, capsules[0]->nlp_out, stage, "x");
+    else if (!strcmp(field, "sens_u"))
+        dim = ocp_nlp_dims_get_from_attr(capsules[0]->nlp_config, capsules[0]->nlp_dims, capsules[0]->nlp_out, stage, "u");
+    else
+        dim = ocp_nlp_dims_get_from_attr(capsules[0]->nlp_config, capsules[0]->nlp_dims, capsules[0]->nlp_out, stage, field);
+
+    if (N_batch * dim != N_data)
+    {
+        printf("acados_batch_set: wrong input dimension, expected %d, got %d\n", N_batch * dim, N_data);
+        exit(1);
+    }
+
+    int num_threads_bkp;
+    if (num_threads_in_batch_solve > 1)
+    {
+        num_threads_bkp = omp_get_num_threads();
+        omp_set_num_threads(num_threads_in_batch_solve);
+    }
+
+    if (!strcmp(field, "sens_x"))
+    {
+        #pragma omp parallel for
+        for (int i = 0; i < N_batch; i++)
+        {
+            ocp_nlp_out_set(capsules[i]->nlp_config, capsules[i]->nlp_dims, capsules[i]->sens_out, capsules[i]->nlp_in, stage, "x", data + i * dim);
+        }
+    }
+    else if (!strcmp(field, "sens_u"))
+    {
+        #pragma omp parallel for
+        for (int i = 0; i < N_batch; i++)
+        {
+            ocp_nlp_out_set(capsules[i]->nlp_config, capsules[i]->nlp_dims, capsules[i]->sens_out, capsules[i]->nlp_in, stage, "u", data + i * dim);
+        }
+    }
+    else if (!strcmp(field, "p"))
+    {
+        #pragma omp parallel for
+        for (int i = 0; i < N_batch; i++)
+        {
+            {{ model.name }}_acados_update_params(capsules[i], stage, data + i * dim, dim);
+        }
+    }
+    else if (!strcmp(field, "xdot_guess") || !strcmp(field, "z_guess"))
+    {
+        #pragma omp parallel for
+        for (int i = 0; i < N_batch; i++)
+        {
+            ocp_nlp_set(capsules[i]->nlp_solver, stage, field, data + i * dim);
+        }
+    }
+    else if (!strcmp(field, "z"))
+    {
+        // set z in nlp_out and also set z_guess in nlp solver memory (same as AcadosOcpSolver.set behavior)
+        #pragma omp parallel for
+        for (int i = 0; i < N_batch; i++)
+        {
+            ocp_nlp_out_set(capsules[i]->nlp_config, capsules[i]->nlp_dims, capsules[i]->nlp_out, capsules[i]->nlp_in, stage, field, data + i * dim);
+            ocp_nlp_set(capsules[i]->nlp_solver, stage, "z_guess", data + i * dim);
+        }
+    }
+    else
+    {
+        // out_fields: x, u, pi, lam, sl, su
+        #pragma omp parallel for
+        for (int i = 0; i < N_batch; i++)
+        {
+            ocp_nlp_out_set(capsules[i]->nlp_config, capsules[i]->nlp_dims, capsules[i]->nlp_out, capsules[i]->nlp_in, stage, field, data + i * dim);
+        }
+    }
+
+    if (num_threads_in_batch_solve > 1)
+    {
+        omp_set_num_threads( num_threads_bkp );
+    }
+    return;
+}
 {% endif %}
 
 

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.h
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.h
@@ -324,6 +324,7 @@ ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_solve({{ model.name }}_s
 ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_set_flat({{ model.name }}_solver_capsule ** capsules, const char *field, double *data, int N_data, int N_batch, int num_threads_in_batch_solve);
 ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_get_flat({{ model.name }}_solver_capsule ** capsules, const char *field, double *data, int N_data, int N_batch, int num_threads_in_batch_solve);
 ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_set({{ model.name }}_solver_capsule ** capsules, const char *field, int stage, double *data, int N_data, int N_batch, int num_threads_in_batch_solve);
+ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_reset_sens_out({{ model.name }}_solver_capsule ** capsules, int N_batch, int num_threads_in_batch_solve);
 
 ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_eval_solution_sens_adj_p({{ model.name }}_solver_capsule ** capsules, const char *field, int stage, double *out, int offset, int N_batch, int num_threads_in_batch_solve);
 ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_eval_params_jac({{ model.name }}_solver_capsule ** capsules, int N_batch, int num_threads_in_batch_solve);

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.h
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.h
@@ -323,6 +323,7 @@ ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_solve({{ model.name }}_s
 
 ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_set_flat({{ model.name }}_solver_capsule ** capsules, const char *field, double *data, int N_data, int N_batch, int num_threads_in_batch_solve);
 ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_get_flat({{ model.name }}_solver_capsule ** capsules, const char *field, double *data, int N_data, int N_batch, int num_threads_in_batch_solve);
+ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_set({{ model.name }}_solver_capsule ** capsules, const char *field, int stage, double *data, int N_data, int N_batch, int num_threads_in_batch_solve);
 
 ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_eval_solution_sens_adj_p({{ model.name }}_solver_capsule ** capsules, const char *field, int stage, double *out, int offset, int N_batch, int num_threads_in_batch_solve);
 ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_eval_params_jac({{ model.name }}_solver_capsule ** capsules, int N_batch, int num_threads_in_batch_solve);


### PR DESCRIPTION
For the example in the benchmark setting, time in `eval_adjoint_solution_sensitivity`, I get now:sd
time reset + set seed ~1.2 ms
time C adj solve ~61 ms

Before, time reset + set seed was ~22ms