### PR TITLE
Python: Fix minor bug regarding y_ref in `AcadosCasadiOcp`

### DIFF
--- a/interfaces/acados_template/acados_template/acados_casadi_ocp.py
+++ b/interfaces/acados_template/acados_template/acados_casadi_ocp.py
@@ -476,7 +476,7 @@ class AcadosCasadiOcp:
         p_list.append(ocp.parameter_values)
         self._index_map['p_in_p_nlp'].append(list(range(self.offset_p, self.offset_p + ocp.dims.np)))
         self.offset_p += ocp.dims.np
-        p_list.append(yref)
+        p_list.append(yref) if yref is not None else p_list.append([])
         self._index_map['yref_in_p_nlp'].append(list(range(self.offset_p, self.offset_p + ny)))
         self.offset_p += ny
 


### PR DESCRIPTION
This pull request makes a small change to how `yref` is appended to the parameter list in the `_append_node_and_value_for_params` method. 

Now, if `yref` is `None`, an empty list is appended instead, ensuring the parameter list always has a valid entry for `yref`.