### PR TITLE
Add `AcadosOcpBatchSolver` functionality

### DIFF
--- a/.github/workflows/full_build.yml
+++ b/.github/workflows/full_build.yml
@@ -678,7 +678,7 @@ jobs:
         cd ${{ github.workspace }}/examples/acados_python/chain_mass/
         python solution_sensitivity_example.py
 
-    - name: Python Furuta pendulum timeout test, minimal batch examples
+    - name: Python Furuta pendulum timeout test, batch tests
       if: always()
       working-directory: ${{ github.workspace }}/build
       shell: bash
@@ -691,6 +691,8 @@ jobs:
         python minimal_example_batch_ocp_solver.py
         cd ${{ github.workspace }}/examples/acados_python/pendulum_on_cart/sim
         python minimal_example_batch_sim_solver.py
+        cd ${{ github.workspace }}/examples/acados_python/tests
+        python test_batch_solvers.py
 
 
     - name: Python evaluator test

--- a/examples/acados_python/pendulum_on_cart/ocp/minimal_example_batch_ocp_solver.py
+++ b/examples/acados_python/pendulum_on_cart/ocp/minimal_example_batch_ocp_solver.py
@@ -157,6 +157,11 @@ def main_batch(Xinit, simU, tol, num_threads_in_batch_solve=1):
         if not np.linalg.norm(U_batch[n, :ocp.dims.nu] - simU[n]) < tol*10:
             raise Exception(f"solution should match sequential call up to {tol*10} got error {np.linalg.norm(U_batch[n, :ocp.dims.nu] - simU[n])} for {n}th batch solve")
 
+    # test get
+    u_1 = batch_solver.get(ocp.solver_options.N_horizon - 1, "u")
+    if np.linalg.norm(u_1.flatten() - U_batch[:, -1]) > 1e-12:
+        raise Exception("batch getter should return the same result.")
+
     # test N_batch_max is respected
     try:
         batch_solver.get_flat("x", N_batch_max+1)

--- a/examples/acados_python/pendulum_on_cart/ocp/minimal_example_batch_ocp_solver.py
+++ b/examples/acados_python/pendulum_on_cart/ocp/minimal_example_batch_ocp_solver.py
@@ -91,6 +91,8 @@ def setup_ocp(tol=1e-7):
 
     ocp.solver_options.tf = Tf
 
+    ocp.solver_options.with_batch_functionality = True
+
     return ocp
 
 
@@ -131,9 +133,8 @@ def main_batch(Xinit, simU, tol, num_threads_in_batch_solve=1):
     batch_solver.num_threads_in_batch_solve = num_threads_in_batch_solve
     assert batch_solver.num_threads_in_batch_solve == num_threads_in_batch_solve
 
-    for n in range(N_batch):
-        batch_solver.ocp_solvers[n].constraints_set(0, "lbx", Xinit[n])
-        batch_solver.ocp_solvers[n].constraints_set(0, "ubx", Xinit[n])
+    batch_solver.constraints_set(0, "lbx", Xinit)
+    batch_solver.constraints_set(0, "ubx", Xinit)
 
     # set initial guess
     Xinit_batch = np.array([np.tile(Xinit[i], (ocp.solver_options.N_horizon+1,)) for i in range(N_batch)])

--- a/examples/acados_python/solution_sensitivities_convex_example/batch_adjoint_solution_sensitivity_example.py
+++ b/examples/acados_python/solution_sensitivities_convex_example/batch_adjoint_solution_sensitivity_example.py
@@ -102,14 +102,15 @@ def main_batch(Xinit, simU, param_vals, adjoints_ref, tol, nx: int, nu: int, num
     ocp = export_parametric_ocp(nx, nu, learnable_params=learnable_params)
     ocp.code_gen_options.with_solution_sens_wrt_params_adj = True
     ocp.solver_options.qp_solver_ric_alg = 0
+    ocp.solver_options.with_batch_functionality = True
 
     batch_solver = AcadosOcpBatchSolver(ocp, N_batch, num_threads_in_batch_solve=num_threads_in_batch_solve, verbose=False)
 
     # reset, set bounds and p_global
     t0 = time.time()
+    batch_solver.constraints_set(0, "lbx", Xinit)
+    batch_solver.constraints_set(0, "ubx", Xinit)
     for n in range(N_batch):
-        batch_solver.ocp_solvers[n].constraints_set(0, "lbx", Xinit[n])
-        batch_solver.ocp_solvers[n].constraints_set(0, "ubx", Xinit[n])
         batch_solver.ocp_solvers[n].reset()
         batch_solver.ocp_solvers[n].set_p_global_and_precompute_dependencies(param_vals[n])
     t_elapsed = 1e3 * (time.time() - t0)
@@ -151,6 +152,7 @@ def dynamic_batch_size(Xinit, simU, param_vals, adjoints_ref, tol, nx: int, nu: 
     ocp = export_parametric_ocp(nx, nu, learnable_params=learnable_params)
     ocp.code_gen_options.with_solution_sens_wrt_params_adj = True
     ocp.solver_options.qp_solver_ric_alg = 0
+    ocp.solver_options.with_batch_functionality = True
 
     batch_solver = AcadosOcpBatchSolver(ocp, 2, num_threads_in_batch_solve=num_threads_in_batch_solve, verbose=False)
 

--- a/examples/acados_python/tests/test_batch_solvers.py
+++ b/examples/acados_python/tests/test_batch_solvers.py
@@ -1,0 +1,353 @@
+#
+# Copyright (c) The acados authors.
+#
+# This file is part of acados.
+#
+# The 2-Clause BSD License
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.;
+#
+
+"""
+Tests that verify AcadosOcpBatchSolver and AcadosSimBatchSolver produce the same
+results as calling the corresponding non-batch solvers individually.
+
+The individual comparison is done via AcadosOcpBatchSolver.ocp_solvers[i] and
+AcadosSimBatchSolver.sim_solvers[i] to avoid creating additional solver instances.
+"""
+
+import sys
+sys.path.insert(0, '../pendulum_on_cart/common')
+sys.path.insert(0, '../solution_sensitivities_convex_example')
+
+import numpy as np
+import scipy.linalg
+import casadi as ca
+
+from acados_template import (
+    AcadosOcp, AcadosOcpBatchSolver,
+    AcadosSim, AcadosSimBatchSolver,
+)
+from pendulum_model import export_pendulum_ode_model
+from setup_parametric_ocp import export_parametric_ocp
+
+TOL = 1e-7
+N_BATCH = 5
+
+
+# ---------------------------------------------------------------------------
+# OCP helpers
+# ---------------------------------------------------------------------------
+
+def setup_ocp(tol: float = TOL) -> AcadosOcp:
+    ocp = AcadosOcp()
+    ocp.model = export_pendulum_ode_model()
+
+    Tf = 1.0
+    N = 20
+    ocp.solver_options.N_horizon = N
+
+    Q_mat = 2 * np.diag([1e3, 1e3, 1e-2, 1e-2])
+    R_mat = 2 * np.diag([1e-2])
+    cost_W = scipy.linalg.block_diag(Q_mat, R_mat)
+
+    ocp.cost.cost_type = 'NONLINEAR_LS'
+    ocp.cost.cost_type_e = 'NONLINEAR_LS'
+    ocp.cost.W_e = Q_mat
+    ocp.cost.W = cost_W
+    ocp.model.cost_y_expr = ca.vertcat(ocp.model.x, ocp.model.u)
+    ocp.model.cost_y_expr_e = ocp.model.x
+    ocp.cost.yref = np.zeros(ocp.model.cost_y_expr.shape).flatten()
+    ocp.cost.yref_e = np.zeros(ocp.model.cost_y_expr_e.shape).flatten()
+
+    Fmax = 80
+    ocp.constraints.lbu = np.array([-Fmax])
+    ocp.constraints.ubu = np.array([+Fmax])
+    ocp.constraints.idxbu = np.array([0])
+    ocp.constraints.x0 = np.array([0.0, np.pi, 0.0, 0.0])
+
+    ocp.solver_options.qp_solver = 'PARTIAL_CONDENSING_HPIPM'
+    ocp.solver_options.hessian_approx = 'GAUSS_NEWTON'
+    ocp.solver_options.integrator_type = 'IRK'
+    ocp.solver_options.nlp_solver_type = 'SQP'
+    ocp.solver_options.nlp_solver_tol_stat = tol
+    ocp.solver_options.nlp_solver_tol_eq = tol
+    ocp.solver_options.nlp_solver_tol_ineq = tol
+    ocp.solver_options.nlp_solver_tol_comp = tol
+    ocp.solver_options.tf = Tf
+    ocp.solver_options.with_batch_functionality = True
+
+    return ocp
+
+
+# ---------------------------------------------------------------------------
+# Sim helpers
+# ---------------------------------------------------------------------------
+
+def setup_sim() -> AcadosSim:
+    sim = AcadosSim()
+    sim.model = export_pendulum_ode_model()
+    sim.solver_options.T = 0.2
+    sim.solver_options.integrator_type = 'IRK'
+    sim.solver_options.num_stages = 3
+    sim.solver_options.num_steps = 3
+    sim.solver_options.newton_iter = 10
+    sim.solver_options.with_batch_functionality = True
+    return sim
+
+
+# ---------------------------------------------------------------------------
+# Test functions
+# ---------------------------------------------------------------------------
+
+def test_ocp_batch_get_and_get_flat():
+    """
+    Create one AcadosOcpBatchSolver, solve N_BATCH problems, then verify that:
+      - batch.get()      matches ocp_solvers[i].get()
+      - batch.get_flat() matches ocp_solvers[i].get_flat()
+      - num_threads_in_batch_solve property getter/setter works
+      - requesting n_batch > N_batch_max raises ValueError
+    """
+    x0_batch = np.tile(np.array([0.0, np.pi, 0.0, 0.0]), (N_BATCH, 1))
+    rng = np.random.default_rng(0)
+    x0_batch += 0.1 * rng.standard_normal(x0_batch.shape)
+
+    ocp = setup_ocp()
+    batch_solver = AcadosOcpBatchSolver(ocp, N_batch_init=N_BATCH, num_threads_in_batch_solve=1, verbose=False)
+
+    # --- num_threads property ---
+    assert batch_solver.num_threads_in_batch_solve == 1
+    batch_solver.num_threads_in_batch_solve = 2
+    assert batch_solver.num_threads_in_batch_solve == 2
+    batch_solver.num_threads_in_batch_solve = 1
+
+    batch_solver.constraints_set(0, 'lbx', x0_batch)
+    batch_solver.constraints_set(0, 'ubx', x0_batch)
+    batch_solver.solve()
+
+    nx = ocp.dims.nx
+    nu = ocp.dims.nu
+
+    # --- get() ---
+    batch_x1 = batch_solver.get(1, 'x')   # shape (N_BATCH, nx)
+    batch_u0 = batch_solver.get(0, 'u')   # shape (N_BATCH, nu)
+    for i in range(N_BATCH):
+        err_x = np.max(np.abs(batch_solver.ocp_solvers[i].get(1, 'x') - batch_x1[i]))
+        err_u = np.max(np.abs(batch_solver.ocp_solvers[i].get(0, 'u') - batch_u0[i]))
+        assert err_x < TOL * 100, f"get(1,'x') mismatch at index {i}: {err_x:.2e}"
+        assert err_u < TOL * 100, f"get(0,'u') mismatch at index {i}: {err_u:.2e}"
+
+    # --- get_flat() ---
+    batch_xflat = batch_solver.get_flat('x')   # shape (N_BATCH, nx*(N+1))
+    batch_uflat = batch_solver.get_flat('u')   # shape (N_BATCH, nu*N)
+    for i in range(N_BATCH):
+        err_x = np.max(np.abs(batch_solver.ocp_solvers[i].get_flat('x') - batch_xflat[i]))
+        err_u = np.max(np.abs(batch_solver.ocp_solvers[i].get_flat('u') - batch_uflat[i]))
+        assert err_x < TOL * 100, f"get_flat('x') mismatch at index {i}: {err_x:.2e}"
+        assert err_u < TOL * 100, f"get_flat('u') mismatch at index {i}: {err_u:.2e}"
+
+    # --- n_batch > N_batch_max should raise ---
+    try:
+        batch_solver.get_flat('x', N_BATCH + 1)
+        raise AssertionError("Expected ValueError was not raised")
+    except ValueError:
+        pass
+
+    print("test_ocp_batch_get_and_get_flat: PASSED")
+
+
+def test_ocp_batch_eval_solution_sensitivity_wrt_initial_state():
+    """
+    Create one AcadosOcpBatchSolver, solve N_BATCH problems, then verify that
+    batch.eval_solution_sensitivity(with_respect_to='initial_state') agrees with
+    ocp_solvers[i].eval_solution_sensitivity() called individually.
+    """
+    x0_batch = np.tile(np.array([0.0, np.pi, 0.0, 0.0]), (N_BATCH, 1))
+    rng = np.random.default_rng(2)
+    x0_batch += 0.1 * rng.standard_normal(x0_batch.shape)
+
+    ocp = setup_ocp()
+    batch_solver = AcadosOcpBatchSolver(ocp, N_batch_init=N_BATCH, verbose=False)
+    batch_solver.constraints_set(0, 'lbx', x0_batch)
+    batch_solver.constraints_set(0, 'ubx', x0_batch)
+    batch_solver.solve()
+    batch_solver.setup_qp_matrices_and_factorize()
+
+    batch_d = batch_solver.eval_solution_sensitivity(
+        0,
+        sanity_checks=False,
+        with_respect_to='initial_state',
+        return_sens_x=True,
+        return_sens_u=True,
+    )
+
+    nx = ocp.dims.nx
+    nu = ocp.dims.nu
+
+    for i in range(N_BATCH):
+        solver_i = batch_solver.ocp_solvers[i]
+        solver_i.setup_qp_matrices_and_factorize()
+        d_i = solver_i.eval_solution_sensitivity(
+            0,
+            sanity_checks=False,
+            with_respect_to='initial_state',
+            return_sens_x=True,
+            return_sens_u=True,
+        )
+        err_u = np.max(np.abs(d_i['sens_u'] - batch_d['sens_u'][i]))
+        err_x = np.max(np.abs(d_i['sens_x'] - batch_d['sens_x'][i]))
+        assert err_u < TOL * 100, f"sens_u mismatch at index {i}: {err_u:.2e}"
+        assert err_x < TOL * 100, f"sens_x mismatch at index {i}: {err_x:.2e}"
+
+    print("test_ocp_batch_eval_solution_sensitivity_wrt_initial_state: PASSED")
+
+
+def test_ocp_batch_parametric_sensitivity():
+    """
+    Create one AcadosOcpBatchSolver with the parametric convex OCP, then verify:
+      - eval_solution_sensitivity(with_respect_to='p_global') agrees with ocp_solvers[i]
+      - eval_adjoint_solution_sensitivity() agrees with ocp_solvers[i]
+    Both forward and adjoint sensitivities are compiled into the same solver
+    (with_solution_sens_wrt_params_forw=True, with_solution_sens_wrt_params_adj=True).
+    """
+    ocp_nx, ocp_nu = 4, 2
+    learnable_params = ["A", "Q", "b"]
+
+    x0_batch = 0.1 * (-1) ** np.arange(ocp_nx)
+    x0_batch = np.tile(x0_batch, (N_BATCH, 1))
+    rng = np.random.default_rng(5)
+    x0_batch += 0.05 * rng.standard_normal(x0_batch.shape)
+
+    seed_x_val = np.ones((ocp_nx, 1))
+    seed_u_val = np.ones((ocp_nu, 1))
+
+    # Build OCP with both forward and adjoint sensitivity support
+    ocp = export_parametric_ocp(ocp_nx, ocp_nu, learnable_params=learnable_params)
+    ocp.code_gen_options.with_solution_sens_wrt_params_forw = True
+    ocp.code_gen_options.with_solution_sens_wrt_params_adj = True
+    ocp.solver_options.qp_solver_ric_alg = 0
+    ocp.solver_options.with_batch_functionality = True
+
+    batch_solver = AcadosOcpBatchSolver(ocp, N_batch_init=N_BATCH, verbose=False)
+    batch_solver.constraints_set(0, 'lbx', x0_batch)
+    batch_solver.constraints_set(0, 'ubx', x0_batch)
+    for n in range(N_BATCH):
+        batch_solver.ocp_solvers[n].reset()
+    batch_solver.solve()
+    batch_solver.setup_qp_matrices_and_factorize()
+
+    n_p_global = ocp.p_global_values.shape[0]
+
+    # --- forward sensitivity wrt p_global ---
+    batch_fwd = batch_solver.eval_solution_sensitivity(
+        0,
+        with_respect_to='p_global',
+        return_sens_x=True,
+        return_sens_u=True,
+    )
+
+    # --- adjoint sensitivity wrt p_global ---
+    batch_seed_x = np.tile(seed_x_val[np.newaxis, :, :], (N_BATCH, 1, 1))
+    batch_seed_u = np.tile(seed_u_val[np.newaxis, :, :], (N_BATCH, 1, 1))
+    batch_adj = batch_solver.eval_adjoint_solution_sensitivity(
+        seed_x=[(1, batch_seed_x)],
+        seed_u=[(0, batch_seed_u)],
+    )
+
+    # compare against individual ocp_solvers[i]
+    for i in range(N_BATCH):
+        solver_i = batch_solver.ocp_solvers[i]
+        solver_i.setup_qp_matrices_and_factorize()
+
+        # forward
+        d_i = solver_i.eval_solution_sensitivity(
+            0,
+            with_respect_to='p_global',
+            return_sens_x=True,
+            return_sens_u=True,
+        )
+        err_u = np.max(np.abs(d_i['sens_u'] - batch_fwd['sens_u'][i]))
+        err_x = np.max(np.abs(d_i['sens_x'] - batch_fwd['sens_x'][i]))
+        assert err_u < TOL * 100, f"fwd sens_u mismatch at index {i}: {err_u:.2e}"
+        assert err_x < TOL * 100, f"fwd sens_x mismatch at index {i}: {err_x:.2e}"
+
+        # adjoint
+        solver_i.setup_qp_matrices_and_factorize()
+        adj_i = solver_i.eval_adjoint_solution_sensitivity(
+            seed_x=[(1, seed_x_val)],
+            seed_u=[(0, seed_u_val)],
+        )
+        err_adj = np.max(np.abs(adj_i - batch_adj[i]))
+        assert err_adj < TOL * 100, f"adj sens mismatch at index {i}: {err_adj:.2e}"
+
+    print("test_ocp_batch_parametric_sensitivity: PASSED")
+
+
+def test_sim_batch():
+    """
+    Create one AcadosSimBatchSolver, run N_BATCH integrations, then verify:
+      - sim_solvers[i].get('x') after batch solve matches a fresh individual simulate() call
+      - num_threads_in_batch_solve property getter/setter works
+    The individual reference is obtained by calling sim_solvers[i].simulate() on each
+    solver from the same batch object, so no additional solver is created.
+    """
+    rng = np.random.default_rng(4)
+    x_batch = rng.standard_normal((N_BATCH, 4))
+    u_batch = rng.standard_normal((N_BATCH, 1))
+
+    sim = setup_sim()
+    batch_integrator = AcadosSimBatchSolver(sim, N_batch_init=N_BATCH, num_threads_in_batch_solve=1, verbose=False)
+
+    # --- num_threads property ---
+    assert batch_integrator.num_threads_in_batch_solve == 1
+    batch_integrator.num_threads_in_batch_solve = 2
+    assert batch_integrator.num_threads_in_batch_solve == 2
+    batch_integrator.num_threads_in_batch_solve = 1
+
+    # Set inputs and run batch solve
+    for n in range(N_BATCH):
+        batch_integrator.sim_solvers[n].set('x', x_batch[n])
+        batch_integrator.sim_solvers[n].set('u', u_batch[n])
+    batch_integrator.solve()
+
+    # Collect batch outputs
+    x_next_batch = np.array([batch_integrator.sim_solvers[n].get('x') for n in range(N_BATCH)])
+
+    # Individual reference: run each sim_solver sequentially via simulate()
+    x_next_ref = np.zeros_like(x_next_batch)
+    for n in range(N_BATCH):
+        x_next_ref[n] = batch_integrator.sim_solvers[n].simulate(x=x_batch[n], u=u_batch[n])
+
+    err = np.max(np.abs(x_next_ref - x_next_batch))
+    assert err < 1e-10, f"SimBatchSolver: max error {err:.2e} exceeds tolerance"
+
+    print("test_sim_batch: PASSED")
+
+
+if __name__ == '__main__':
+    test_ocp_batch_get_and_get_flat()
+    test_ocp_batch_eval_solution_sensitivity_wrt_initial_state()
+    test_ocp_batch_parametric_sensitivity()
+    test_sim_batch()
+    print("\nAll batch solver tests passed.")
+

--- a/interfaces/acados_template/acados_template/acados_ocp_batch_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_batch_solver.py
@@ -31,7 +31,7 @@
 from .acados_ocp_solver import AcadosOcpSolver
 from .acados_ocp import AcadosOcp
 from .acados_ocp_iterate import AcadosOcpFlattenedBatchIterate
-from typing import Optional, List, Tuple, Sequence, Union
+from typing import Optional, List, Tuple, Sequence, Union, Dict
 from ctypes import (POINTER, c_int, c_void_p, cast, c_double, c_char_p)
 import numpy as np
 import time
@@ -103,6 +103,9 @@ class AcadosOcpBatchSolver():
         getattr(self.__shared_lib, f"{self.__name}_acados_batch_eval_params_jac").argtypes = [POINTER(c_void_p), c_int, c_int]
         getattr(self.__shared_lib, f"{self.__name}_acados_batch_eval_params_jac").restype = c_void_p
 
+        getattr(self.__shared_lib, f"{self.__name}_acados_batch_eval_param_sens").argtypes = [POINTER(c_void_p), c_char_p, c_int, c_int, c_int, c_int]
+        getattr(self.__shared_lib, f"{self.__name}_acados_batch_eval_param_sens").restype = c_void_p
+
         getattr(self.__shared_lib, f"{self.__name}_acados_batch_eval_solution_sens_adj_p").argtypes = [POINTER(c_void_p), c_char_p, c_int, POINTER(c_double), c_int, c_int, c_int]
         getattr(self.__shared_lib, f"{self.__name}_acados_batch_eval_solution_sens_adj_p").restype = c_void_p
 
@@ -114,6 +117,9 @@ class AcadosOcpBatchSolver():
 
         getattr(self.__shared_lib, f"{self.__name}_acados_batch_set").argtypes = [POINTER(c_void_p), c_char_p, c_int, POINTER(c_double), c_int, c_int, c_int]
         getattr(self.__shared_lib, f"{self.__name}_acados_batch_set").restype = c_void_p
+
+        getattr(self.__shared_lib, f"{self.__name}_acados_batch_get").argtypes = [POINTER(c_void_p), c_char_p, c_int, POINTER(c_double), c_int, c_int, c_int]
+        getattr(self.__shared_lib, f"{self.__name}_acados_batch_get").restype = c_void_p
 
         getattr(self.__shared_lib, f"{self.__name}_acados_batch_constraints_set").argtypes = [POINTER(c_void_p), c_char_p, c_int, POINTER(c_double), c_int, c_int, c_int]
         getattr(self.__shared_lib, f"{self.__name}_acados_batch_constraints_set").restype = c_void_p
@@ -132,6 +138,8 @@ class AcadosOcpBatchSolver():
         if verbose:
             print(msg)
         self.verbose = verbose
+        self.time_solution_sens_lin = 0.0
+        self.time_solution_sens_solve = 0.0
 
 
     @property
@@ -326,6 +334,220 @@ class AcadosOcpBatchSolver():
         getattr(self.__shared_lib, f"{self.__name}_acados_batch_reset_sens_out")(
             self.__ocp_solvers_pointer, c_int(n_batch), c_int(self.__num_threads_in_batch_solve)
         )
+
+
+    def eval_solution_sensitivity(self,
+                                  stages: Union[int, List[int]],
+                                  with_respect_to: str,
+                                  return_sens_x: bool = False,
+                                  return_sens_u: bool = True,
+                                  return_sens_pi: bool = False,
+                                  return_sens_lam: bool = False,
+                                  return_sens_su: bool = False,
+                                  return_sens_sl: bool = False,
+                                  sanity_checks: bool = True,
+                                  ) -> Dict:
+        """
+        Evaluate forward sensitivities of the current batched solutions with respect to the initial state or global parameters.
+
+        :param stages: stages for which sensitivities are returned, int or list of int
+        :param with_respect_to: string in ["initial_state", "p_global"]
+        :param return_sens_x: whether to return sensitivities of x. Default: True.
+        :param return_sens_u: whether to return sensitivities of u. Default: True.
+        :param return_sens_pi: whether to return sensitivities of pi. Default: False.
+        :param return_sens_lam: whether to return sensitivities of lam. Default: False.
+        :param return_sens_su: whether to return sensitivities of su. Default: False.
+        :param return_sens_sl: whether to return sensitivities of sl. Default: False.
+        :param sanity_checks: bool - whether to perform sanity checks, turn off for minimal overhead, default: True
+
+        :returns: dictionary with requested sensitivity fields.
+                  For each requested field and stage, entries have shape (n_batch, field_dim, ngrad).
+                  If stages is a list, each dictionary value is a list over stages.
+                  If stages is a scalar, each dictionary value is a single np.ndarray.
+        """
+
+        stages_is_list = isinstance(stages, list)
+        stages_ = stages if stages_is_list else [stages]
+
+        n_batch = self.n_batch_current
+        solver0 = self.__ocp_solvers[0]
+        N_horizon = solver0.N
+
+        sens_x = []
+        sens_u = []
+        sens_pi = []
+        sens_lam = []
+        sens_sl = []
+        sens_su = []
+
+        if sanity_checks:
+            for s in stages_:
+                if not isinstance(s, int) or s < 0 or s > N_horizon:
+                    raise TypeError(
+                        "AcadosOcpBatchSolver.eval_solution_sensitivity(): stages need to be int or list[int] "
+                        f"and in [0, N], got stages = {stages_}."
+                    )
+
+        if with_respect_to == "initial_state":
+            nx = self.__acados_lib.ocp_nlp_dims_get_from_attr(
+                solver0.nlp_config, solver0.nlp_dims, solver0.nlp_out, 0, "x".encode('utf-8'))
+            ngrad = nx
+            field = "ex".encode('utf-8')
+            if sanity_checks:
+                self.__ocp_solvers[0]._ensure_solution_sensitivities_available(parametric=False)
+            self.time_solution_sens_lin = 0.0
+
+        elif with_respect_to == "p_global":
+            np_global = self.__acados_lib.ocp_nlp_dims_get_from_attr(
+                solver0.nlp_config, solver0.nlp_dims, solver0.nlp_out, 0, "p_global".encode('utf-8'))
+            ngrad = np_global
+            field = "p_global".encode('utf-8')
+            if sanity_checks:
+                self.__ocp_solvers[0]._ensure_solution_sensitivities_available(forward=True, parametric=True)
+
+            # Compute jacobians wrt params for all batch instances.
+            t0 = time.time()
+            getattr(self.__shared_lib, f"{self.__name}_acados_batch_eval_params_jac")(
+                self.__ocp_solvers_pointer, c_int(n_batch), c_int(self.__num_threads_in_batch_solve)
+            )
+            self.time_solution_sens_lin = time.time() - t0
+
+        else:
+            raise ValueError(
+                f"AcadosOcpBatchSolver.eval_solution_sensitivity(): Unknown field: with_respect_to = {with_respect_to}"
+            )
+
+        # Initialize output arrays.
+        for s in stages_:
+            if return_sens_x:
+                nx = self.__acados_lib.ocp_nlp_dims_get_from_attr(
+                    solver0.nlp_config, solver0.nlp_dims, solver0.nlp_out, s, "x".encode('utf-8'))
+                sens_x.append(np.zeros((n_batch, nx, ngrad), dtype=np.float64, order="C"))
+
+            if return_sens_lam:
+                nlam = self.__acados_lib.ocp_nlp_dims_get_from_attr(
+                    solver0.nlp_config, solver0.nlp_dims, solver0.nlp_out, s, "lam".encode('utf-8'))
+                sens_lam.append(np.zeros((n_batch, nlam, ngrad), dtype=np.float64, order="C"))
+
+            if return_sens_sl:
+                ns = self.__acados_lib.ocp_nlp_dims_get_from_attr(
+                    solver0.nlp_config, solver0.nlp_dims, solver0.nlp_out, s, "s".encode('utf-8'))
+                sens_sl.append(np.zeros((n_batch, ns, ngrad), dtype=np.float64, order="C"))
+
+            if return_sens_su:
+                ns = self.__acados_lib.ocp_nlp_dims_get_from_attr(
+                    solver0.nlp_config, solver0.nlp_dims, solver0.nlp_out, s, "s".encode('utf-8'))
+                sens_su.append(np.zeros((n_batch, ns, ngrad), dtype=np.float64, order="C"))
+
+            if s < N_horizon:
+                if return_sens_u:
+                    nu = self.__acados_lib.ocp_nlp_dims_get_from_attr(
+                        solver0.nlp_config, solver0.nlp_dims, solver0.nlp_out, s, "u".encode('utf-8'))
+                    sens_u.append(np.zeros((n_batch, nu, ngrad), dtype=np.float64, order="C"))
+
+                if return_sens_pi:
+                    npi = self.__acados_lib.ocp_nlp_dims_get_from_attr(
+                        solver0.nlp_config, solver0.nlp_dims, solver0.nlp_out, s, "pi".encode('utf-8'))
+                    sens_pi.append(np.zeros((n_batch, npi, ngrad), dtype=np.float64, order="C"))
+
+        t0 = time.time()
+        for k in range(ngrad):
+            # Evaluate sensitivity for all batch instances.
+            getattr(self.__shared_lib, f"{self.__name}_acados_batch_eval_param_sens")(
+                self.__ocp_solvers_pointer, field, c_int(0), c_int(k), c_int(n_batch), c_int(self.__num_threads_in_batch_solve)
+            )
+
+            # Extract sensitivities for requested stages.
+            for n, s in enumerate(stages_):
+                if return_sens_x:
+                    sens_x[n][:, :, k] = self.get(s, "sens_x", n_batch=n_batch)
+                if return_sens_lam:
+                    sens_lam[n][:, :, k] = self.get(s, "sens_lam", n_batch=n_batch)
+                if return_sens_sl:
+                    sens_sl[n][:, :, k] = self.get(s, "sens_sl", n_batch=n_batch)
+                if return_sens_su:
+                    sens_su[n][:, :, k] = self.get(s, "sens_su", n_batch=n_batch)
+
+                if s < N_horizon:
+                    if return_sens_u:
+                        sens_u[n][:, :, k] = self.get(s, "sens_u", n_batch=n_batch)
+                    if return_sens_pi:
+                        sens_pi[n][:, :, k] = self.get(s, "sens_pi", n_batch=n_batch)
+
+        self.time_solution_sens_solve = time.time() - t0
+
+        out = {}
+
+        if return_sens_x:
+            out["sens_x"] = sens_x if stages_is_list else sens_x[0]
+
+        if return_sens_u:
+            out["sens_u"] = sens_u if stages_is_list else sens_u[0]
+
+        if return_sens_pi:
+            out["sens_pi"] = sens_pi if stages_is_list else sens_pi[0]
+
+        if return_sens_lam:
+            out["sens_lam"] = sens_lam if stages_is_list else sens_lam[0]
+
+        if return_sens_sl:
+            out["sens_sl"] = sens_sl if stages_is_list else sens_sl[0]
+
+        if return_sens_su:
+            out["sens_su"] = sens_su if stages_is_list else sens_su[0]
+
+        return out
+
+
+    def get(self, stage_: int, field_: str, n_batch: Optional[int] = None) -> np.ndarray:
+        """
+        Get field values at one stage for a batch of solvers.
+
+        :param stage_: integer corresponding to shooting node
+        :param field_: string in ['x', 'u', 'z', 'pi', 'lam', 'sl', 'su', 'p',
+                       'sens_u', 'sens_pi', 'sens_x', 'sens_lam', 'sens_sl', 'sens_su']
+        :param n_batch: number of batch entries to read. If None, uses n_batch_current.
+        :returns: np.ndarray of shape (n_batch, field_dim)
+        """
+        out_fields = ['x', 'u', 'z', 'pi', 'lam', 'sl', 'su']
+        in_fields = ['p']
+        sens_fields = ['sens_u', 'sens_x', 'sens_pi', 'sens_lam', 'sens_sl', 'sens_su']
+        all_fields = out_fields + in_fields + sens_fields
+
+        if field_ not in all_fields:
+            raise ValueError(f"AcadosOcpBatchSolver.get(stage={stage_}, field={field_}): '{field_}' is an invalid argument.\n"
+                             f" Possible values are {all_fields}.")
+
+        if not isinstance(stage_, int):
+            raise TypeError(f"AcadosOcpBatchSolver.get(stage={stage_}, field={field_}): stage index must be an integer, got type {type(stage_)}.")
+
+        N_horizon = self.__ocp_solvers[0].N
+        if stage_ < 0 or stage_ > N_horizon:
+            raise ValueError(f"AcadosOcpBatchSolver.get(stage={stage_}, field={field_}): stage index must be in [0, {N_horizon}], got: {stage_}.")
+
+        if stage_ == N_horizon and field_ in ['u', 'pi', 'z', 'sens_u', 'sens_pi']:
+            raise KeyError(f"AcadosOcpBatchSolver.get(stage={stage_}, field={field_}): field '{field_}' does not exist at final stage {stage_}.")
+
+        if n_batch is None:
+            n_batch = self.n_batch_current
+        elif n_batch <= self.n_batch_current:
+            self.__n_batch_current = n_batch
+        else:
+            raise ValueError("You are attempting to get more samples than problem instances initialized so far. "
+                             "First initialize enough problem instances by using the setter methods.")
+
+        field_dim = field_.replace('sens_', '') if field_ in sens_fields else field_
+        dim = self.__ocp_solvers[0].dims_get(field_dim, stage_)
+
+        out = np.zeros((n_batch, dim), dtype=np.float64, order="C")
+        out_data = cast(out.ctypes.data, POINTER(c_double))
+
+        getattr(self.__shared_lib, f"{self.__name}_acados_batch_get")(
+            self.__ocp_solvers_pointer, field_.encode('utf-8'), c_int(stage_), out_data,
+            c_int(n_batch * dim), c_int(n_batch), c_int(self.__num_threads_in_batch_solve)
+        )
+
+        return out
 
 
     def set_flat(self, field_: str, value_: np.ndarray) -> None:

--- a/interfaces/acados_template/acados_template/acados_ocp_batch_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_batch_solver.py
@@ -115,6 +115,9 @@ class AcadosOcpBatchSolver():
         getattr(self.__shared_lib, f"{self.__name}_acados_batch_set").argtypes = [POINTER(c_void_p), c_char_p, c_int, POINTER(c_double), c_int, c_int, c_int]
         getattr(self.__shared_lib, f"{self.__name}_acados_batch_set").restype = c_void_p
 
+        getattr(self.__shared_lib, f"{self.__name}_acados_batch_constraints_set").argtypes = [POINTER(c_void_p), c_char_p, c_int, POINTER(c_double), c_int, c_int, c_int]
+        getattr(self.__shared_lib, f"{self.__name}_acados_batch_constraints_set").restype = c_void_p
+
         getattr(self.__shared_lib, f"{self.__name}_acados_batch_reset_sens_out").argtypes = [POINTER(c_void_p), c_int, c_int]
         getattr(self.__shared_lib, f"{self.__name}_acados_batch_reset_sens_out").restype = c_void_p
 
@@ -464,13 +467,17 @@ class AcadosOcpBatchSolver():
             self.__status_p = cast(self.__status.ctypes.data, POINTER(c_int))
             self.__status[:n_batch_max_old] = status_old
 
-    def constraints_set(self, stage_: int, field_: str, value_: np.ndarray, api='warn'):
+    def constraints_set(self, stage_: int, field_: str, value_: np.ndarray):
         """
         Set numerical data in the constraint module of the solvers.
 
         :param stage: integer corresponding to shooting node
         :param field: string in ['lbx', 'ubx', 'lbu', 'ubu', 'lg', 'ug', 'lh', 'uh', 'uphi', 'C', 'D']
-        :param value: of shape (n_batch, value_dim)
+        :param value: of shape (n_batch, value_dim) for vector-valued fields,
+                      or (n_batch, rows, cols) for matrix-valued fields (e.g., 'C', 'D').
+
+        Note: For matrix-valued fields, values are expected in column-major (Fortran) order per sample,
+        corresponding to the 'new' API variant of :py:meth:`~acados_template.acados_ocp_solver.AcadosOcpSolver.constraints_set`.
         """
         n_batch = value_.shape[0]
 
@@ -483,8 +490,21 @@ class AcadosOcpBatchSolver():
             self.__n_batch_current = n_batch
             self._create_missing_solvers(n_batch)
 
-        for i, solver in enumerate(self.ocp_solvers[:n_batch]):
-            solver.constraints_set(stage_, field_, value_[i], api=api)
+        # For 3D input (matrix-valued fields like C, D), flatten each sample in Fortran (column-major) order.
+        # For 2D input (vector-valued fields), data is already flat per sample.
+        if value_.ndim == 3:
+            data = np.ascontiguousarray(value_.transpose(0, 2, 1).reshape(n_batch, -1), dtype=np.float64)
+        else:
+            data = np.ascontiguousarray(value_, dtype=np.float64)
+
+        field = field_.encode('utf-8')
+        N_data = data.size
+        data_p = cast(data.ctypes.data, POINTER(c_double))
+
+        getattr(self.__shared_lib, f"{self.__name}_acados_batch_constraints_set")(
+            self.__ocp_solvers_pointer, field, c_int(stage_), data_p, c_int(N_data),
+            c_int(n_batch), c_int(self.__num_threads_in_batch_solve)
+        )
 
     def set_p_global_and_precompute_dependencies(self, data_: np.ndarray):
         """

--- a/interfaces/acados_template/acados_template/acados_ocp_batch_solver.py
+++ b/interfaces/acados_template/acados_template/acados_ocp_batch_solver.py
@@ -69,7 +69,7 @@ class AcadosOcpBatchSolver():
         if not isinstance(num_threads_in_batch_solve, int) or num_threads_in_batch_solve <= 0:
             raise ValueError("AcadosOcpBatchSolver: argument num_threads_in_batch_solve should be a positive integer.")
         if not ocp.solver_options.with_batch_functionality:
-            warnings.warn("Using AcadosOcpBatchSolver, but ocp.solver_options.with_batch_functionality is False. Attempting to compile with openmp nonetheless.")
+            warnings.warn("Using AcadosOcpBatchSolver, but ocp.solver_options.with_batch_functionality is False. Setting to True and attempting to compile with openmp nonetheless.")
             ocp.solver_options.with_batch_functionality = True
 
         self.__num_threads_in_batch_solve = num_threads_in_batch_solve

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -3481,6 +3481,40 @@ void {{ model.name }}_acados_batch_set({{ model.name }}_solver_capsule ** capsul
     }
     return;
 }
+
+
+void {{ model.name }}_acados_batch_constraints_set({{ model.name }}_solver_capsule ** capsules, const char *field, int stage, double *data, int N_data, int N_batch, int num_threads_in_batch_solve)
+{
+    // get flattened dimension (rows * cols, where cols == 0 for vector fields)
+    int dims[2] = {0, 0};
+    ocp_nlp_constraint_dims_get_from_attr(capsules[0]->nlp_config, capsules[0]->nlp_dims, capsules[0]->nlp_out, stage, field, dims);
+    int dim = dims[0] * (dims[1] == 0 ? 1 : dims[1]);
+
+    if (N_batch * dim != N_data)
+    {
+        printf("acados_batch_constraints_set: wrong input dimension, expected %d, got %d\n", N_batch * dim, N_data);
+        exit(1);
+    }
+
+    int num_threads_bkp;
+    if (num_threads_in_batch_solve > 1)
+    {
+        num_threads_bkp = omp_get_num_threads();
+        omp_set_num_threads(num_threads_in_batch_solve);
+    }
+
+    #pragma omp parallel for
+    for (int i = 0; i < N_batch; i++)
+    {
+        ocp_nlp_constraints_model_set(capsules[i]->nlp_config, capsules[i]->nlp_dims, capsules[i]->nlp_in, capsules[i]->nlp_out, stage, field, data + i * dim);
+    }
+
+    if (num_threads_in_batch_solve > 1)
+    {
+        omp_set_num_threads( num_threads_bkp );
+    }
+    return;
+}
 {% endif %}
 
 

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.c
@@ -3289,6 +3289,29 @@ void {{ model.name }}_acados_batch_eval_params_jac({{ model.name }}_solver_capsu
 }
 
 
+void {{ model.name }}_acados_batch_eval_param_sens({{ model.name }}_solver_capsule ** capsules, const char *field, int stage, int index, int N_batch, int num_threads_in_batch_solve)
+{
+    int num_threads_bkp;
+    if (num_threads_in_batch_solve > 1)
+    {
+        num_threads_bkp = omp_get_num_threads();
+        omp_set_num_threads(num_threads_in_batch_solve);
+    }
+
+    #pragma omp parallel for
+    for (int i = 0; i < N_batch; i++)
+    {
+        ocp_nlp_eval_param_sens(capsules[i]->nlp_solver, field, stage, index, capsules[i]->sens_out);
+    }
+
+    if (num_threads_in_batch_solve > 1)
+    {
+        omp_set_num_threads( num_threads_bkp );
+    }
+    return;
+}
+
+
 
 void {{ model.name }}_acados_batch_eval_solution_sens_adj_p({{ model.name }}_solver_capsule ** capsules, const char *field, int stage, double *out, int offset, int N_batch, int num_threads_in_batch_solve)
 {
@@ -3472,6 +3495,97 @@ void {{ model.name }}_acados_batch_set({{ model.name }}_solver_capsule ** capsul
         for (int i = 0; i < N_batch; i++)
         {
             ocp_nlp_out_set(capsules[i]->nlp_config, capsules[i]->nlp_dims, capsules[i]->nlp_out, capsules[i]->nlp_in, stage, field, data + i * dim);
+        }
+    }
+
+    if (num_threads_in_batch_solve > 1)
+    {
+        omp_set_num_threads( num_threads_bkp );
+    }
+    return;
+}
+
+
+void {{ model.name }}_acados_batch_get({{ model.name }}_solver_capsule ** capsules, const char *field, int stage, double *data, int N_data, int N_batch, int num_threads_in_batch_solve)
+{
+    // determine field dimension and storage location.
+    // sens_* fields are aliases that live in sens_out under their base field names.
+    const char *base_field = field;
+    int from_sens_out = 0;
+    int from_nlp_in = 0;
+
+    if (!strcmp(field, "sens_x"))
+    {
+        base_field = "x";
+        from_sens_out = 1;
+    }
+    else if (!strcmp(field, "sens_u"))
+    {
+        base_field = "u";
+        from_sens_out = 1;
+    }
+    else if (!strcmp(field, "sens_pi"))
+    {
+        base_field = "pi";
+        from_sens_out = 1;
+    }
+    else if (!strcmp(field, "sens_lam"))
+    {
+        base_field = "lam";
+        from_sens_out = 1;
+    }
+    else if (!strcmp(field, "sens_sl"))
+    {
+        base_field = "sl";
+        from_sens_out = 1;
+    }
+    else if (!strcmp(field, "sens_su"))
+    {
+        base_field = "su";
+        from_sens_out = 1;
+    }
+    else if (!strcmp(field, "p"))
+    {
+        from_nlp_in = 1;
+    }
+
+    int dim = ocp_nlp_dims_get_from_attr(capsules[0]->nlp_config, capsules[0]->nlp_dims, capsules[0]->nlp_out, stage, base_field);
+
+    if (N_batch * dim != N_data)
+    {
+        printf("acados_batch_get: wrong input dimension, expected %d, got %d\n", N_batch * dim, N_data);
+        exit(1);
+    }
+
+    int num_threads_bkp;
+    if (num_threads_in_batch_solve > 1)
+    {
+        num_threads_bkp = omp_get_num_threads();
+        omp_set_num_threads(num_threads_in_batch_solve);
+    }
+
+    if (from_nlp_in)
+    {
+        #pragma omp parallel for
+        for (int i = 0; i < N_batch; i++)
+        {
+            ocp_nlp_in_get(capsules[i]->nlp_config, capsules[i]->nlp_dims, capsules[i]->nlp_in, stage, base_field, data + i * dim);
+        }
+    }
+    else if (from_sens_out)
+    {
+        #pragma omp parallel for
+        for (int i = 0; i < N_batch; i++)
+        {
+            ocp_nlp_out_get(capsules[i]->nlp_config, capsules[i]->nlp_dims, capsules[i]->sens_out, stage, base_field, data + i * dim);
+        }
+    }
+    else
+    {
+        #pragma omp parallel for
+        for (int i = 0; i < N_batch; i++)
+        {
+            ocp_nlp_out_get(capsules[i]->nlp_config, capsules[i]->nlp_dims, capsules[i]->nlp_out, stage, base_field, data + i * dim);
         }
     }
 

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.h
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.h
@@ -324,9 +324,11 @@ ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_solve({{ model.name }}_s
 ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_set_flat({{ model.name }}_solver_capsule ** capsules, const char *field, double *data, int N_data, int N_batch, int num_threads_in_batch_solve);
 ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_get_flat({{ model.name }}_solver_capsule ** capsules, const char *field, double *data, int N_data, int N_batch, int num_threads_in_batch_solve);
 ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_set({{ model.name }}_solver_capsule ** capsules, const char *field, int stage, double *data, int N_data, int N_batch, int num_threads_in_batch_solve);
+ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_get({{ model.name }}_solver_capsule ** capsules, const char *field, int stage, double *data, int N_data, int N_batch, int num_threads_in_batch_solve);
 ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_constraints_set({{ model.name }}_solver_capsule ** capsules, const char *field, int stage, double *data, int N_data, int N_batch, int num_threads_in_batch_solve);
 ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_reset_sens_out({{ model.name }}_solver_capsule ** capsules, int N_batch, int num_threads_in_batch_solve);
 
+ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_eval_param_sens({{ model.name }}_solver_capsule ** capsules, const char *field, int stage, int index, int N_batch, int num_threads_in_batch_solve);
 ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_eval_solution_sens_adj_p({{ model.name }}_solver_capsule ** capsules, const char *field, int stage, double *out, int offset, int N_batch, int num_threads_in_batch_solve);
 ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_eval_params_jac({{ model.name }}_solver_capsule ** capsules, int N_batch, int num_threads_in_batch_solve);
 {% endif %}

--- a/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.h
+++ b/interfaces/acados_template/acados_template/c_templates_tera/acados_solver.in.h
@@ -324,6 +324,7 @@ ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_solve({{ model.name }}_s
 ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_set_flat({{ model.name }}_solver_capsule ** capsules, const char *field, double *data, int N_data, int N_batch, int num_threads_in_batch_solve);
 ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_get_flat({{ model.name }}_solver_capsule ** capsules, const char *field, double *data, int N_data, int N_batch, int num_threads_in_batch_solve);
 ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_set({{ model.name }}_solver_capsule ** capsules, const char *field, int stage, double *data, int N_data, int N_batch, int num_threads_in_batch_solve);
+ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_constraints_set({{ model.name }}_solver_capsule ** capsules, const char *field, int stage, double *data, int N_data, int N_batch, int num_threads_in_batch_solve);
 ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_reset_sens_out({{ model.name }}_solver_capsule ** capsules, int N_batch, int num_threads_in_batch_solve);
 
 ACADOS_SYMBOL_EXPORT void {{ model.name }}_acados_batch_eval_solution_sens_adj_p({{ model.name }}_solver_capsule ** capsules, const char *field, int stage, double *out, int offset, int N_batch, int num_threads_in_batch_solve);


### PR DESCRIPTION
* Added `eval_solution_sensitivity()` to `AcadosOcpBatchSolver`, enabling efficient evaluation of forward sensitivities with respect to initial state or global parameters for all batch instances.
* Introduced `get()` in `AcadosOcpBatchSolver` for retrieving field values (including sensitivities) at a given stage for all batch instances.
* Updated the C template (`acados_solver.in.c`) to add a new function `acados_batch_eval_param_sens`, which evaluates parameter sensitivities for all batch instances in parallel.
* Refactored the `constraints_set` method in `AcadosOcpBatchSolver` to use efficient batch API that directly sets constraints properties for all batch instances.
