### PR TITLE
C: refactor `memory_set` functionality to use field names instead of individual functions

### DIFF
--- a/acados/ocp_nlp/ocp_nlp_common.c
+++ b/acados/ocp_nlp/ocp_nlp_common.c
@@ -2744,8 +2744,8 @@ void ocp_nlp_set_primal_variable_pointers_in_submodules(ocp_nlp_config *config, 
     int N = dims->N;
     for (int i = 0; i < N; i++)
     {
-        config->dynamics[i]->memory_set_ux_ptr(nlp_out->ux+i, nlp_mem->dynamics[i]);
-        config->dynamics[i]->memory_set_ux1_ptr(nlp_out->ux+i+1, nlp_mem->dynamics[i]);
+        config->dynamics[i]->memory_set(config->dynamics[i], dims->dynamics[i], nlp_mem->dynamics[i], "ux", nlp_out->ux+i);
+        config->dynamics[i]->memory_set(config->dynamics[i], dims->dynamics[i], nlp_mem->dynamics[i], "ux1", nlp_out->ux+i+1);
     }
     for (int i = 0; i <= N; i++)
     {
@@ -2796,24 +2796,25 @@ void ocp_nlp_alias_memory_to_submodules(ocp_nlp_config *config, ocp_nlp_dims *di
 #endif
     for (int i = 0; i < N; i++)
     {
-        config->dynamics[i]->memory_set_ux_ptr(nlp_out->ux+i, nlp_mem->dynamics[i]);
-        config->dynamics[i]->memory_set_ux1_ptr(nlp_out->ux+i+1, nlp_mem->dynamics[i]);
-        config->dynamics[i]->memory_set_pi_ptr(nlp_out->pi+i, nlp_mem->dynamics[i]);
-        config->dynamics[i]->memory_set_BAbt_ptr(nlp_mem->qp_in->BAbt+i, nlp_mem->dynamics[i]);
-        config->dynamics[i]->memory_set_RSQrq_ptr(nlp_mem->qp_in->RSQrq+i, nlp_mem->dynamics[i]);
-        config->dynamics[i]->memory_set_dzduxt_ptr(nlp_mem->dzduxt+i, nlp_mem->dynamics[i]);
-        config->dynamics[i]->memory_set_sim_guess_ptr(nlp_mem->sim_guess+i, nlp_mem->set_sim_guess+i, nlp_mem->dynamics[i]);
+        config->dynamics[i]->memory_set(config->dynamics[i], dims->dynamics[i], nlp_mem->dynamics[i], "ux", nlp_out->ux+i);
+        config->dynamics[i]->memory_set(config->dynamics[i], dims->dynamics[i], nlp_mem->dynamics[i], "ux1", nlp_out->ux+i+1);
+        config->dynamics[i]->memory_set(config->dynamics[i], dims->dynamics[i], nlp_mem->dynamics[i], "pi", nlp_out->pi+i);
+        config->dynamics[i]->memory_set(config->dynamics[i], dims->dynamics[i], nlp_mem->dynamics[i], "BAbt", nlp_mem->qp_in->BAbt+i);
+        config->dynamics[i]->memory_set(config->dynamics[i], dims->dynamics[i], nlp_mem->dynamics[i], "RSQrq", nlp_mem->qp_in->RSQrq+i);
+        config->dynamics[i]->memory_set(config->dynamics[i], dims->dynamics[i], nlp_mem->dynamics[i], "dzduxt", nlp_mem->dzduxt+i);
+        config->dynamics[i]->memory_set(config->dynamics[i], dims->dynamics[i], nlp_mem->dynamics[i], "sim_guess", nlp_mem->sim_guess+i);
+        config->dynamics[i]->memory_set(config->dynamics[i], dims->dynamics[i], nlp_mem->dynamics[i], "set_sim_guess", nlp_mem->set_sim_guess+i);
         // NOTE: no z at terminal stage, since dynamics modules dont compute it.
-        config->dynamics[i]->memory_set_z_alg_ptr(nlp_mem->z_alg+i, nlp_mem->dynamics[i]);
+        config->dynamics[i]->memory_set(config->dynamics[i], dims->dynamics[i], nlp_mem->dynamics[i], "z_alg", nlp_mem->z_alg+i);
 
         if (opts->with_solution_sens_wrt_params_forw)
         {
-            config->dynamics[i]->memory_set_dyn_jac_p_global_ptr(nlp_mem->jac_dyn_p_global+i, nlp_mem->dynamics[i]);
-            config->dynamics[i]->memory_set_jac_lag_stat_p_global_ptr(nlp_mem->jac_lag_stat_p_global+i, nlp_mem->dynamics[i]);
+            config->dynamics[i]->memory_set(config->dynamics[i], dims->dynamics[i], nlp_mem->dynamics[i], "dyn_jac_p_global", nlp_mem->jac_dyn_p_global+i);
+            config->dynamics[i]->memory_set(config->dynamics[i], dims->dynamics[i], nlp_mem->dynamics[i], "jac_lag_stat_p_global", nlp_mem->jac_lag_stat_p_global+i);
         }
         if (opts->with_solution_sens_wrt_params_adj)
         {
-            config->dynamics[i]->memory_set_adj_lag_p_global_ptr(&nlp_mem->out_np_global, nlp_mem->dynamics[i]);
+            config->dynamics[i]->memory_set(config->dynamics[i], dims->dynamics[i], nlp_mem->dynamics[i], "adj_lag_p_global", &nlp_mem->out_np_global);
         }
 
         int cost_integration;
@@ -4154,8 +4155,8 @@ void ocp_nlp_common_eval_solution_sens_adj_p(ocp_nlp_config *config, ocp_nlp_dim
             // dynamics
             if (i < N)
             {
-                config->dynamics[i]->memory_set_seed_ux_ptr(tmp_qp_out->ux+i, mem->dynamics[i]);
-                config->dynamics[i]->memory_set_seed_pi_ptr(tmp_qp_out->pi+i, mem->dynamics[i]);
+                config->dynamics[i]->memory_set(config->dynamics[i], dims->dynamics[i], mem->dynamics[i], "seed_ux", tmp_qp_out->ux+i);
+                config->dynamics[i]->memory_set(config->dynamics[i], dims->dynamics[i], mem->dynamics[i], "seed_pi", tmp_qp_out->pi+i);
                 config->dynamics[i]->compute_adj_sol_sens_pdiff(config->dynamics[i], dims->dynamics[i], in->dynamics[i],
                             opts->dynamics[i], mem->dynamics[i], work->dynamics[i]);
             }

--- a/acados/ocp_nlp/ocp_nlp_common.c
+++ b/acados/ocp_nlp/ocp_nlp_common.c
@@ -2749,7 +2749,7 @@ void ocp_nlp_set_primal_variable_pointers_in_submodules(ocp_nlp_config *config, 
     }
     for (int i = 0; i <= N; i++)
     {
-        config->cost[i]->memory_set_ux_ptr(nlp_out->ux+i, nlp_mem->cost[i]);
+        config->cost[i]->memory_set(config->cost[i], dims->cost[i], nlp_mem->cost[i], "ux", nlp_out->ux+i);
         config->constraints[i]->memory_set(config->constraints[i], dims->constraints[i], nlp_mem->constraints[i], "ux", nlp_out->ux+i);
     }
     return;
@@ -2850,17 +2850,17 @@ void ocp_nlp_alias_memory_to_submodules(ocp_nlp_config *config, ocp_nlp_dims *di
     {
         if (opts->with_solution_sens_wrt_params_forw)
         {
-            config->cost[i]->memory_set_jac_lag_stat_p_global_ptr(nlp_mem->jac_lag_stat_p_global+i, nlp_mem->cost[i]);
+            config->cost[i]->memory_set(config->cost[i], dims->cost[i], nlp_mem->cost[i], "jac_lag_stat_p_global", nlp_mem->jac_lag_stat_p_global+i);
         }
         if (opts->with_solution_sens_wrt_params_adj)
         {
-            config->cost[i]->memory_set_adj_lag_p_global_ptr(&nlp_mem->out_np_global, nlp_mem->cost[i]);
+            config->cost[i]->memory_set(config->cost[i], dims->cost[i], nlp_mem->cost[i], "adj_lag_p_global", &nlp_mem->out_np_global);
         }
-        config->cost[i]->memory_set_ux_ptr(nlp_out->ux+i, nlp_mem->cost[i]);
-        config->cost[i]->memory_set_z_alg_ptr(nlp_mem->z_alg+i, nlp_mem->cost[i]);
-        config->cost[i]->memory_set_dzdux_tran_ptr(nlp_mem->dzduxt+i, nlp_mem->cost[i]);
-        config->cost[i]->memory_set_RSQrq_ptr(nlp_mem->qp_in->RSQrq+i, nlp_mem->cost[i]);
-        config->cost[i]->memory_set_Z_ptr(nlp_mem->qp_in->Z+i, nlp_mem->cost[i]);
+        config->cost[i]->memory_set(config->cost[i], dims->cost[i], nlp_mem->cost[i], "ux", nlp_out->ux+i);
+        config->cost[i]->memory_set(config->cost[i], dims->cost[i], nlp_mem->cost[i], "z_alg", nlp_mem->z_alg+i);
+        config->cost[i]->memory_set(config->cost[i], dims->cost[i], nlp_mem->cost[i], "dzdux_tran", nlp_mem->dzduxt+i);
+        config->cost[i]->memory_set(config->cost[i], dims->cost[i], nlp_mem->cost[i], "RSQrq", nlp_mem->qp_in->RSQrq+i);
+        config->cost[i]->memory_set(config->cost[i], dims->cost[i], nlp_mem->cost[i], "Z", nlp_mem->qp_in->Z+i);
     }
 
     // alias to constraints_memory
@@ -4148,7 +4148,7 @@ void ocp_nlp_common_eval_solution_sens_adj_p(ocp_nlp_config *config, ocp_nlp_dim
         for (i = 0; i <= N; i++)
         {
             // cost
-            config->cost[i]->memory_set_seed_ux_ptr(tmp_qp_out->ux+i, mem->cost[i]);
+            config->cost[i]->memory_set(config->cost[i], dims->cost[i], mem->cost[i], "seed_ux", tmp_qp_out->ux+i);
             config->cost[i]->compute_adj_sol_sens_pdiff(config->cost[i], dims->cost[i], in->cost[i],
                             opts->cost[i], mem->cost[i], work->cost[i]);
             // dynamics

--- a/acados/ocp_nlp/ocp_nlp_common.c
+++ b/acados/ocp_nlp/ocp_nlp_common.c
@@ -2744,13 +2744,13 @@ void ocp_nlp_set_primal_variable_pointers_in_submodules(ocp_nlp_config *config, 
     int N = dims->N;
     for (int i = 0; i < N; i++)
     {
-        config->dynamics[i]->memory_set(config->dynamics[i], dims->dynamics[i], nlp_mem->dynamics[i], "ux", nlp_out->ux+i);
-        config->dynamics[i]->memory_set(config->dynamics[i], dims->dynamics[i], nlp_mem->dynamics[i], "ux1", nlp_out->ux+i+1);
+        config->dynamics[i]->memory_set(config->dynamics[i], dims->dynamics[i], nlp_mem->dynamics[i], "ux_ptr", nlp_out->ux+i);
+        config->dynamics[i]->memory_set(config->dynamics[i], dims->dynamics[i], nlp_mem->dynamics[i], "ux1_ptr", nlp_out->ux+i+1);
     }
     for (int i = 0; i <= N; i++)
     {
-        config->cost[i]->memory_set(config->cost[i], dims->cost[i], nlp_mem->cost[i], "ux", nlp_out->ux+i);
-        config->constraints[i]->memory_set(config->constraints[i], dims->constraints[i], nlp_mem->constraints[i], "ux", nlp_out->ux+i);
+        config->cost[i]->memory_set(config->cost[i], dims->cost[i], nlp_mem->cost[i], "ux_ptr", nlp_out->ux+i);
+        config->constraints[i]->memory_set(config->constraints[i], dims->constraints[i], nlp_mem->constraints[i], "ux_ptr", nlp_out->ux+i);
     }
     return;
 }
@@ -2796,25 +2796,25 @@ void ocp_nlp_alias_memory_to_submodules(ocp_nlp_config *config, ocp_nlp_dims *di
 #endif
     for (int i = 0; i < N; i++)
     {
-        config->dynamics[i]->memory_set(config->dynamics[i], dims->dynamics[i], nlp_mem->dynamics[i], "ux", nlp_out->ux+i);
-        config->dynamics[i]->memory_set(config->dynamics[i], dims->dynamics[i], nlp_mem->dynamics[i], "ux1", nlp_out->ux+i+1);
-        config->dynamics[i]->memory_set(config->dynamics[i], dims->dynamics[i], nlp_mem->dynamics[i], "pi", nlp_out->pi+i);
-        config->dynamics[i]->memory_set(config->dynamics[i], dims->dynamics[i], nlp_mem->dynamics[i], "BAbt", nlp_mem->qp_in->BAbt+i);
-        config->dynamics[i]->memory_set(config->dynamics[i], dims->dynamics[i], nlp_mem->dynamics[i], "RSQrq", nlp_mem->qp_in->RSQrq+i);
-        config->dynamics[i]->memory_set(config->dynamics[i], dims->dynamics[i], nlp_mem->dynamics[i], "dzduxt", nlp_mem->dzduxt+i);
+        config->dynamics[i]->memory_set(config->dynamics[i], dims->dynamics[i], nlp_mem->dynamics[i], "ux_ptr", nlp_out->ux+i);
+        config->dynamics[i]->memory_set(config->dynamics[i], dims->dynamics[i], nlp_mem->dynamics[i], "ux1_ptr", nlp_out->ux+i+1);
+        config->dynamics[i]->memory_set(config->dynamics[i], dims->dynamics[i], nlp_mem->dynamics[i], "pi_ptr", nlp_out->pi+i);
+        config->dynamics[i]->memory_set(config->dynamics[i], dims->dynamics[i], nlp_mem->dynamics[i], "BAbt_ptr", nlp_mem->qp_in->BAbt+i);
+        config->dynamics[i]->memory_set(config->dynamics[i], dims->dynamics[i], nlp_mem->dynamics[i], "RSQrq_ptr", nlp_mem->qp_in->RSQrq+i);
+        config->dynamics[i]->memory_set(config->dynamics[i], dims->dynamics[i], nlp_mem->dynamics[i], "dzduxt_ptr", nlp_mem->dzduxt+i);
         config->dynamics[i]->memory_set(config->dynamics[i], dims->dynamics[i], nlp_mem->dynamics[i], "sim_guess", nlp_mem->sim_guess+i);
         config->dynamics[i]->memory_set(config->dynamics[i], dims->dynamics[i], nlp_mem->dynamics[i], "set_sim_guess", nlp_mem->set_sim_guess+i);
         // NOTE: no z at terminal stage, since dynamics modules dont compute it.
-        config->dynamics[i]->memory_set(config->dynamics[i], dims->dynamics[i], nlp_mem->dynamics[i], "z_alg", nlp_mem->z_alg+i);
+        config->dynamics[i]->memory_set(config->dynamics[i], dims->dynamics[i], nlp_mem->dynamics[i], "z_alg_ptr", nlp_mem->z_alg+i);
 
         if (opts->with_solution_sens_wrt_params_forw)
         {
-            config->dynamics[i]->memory_set(config->dynamics[i], dims->dynamics[i], nlp_mem->dynamics[i], "dyn_jac_p_global", nlp_mem->jac_dyn_p_global+i);
-            config->dynamics[i]->memory_set(config->dynamics[i], dims->dynamics[i], nlp_mem->dynamics[i], "jac_lag_stat_p_global", nlp_mem->jac_lag_stat_p_global+i);
+            config->dynamics[i]->memory_set(config->dynamics[i], dims->dynamics[i], nlp_mem->dynamics[i], "dyn_jac_p_global_ptr", nlp_mem->jac_dyn_p_global+i);
+            config->dynamics[i]->memory_set(config->dynamics[i], dims->dynamics[i], nlp_mem->dynamics[i], "jac_lag_stat_p_global_ptr", nlp_mem->jac_lag_stat_p_global+i);
         }
         if (opts->with_solution_sens_wrt_params_adj)
         {
-            config->dynamics[i]->memory_set(config->dynamics[i], dims->dynamics[i], nlp_mem->dynamics[i], "adj_lag_p_global", &nlp_mem->out_np_global);
+            config->dynamics[i]->memory_set(config->dynamics[i], dims->dynamics[i], nlp_mem->dynamics[i], "adj_lag_p_global_ptr", &nlp_mem->out_np_global);
         }
 
         int cost_integration;
@@ -2851,17 +2851,17 @@ void ocp_nlp_alias_memory_to_submodules(ocp_nlp_config *config, ocp_nlp_dims *di
     {
         if (opts->with_solution_sens_wrt_params_forw)
         {
-            config->cost[i]->memory_set(config->cost[i], dims->cost[i], nlp_mem->cost[i], "jac_lag_stat_p_global", nlp_mem->jac_lag_stat_p_global+i);
+            config->cost[i]->memory_set(config->cost[i], dims->cost[i], nlp_mem->cost[i], "jac_lag_stat_p_global_ptr", nlp_mem->jac_lag_stat_p_global+i);
         }
         if (opts->with_solution_sens_wrt_params_adj)
         {
-            config->cost[i]->memory_set(config->cost[i], dims->cost[i], nlp_mem->cost[i], "adj_lag_p_global", &nlp_mem->out_np_global);
+            config->cost[i]->memory_set(config->cost[i], dims->cost[i], nlp_mem->cost[i], "adj_lag_p_global_ptr", &nlp_mem->out_np_global);
         }
-        config->cost[i]->memory_set(config->cost[i], dims->cost[i], nlp_mem->cost[i], "ux", nlp_out->ux+i);
-        config->cost[i]->memory_set(config->cost[i], dims->cost[i], nlp_mem->cost[i], "z_alg", nlp_mem->z_alg+i);
-        config->cost[i]->memory_set(config->cost[i], dims->cost[i], nlp_mem->cost[i], "dzdux_tran", nlp_mem->dzduxt+i);
-        config->cost[i]->memory_set(config->cost[i], dims->cost[i], nlp_mem->cost[i], "RSQrq", nlp_mem->qp_in->RSQrq+i);
-        config->cost[i]->memory_set(config->cost[i], dims->cost[i], nlp_mem->cost[i], "Z", nlp_mem->qp_in->Z+i);
+        config->cost[i]->memory_set(config->cost[i], dims->cost[i], nlp_mem->cost[i], "ux_ptr", nlp_out->ux+i);
+        config->cost[i]->memory_set(config->cost[i], dims->cost[i], nlp_mem->cost[i], "z_alg_ptr", nlp_mem->z_alg+i);
+        config->cost[i]->memory_set(config->cost[i], dims->cost[i], nlp_mem->cost[i], "dzdux_tran_ptr", nlp_mem->dzduxt+i);
+        config->cost[i]->memory_set(config->cost[i], dims->cost[i], nlp_mem->cost[i], "RSQrq_ptr", nlp_mem->qp_in->RSQrq+i);
+        config->cost[i]->memory_set(config->cost[i], dims->cost[i], nlp_mem->cost[i], "Z_ptr", nlp_mem->qp_in->Z+i);
     }
 
     // alias to constraints_memory
@@ -2870,24 +2870,24 @@ void ocp_nlp_alias_memory_to_submodules(ocp_nlp_config *config, ocp_nlp_dims *di
 #endif
     for (int i = 0; i <= N; i++)
     {
-        config->constraints[i]->memory_set(config->constraints[i], dims->constraints[i], nlp_mem->constraints[i], "ux", nlp_out->ux+i);
-        config->constraints[i]->memory_set(config->constraints[i], dims->constraints[i], nlp_mem->constraints[i], "lam", nlp_out->lam+i);
-        config->constraints[i]->memory_set(config->constraints[i], dims->constraints[i], nlp_mem->constraints[i], "z_alg", nlp_mem->z_alg+i);
-        config->constraints[i]->memory_set(config->constraints[i], dims->constraints[i], nlp_mem->constraints[i], "dzduxt", nlp_mem->dzduxt+i);
-        config->constraints[i]->memory_set(config->constraints[i], dims->constraints[i], nlp_mem->constraints[i], "DCt", nlp_mem->qp_in->DCt+i);
-        config->constraints[i]->memory_set(config->constraints[i], dims->constraints[i], nlp_mem->constraints[i], "RSQrq", nlp_mem->qp_in->RSQrq+i);
-        config->constraints[i]->memory_set(config->constraints[i], dims->constraints[i], nlp_mem->constraints[i], "idxb", nlp_mem->qp_in->idxb[i]);
-        config->constraints[i]->memory_set(config->constraints[i], dims->constraints[i], nlp_mem->constraints[i], "idxs_rev", nlp_mem->qp_in->idxs_rev[i]);
-        config->constraints[i]->memory_set(config->constraints[i], dims->constraints[i], nlp_mem->constraints[i], "idxe", nlp_mem->qp_in->idxe[i]);
+        config->constraints[i]->memory_set(config->constraints[i], dims->constraints[i], nlp_mem->constraints[i], "ux_ptr", nlp_out->ux+i);
+        config->constraints[i]->memory_set(config->constraints[i], dims->constraints[i], nlp_mem->constraints[i], "lam_ptr", nlp_out->lam+i);
+        config->constraints[i]->memory_set(config->constraints[i], dims->constraints[i], nlp_mem->constraints[i], "z_alg_ptr", nlp_mem->z_alg+i);
+        config->constraints[i]->memory_set(config->constraints[i], dims->constraints[i], nlp_mem->constraints[i], "dzduxt_ptr", nlp_mem->dzduxt+i);
+        config->constraints[i]->memory_set(config->constraints[i], dims->constraints[i], nlp_mem->constraints[i], "DCt_ptr", nlp_mem->qp_in->DCt+i);
+        config->constraints[i]->memory_set(config->constraints[i], dims->constraints[i], nlp_mem->constraints[i], "RSQrq_ptr", nlp_mem->qp_in->RSQrq+i);
+        config->constraints[i]->memory_set(config->constraints[i], dims->constraints[i], nlp_mem->constraints[i], "idxb_ptr", nlp_mem->qp_in->idxb[i]);
+        config->constraints[i]->memory_set(config->constraints[i], dims->constraints[i], nlp_mem->constraints[i], "idxs_rev_ptr", nlp_mem->qp_in->idxs_rev[i]);
+        config->constraints[i]->memory_set(config->constraints[i], dims->constraints[i], nlp_mem->constraints[i], "idxe_ptr", nlp_mem->qp_in->idxe[i]);
         if (opts->with_solution_sens_wrt_params_forw)
         {
-            config->constraints[i]->memory_set(config->constraints[i], dims->constraints[i], nlp_mem->constraints[i], "jac_lag_stat_p_global", nlp_mem->jac_lag_stat_p_global+i);
-            config->constraints[i]->memory_set(config->constraints[i], dims->constraints[i], nlp_mem->constraints[i], "jac_ineq_p_global", nlp_mem->jac_ineq_p_global+i);
+            config->constraints[i]->memory_set(config->constraints[i], dims->constraints[i], nlp_mem->constraints[i], "jac_lag_stat_p_global_ptr", nlp_mem->jac_lag_stat_p_global+i);
+            config->constraints[i]->memory_set(config->constraints[i], dims->constraints[i], nlp_mem->constraints[i], "jac_ineq_p_global_ptr", nlp_mem->jac_ineq_p_global+i);
         }
         if (opts->with_solution_sens_wrt_params_adj)
         {
             config->constraints[i]->memory_set(config->constraints[i], dims->constraints[i],
-                nlp_mem->constraints[i], "adj_lag_p_global", &nlp_mem->out_np_global);
+                nlp_mem->constraints[i], "adj_lag_p_global_ptr", &nlp_mem->out_np_global);
         }
     }
 
@@ -4149,21 +4149,21 @@ void ocp_nlp_common_eval_solution_sens_adj_p(ocp_nlp_config *config, ocp_nlp_dim
         for (i = 0; i <= N; i++)
         {
             // cost
-            config->cost[i]->memory_set(config->cost[i], dims->cost[i], mem->cost[i], "seed_ux", tmp_qp_out->ux+i);
+            config->cost[i]->memory_set(config->cost[i], dims->cost[i], mem->cost[i], "seed_ux_ptr", tmp_qp_out->ux+i);
             config->cost[i]->compute_adj_sol_sens_pdiff(config->cost[i], dims->cost[i], in->cost[i],
                             opts->cost[i], mem->cost[i], work->cost[i]);
             // dynamics
             if (i < N)
             {
-                config->dynamics[i]->memory_set(config->dynamics[i], dims->dynamics[i], mem->dynamics[i], "seed_ux", tmp_qp_out->ux+i);
-                config->dynamics[i]->memory_set(config->dynamics[i], dims->dynamics[i], mem->dynamics[i], "seed_pi", tmp_qp_out->pi+i);
+                config->dynamics[i]->memory_set(config->dynamics[i], dims->dynamics[i], mem->dynamics[i], "seed_ux_ptr", tmp_qp_out->ux+i);
+                config->dynamics[i]->memory_set(config->dynamics[i], dims->dynamics[i], mem->dynamics[i], "seed_pi_ptr", tmp_qp_out->pi+i);
                 config->dynamics[i]->compute_adj_sol_sens_pdiff(config->dynamics[i], dims->dynamics[i], in->dynamics[i],
                             opts->dynamics[i], mem->dynamics[i], work->dynamics[i]);
             }
 
             // constraints
-            config->constraints[i]->memory_set(config->constraints[i], dims->constraints[i], mem->constraints[i], "seed_ux", tmp_qp_out->ux+i);
-            config->constraints[i]->memory_set(config->constraints[i], dims->constraints[i], mem->constraints[i], "seed_lam", tmp_qp_out->lam+i);
+            config->constraints[i]->memory_set(config->constraints[i], dims->constraints[i], mem->constraints[i], "seed_ux_ptr", tmp_qp_out->ux+i);
+            config->constraints[i]->memory_set(config->constraints[i], dims->constraints[i], mem->constraints[i], "seed_lam_ptr", tmp_qp_out->lam+i);
             config->constraints[i]->compute_adj_sol_sens_pdiff(config->constraints[i], dims->constraints[i],
                 in->constraints[i], opts->constraints[i], mem->constraints[i], work->constraints[i]);
         }

--- a/acados/ocp_nlp/ocp_nlp_common.c
+++ b/acados/ocp_nlp/ocp_nlp_common.c
@@ -2750,7 +2750,7 @@ void ocp_nlp_set_primal_variable_pointers_in_submodules(ocp_nlp_config *config, 
     for (int i = 0; i <= N; i++)
     {
         config->cost[i]->memory_set_ux_ptr(nlp_out->ux+i, nlp_mem->cost[i]);
-        config->constraints[i]->memory_set_ux_ptr(nlp_out->ux+i, nlp_mem->constraints[i]);
+        config->constraints[i]->memory_set(config->constraints[i], dims->constraints[i], nlp_mem->constraints[i], "ux", nlp_out->ux+i);
     }
     return;
 }
@@ -2869,24 +2869,24 @@ void ocp_nlp_alias_memory_to_submodules(ocp_nlp_config *config, ocp_nlp_dims *di
 #endif
     for (int i = 0; i <= N; i++)
     {
-        config->constraints[i]->memory_set_ux_ptr(nlp_out->ux+i, nlp_mem->constraints[i]);
-        config->constraints[i]->memory_set_lam_ptr(nlp_out->lam+i, nlp_mem->constraints[i]);
-        config->constraints[i]->memory_set_z_alg_ptr(nlp_mem->z_alg+i, nlp_mem->constraints[i]);
-        config->constraints[i]->memory_set_dzdux_tran_ptr(nlp_mem->dzduxt+i, nlp_mem->constraints[i]);
-        config->constraints[i]->memory_set_DCt_ptr(nlp_mem->qp_in->DCt+i, nlp_mem->constraints[i]);
-        config->constraints[i]->memory_set_RSQrq_ptr(nlp_mem->qp_in->RSQrq+i, nlp_mem->constraints[i]);
-        config->constraints[i]->memory_set_idxb_ptr(nlp_mem->qp_in->idxb[i], nlp_mem->constraints[i]);
-        config->constraints[i]->memory_set_idxs_rev_ptr(nlp_mem->qp_in->idxs_rev[i], nlp_mem->constraints[i]);
-        config->constraints[i]->memory_set_idxe_ptr(nlp_mem->qp_in->idxe[i], nlp_mem->constraints[i]);
+        config->constraints[i]->memory_set(config->constraints[i], dims->constraints[i], nlp_mem->constraints[i], "ux", nlp_out->ux+i);
+        config->constraints[i]->memory_set(config->constraints[i], dims->constraints[i], nlp_mem->constraints[i], "lam", nlp_out->lam+i);
+        config->constraints[i]->memory_set(config->constraints[i], dims->constraints[i], nlp_mem->constraints[i], "z_alg", nlp_mem->z_alg+i);
+        config->constraints[i]->memory_set(config->constraints[i], dims->constraints[i], nlp_mem->constraints[i], "dzduxt", nlp_mem->dzduxt+i);
+        config->constraints[i]->memory_set(config->constraints[i], dims->constraints[i], nlp_mem->constraints[i], "DCt", nlp_mem->qp_in->DCt+i);
+        config->constraints[i]->memory_set(config->constraints[i], dims->constraints[i], nlp_mem->constraints[i], "RSQrq", nlp_mem->qp_in->RSQrq+i);
+        config->constraints[i]->memory_set(config->constraints[i], dims->constraints[i], nlp_mem->constraints[i], "idxb", nlp_mem->qp_in->idxb[i]);
+        config->constraints[i]->memory_set(config->constraints[i], dims->constraints[i], nlp_mem->constraints[i], "idxs_rev", nlp_mem->qp_in->idxs_rev[i]);
+        config->constraints[i]->memory_set(config->constraints[i], dims->constraints[i], nlp_mem->constraints[i], "idxe", nlp_mem->qp_in->idxe[i]);
         if (opts->with_solution_sens_wrt_params_forw)
         {
-            config->constraints[i]->memory_set_jac_lag_stat_p_global_ptr(nlp_mem->jac_lag_stat_p_global+i, nlp_mem->constraints[i]);
-            config->constraints[i]->memory_set_jac_ineq_p_global_ptr(nlp_mem->jac_ineq_p_global+i, nlp_mem->constraints[i]);
+            config->constraints[i]->memory_set(config->constraints[i], dims->constraints[i], nlp_mem->constraints[i], "jac_lag_stat_p_global", nlp_mem->jac_lag_stat_p_global+i);
+            config->constraints[i]->memory_set(config->constraints[i], dims->constraints[i], nlp_mem->constraints[i], "jac_ineq_p_global", nlp_mem->jac_ineq_p_global+i);
         }
         if (opts->with_solution_sens_wrt_params_adj)
         {
             config->constraints[i]->memory_set(config->constraints[i], dims->constraints[i],
-                nlp_mem->constraints[i], "adj_lag_p_global_ptr", &nlp_mem->out_np_global);
+                nlp_mem->constraints[i], "adj_lag_p_global", &nlp_mem->out_np_global);
         }
     }
 

--- a/acados/ocp_nlp/ocp_nlp_constraints_bgh.c
+++ b/acados/ocp_nlp/ocp_nlp_constraints_bgh.c
@@ -966,59 +966,59 @@ void ocp_nlp_constraints_bgh_memory_set(void *config_, void *dims_, void *memory
 {
     ocp_nlp_constraints_bgh_memory *memory = memory_;
 
-    if (!strcmp(field, "ux"))
+    if (!strcmp(field, "ux_ptr"))
     {
         memory->ux = value;
     }
-    else if (!strcmp(field, "lam"))
+    else if (!strcmp(field, "lam_ptr"))
     {
         memory->lam = value;
     }
-    else if (!strcmp(field, "DCt"))
+    else if (!strcmp(field, "DCt_ptr"))
     {
         memory->DCt = value;
     }
-    else if (!strcmp(field, "RSQrq"))
+    else if (!strcmp(field, "RSQrq_ptr"))
     {
         memory->RSQrq = value;
     }
-    else if (!strcmp(field, "z_alg"))
+    else if (!strcmp(field, "z_alg_ptr"))
     {
         memory->z_alg = value;
     }
-    else if (!strcmp(field, "dzduxt"))
+    else if (!strcmp(field, "dzduxt_ptr"))
     {
         memory->dzduxt = value;
     }
-    else if (!strcmp(field, "idxb"))
+    else if (!strcmp(field, "idxb_ptr"))
     {
         memory->idxb = value;
     }
-    else if (!strcmp(field, "idxs_rev"))
+    else if (!strcmp(field, "idxs_rev_ptr"))
     {
         memory->idxs_rev = value;
     }
-    else if (!strcmp(field, "idxe"))
+    else if (!strcmp(field, "idxe_ptr"))
     {
         memory->idxe = value;
     }
-    else if (!strcmp(field, "jac_lag_stat_p_global"))
+    else if (!strcmp(field, "jac_lag_stat_p_global_ptr"))
     {
         memory->jac_lag_stat_p_global = value;
     }
-    else if (!strcmp(field, "jac_ineq_p_global"))
+    else if (!strcmp(field, "jac_ineq_p_global_ptr"))
     {
         memory->jac_ineq_p_global = value;
     }
-    else if (!strcmp(field, "seed_ux"))
+    else if (!strcmp(field, "seed_ux_ptr"))
     {
         memory->seed_ux = value;
     }
-    else if (!strcmp(field, "seed_lam"))
+    else if (!strcmp(field, "seed_lam_ptr"))
     {
         memory->seed_lam = value;
     }
-    else if (!strcmp(field, "adj_lag_p_global"))
+    else if (!strcmp(field, "adj_lag_p_global_ptr"))
     {
         memory->adj_lag_p_global = value;
     }
@@ -1030,6 +1030,7 @@ void ocp_nlp_constraints_bgh_memory_set(void *config_, void *dims_, void *memory
 
     return;
 }
+
 /************************************************
  * workspace
  ************************************************/

--- a/acados/ocp_nlp/ocp_nlp_constraints_bgh.c
+++ b/acados/ocp_nlp/ocp_nlp_constraints_bgh.c
@@ -966,23 +966,61 @@ void ocp_nlp_constraints_bgh_memory_set(void *config_, void *dims_, void *memory
 {
     ocp_nlp_constraints_bgh_memory *memory = memory_;
 
-    if (!strcmp(field, "seed_ux"))
+    if (!strcmp(field, "ux"))
     {
-        struct blasfeo_dvec *seed_ux = value;
-        memory->seed_ux = seed_ux;
-        // printf("ocp_nlp_constraints_bgh_memory_set: got seed_ux %p\n", memory->seed_ux);
+        memory->ux = value;
+    }
+    else if (!strcmp(field, "lam"))
+    {
+        memory->lam = value;
+    }
+    else if (!strcmp(field, "DCt"))
+    {
+        memory->DCt = value;
+    }
+    else if (!strcmp(field, "RSQrq"))
+    {
+        memory->RSQrq = value;
+    }
+    else if (!strcmp(field, "z_alg"))
+    {
+        memory->z_alg = value;
+    }
+    else if (!strcmp(field, "dzduxt"))
+    {
+        memory->dzduxt = value;
+    }
+    else if (!strcmp(field, "idxb"))
+    {
+        memory->idxb = value;
+    }
+    else if (!strcmp(field, "idxs_rev"))
+    {
+        memory->idxs_rev = value;
+    }
+    else if (!strcmp(field, "idxe"))
+    {
+        memory->idxe = value;
+    }
+    else if (!strcmp(field, "jac_lag_stat_p_global"))
+    {
+        memory->jac_lag_stat_p_global = value;
+    }
+    else if (!strcmp(field, "jac_ineq_p_global"))
+    {
+        memory->jac_ineq_p_global = value;
+    }
+    else if (!strcmp(field, "seed_ux"))
+    {
+        memory->seed_ux = value;
     }
     else if (!strcmp(field, "seed_lam"))
     {
-        struct blasfeo_dvec *seed_lam = value;
-        memory->seed_lam = seed_lam;
-        // printf("ocp_nlp_constraints_bgh_memory_set: got seed_lam %p\n", memory->seed_lam);
+        memory->seed_lam = value;
     }
-    else if (!strcmp(field, "adj_lag_p_global_ptr"))
+    else if (!strcmp(field, "adj_lag_p_global"))
     {
-        struct blasfeo_dvec *adj_lag_p_global = value;
-        memory->adj_lag_p_global = adj_lag_p_global;
-        // printf("ocp_nlp_constraints_bgh_memory_set: got adj_lag_p_global %p\n", memory->adj_lag_p_global);
+        memory->adj_lag_p_global = value;
     }
     else
     {
@@ -992,104 +1030,6 @@ void ocp_nlp_constraints_bgh_memory_set(void *config_, void *dims_, void *memory
 
     return;
 }
-
-
-
-void ocp_nlp_constraints_bgh_memory_set_ux_ptr(struct blasfeo_dvec *ux, void *memory_)
-{
-    ocp_nlp_constraints_bgh_memory *memory = memory_;
-
-    memory->ux = ux;
-}
-
-
-
-
-void ocp_nlp_constraints_bgh_memory_set_lam_ptr(struct blasfeo_dvec *lam, void *memory_)
-{
-    ocp_nlp_constraints_bgh_memory *memory = memory_;
-
-    memory->lam = lam;
-}
-
-
-
-
-void ocp_nlp_constraints_bgh_memory_set_DCt_ptr(struct blasfeo_dmat *DCt, void *memory_)
-{
-    ocp_nlp_constraints_bgh_memory *memory = memory_;
-
-    memory->DCt = DCt;
-}
-
-
-
-void ocp_nlp_constraints_bgh_memory_set_RSQrq_ptr(struct blasfeo_dmat *RSQrq, void *memory_)
-{
-    ocp_nlp_constraints_bgh_memory *memory = memory_;
-
-    memory->RSQrq = RSQrq;
-}
-
-
-
-
-void ocp_nlp_constraints_bgh_memory_set_z_alg_ptr(struct blasfeo_dvec *z_alg, void *memory_)
-{
-    ocp_nlp_constraints_bgh_memory *memory = memory_;
-
-    memory->z_alg = z_alg;
-}
-
-
-void ocp_nlp_constraints_bgh_memory_set_dzduxt_ptr(struct blasfeo_dmat *dzduxt, void *memory_)
-{
-    ocp_nlp_constraints_bgh_memory *memory = memory_;
-
-    memory->dzduxt = dzduxt;
-}
-
-
-
-void ocp_nlp_constraints_bgh_memory_set_idxb_ptr(int *idxb, void *memory_)
-{
-    ocp_nlp_constraints_bgh_memory *memory = memory_;
-
-    memory->idxb = idxb;
-}
-
-
-
-void ocp_nlp_constraints_bgh_memory_set_idxs_rev_ptr(int *idxs_rev, void *memory_)
-{
-    ocp_nlp_constraints_bgh_memory *memory = memory_;
-
-    memory->idxs_rev = idxs_rev;
-}
-
-
-
-void ocp_nlp_constraints_bgh_memory_set_idxe_ptr(int *idxe, void *memory_)
-{
-    ocp_nlp_constraints_bgh_memory *memory = memory_;
-
-    memory->idxe = idxe;
-}
-
-
-void ocp_nlp_constraints_bgh_memory_set_jac_lag_stat_p_global_ptr(struct blasfeo_dmat *jac_lag_stat_p_global, void *memory_)
-{
-    ocp_nlp_constraints_bgh_memory *memory = memory_;
-    memory->jac_lag_stat_p_global = jac_lag_stat_p_global;
-}
-
-void ocp_nlp_constraints_bgh_memory_set_jac_ineq_p_global_ptr(struct blasfeo_dmat *jac_ineq_p_global, void *memory_)
-{
-    ocp_nlp_constraints_bgh_memory *memory = memory_;
-    memory->jac_ineq_p_global = jac_ineq_p_global;
-}
-
-
 /************************************************
  * workspace
  ************************************************/
@@ -1991,17 +1931,6 @@ void ocp_nlp_constraints_bgh_config_initialize_default(void *config_, int stage)
     config->memory_get_fun_ptr = &ocp_nlp_constraints_bgh_memory_get_fun_ptr;
     config->memory_get_adj_ptr = &ocp_nlp_constraints_bgh_memory_get_adj_ptr;
     config->memory_set = &ocp_nlp_constraints_bgh_memory_set;
-    config->memory_set_ux_ptr = &ocp_nlp_constraints_bgh_memory_set_ux_ptr;
-    config->memory_set_lam_ptr = &ocp_nlp_constraints_bgh_memory_set_lam_ptr;
-    config->memory_set_DCt_ptr = &ocp_nlp_constraints_bgh_memory_set_DCt_ptr;
-    config->memory_set_RSQrq_ptr = &ocp_nlp_constraints_bgh_memory_set_RSQrq_ptr;
-    config->memory_set_z_alg_ptr = &ocp_nlp_constraints_bgh_memory_set_z_alg_ptr;
-    config->memory_set_dzdux_tran_ptr = &ocp_nlp_constraints_bgh_memory_set_dzduxt_ptr;
-    config->memory_set_idxb_ptr = &ocp_nlp_constraints_bgh_memory_set_idxb_ptr;
-    config->memory_set_idxs_rev_ptr = &ocp_nlp_constraints_bgh_memory_set_idxs_rev_ptr;
-    config->memory_set_idxe_ptr = &ocp_nlp_constraints_bgh_memory_set_idxe_ptr;
-    config->memory_set_jac_ineq_p_global_ptr = &ocp_nlp_constraints_bgh_memory_set_jac_ineq_p_global_ptr;
-    config->memory_set_jac_lag_stat_p_global_ptr = &ocp_nlp_constraints_bgh_memory_set_jac_lag_stat_p_global_ptr;
     config->workspace_calculate_size = &ocp_nlp_constraints_bgh_workspace_calculate_size;
     config->get_external_fun_workspace_requirement = &ocp_nlp_constraints_bgh_get_external_fun_workspace_requirement;
     config->set_external_fun_workspaces = &ocp_nlp_constraints_bgh_set_external_fun_workspaces;

--- a/acados/ocp_nlp/ocp_nlp_constraints_bgh.c
+++ b/acados/ocp_nlp/ocp_nlp_constraints_bgh.c
@@ -962,7 +962,7 @@ struct blasfeo_dvec *ocp_nlp_constraints_bgh_memory_get_adj_ptr(void *memory_)
 
 
 
-void ocp_nlp_constraints_bgh_memory_set(void *config_, void *dims_, void *memory_, char *field, void *value)
+void ocp_nlp_constraints_bgh_memory_set(void *config_, void *dims_, void *memory_, const char *field, void *value)
 {
     ocp_nlp_constraints_bgh_memory *memory = memory_;
 

--- a/acados/ocp_nlp/ocp_nlp_constraints_bgh.h
+++ b/acados/ocp_nlp/ocp_nlp_constraints_bgh.h
@@ -184,7 +184,7 @@ struct blasfeo_dvec *ocp_nlp_constraints_bgh_memory_get_fun_ptr(void *memory_);
 //
 struct blasfeo_dvec *ocp_nlp_constraints_bgh_memory_get_adj_ptr(void *memory_);
 //
-void ocp_nlp_constraints_bgh_memory_set(void *config_, void *dims_, void *memory_, char *field, void *value);
+void ocp_nlp_constraints_bgh_memory_set(void *config_, void *dims_, void *memory_, const char *field, void *value);
 //
 
 

--- a/acados/ocp_nlp/ocp_nlp_constraints_bgh.h
+++ b/acados/ocp_nlp/ocp_nlp_constraints_bgh.h
@@ -184,28 +184,8 @@ struct blasfeo_dvec *ocp_nlp_constraints_bgh_memory_get_fun_ptr(void *memory_);
 //
 struct blasfeo_dvec *ocp_nlp_constraints_bgh_memory_get_adj_ptr(void *memory_);
 //
-void ocp_nlp_constraints_bgh_memory_set_ux_ptr(struct blasfeo_dvec *ux, void *memory_);
+void ocp_nlp_constraints_bgh_memory_set(void *config_, void *dims_, void *memory_, char *field, void *value);
 //
-void ocp_nlp_constraints_bgh_memory_set_lam_ptr(struct blasfeo_dvec *lam, void *memory_);
-//
-void ocp_nlp_constraints_bgh_memory_set_DCt_ptr(struct blasfeo_dmat *DCt, void *memory);
-//
-void ocp_nlp_constraints_bgh_memory_set_RSQrq_ptr(struct blasfeo_dmat *RSQrq, void *memory_);
-//
-void ocp_nlp_constraints_bgh_memory_set_z_alg_ptr(struct blasfeo_dvec *z_alg, void *memory_);
-//
-void ocp_nlp_constraints_bgh_memory_set_dzduxt_ptr(struct blasfeo_dmat *dzduxt, void *memory_);
-//
-void ocp_nlp_constraints_bgh_memory_set_idxb_ptr(int *idxb, void *memory_);
-//
-void ocp_nlp_constraints_bgh_memory_set_idxs_rev_ptr(int *idxs_rev, void *memory_);
-//
-void ocp_nlp_constraints_bgh_memory_set_idxe_ptr(int *idxe, void *memory_);
-//
-void ocp_nlp_constraints_bgh_memory_set_jac_lag_stat_p_global_ptr(struct blasfeo_dmat *jac_lag_stat_p_global, void *memory_);
-//
-void ocp_nlp_constraints_bgh_memory_set_jac_ineq_p_global_ptr(struct blasfeo_dmat *jac_ineq_p_global, void *memory_);
-
 
 
 /************************************************

--- a/acados/ocp_nlp/ocp_nlp_constraints_bgp.c
+++ b/acados/ocp_nlp/ocp_nlp_constraints_bgp.c
@@ -943,44 +943,44 @@ void ocp_nlp_constraints_bgp_memory_set(void *config_, void *dims_, void *memory
 {
     ocp_nlp_constraints_bgp_memory *memory = memory_;
 
-    if (!strcmp(field, "ux"))
+    if (!strcmp(field, "ux_ptr"))
     {
         memory->ux = value;
     }
-    else if (!strcmp(field, "lam"))
+    else if (!strcmp(field, "lam_ptr"))
     {
         memory->lam = value;
     }
-    else if (!strcmp(field, "DCt"))
+    else if (!strcmp(field, "DCt_ptr"))
     {
         memory->DCt = value;
     }
-    else if (!strcmp(field, "RSQrq"))
+    else if (!strcmp(field, "RSQrq_ptr"))
     {
         memory->RSQrq = value;
     }
-    else if (!strcmp(field, "z_alg"))
+    else if (!strcmp(field, "z_alg_ptr"))
     {
         memory->z_alg = value;
     }
-    else if (!strcmp(field, "dzduxt"))
+    else if (!strcmp(field, "dzduxt_ptr"))
     {
         memory->dzduxt = value;
     }
-    else if (!strcmp(field, "idxb"))
+    else if (!strcmp(field, "idxb_ptr"))
     {
         memory->idxb = value;
     }
-    else if (!strcmp(field, "idxs_rev"))
+    else if (!strcmp(field, "idxs_rev_ptr"))
     {
         memory->idxs_rev = value;
     }
-    else if (!strcmp(field, "idxe"))
+    else if (!strcmp(field, "idxe_ptr"))
     {
         memory->idxe = value;
     }
-    else if (!strcmp(field, "jac_lag_stat_p_global") || !strcmp(field, "jac_ineq_p_global") ||
-              !strcmp(field, "adj_lag_p_global") || !strcmp(field, "seed_ux") || !strcmp(field, "seed_lam"))
+    else if (!strcmp(field, "jac_lag_stat_p_global_ptr") || !strcmp(field, "jac_ineq_p_global_ptr") ||
+              !strcmp(field, "adj_lag_p_global_ptr") || !strcmp(field, "seed_ux_ptr") || !strcmp(field, "seed_lam_ptr"))
      {
          return; // Do nothing. Sensitivities are not implemented for BGP constraints.
             //  Interface checks if any p_global dependencies are there.

--- a/acados/ocp_nlp/ocp_nlp_constraints_bgp.c
+++ b/acados/ocp_nlp/ocp_nlp_constraints_bgp.c
@@ -941,105 +941,51 @@ struct blasfeo_dvec *ocp_nlp_constraints_bgp_memory_get_adj_ptr(void *memory_)
 
 void ocp_nlp_constraints_bgp_memory_set(void *config_, void *dims_, void *memory_, char *field, void *value)
 {
-    // ocp_nlp_constraints_bgp_memory *memory = memory_;
-    printf("\nerror: field %s not available in ocp_nlp_constraints_bgp_memory_set\n", field);
-    exit(1);
+    ocp_nlp_constraints_bgp_memory *memory = memory_;
+
+    if (!strcmp(field, "ux"))
+    {
+        memory->ux = value;
+    }
+    else if (!strcmp(field, "lam"))
+    {
+        memory->lam = value;
+    }
+    else if (!strcmp(field, "DCt"))
+    {
+        memory->DCt = value;
+    }
+    else if (!strcmp(field, "RSQrq"))
+    {
+        memory->RSQrq = value;
+    }
+    else if (!strcmp(field, "z_alg"))
+    {
+        memory->z_alg = value;
+    }
+    else if (!strcmp(field, "dzduxt"))
+    {
+        memory->dzduxt = value;
+    }
+    else if (!strcmp(field, "idxb"))
+    {
+        memory->idxb = value;
+    }
+    else if (!strcmp(field, "idxs_rev"))
+    {
+        memory->idxs_rev = value;
+    }
+    else if (!strcmp(field, "idxe"))
+    {
+        memory->idxe = value;
+    }
+    else
+    {
+        printf("\nerror: field %s not available in ocp_nlp_constraints_bgp_memory_set\n", field);
+        exit(1);
+    }
 
     return;
-}
-
-
-
-void ocp_nlp_constraints_bgp_memory_set_ux_ptr(struct blasfeo_dvec *ux, void *memory_)
-{
-    ocp_nlp_constraints_bgp_memory *memory = memory_;
-
-    memory->ux = ux;
-}
-
-
-void ocp_nlp_constraints_bgp_memory_set_lam_ptr(struct blasfeo_dvec *lam, void *memory_)
-{
-    ocp_nlp_constraints_bgp_memory *memory = memory_;
-
-    memory->lam = lam;
-}
-
-
-
-
-void ocp_nlp_constraints_bgp_memory_set_DCt_ptr(struct blasfeo_dmat *DCt, void *memory_)
-{
-    ocp_nlp_constraints_bgp_memory *memory = memory_;
-
-    memory->DCt = DCt;
-}
-
-
-void ocp_nlp_constraints_bgp_memory_set_RSQrq_ptr(struct blasfeo_dmat *RSQrq, void *memory_)
-{
-    ocp_nlp_constraints_bgp_memory *memory = memory_;
-
-    memory->RSQrq = RSQrq;
-}
-
-
-
-void ocp_nlp_constraints_bgp_memory_set_z_alg_ptr(struct blasfeo_dvec *z_alg, void *memory_)
-{
-    ocp_nlp_constraints_bgp_memory *memory = memory_;
-
-    memory->z_alg = z_alg;
-}
-
-
-
-void ocp_nlp_constraints_bgp_memory_set_dzduxt_ptr(struct blasfeo_dmat *dzduxt, void *memory_)
-{
-    ocp_nlp_constraints_bgp_memory *memory = memory_;
-
-    memory->dzduxt = dzduxt;
-}
-
-
-
-
-void ocp_nlp_constraints_bgp_memory_set_idxb_ptr(int *idxb, void *memory_)
-{
-    ocp_nlp_constraints_bgp_memory *memory = memory_;
-
-    memory->idxb = idxb;
-}
-
-
-
-void ocp_nlp_constraints_bgp_memory_set_idxs_rev_ptr(int *idxs_rev, void *memory_)
-{
-    ocp_nlp_constraints_bgp_memory *memory = memory_;
-
-    memory->idxs_rev = idxs_rev;
-}
-
-
-
-void ocp_nlp_constraints_bgp_memory_set_idxe_ptr(int *idxe, void *memory_)
-{
-    ocp_nlp_constraints_bgp_memory *memory = memory_;
-
-    memory->idxe = idxe;
-}
-
-
-void ocp_nlp_constraints_bgp_memory_set_jac_lag_stat_p_global_ptr(struct blasfeo_dmat *jac_lag_stat_p_global, void *memory_)
-{
-    // ocp_nlp_constraints_bgp_memory *memory = memory_;
-    // memory->jac_lag_stat_p_global = jac_lag_stat_p_global;
-}
-
-void ocp_nlp_constraints_bgp_memory_set_jac_ineq_p_global_ptr(struct blasfeo_dmat *jac_ineq_p_global, void *memory_)
-{
-    // ocp_nlp_constraints_bgp_memory *memory = memory_;
-    // memory->jac_ineq_p_global = jac_ineq_p_global;
 }
 
 
@@ -1651,17 +1597,6 @@ void ocp_nlp_constraints_bgp_config_initialize_default(void *config_, int stage)
     config->memory_get_fun_ptr = &ocp_nlp_constraints_bgp_memory_get_fun_ptr;
     config->memory_get_adj_ptr = &ocp_nlp_constraints_bgp_memory_get_adj_ptr;
     config->memory_set = &ocp_nlp_constraints_bgp_memory_set;
-    config->memory_set_ux_ptr = &ocp_nlp_constraints_bgp_memory_set_ux_ptr;
-    config->memory_set_lam_ptr = &ocp_nlp_constraints_bgp_memory_set_lam_ptr;
-    config->memory_set_DCt_ptr = &ocp_nlp_constraints_bgp_memory_set_DCt_ptr;
-    config->memory_set_RSQrq_ptr = &ocp_nlp_constraints_bgp_memory_set_RSQrq_ptr;
-    config->memory_set_z_alg_ptr = &ocp_nlp_constraints_bgp_memory_set_z_alg_ptr;
-    config->memory_set_dzdux_tran_ptr = &ocp_nlp_constraints_bgp_memory_set_dzduxt_ptr;
-    config->memory_set_idxb_ptr = &ocp_nlp_constraints_bgp_memory_set_idxb_ptr;
-    config->memory_set_idxs_rev_ptr = &ocp_nlp_constraints_bgp_memory_set_idxs_rev_ptr;
-    config->memory_set_idxe_ptr = &ocp_nlp_constraints_bgp_memory_set_idxe_ptr;
-    config->memory_set_jac_ineq_p_global_ptr = &ocp_nlp_constraints_bgp_memory_set_jac_ineq_p_global_ptr;
-    config->memory_set_jac_lag_stat_p_global_ptr = &ocp_nlp_constraints_bgp_memory_set_jac_lag_stat_p_global_ptr;
     config->workspace_calculate_size = &ocp_nlp_constraints_bgp_workspace_calculate_size;
     config->get_external_fun_workspace_requirement = &ocp_nlp_constraints_bgp_get_external_fun_workspace_requirement;
     config->set_external_fun_workspaces = &ocp_nlp_constraints_bgp_set_external_fun_workspaces;

--- a/acados/ocp_nlp/ocp_nlp_constraints_bgp.c
+++ b/acados/ocp_nlp/ocp_nlp_constraints_bgp.c
@@ -979,6 +979,13 @@ void ocp_nlp_constraints_bgp_memory_set(void *config_, void *dims_, void *memory
     {
         memory->idxe = value;
     }
+    else if (!strcmp(field, "jac_lag_stat_p_global") || !strcmp(field, "jac_ineq_p_global") ||
+              !strcmp(field, "adj_lag_p_global") || !strcmp(field, "seed_ux") || !strcmp(field, "seed_lam"))
+     {
+         return; // Do nothing. Sensitivities are not implemented for BGP constraints.
+            //  Interface checks if any p_global dependencies are there.
+            // If not, we allow using BGP.
+     }
     else
     {
         printf("\nerror: field %s not available in ocp_nlp_constraints_bgp_memory_set\n", field);

--- a/acados/ocp_nlp/ocp_nlp_constraints_bgp.c
+++ b/acados/ocp_nlp/ocp_nlp_constraints_bgp.c
@@ -939,7 +939,7 @@ struct blasfeo_dvec *ocp_nlp_constraints_bgp_memory_get_adj_ptr(void *memory_)
 }
 
 
-void ocp_nlp_constraints_bgp_memory_set(void *config_, void *dims_, void *memory_, char *field, void *value)
+void ocp_nlp_constraints_bgp_memory_set(void *config_, void *dims_, void *memory_, const char *field, void *value)
 {
     ocp_nlp_constraints_bgp_memory *memory = memory_;
 

--- a/acados/ocp_nlp/ocp_nlp_constraints_bgp.h
+++ b/acados/ocp_nlp/ocp_nlp_constraints_bgp.h
@@ -157,27 +157,6 @@ struct blasfeo_dvec *ocp_nlp_constraints_bgp_memory_get_fun_ptr(void *memory_);
 //
 struct blasfeo_dvec *ocp_nlp_constraints_bgp_memory_get_adj_ptr(void *memory_);
 //
-void ocp_nlp_constraints_bgp_memory_set_ux_ptr(struct blasfeo_dvec *ux, void *memory_);
-//
-void ocp_nlp_constraints_bgp_memory_set_lam_ptr(struct blasfeo_dvec *lam, void *memory_);
-//
-void ocp_nlp_constraints_bgp_memory_set_DCt_ptr(struct blasfeo_dmat *DCt, void *memory);
-//
-void ocp_nlp_constraints_bgp_memory_set_z_alg_ptr(struct blasfeo_dvec *z_alg, void *memory_);
-//
-void ocp_nlp_constraints_bgp_memory_set_dzduxt_ptr(struct blasfeo_dmat *dzduxt, void *memory_);
-//
-void ocp_nlp_constraints_bgp_memory_set_idxb_ptr(int *idxb, void *memory_);
-//
-void ocp_nlp_constraints_bgp_memory_set_idxs_rev_ptr(int *idxs_rev, void *memory_);
-//
-void ocp_nlp_constraints_bgp_memory_set_idxe_ptr(int *idxe, void *memory_);
-//
-void ocp_nlp_constraints_bgp_memory_set_jac_lag_stat_p_global_ptr(struct blasfeo_dmat *jac_lag_stat_p_global, void *memory_);
-//
-void ocp_nlp_constraints_bgp_memory_set_jac_ineq_p_global_ptr(struct blasfeo_dmat *jac_ineq_p_global, void *memory_);
-
-
 /* workspace */
 
 typedef struct

--- a/acados/ocp_nlp/ocp_nlp_constraints_common.h
+++ b/acados/ocp_nlp/ocp_nlp_constraints_common.h
@@ -71,17 +71,6 @@ typedef struct
     struct blasfeo_dvec *(*memory_get_fun_ptr)(void *memory);
     struct blasfeo_dvec *(*memory_get_adj_ptr)(void *memory);
     void (*memory_set)(void *config_, void *dims_, void *memory_, char *field, void *value);
-    void (*memory_set_ux_ptr)(struct blasfeo_dvec *ux, void *memory);
-    void (*memory_set_lam_ptr)(struct blasfeo_dvec *lam, void *memory);
-    void (*memory_set_DCt_ptr)(struct blasfeo_dmat *DCt, void *memory);
-    void (*memory_set_RSQrq_ptr)(struct blasfeo_dmat *RSQrq, void *memory);
-    void (*memory_set_z_alg_ptr)(struct blasfeo_dvec *z_alg, void *memory);
-    void (*memory_set_dzdux_tran_ptr)(struct blasfeo_dmat *dzduxt, void *memory);
-    void (*memory_set_idxb_ptr)(int *idxb, void *memory);
-    void (*memory_set_idxs_rev_ptr)(int *idxs_rev, void *memory);
-    void (*memory_set_idxe_ptr)(int *idxe, void *memory);
-    void (*memory_set_jac_lag_stat_p_global_ptr)(struct blasfeo_dmat *jac_lag_stat_p_global, void *memory);
-    void (*memory_set_jac_ineq_p_global_ptr)(struct blasfeo_dmat *jac_ineq_p_global, void *memory);
 
     void *(*memory_assign)(void *config, void *dims, void *opts, void *raw_memory);
     acados_size_t (*workspace_calculate_size)(void *config, void *dims, void *opts);

--- a/acados/ocp_nlp/ocp_nlp_constraints_common.h
+++ b/acados/ocp_nlp/ocp_nlp_constraints_common.h
@@ -70,7 +70,7 @@ typedef struct
     acados_size_t (*memory_calculate_size)(void *config, void *dims, void *opts);
     struct blasfeo_dvec *(*memory_get_fun_ptr)(void *memory);
     struct blasfeo_dvec *(*memory_get_adj_ptr)(void *memory);
-    void (*memory_set)(void *config_, void *dims_, void *memory_, char *field, void *value);
+    void (*memory_set)(void *config_, void *dims_, void *memory_, const char *field, void *value);
 
     void *(*memory_assign)(void *config, void *dims, void *opts, void *raw_memory);
     acados_size_t (*workspace_calculate_size)(void *config, void *dims, void *opts);

--- a/acados/ocp_nlp/ocp_nlp_cost_common.h
+++ b/acados/ocp_nlp/ocp_nlp_cost_common.h
@@ -79,14 +79,7 @@ typedef struct
     struct blasfeo_dmat *(*memory_get_W_chol_ptr)(void *memory_);
     struct blasfeo_dvec *(*memory_get_W_chol_diag_ptr)(void *memory_);
     double *(*get_outer_hess_is_diag_ptr)(void *memory_, void *model_);
-    void (*memory_set_ux_ptr)(struct blasfeo_dvec *ux, void *memory);
-    void (*memory_set_z_alg_ptr)(struct blasfeo_dvec *z_alg, void *memory);
-    void (*memory_set_dzdux_tran_ptr)(struct blasfeo_dmat *dzdux, void *memory);
-    void (*memory_set_RSQrq_ptr)(struct blasfeo_dmat *RSQrq, void *memory);
-    void (*memory_set_Z_ptr)(struct blasfeo_dvec *Z, void *memory);
-    void (*memory_set_jac_lag_stat_p_global_ptr)(struct blasfeo_dmat *jac_lag_stat_p_global, void *memory);
-    void (*memory_set_adj_lag_p_global_ptr)(struct blasfeo_dvec *adj_lag_p_global, void *memory);
-    void (*memory_set_seed_ux_ptr)(struct blasfeo_dvec *seed_ux, void *memory);
+    void (*memory_set)(void *config_, void *dims_, void *memory_, char *field, void *value);
     void *(*memory_assign)(void *config, void *dims, void *opts, void *raw_memory);
     acados_size_t (*workspace_calculate_size)(void *config, void *dims, void *opts);
     acados_size_t (*get_external_fun_workspace_requirement)(void *config, void *dims, void *opts_, void *in);

--- a/acados/ocp_nlp/ocp_nlp_cost_common.h
+++ b/acados/ocp_nlp/ocp_nlp_cost_common.h
@@ -79,7 +79,7 @@ typedef struct
     struct blasfeo_dmat *(*memory_get_W_chol_ptr)(void *memory_);
     struct blasfeo_dvec *(*memory_get_W_chol_diag_ptr)(void *memory_);
     double *(*get_outer_hess_is_diag_ptr)(void *memory_, void *model_);
-    void (*memory_set)(void *config_, void *dims_, void *memory_, char *field, void *value);
+    void (*memory_set)(void *config_, void *dims_, void *memory_, const char *field, void *value);
     void *(*memory_assign)(void *config, void *dims, void *opts, void *raw_memory);
     acados_size_t (*workspace_calculate_size)(void *config, void *dims, void *opts);
     acados_size_t (*get_external_fun_workspace_requirement)(void *config, void *dims, void *opts_, void *in);

--- a/acados/ocp_nlp/ocp_nlp_cost_conl.c
+++ b/acados/ocp_nlp/ocp_nlp_cost_conl.c
@@ -545,7 +545,7 @@ struct blasfeo_dvec *ocp_nlp_cost_conl_model_get_y_ref_ptr(void *in_)
 }
 
 
-void ocp_nlp_cost_conl_memory_set(void *config_, void *dims_, void *memory_, char *field, void *value)
+void ocp_nlp_cost_conl_memory_set(void *config_, void *dims_, void *memory_, const char *field, void *value)
 {
     ocp_nlp_cost_conl_memory *memory = memory_;
 

--- a/acados/ocp_nlp/ocp_nlp_cost_conl.c
+++ b/acados/ocp_nlp/ocp_nlp_cost_conl.c
@@ -545,53 +545,40 @@ struct blasfeo_dvec *ocp_nlp_cost_conl_model_get_y_ref_ptr(void *in_)
 }
 
 
-void ocp_nlp_cost_conl_memory_set_RSQrq_ptr(struct blasfeo_dmat *RSQrq, void *memory_)
+void ocp_nlp_cost_conl_memory_set(void *config_, void *dims_, void *memory_, char *field, void *value)
 {
     ocp_nlp_cost_conl_memory *memory = memory_;
 
-    memory->RSQrq = RSQrq;
-
-    return;
-}
-
-
-
-void ocp_nlp_cost_conl_memory_set_Z_ptr(struct blasfeo_dvec *Z, void *memory_)
-{
-    ocp_nlp_cost_conl_memory *memory = memory_;
-
-    memory->Z = Z;
-
-    return;
-}
-
-
-
-void ocp_nlp_cost_conl_memory_set_ux_ptr(struct blasfeo_dvec *ux, void *memory_)
-{
-    ocp_nlp_cost_conl_memory *memory = memory_;
-
-    memory->ux = ux;
-
-    return;
-}
-
-
-
-void ocp_nlp_cost_conl_memory_set_z_alg_ptr(struct blasfeo_dvec *z_alg, void *memory_)
-{
-    ocp_nlp_cost_conl_memory *memory = memory_;
-
-    memory->z_alg = z_alg;
-}
-
-
-
-void ocp_nlp_cost_conl_memory_set_dzdux_tran_ptr(struct blasfeo_dmat *dzdux_tran, void *memory_)
-{
-    ocp_nlp_cost_conl_memory *memory = memory_;
-
-    memory->dzdux_tran = dzdux_tran;
+    if (!strcmp(field, "ux"))
+    {
+        memory->ux = value;
+    }
+    else if (!strcmp(field, "z_alg"))
+    {
+        memory->z_alg = value;
+    }
+    else if (!strcmp(field, "dzdux_tran"))
+    {
+        memory->dzdux_tran = value;
+    }
+    else if (!strcmp(field, "RSQrq"))
+    {
+        memory->RSQrq = value;
+    }
+    else if (!strcmp(field, "Z"))
+    {
+        memory->Z = value;
+    }
+    else if (!strcmp(field, "jac_lag_stat_p_global") || !strcmp(field, "adj_lag_p_global") ||
+             !strcmp(field, "seed_ux"))
+    {
+        return;
+    }
+    else
+    {
+        printf("\nerror: field %s not available in ocp_nlp_cost_conl_memory_set\n", field);
+        exit(1);
+    }
 }
 
 
@@ -1121,11 +1108,7 @@ void ocp_nlp_cost_conl_config_initialize_default(void *config_, int stage)
     config->memory_get_W_chol_diag_ptr = &ocp_nlp_cost_conl_memory_get_W_chol_diag_ptr;
     config->model_get_y_ref_ptr = &ocp_nlp_cost_conl_model_get_y_ref_ptr;
     config->model_get_scaling_ptr = &ocp_nlp_cost_conl_model_get_scaling_ptr;
-    config->memory_set_ux_ptr = &ocp_nlp_cost_conl_memory_set_ux_ptr;
-    config->memory_set_z_alg_ptr = &ocp_nlp_cost_conl_memory_set_z_alg_ptr;
-    config->memory_set_dzdux_tran_ptr = &ocp_nlp_cost_conl_memory_set_dzdux_tran_ptr;
-    config->memory_set_RSQrq_ptr = &ocp_nlp_cost_conl_memory_set_RSQrq_ptr;
-    config->memory_set_Z_ptr = &ocp_nlp_cost_conl_memory_set_Z_ptr;
+    config->memory_set = &ocp_nlp_cost_conl_memory_set;
     config->workspace_calculate_size = &ocp_nlp_cost_conl_workspace_calculate_size;
     config->get_external_fun_workspace_requirement = &ocp_nlp_cost_conl_get_external_fun_workspace_requirement;
     config->set_external_fun_workspaces = &ocp_nlp_cost_conl_set_external_fun_workspaces;

--- a/acados/ocp_nlp/ocp_nlp_cost_conl.c
+++ b/acados/ocp_nlp/ocp_nlp_cost_conl.c
@@ -221,7 +221,7 @@ int ocp_nlp_cost_conl_model_set(void *config_, void *dims_, void *model_,
         double *y_ref = (double *) value_;
         blasfeo_pack_dvec(ny, y_ref, 1, &model->y_ref, 0);
     }
-    else if (!strcmp(field, "Z"))
+    else if (!strcmp(field, "Z_ptr"))
     {
         double *Z = (double *) value_;
         blasfeo_pack_dvec(ns, Z, 1, &model->Z, 0);
@@ -549,28 +549,28 @@ void ocp_nlp_cost_conl_memory_set(void *config_, void *dims_, void *memory_, con
 {
     ocp_nlp_cost_conl_memory *memory = memory_;
 
-    if (!strcmp(field, "ux"))
+    if (!strcmp(field, "ux_ptr"))
     {
         memory->ux = value;
     }
-    else if (!strcmp(field, "z_alg"))
+    else if (!strcmp(field, "z_alg_ptr"))
     {
         memory->z_alg = value;
     }
-    else if (!strcmp(field, "dzdux_tran"))
+    else if (!strcmp(field, "dzdux_tran_ptr"))
     {
         memory->dzdux_tran = value;
     }
-    else if (!strcmp(field, "RSQrq"))
+    else if (!strcmp(field, "RSQrq_ptr"))
     {
         memory->RSQrq = value;
     }
-    else if (!strcmp(field, "Z"))
+    else if (!strcmp(field, "Z_ptr"))
     {
         memory->Z = value;
     }
-    else if (!strcmp(field, "jac_lag_stat_p_global") || !strcmp(field, "adj_lag_p_global") ||
-             !strcmp(field, "seed_ux"))
+    else if (!strcmp(field, "jac_lag_stat_p_global_ptr") || !strcmp(field, "adj_lag_p_global_ptr") ||
+             !strcmp(field, "seed_ux_ptr"))
     {
         return;
     }

--- a/acados/ocp_nlp/ocp_nlp_cost_conl.h
+++ b/acados/ocp_nlp/ocp_nlp_cost_conl.h
@@ -156,16 +156,6 @@ void *ocp_nlp_cost_conl_memory_assign(void *config, void *dims, void *opts, void
 double *ocp_nlp_cost_conl_memory_get_fun_ptr(void *memory_);
 //
 struct blasfeo_dvec *ocp_nlp_cost_conl_memory_get_grad_ptr(void *memory_);
-//
-void ocp_nlp_cost_conl_memory_set_RSQrq_ptr(struct blasfeo_dmat *RSQrq, void *memory);
-//
-void ocp_nlp_cost_conl_memory_set_Z_ptr(struct blasfeo_dvec *Z, void *memory);
-//
-void ocp_nlp_cost_conl_memory_set_ux_ptr(struct blasfeo_dvec *ux, void *memory_);
-//
-void ocp_nlp_cost_conl_memory_set_z_alg_ptr(struct blasfeo_dvec *z_alg, void *memory_);
-//
-void ocp_nlp_cost_conl_memory_set_dzdux_tran_ptr(struct blasfeo_dmat *dzdux_tran, void *memory_);
 
 /************************************************
  * workspace

--- a/acados/ocp_nlp/ocp_nlp_cost_external.c
+++ b/acados/ocp_nlp/ocp_nlp_cost_external.c
@@ -553,7 +553,7 @@ void ocp_nlp_cost_external_memory_set(void *config_, void *dims_, void *memory_,
     {
         memory->Z = value;
     }
-    else if (!strcmp(field, "jac_lag_stat_p_global_ptr"))
+    else if (!strcmp(field, "jac_lag_stat_p_global"))
     {
         memory->jac_lag_stat_p_global = value;
     }

--- a/acados/ocp_nlp/ocp_nlp_cost_external.c
+++ b/acados/ocp_nlp/ocp_nlp_cost_external.c
@@ -557,6 +557,19 @@ void ocp_nlp_cost_external_memory_set(void *config_, void *dims_, void *memory_,
     {
         memory->jac_lag_stat_p_global = value;
     }
+    else if (!strcmp(field, "adj_lag_p_global"))
+    {
+        memory->adj_lag_p_global = value;
+    }
+    else if (!strcmp(field, "seed_ux"))
+    {
+        memory->seed_ux = value;
+    }
+    else
+    {
+        printf("\nerror: field %s not available in ocp_nlp_cost_external_memory_set\n", field);
+        exit(1);
+    }
 }
 
 

--- a/acados/ocp_nlp/ocp_nlp_cost_external.c
+++ b/acados/ocp_nlp/ocp_nlp_cost_external.c
@@ -242,7 +242,7 @@ int ocp_nlp_cost_external_model_set(void *config_, void *dims_, void *model_,
         double *numerical_hessian = (double *) value_;
         blasfeo_pack_dmat(nx+nu, nx+nu, numerical_hessian, nx+nu, &model->numerical_hessian, 0, 0);
     }
-    else if (!strcmp(field, "Z"))
+    else if (!strcmp(field, "Z_ptr"))
     {
         double *Z = (double *) value_;
         blasfeo_pack_dvec(ns, Z, 1, &model->Z, 0);
@@ -533,35 +533,35 @@ void ocp_nlp_cost_external_memory_set(void *config_, void *dims_, void *memory_,
 {
     ocp_nlp_cost_external_memory *memory = memory_;
 
-    if (!strcmp(field, "ux"))
+    if (!strcmp(field, "ux_ptr"))
     {
         memory->ux = value;
     }
-    else if (!strcmp(field, "z_alg"))
+    else if (!strcmp(field, "z_alg_ptr"))
     {
         memory->z_alg = value;
     }
-    else if (!strcmp(field, "dzdux_tran"))
+    else if (!strcmp(field, "dzdux_tran_ptr"))
     {
         memory->dzdux_tran = value;
     }
-    else if (!strcmp(field, "RSQrq"))
+    else if (!strcmp(field, "RSQrq_ptr"))
     {
         memory->RSQrq = value;
     }
-    else if (!strcmp(field, "Z"))
+    else if (!strcmp(field, "Z_ptr"))
     {
         memory->Z = value;
     }
-    else if (!strcmp(field, "jac_lag_stat_p_global"))
+    else if (!strcmp(field, "jac_lag_stat_p_global_ptr"))
     {
         memory->jac_lag_stat_p_global = value;
     }
-    else if (!strcmp(field, "adj_lag_p_global"))
+    else if (!strcmp(field, "adj_lag_p_global_ptr"))
     {
         memory->adj_lag_p_global = value;
     }
-    else if (!strcmp(field, "seed_ux"))
+    else if (!strcmp(field, "seed_ux_ptr"))
     {
         memory->seed_ux = value;
     }

--- a/acados/ocp_nlp/ocp_nlp_cost_external.c
+++ b/acados/ocp_nlp/ocp_nlp_cost_external.c
@@ -529,61 +529,34 @@ struct blasfeo_dvec *ocp_nlp_cost_external_memory_get_grad_ptr(void *memory_)
     return &memory->grad;
 }
 
-
-
-void ocp_nlp_cost_external_memory_set_RSQrq_ptr(struct blasfeo_dmat *RSQrq, void *memory_)
+void ocp_nlp_cost_external_memory_set(void *config_, void *dims_, void *memory_, char *field, void *value)
 {
     ocp_nlp_cost_external_memory *memory = memory_;
 
-    memory->RSQrq = RSQrq;
-
-    return;
-}
-
-
-
-void ocp_nlp_cost_external_memory_set_Z_ptr(struct blasfeo_dvec *Z, void *memory_)
-{
-    ocp_nlp_cost_external_memory *memory = memory_;
-
-    memory->Z = Z;
-}
-
-
-
-void ocp_nlp_cost_external_memory_set_ux_ptr(struct blasfeo_dvec *ux, void *memory_)
-{
-    ocp_nlp_cost_external_memory *memory = memory_;
-
-    memory->ux = ux;
-
-    return;
-}
-
-
-void ocp_nlp_cost_external_memory_set_z_alg_ptr(struct blasfeo_dvec *z_alg, void *memory_)
-{
-    ocp_nlp_cost_external_memory *memory = memory_;
-
-    memory->z_alg = z_alg;
-}
-
-
-
-void ocp_nlp_cost_external_memory_set_dzdux_tran_ptr(struct blasfeo_dmat *dzdux_tran, void *memory_)
-{
-    ocp_nlp_cost_external_memory *memory = memory_;
-
-    memory->dzdux_tran = dzdux_tran;
-}
-
-
-
-void ocp_nlp_cost_external_memory_set_jac_lag_stat_p_global_ptr(struct blasfeo_dmat *jac_lag_stat_p_global, void *memory_)
-{
-    ocp_nlp_cost_external_memory *memory = memory_;
-
-    memory->jac_lag_stat_p_global = jac_lag_stat_p_global;
+    if (!strcmp(field, "ux"))
+    {
+        memory->ux = value;
+    }
+    else if (!strcmp(field, "z_alg"))
+    {
+        memory->z_alg = value;
+    }
+    else if (!strcmp(field, "dzdux_tran"))
+    {
+        memory->dzdux_tran = value;
+    }
+    else if (!strcmp(field, "RSQrq"))
+    {
+        memory->RSQrq = value;
+    }
+    else if (!strcmp(field, "Z"))
+    {
+        memory->Z = value;
+    }
+    else if (!strcmp(field, "jac_lag_stat_p_global_ptr"))
+    {
+        memory->jac_lag_stat_p_global = value;
+    }
 }
 
 
@@ -1239,14 +1212,7 @@ void ocp_nlp_cost_external_config_initialize_default(void *config_, int stage)
     config->memory_assign = &ocp_nlp_cost_external_memory_assign;
     config->memory_get_fun_ptr = &ocp_nlp_cost_external_memory_get_fun_ptr;
     config->memory_get_grad_ptr = &ocp_nlp_cost_external_memory_get_grad_ptr;
-    config->memory_set_ux_ptr = &ocp_nlp_cost_external_memory_set_ux_ptr;
-    config->memory_set_z_alg_ptr = &ocp_nlp_cost_external_memory_set_z_alg_ptr;
-    config->memory_set_dzdux_tran_ptr = &ocp_nlp_cost_external_memory_set_dzdux_tran_ptr;
-    config->memory_set_RSQrq_ptr = &ocp_nlp_cost_external_memory_set_RSQrq_ptr;
-    config->memory_set_Z_ptr = &ocp_nlp_cost_external_memory_set_Z_ptr;
-    config->memory_set_jac_lag_stat_p_global_ptr = &ocp_nlp_cost_external_memory_set_jac_lag_stat_p_global_ptr;
-    config->memory_set_adj_lag_p_global_ptr = &ocp_nlp_cost_external_memory_set_adj_lag_p_global_ptr;
-    config->memory_set_seed_ux_ptr = &ocp_nlp_cost_external_memory_set_seed_ux_ptr;
+    config->memory_set = &ocp_nlp_cost_external_memory_set;
     config->workspace_calculate_size = &ocp_nlp_cost_external_workspace_calculate_size;
     config->get_external_fun_workspace_requirement = &ocp_nlp_cost_external_get_external_fun_workspace_requirement;
     config->set_external_fun_workspaces = &ocp_nlp_cost_external_set_external_fun_workspaces;

--- a/acados/ocp_nlp/ocp_nlp_cost_external.c
+++ b/acados/ocp_nlp/ocp_nlp_cost_external.c
@@ -529,7 +529,7 @@ struct blasfeo_dvec *ocp_nlp_cost_external_memory_get_grad_ptr(void *memory_)
     return &memory->grad;
 }
 
-void ocp_nlp_cost_external_memory_set(void *config_, void *dims_, void *memory_, char *field, void *value)
+void ocp_nlp_cost_external_memory_set(void *config_, void *dims_, void *memory_, const char *field, void *value)
 {
     ocp_nlp_cost_external_memory *memory = memory_;
 

--- a/acados/ocp_nlp/ocp_nlp_cost_external.h
+++ b/acados/ocp_nlp/ocp_nlp_cost_external.h
@@ -142,18 +142,6 @@ void *ocp_nlp_cost_external_memory_assign(void *config, void *dims, void *opts, 
 double *ocp_nlp_cost_external_memory_get_fun_ptr(void *memory_);
 //
 struct blasfeo_dvec *ocp_nlp_cost_external_memory_get_grad_ptr(void *memory_);
-//
-void ocp_nlp_cost_external_memory_set_RSQrq_ptr(struct blasfeo_dmat *RSQrq, void *memory);
-//
-void ocp_nlp_cost_ls_memory_set_Z_ptr(struct blasfeo_dvec *Z, void *memory);
-//
-void ocp_nlp_cost_external_memory_set_ux_ptr(struct blasfeo_dvec *ux, void *memory_);
-//
-void ocp_nlp_cost_external_memory_set_z_alg_ptr(struct blasfeo_dvec *z_alg, void *memory_);
-//
-void ocp_nlp_cost_external_memory_set_dzdux_tran_ptr(struct blasfeo_dmat *dzdux_tran, void *memory_);
-//
-void ocp_nlp_cost_external_memory_set_jac_lag_stat_p_global_ptr(struct blasfeo_dmat *jac_lag_stat_p_global, void *memory_);
 
 /************************************************
  * workspace

--- a/acados/ocp_nlp/ocp_nlp_cost_ls.c
+++ b/acados/ocp_nlp/ocp_nlp_cost_ls.c
@@ -322,7 +322,7 @@ int ocp_nlp_cost_ls_model_set(void *config_, void *dims_, void *model_,
         double *y_ref = (double *) value_;
         blasfeo_pack_dvec(ny, y_ref, 1, &model->y_ref, 0);
     }
-    else if (!strcmp(field, "Z"))
+    else if (!strcmp(field, "Z_ptr"))
     {
         double *Z = (double *) value_;
         blasfeo_pack_dvec(ns, Z, 1, &model->Z, 0);
@@ -651,29 +651,30 @@ void ocp_nlp_cost_ls_memory_set(void *config_, void *dims_, void *memory_, const
 {
     ocp_nlp_cost_ls_memory *memory = memory_;
 
-    if (!strcmp(field, "ux"))
+    if (!strcmp(field, "ux_ptr"))
     {
         memory->ux = value;
     }
-    else if (!strcmp(field, "z_alg"))
+    else if (!strcmp(field, "z_alg_ptr"))
     {
         memory->z_alg = value;
     }
-    else if (!strcmp(field, "dzdux_tran"))
+    else if (!strcmp(field, "dzdux_tran_ptr"))
     {
         memory->dzdux_tran = value;
     }
-    else if (!strcmp(field, "RSQrq"))
+    else if (!strcmp(field, "RSQrq_ptr"))
     {
         memory->RSQrq = value;
     }
-    else if (!strcmp(field, "Z"))
+    else if (!strcmp(field, "Z_ptr"))
     {
         memory->Z = value;
     }
-    else if (!strcmp(field, "jac_lag_stat_p_global") || !strcmp(field, "adj_lag_p_global") ||
-             !strcmp(field, "seed_ux"))
+    else if (!strcmp(field, "jac_lag_stat_p_global_ptr") || !strcmp(field, "adj_lag_p_global_ptr") ||
+             !strcmp(field, "seed_ux_ptr"))
     {
+        // nothing to do, there can be no dependency on p_global.
         return;
     }
     else

--- a/acados/ocp_nlp/ocp_nlp_cost_ls.c
+++ b/acados/ocp_nlp/ocp_nlp_cost_ls.c
@@ -647,7 +647,7 @@ struct blasfeo_dvec *ocp_nlp_cost_ls_memory_get_grad_ptr(void *memory_)
     return &memory->grad;
 }
 
-void ocp_nlp_cost_ls_memory_set(void *config_, void *dims_, void *memory_, char *field, void *value)
+void ocp_nlp_cost_ls_memory_set(void *config_, void *dims_, void *memory_, const char *field, void *value)
 {
     ocp_nlp_cost_ls_memory *memory = memory_;
 

--- a/acados/ocp_nlp/ocp_nlp_cost_ls.c
+++ b/acados/ocp_nlp/ocp_nlp_cost_ls.c
@@ -640,7 +640,6 @@ double *ocp_nlp_cost_ls_memory_get_fun_ptr(void *memory_)
 }
 
 
-
 struct blasfeo_dvec *ocp_nlp_cost_ls_memory_get_grad_ptr(void *memory_)
 {
     ocp_nlp_cost_ls_memory *memory = memory_;
@@ -648,59 +647,40 @@ struct blasfeo_dvec *ocp_nlp_cost_ls_memory_get_grad_ptr(void *memory_)
     return &memory->grad;
 }
 
-
-
-void ocp_nlp_cost_ls_memory_set_RSQrq_ptr(struct
-    blasfeo_dmat *RSQrq, void *memory_)
+void ocp_nlp_cost_ls_memory_set(void *config_, void *dims_, void *memory_, char *field, void *value)
 {
     ocp_nlp_cost_ls_memory *memory = memory_;
 
-    memory->RSQrq = RSQrq;
-}
-
-
-
-void ocp_nlp_cost_ls_memory_set_Z_ptr(struct blasfeo_dvec *Z, void *memory_)
-{
-    ocp_nlp_cost_ls_memory *memory = memory_;
-
-    memory->Z = Z;
-}
-
-
-
-void ocp_nlp_cost_ls_memory_set_ux_ptr(struct blasfeo_dvec *ux, void *memory_)
-{
-    ocp_nlp_cost_ls_memory *memory = memory_;
-
-    memory->ux = ux;
-}
-
-
-
-void ocp_nlp_cost_ls_memory_set_z_alg_ptr(struct blasfeo_dvec *z_alg, void *memory_)
-{
-    ocp_nlp_cost_ls_memory *memory = memory_;
-
-    memory->z_alg = z_alg;
-}
-
-
-
-void ocp_nlp_cost_ls_memory_set_dzdux_tran_ptr(struct blasfeo_dmat *dzdux_tran, void *memory_)
-{
-    ocp_nlp_cost_ls_memory *memory = memory_;
-
-    memory->dzdux_tran = dzdux_tran;
-}
-
-
-void ocp_nlp_cost_ls_memory_set_jac_lag_stat_p_global_ptr(struct blasfeo_dmat *jac_lag_stat_p_global, void *memory_)
-{
-    // do nothing -- ls cost can not depend on p_global, as it is not parametric
-
-    // ocp_nlp_cost_ls_memory *memory = memory_;
-    // memory->jac_lag_stat_p_global = jac_lag_stat_p_global;
+    if (!strcmp(field, "ux"))
+    {
+        memory->ux = value;
+    }
+    else if (!strcmp(field, "z_alg"))
+    {
+        memory->z_alg = value;
+    }
+    else if (!strcmp(field, "dzdux_tran"))
+    {
+        memory->dzdux_tran = value;
+    }
+    else if (!strcmp(field, "RSQrq"))
+    {
+        memory->RSQrq = value;
+    }
+    else if (!strcmp(field, "Z"))
+    {
+        memory->Z = value;
+    }
+    else if (!strcmp(field, "jac_lag_stat_p_global") || !strcmp(field, "adj_lag_p_global") ||
+             !strcmp(field, "seed_ux"))
+    {
+        return;
+    }
+    else
+    {
+        printf("\nerror: field %s not available in ocp_nlp_cost_ls_memory_set\n", field);
+        exit(1);
+    }
 }
 
 
@@ -1167,12 +1147,7 @@ void ocp_nlp_cost_ls_config_initialize_default(void *config_, int stage)
     config->memory_assign = &ocp_nlp_cost_ls_memory_assign;
     config->memory_get_fun_ptr = &ocp_nlp_cost_ls_memory_get_fun_ptr;
     config->memory_get_grad_ptr = &ocp_nlp_cost_ls_memory_get_grad_ptr;
-    config->memory_set_ux_ptr = &ocp_nlp_cost_ls_memory_set_ux_ptr;
-    config->memory_set_z_alg_ptr = &ocp_nlp_cost_ls_memory_set_z_alg_ptr;
-    config->memory_set_dzdux_tran_ptr = &ocp_nlp_cost_ls_memory_set_dzdux_tran_ptr;
-    config->memory_set_RSQrq_ptr = &ocp_nlp_cost_ls_memory_set_RSQrq_ptr;
-    config->memory_set_Z_ptr = &ocp_nlp_cost_ls_memory_set_Z_ptr;
-    config->memory_set_jac_lag_stat_p_global_ptr = &ocp_nlp_cost_ls_memory_set_jac_lag_stat_p_global_ptr;
+    config->memory_set = &ocp_nlp_cost_ls_memory_set;
     config->workspace_calculate_size = &ocp_nlp_cost_ls_workspace_calculate_size;
     config->get_external_fun_workspace_requirement = &ocp_nlp_cost_ls_get_external_fun_workspace_requirement;
     config->set_external_fun_workspaces = &ocp_nlp_cost_ls_set_external_fun_workspaces;

--- a/acados/ocp_nlp/ocp_nlp_cost_ls.h
+++ b/acados/ocp_nlp/ocp_nlp_cost_ls.h
@@ -185,16 +185,6 @@ void *ocp_nlp_cost_ls_memory_assign(void *config, void *dims, void *opts, void *
 double *ocp_nlp_cost_ls_memory_get_fun_ptr(void *memory_);
 //
 struct blasfeo_dvec *ocp_nlp_cost_ls_memory_get_grad_ptr(void *memory_);
-//
-void ocp_nlp_cost_ls_memory_set_RSQrq_ptr(struct blasfeo_dmat *RSQrq, void *memory);
-//
-void ocp_nlp_cost_ls_memory_set_Z_ptr(struct blasfeo_dvec *Z, void *memory);
-//
-void ocp_nlp_cost_ls_memory_set_ux_ptr(struct blasfeo_dvec *ux, void *memory_);
-//
-void ocp_nlp_cost_ls_memory_set_z_alg_ptr(struct blasfeo_dvec *z_alg, void *memory_);
-//
-void ocp_nlp_cost_ls_memory_set_dzdux_tran_ptr(struct blasfeo_dmat *dzdux_tran, void *memory_);
 
 
 

--- a/acados/ocp_nlp/ocp_nlp_cost_nls.c
+++ b/acados/ocp_nlp/ocp_nlp_cost_nls.c
@@ -634,55 +634,40 @@ struct blasfeo_dvec *ocp_nlp_cost_nls_memory_get_grad_ptr(void *memory_)
     return &memory->grad;
 }
 
-
-
-void ocp_nlp_cost_nls_memory_set_RSQrq_ptr(struct blasfeo_dmat *RSQrq, void *memory_)
+void ocp_nlp_cost_nls_memory_set(void *config_, void *dims_, void *memory_, char *field, void *value)
 {
     ocp_nlp_cost_nls_memory *memory = memory_;
 
-    memory->RSQrq = RSQrq;
-
-    return;
-}
-
-
-
-void ocp_nlp_cost_nls_memory_set_Z_ptr(struct blasfeo_dvec *Z, void *memory_)
-{
-    ocp_nlp_cost_nls_memory *memory = memory_;
-
-    memory->Z = Z;
-
-    return;
-}
-
-
-
-void ocp_nlp_cost_nls_memory_set_ux_ptr(struct blasfeo_dvec *ux, void *memory_)
-{
-    ocp_nlp_cost_nls_memory *memory = memory_;
-
-    memory->ux = ux;
-
-    return;
-}
-
-
-
-void ocp_nlp_cost_nls_memory_set_z_alg_ptr(struct blasfeo_dvec *z_alg, void *memory_)
-{
-    ocp_nlp_cost_nls_memory *memory = memory_;
-
-    memory->z_alg = z_alg;
-}
-
-
-
-void ocp_nlp_cost_nls_memory_set_dzdux_tran_ptr(struct blasfeo_dmat *dzdux_tran, void *memory_)
-{
-    ocp_nlp_cost_nls_memory *memory = memory_;
-
-    memory->dzdux_tran = dzdux_tran;
+    if (!strcmp(field, "ux"))
+    {
+        memory->ux = value;
+    }
+    else if (!strcmp(field, "z_alg"))
+    {
+        memory->z_alg = value;
+    }
+    else if (!strcmp(field, "dzdux_tran"))
+    {
+        memory->dzdux_tran = value;
+    }
+    else if (!strcmp(field, "RSQrq"))
+    {
+        memory->RSQrq = value;
+    }
+    else if (!strcmp(field, "Z"))
+    {
+        memory->Z = value;
+    }
+    else if (!strcmp(field, "jac_lag_stat_p_global") || !strcmp(field, "adj_lag_p_global") ||
+             !strcmp(field, "seed_ux"))
+    {
+        return;
+    }
+    else
+    {
+        printf("\nerror: field %s not available in ocp_nlp_cost_nls_memory_set\n", field);
+        exit(1);
+    }
 }
 
 
@@ -1213,11 +1198,7 @@ void ocp_nlp_cost_nls_config_initialize_default(void *config_, int stage)
     config->memory_get_W_chol_diag_ptr = &ocp_nlp_cost_nls_memory_get_W_chol_diag_ptr;
     config->get_outer_hess_is_diag_ptr = &ocp_nlp_cost_nls_get_outer_hess_is_diag_ptr;
     config->model_get_y_ref_ptr = &ocp_nlp_cost_nls_model_get_y_ref_ptr;
-    config->memory_set_ux_ptr = &ocp_nlp_cost_nls_memory_set_ux_ptr;
-    config->memory_set_z_alg_ptr = &ocp_nlp_cost_nls_memory_set_z_alg_ptr;
-    config->memory_set_dzdux_tran_ptr = &ocp_nlp_cost_nls_memory_set_dzdux_tran_ptr;
-    config->memory_set_RSQrq_ptr = &ocp_nlp_cost_nls_memory_set_RSQrq_ptr;
-    config->memory_set_Z_ptr = &ocp_nlp_cost_nls_memory_set_Z_ptr;
+    config->memory_set = &ocp_nlp_cost_nls_memory_set;
     config->workspace_calculate_size = &ocp_nlp_cost_nls_workspace_calculate_size;
     config->get_external_fun_workspace_requirement = &ocp_nlp_cost_nls_get_external_fun_workspace_requirement;
     config->set_external_fun_workspaces = &ocp_nlp_cost_nls_set_external_fun_workspaces;

--- a/acados/ocp_nlp/ocp_nlp_cost_nls.c
+++ b/acados/ocp_nlp/ocp_nlp_cost_nls.c
@@ -272,7 +272,7 @@ int ocp_nlp_cost_nls_model_set(void *config_, void *dims_, void *model_,
         double *y_ref = (double *) value_;
         blasfeo_pack_dvec(ny, y_ref, 1, &model->y_ref, 0);
     }
-    else if (!strcmp(field, "Z"))
+    else if (!strcmp(field, "Z_ptr"))
     {
         double *Z = (double *) value_;
         blasfeo_pack_dvec(ns, Z, 1, &model->Z, 0);
@@ -638,28 +638,28 @@ void ocp_nlp_cost_nls_memory_set(void *config_, void *dims_, void *memory_, cons
 {
     ocp_nlp_cost_nls_memory *memory = memory_;
 
-    if (!strcmp(field, "ux"))
+    if (!strcmp(field, "ux_ptr"))
     {
         memory->ux = value;
     }
-    else if (!strcmp(field, "z_alg"))
+    else if (!strcmp(field, "z_alg_ptr"))
     {
         memory->z_alg = value;
     }
-    else if (!strcmp(field, "dzdux_tran"))
+    else if (!strcmp(field, "dzdux_tran_ptr"))
     {
         memory->dzdux_tran = value;
     }
-    else if (!strcmp(field, "RSQrq"))
+    else if (!strcmp(field, "RSQrq_ptr"))
     {
         memory->RSQrq = value;
     }
-    else if (!strcmp(field, "Z"))
+    else if (!strcmp(field, "Z_ptr"))
     {
         memory->Z = value;
     }
-    else if (!strcmp(field, "jac_lag_stat_p_global") || !strcmp(field, "adj_lag_p_global") ||
-             !strcmp(field, "seed_ux"))
+    else if (!strcmp(field, "jac_lag_stat_p_global_ptr") || !strcmp(field, "adj_lag_p_global_ptr") ||
+             !strcmp(field, "seed_ux_ptr"))
     {
         return;
     }

--- a/acados/ocp_nlp/ocp_nlp_cost_nls.c
+++ b/acados/ocp_nlp/ocp_nlp_cost_nls.c
@@ -634,7 +634,7 @@ struct blasfeo_dvec *ocp_nlp_cost_nls_memory_get_grad_ptr(void *memory_)
     return &memory->grad;
 }
 
-void ocp_nlp_cost_nls_memory_set(void *config_, void *dims_, void *memory_, char *field, void *value)
+void ocp_nlp_cost_nls_memory_set(void *config_, void *dims_, void *memory_, const char *field, void *value)
 {
     ocp_nlp_cost_nls_memory *memory = memory_;
 

--- a/acados/ocp_nlp/ocp_nlp_cost_nls.h
+++ b/acados/ocp_nlp/ocp_nlp_cost_nls.h
@@ -164,16 +164,6 @@ struct blasfeo_dvec *ocp_nlp_cost_nls_memory_get_grad_ptr(void *memory_);
 struct blasfeo_dmat *ocp_nlp_cost_nls_memory_get_W_chol_ptr(void *memory_);
 //
 struct blasfeo_dvec *ocp_nlp_cost_nls_memory_get_W_chol_diag_ptr(void *memory_);
-//
-void ocp_nlp_cost_nls_memory_set_RSQrq_ptr(struct blasfeo_dmat *RSQrq, void *memory);
-//
-void ocp_nlp_cost_nls_memory_set_Z_ptr(struct blasfeo_dvec *Z, void *memory);
-//
-void ocp_nlp_cost_nls_memory_set_ux_ptr(struct blasfeo_dvec *ux, void *memory_);
-//
-void ocp_nlp_cost_nls_memory_set_z_alg_ptr(struct blasfeo_dvec *z_alg, void *memory_);
-//
-void ocp_nlp_cost_nls_memory_set_dzdux_tran_ptr(struct blasfeo_dmat *dzdux_tran, void *memory_);
 
 /************************************************
  * workspace

--- a/acados/ocp_nlp/ocp_nlp_ddp.c
+++ b/acados/ocp_nlp/ocp_nlp_ddp.c
@@ -385,10 +385,10 @@ void ocp_nlp_ddp_compute_trial_iterate(void *config_, void *dims_,
 
         // evalutate dynamics
         // x_{i+1} = f_dyn_i(x_i, u_i)
-        config->dynamics[i]->memory_set(config->dynamics[i], dims->dynamics[i], mem->dynamics[i], "ux", out_destination->ux+i);
+        config->dynamics[i]->memory_set(config->dynamics[i], dims->dynamics[i], mem->dynamics[i], "ux_ptr", out_destination->ux+i);
         config->dynamics[i]->compute_fun(config->dynamics[i], dims->dynamics[i],
             in->dynamics[i], opts->dynamics[i], mem->dynamics[i], work->dynamics[i]);
-        config->dynamics[i]->memory_set(config->dynamics[i], dims->dynamics[i], mem->dynamics[i], "ux", out->ux+i);
+        config->dynamics[i]->memory_set(config->dynamics[i], dims->dynamics[i], mem->dynamics[i], "ux_ptr", out->ux+i);
 
         // f_dyn_i(x_i, u_i) - x_{i+1}
         // NOTE/TODO: store function output in dynamics module instead?

--- a/acados/ocp_nlp/ocp_nlp_ddp.c
+++ b/acados/ocp_nlp/ocp_nlp_ddp.c
@@ -385,10 +385,10 @@ void ocp_nlp_ddp_compute_trial_iterate(void *config_, void *dims_,
 
         // evalutate dynamics
         // x_{i+1} = f_dyn_i(x_i, u_i)
-        config->dynamics[i]->memory_set_ux_ptr(out_destination->ux+i, mem->dynamics[i]);
+        config->dynamics[i]->memory_set(config->dynamics[i], dims->dynamics[i], mem->dynamics[i], "ux", out_destination->ux+i);
         config->dynamics[i]->compute_fun(config->dynamics[i], dims->dynamics[i],
             in->dynamics[i], opts->dynamics[i], mem->dynamics[i], work->dynamics[i]);
-        config->dynamics[i]->memory_set_ux_ptr(out->ux+i, mem->dynamics[i]);
+        config->dynamics[i]->memory_set(config->dynamics[i], dims->dynamics[i], mem->dynamics[i], "ux", out->ux+i);
 
         // f_dyn_i(x_i, u_i) - x_{i+1}
         // NOTE/TODO: store function output in dynamics module instead?

--- a/acados/ocp_nlp/ocp_nlp_dynamics_common.h
+++ b/acados/ocp_nlp/ocp_nlp_dynamics_common.h
@@ -84,21 +84,7 @@ typedef struct
     // get shooting node gap x_next(x_n, u_n) - x_{n+1}
     struct blasfeo_dvec *(*memory_get_fun_ptr)(void *memory_);
     struct blasfeo_dvec *(*memory_get_adj_ptr)(void *memory_);
-    void (*memory_set_ux_ptr)(struct blasfeo_dvec *ux, void *memory_);
-    void (*memory_set_ux1_ptr)(struct blasfeo_dvec *ux1, void *memory_);
-    void (*memory_set_pi_ptr)(struct blasfeo_dvec *pi, void *memory_);
-    void (*memory_set_BAbt_ptr)(struct blasfeo_dmat *BAbt, void *memory_);
-    void (*memory_set_RSQrq_ptr)(struct blasfeo_dmat *RSQrq, void *memory_);
-    void (*memory_set_dzduxt_ptr)(struct blasfeo_dmat *mat, void *memory_);
-    void (*memory_set_sim_guess_ptr)(struct blasfeo_dvec *vec, bool *bool_ptr, void *memory_);
-    void (*memory_set_z_alg_ptr)(struct blasfeo_dvec *vec, void *memory_);
-    void (*memory_set_dyn_jac_p_global_ptr)(struct blasfeo_dmat *dyn_jac_p_global, void *memory);
-    void (*memory_set_jac_lag_stat_p_global_ptr)(struct blasfeo_dmat *jac_lag_stat_p_global, void *memory);
-    void (*memory_set_seed_ux_ptr)(struct blasfeo_dvec *seed_ux, void *memory_);
-    void (*memory_set_seed_pi_ptr)(struct blasfeo_dvec *seed_pi, void *memory_);
-    void (*memory_set_adj_lag_p_global_ptr)(struct blasfeo_dvec *adj_lag_p_global, void *memory_);
     void (*memory_get)(void *config, void *dims, void *mem, const char *field, void* value);
-    // TODO: what about actually using this instead of the bunch of set functions above?
     void (*memory_set)(void *config, void *dims, void *mem, const char *field, void* value);
     /* workspace */
     acados_size_t (*workspace_calculate_size)(void *config, void *dims, void *opts);

--- a/acados/ocp_nlp/ocp_nlp_dynamics_cont.c
+++ b/acados/ocp_nlp/ocp_nlp_dynamics_cont.c
@@ -477,27 +477,27 @@ void ocp_nlp_dynamics_cont_memory_set(void *config_, void *dims_, void *mem_, co
 
     sim_config *sim = config->sim_solver;
 
-    if (!strcmp(field, "ux"))
+    if (!strcmp(field, "ux_ptr"))
     {
         mem->ux = value;
     }
-    else if (!strcmp(field, "ux1"))
+    else if (!strcmp(field, "ux1_ptr"))
     {
         mem->ux1 = value;
     }
-    else if (!strcmp(field, "pi"))
+    else if (!strcmp(field, "pi_ptr"))
     {
         mem->pi = value;
     }
-    else if (!strcmp(field, "BAbt"))
+    else if (!strcmp(field, "BAbt_ptr"))
     {
         mem->BAbt = value;
     }
-    else if (!strcmp(field, "RSQrq"))
+    else if (!strcmp(field, "RSQrq_ptr"))
     {
         mem->RSQrq = value;
     }
-    else if (!strcmp(field, "dzduxt"))
+    else if (!strcmp(field, "dzduxt_ptr"))
     {
         mem->dzduxt = value;
     }
@@ -509,12 +509,12 @@ void ocp_nlp_dynamics_cont_memory_set(void *config_, void *dims_, void *mem_, co
     {
         mem->set_sim_guess = value;
     }
-    else if (!strcmp(field, "z_alg"))
+    else if (!strcmp(field, "z_alg_ptr"))
     {
         mem->z_alg = value;
     }
-    else if (!strcmp(field, "dyn_jac_p_global") || !strcmp(field, "jac_lag_stat_p_global") ||
-             !strcmp(field, "adj_lag_p_global") || !strcmp(field, "seed_ux") || !strcmp(field, "seed_pi"))
+    else if (!strcmp(field, "dyn_jac_p_global_ptr") || !strcmp(field, "jac_lag_stat_p_global_ptr") ||
+             !strcmp(field, "adj_lag_p_global_ptr") || !strcmp(field, "seed_ux_ptr") || !strcmp(field, "seed_pi_ptr"))
     {
         return;
     }

--- a/acados/ocp_nlp/ocp_nlp_dynamics_cont.c
+++ b/acados/ocp_nlp/ocp_nlp_dynamics_cont.c
@@ -469,93 +469,6 @@ struct blasfeo_dvec *ocp_nlp_dynamics_cont_memory_get_adj_ptr(void *memory_)
 
 
 
-void ocp_nlp_dynamics_cont_memory_set_ux_ptr(struct blasfeo_dvec *ux, void *memory_)
-{
-    ocp_nlp_dynamics_cont_memory *memory = memory_;
-
-    memory->ux = ux;
-
-    return;
-}
-
-
-
-void ocp_nlp_dynamics_cont_memory_set_ux1_ptr(struct blasfeo_dvec *ux1, void *memory_)
-{
-    ocp_nlp_dynamics_cont_memory *memory = memory_;
-
-    memory->ux1 = ux1;
-
-    return;
-}
-
-
-void ocp_nlp_dynamics_cont_memory_set_pi_ptr(struct blasfeo_dvec *pi, void *memory_)
-{
-    ocp_nlp_dynamics_cont_memory *memory = memory_;
-
-    memory->pi = pi;
-
-    return;
-}
-
-
-
-void ocp_nlp_dynamics_cont_memory_set_BAbt_ptr(struct blasfeo_dmat *BAbt, void *memory_)
-{
-    ocp_nlp_dynamics_cont_memory *memory = memory_;
-
-    memory->BAbt = BAbt;
-
-    return;
-}
-
-
-
-void ocp_nlp_dynamics_cont_memory_set_RSQrq_ptr(struct blasfeo_dmat *RSQrq, void *memory_)
-{
-    ocp_nlp_dynamics_cont_memory *memory = memory_;
-
-    memory->RSQrq = RSQrq;
-
-    return;
-}
-
-
-
-void ocp_nlp_dynamics_cont_memory_set_dzduxt_ptr(struct blasfeo_dmat *mat, void *memory_)
-{
-    ocp_nlp_dynamics_cont_memory *memory = memory_;
-
-    memory->dzduxt = mat;
-
-    return;
-}
-
-
-
-void ocp_nlp_dynamics_cont_memory_set_sim_guess_ptr(struct blasfeo_dvec *vec, bool *bool_ptr, void *memory_)
-{
-    ocp_nlp_dynamics_cont_memory *memory = memory_;
-
-    memory->sim_guess = vec;
-    memory->set_sim_guess = bool_ptr;
-
-    return;
-}
-
-
-
-void ocp_nlp_dynamics_cont_memory_set_z_alg_ptr(struct blasfeo_dvec *vec, void *memory_)
-{
-    ocp_nlp_dynamics_cont_memory *memory = memory_;
-
-    memory->z_alg = vec;
-
-    return;
-}
-
-
 void ocp_nlp_dynamics_cont_memory_set(void *config_, void *dims_, void *mem_, const char *field, void* value)
 {
     ocp_nlp_dynamics_config *config = config_;
@@ -564,7 +477,48 @@ void ocp_nlp_dynamics_cont_memory_set(void *config_, void *dims_, void *mem_, co
 
     sim_config *sim = config->sim_solver;
 
-    if (!strcmp(field, "W_chol") || !strcmp(field, "W_chol_diag") || !strcmp(field, "cost_fun") || !strcmp(field, "outer_hess_is_diag") || !strcmp(field, "cost_hess") || !strcmp(field, "cost_grad")
+    if (!strcmp(field, "ux"))
+    {
+        mem->ux = value;
+    }
+    else if (!strcmp(field, "ux1"))
+    {
+        mem->ux1 = value;
+    }
+    else if (!strcmp(field, "pi"))
+    {
+        mem->pi = value;
+    }
+    else if (!strcmp(field, "BAbt"))
+    {
+        mem->BAbt = value;
+    }
+    else if (!strcmp(field, "RSQrq"))
+    {
+        mem->RSQrq = value;
+    }
+    else if (!strcmp(field, "dzduxt"))
+    {
+        mem->dzduxt = value;
+    }
+    else if (!strcmp(field, "sim_guess"))
+    {
+        mem->sim_guess = value;
+    }
+    else if (!strcmp(field, "set_sim_guess"))
+    {
+        mem->set_sim_guess = value;
+    }
+    else if (!strcmp(field, "z_alg"))
+    {
+        mem->z_alg = value;
+    }
+    else if (!strcmp(field, "dyn_jac_p_global") || !strcmp(field, "jac_lag_stat_p_global") ||
+             !strcmp(field, "adj_lag_p_global") || !strcmp(field, "seed_ux") || !strcmp(field, "seed_pi"))
+    {
+        return;
+    }
+    else if (!strcmp(field, "W_chol") || !strcmp(field, "W_chol_diag") || !strcmp(field, "cost_fun") || !strcmp(field, "outer_hess_is_diag") || !strcmp(field, "cost_hess") || !strcmp(field, "cost_grad")
          || !strcmp(field, "y_ref"))
     {
         sim->memory_set(sim, dims->sim, mem->sim_solver, field, value);
@@ -609,20 +563,6 @@ void ocp_nlp_dynamics_cont_memory_get(void *config_, void *dims_, void *mem_, co
     }
 
 }
-
-
-void ocp_nlp_dynamics_cont_memory_set_dyn_jac_p_global_ptr(struct blasfeo_dmat *dyn_jac_p_global, void *memory_)
-{
-    // ocp_nlp_dynamics_cont_memory *memory = memory_;
-    // memory->dyn_jac_p_global = dyn_jac_p_global;
-}
-
-void ocp_nlp_dynamics_cont_memory_set_jac_lag_stat_p_global_ptr(struct blasfeo_dmat *jac_lag_stat_p_global, void *memory_)
-{
-    // ocp_nlp_dynamics_cont_memory *memory = memory_;
-    // memory->jac_lag_stat_p_global = jac_lag_stat_p_global;
-}
-
 
 
 /************************************************
@@ -1180,16 +1120,6 @@ void ocp_nlp_dynamics_cont_config_initialize_default(void *config_, int stage)
     config->memory_get_fun_ptr = &ocp_nlp_dynamics_cont_memory_get_fun_ptr;
     config->memory_get_adj_ptr = &ocp_nlp_dynamics_cont_memory_get_adj_ptr;
     config->memory_set = &ocp_nlp_dynamics_cont_memory_set;
-    config->memory_set_ux_ptr = &ocp_nlp_dynamics_cont_memory_set_ux_ptr;
-    config->memory_set_ux1_ptr = &ocp_nlp_dynamics_cont_memory_set_ux1_ptr;
-    config->memory_set_pi_ptr = &ocp_nlp_dynamics_cont_memory_set_pi_ptr;
-    config->memory_set_BAbt_ptr = &ocp_nlp_dynamics_cont_memory_set_BAbt_ptr;
-    config->memory_set_RSQrq_ptr = &ocp_nlp_dynamics_cont_memory_set_RSQrq_ptr;
-    config->memory_set_dzduxt_ptr = &ocp_nlp_dynamics_cont_memory_set_dzduxt_ptr;
-    config->memory_set_sim_guess_ptr = &ocp_nlp_dynamics_cont_memory_set_sim_guess_ptr;
-    config->memory_set_z_alg_ptr = &ocp_nlp_dynamics_cont_memory_set_z_alg_ptr;
-    config->memory_set_jac_lag_stat_p_global_ptr = &ocp_nlp_dynamics_cont_memory_set_jac_lag_stat_p_global_ptr;
-    config->memory_set_dyn_jac_p_global_ptr = &ocp_nlp_dynamics_cont_memory_set_dyn_jac_p_global_ptr;
     config->memory_get = &ocp_nlp_dynamics_cont_memory_get;
     config->workspace_calculate_size = &ocp_nlp_dynamics_cont_workspace_calculate_size;
     config->get_external_fun_workspace_requirement = &ocp_nlp_dynamics_cont_get_external_fun_workspace_requirement;

--- a/acados/ocp_nlp/ocp_nlp_dynamics_cont.h
+++ b/acados/ocp_nlp/ocp_nlp_dynamics_cont.h
@@ -134,16 +134,6 @@ void *ocp_nlp_dynamics_cont_memory_assign(void *config, void *dims, void *opts, 
 struct blasfeo_dvec *ocp_nlp_dynamics_cont_memory_get_fun_ptr(void *memory);
 //
 struct blasfeo_dvec *ocp_nlp_dynamics_cont_memory_get_adj_ptr(void *memory);
-//
-void ocp_nlp_dynamics_cont_memory_set_ux_ptr(struct blasfeo_dvec *ux, void *memory);
-//
-void ocp_nlp_dynamics_cont_memory_set_ux1_ptr(struct blasfeo_dvec *ux1, void *memory);
-//
-void ocp_nlp_dynamics_cont_memory_set_pi_ptr(struct blasfeo_dvec *pi, void *memory);
-//
-void ocp_nlp_dynamics_cont_memory_set_BAbt_ptr(struct blasfeo_dmat *BAbt, void *memory);
-//
-void ocp_nlp_dynamics_cont_memory_get_params_lag_grad(void *config, void *dims, void *opts, void *memory, int index, struct blasfeo_dvec *out, int offset);
 
 
 

--- a/acados/ocp_nlp/ocp_nlp_dynamics_disc.c
+++ b/acados/ocp_nlp/ocp_nlp_dynamics_disc.c
@@ -366,116 +366,60 @@ struct blasfeo_dvec *ocp_nlp_dynamics_disc_memory_get_adj_ptr(void *memory_)
 
 
 
-void ocp_nlp_dynamics_disc_memory_set_ux_ptr(struct blasfeo_dvec *ux, void *memory_)
+void ocp_nlp_dynamics_disc_memory_set(void *config_, void *dims_, void *mem_, const char *field, void *value)
 {
-    ocp_nlp_dynamics_disc_memory *memory = memory_;
+    ocp_nlp_dynamics_disc_memory *memory = mem_;
 
-    memory->ux = ux;
-
-    return;
-}
-
-
-void ocp_nlp_dynamics_disc_memory_set_ux1_ptr(struct blasfeo_dvec *ux1, void *memory_)
-{
-    ocp_nlp_dynamics_disc_memory *memory = memory_;
-
-    memory->ux1 = ux1;
-
-    return;
-}
-
-
-void ocp_nlp_dynamics_disc_memory_set_pi_ptr(struct blasfeo_dvec *pi, void *memory_)
-{
-    ocp_nlp_dynamics_disc_memory *memory = memory_;
-
-    memory->pi = pi;
-
-    return;
-}
-
-
-
-void ocp_nlp_dynamics_disc_memory_set_seed_ux_ptr(struct blasfeo_dvec *seed_ux, void *memory_)
-{
-    ocp_nlp_dynamics_disc_memory *memory = memory_;
-    memory->seed_ux = seed_ux;
-
-    return;
-}
-
-
-
-void ocp_nlp_dynamics_disc_memory_set_seed_pi_ptr(struct blasfeo_dvec *seed_pi, void *memory_)
-{
-    ocp_nlp_dynamics_disc_memory *memory = memory_;
-    memory->seed_pi = seed_pi;
-
-    return;
-}
-
-void ocp_nlp_dynamics_disc_memory_set_adj_lag_p_global_ptr(struct blasfeo_dvec *adj_lag_p_global, void *memory_)
-{
-    ocp_nlp_dynamics_disc_memory *memory = memory_;
-    memory->adj_lag_p_global = adj_lag_p_global;
-
-    return;
-}
-
-
-
-void ocp_nlp_dynamics_disc_memory_set_BAbt_ptr(struct blasfeo_dmat *BAbt, void *memory_)
-{
-    ocp_nlp_dynamics_disc_memory *memory = memory_;
-
-    memory->BAbt = BAbt;
-
-    return;
-}
-
-
-
-void ocp_nlp_dynamics_disc_memory_set_RSQrq_ptr(struct blasfeo_dmat *RSQrq, void *memory_)
-{
-    ocp_nlp_dynamics_disc_memory *memory = memory_;
-
-    memory->RSQrq = RSQrq;
-
-    return;
-}
-
-
-void ocp_nlp_dynamics_disc_memory_set_dyn_jac_p_global_ptr(struct blasfeo_dmat *dyn_jac_p_global, void *memory_)
-{
-    ocp_nlp_dynamics_disc_memory *memory = memory_;
-    memory->dyn_jac_p_global = dyn_jac_p_global;
-}
-
-void ocp_nlp_dynamics_disc_memory_set_jac_lag_stat_p_global_ptr(struct blasfeo_dmat *jac_lag_stat_p_global, void *memory_)
-{
-    ocp_nlp_dynamics_disc_memory *memory = memory_;
-    memory->jac_lag_stat_p_global = jac_lag_stat_p_global;
-}
-
-
-void ocp_nlp_dynamics_disc_memory_set_dzduxt_ptr(struct blasfeo_dmat *mat, void *memory_)
-{
-    return;  // we don't allow algebraic variables for discrete models for now
-}
-
-
-
-void ocp_nlp_dynamics_disc_memory_set_sim_guess_ptr(struct blasfeo_dvec *z, bool *bool_ptr, void *memory_)
-{
-    return;  // we don't allow algebraic variables for discrete models for now
-}
-
-
-
-void ocp_nlp_dynamics_disc_memory_set_z_alg_ptr(struct blasfeo_dvec *z, void *memory_)
-{
-    return;  // we don't allow algebraic variables for discrete models for now
+    if (!strcmp(field, "ux"))
+    {
+        memory->ux = value;
+    }
+    else if (!strcmp(field, "ux1"))
+    {
+        memory->ux1 = value;
+    }
+    else if (!strcmp(field, "pi"))
+    {
+        memory->pi = value;
+    }
+    else if (!strcmp(field, "BAbt"))
+    {
+        memory->BAbt = value;
+    }
+    else if (!strcmp(field, "RSQrq"))
+    {
+        memory->RSQrq = value;
+    }
+    else if (!strcmp(field, "dyn_jac_p_global"))
+    {
+        memory->dyn_jac_p_global = value;
+    }
+    else if (!strcmp(field, "jac_lag_stat_p_global"))
+    {
+        memory->jac_lag_stat_p_global = value;
+    }
+    else if (!strcmp(field, "seed_ux"))
+    {
+        memory->seed_ux = value;
+    }
+    else if (!strcmp(field, "seed_pi"))
+    {
+        memory->seed_pi = value;
+    }
+    else if (!strcmp(field, "adj_lag_p_global"))
+    {
+        memory->adj_lag_p_global = value;
+    }
+    else if (!strcmp(field, "dzduxt") || !strcmp(field, "sim_guess") ||
+             !strcmp(field, "set_sim_guess") || !strcmp(field, "z_alg"))
+    {
+        return;
+    }
+    else
+    {
+        printf("\nerror: ocp_nlp_dynamics_disc_memory_set: field %s not available\n", field);
+        exit(1);
+    }
 }
 
 
@@ -1119,20 +1063,8 @@ void ocp_nlp_dynamics_disc_config_initialize_default(void *config_, int stage)
     config->memory_assign = &ocp_nlp_dynamics_disc_memory_assign;
     config->memory_get_fun_ptr = &ocp_nlp_dynamics_disc_memory_get_fun_ptr;
     config->memory_get_adj_ptr = &ocp_nlp_dynamics_disc_memory_get_adj_ptr;
-    config->memory_set_ux_ptr = &ocp_nlp_dynamics_disc_memory_set_ux_ptr;
-    config->memory_set_ux1_ptr = &ocp_nlp_dynamics_disc_memory_set_ux1_ptr;
-    config->memory_set_pi_ptr = &ocp_nlp_dynamics_disc_memory_set_pi_ptr;
-    config->memory_set_BAbt_ptr = &ocp_nlp_dynamics_disc_memory_set_BAbt_ptr;
-    config->memory_set_RSQrq_ptr = &ocp_nlp_dynamics_disc_memory_set_RSQrq_ptr;
-    config->memory_set_dzduxt_ptr = &ocp_nlp_dynamics_disc_memory_set_dzduxt_ptr;
-    config->memory_set_sim_guess_ptr = &ocp_nlp_dynamics_disc_memory_set_sim_guess_ptr;
-    config->memory_set_z_alg_ptr = &ocp_nlp_dynamics_disc_memory_set_z_alg_ptr;
-    config->memory_set_seed_ux_ptr = &ocp_nlp_dynamics_disc_memory_set_seed_ux_ptr;
-    config->memory_set_seed_pi_ptr = &ocp_nlp_dynamics_disc_memory_set_seed_pi_ptr;
-    config->memory_set_dyn_jac_p_global_ptr = &ocp_nlp_dynamics_disc_memory_set_dyn_jac_p_global_ptr;
-    config->memory_set_adj_lag_p_global_ptr = &ocp_nlp_dynamics_disc_memory_set_adj_lag_p_global_ptr;
+    config->memory_set = &ocp_nlp_dynamics_disc_memory_set;
     config->memory_get = &ocp_nlp_dynamics_disc_memory_get;
-    config->memory_set_jac_lag_stat_p_global_ptr = &ocp_nlp_dynamics_disc_memory_set_jac_lag_stat_p_global_ptr;
     config->compute_jac_hess_p = &ocp_nlp_dynamics_disc_compute_jac_hess_p;
     config->workspace_calculate_size = &ocp_nlp_dynamics_disc_workspace_calculate_size;
     config->get_external_fun_workspace_requirement = &ocp_nlp_dynamics_disc_get_external_fun_workspace_requirement;

--- a/acados/ocp_nlp/ocp_nlp_dynamics_disc.c
+++ b/acados/ocp_nlp/ocp_nlp_dynamics_disc.c
@@ -370,48 +370,48 @@ void ocp_nlp_dynamics_disc_memory_set(void *config_, void *dims_, void *mem_, co
 {
     ocp_nlp_dynamics_disc_memory *memory = mem_;
 
-    if (!strcmp(field, "ux"))
+    if (!strcmp(field, "ux_ptr"))
     {
         memory->ux = value;
     }
-    else if (!strcmp(field, "ux1"))
+    else if (!strcmp(field, "ux1_ptr"))
     {
         memory->ux1 = value;
     }
-    else if (!strcmp(field, "pi"))
+    else if (!strcmp(field, "pi_ptr"))
     {
         memory->pi = value;
     }
-    else if (!strcmp(field, "BAbt"))
+    else if (!strcmp(field, "BAbt_ptr"))
     {
         memory->BAbt = value;
     }
-    else if (!strcmp(field, "RSQrq"))
+    else if (!strcmp(field, "RSQrq_ptr"))
     {
         memory->RSQrq = value;
     }
-    else if (!strcmp(field, "dyn_jac_p_global"))
+    else if (!strcmp(field, "dyn_jac_p_global_ptr"))
     {
         memory->dyn_jac_p_global = value;
     }
-    else if (!strcmp(field, "jac_lag_stat_p_global"))
+    else if (!strcmp(field, "jac_lag_stat_p_global_ptr"))
     {
         memory->jac_lag_stat_p_global = value;
     }
-    else if (!strcmp(field, "seed_ux"))
+    else if (!strcmp(field, "seed_ux_ptr"))
     {
         memory->seed_ux = value;
     }
-    else if (!strcmp(field, "seed_pi"))
+    else if (!strcmp(field, "seed_pi_ptr"))
     {
         memory->seed_pi = value;
     }
-    else if (!strcmp(field, "adj_lag_p_global"))
+    else if (!strcmp(field, "adj_lag_p_global_ptr"))
     {
         memory->adj_lag_p_global = value;
     }
-    else if (!strcmp(field, "dzduxt") || !strcmp(field, "sim_guess") ||
-             !strcmp(field, "set_sim_guess") || !strcmp(field, "z_alg"))
+    else if (!strcmp(field, "dzduxt_ptr") || !strcmp(field, "sim_guess") ||
+             !strcmp(field, "set_sim_guess") || !strcmp(field, "z_alg_ptr"))
     {
         return;
     }

--- a/acados/ocp_nlp/ocp_nlp_dynamics_disc.h
+++ b/acados/ocp_nlp/ocp_nlp_dynamics_disc.h
@@ -127,18 +127,6 @@ void *ocp_nlp_dynamics_disc_memory_assign(void *config, void *dims, void *opts, 
 struct blasfeo_dvec *ocp_nlp_dynamics_disc_memory_get_fun_ptr(void *memory);
 //
 struct blasfeo_dvec *ocp_nlp_dynamics_disc_memory_get_adj_ptr(void *memory);
-//
-void ocp_nlp_dynamics_disc_memory_set_ux_ptr(struct blasfeo_dvec *ux, void *memory);
-//
-void ocp_nlp_dynamics_disc_memory_set_ux1_ptr(struct blasfeo_dvec *ux1, void *memory);
-//
-void ocp_nlp_dynamics_disc_memory_set_pi_ptr(struct blasfeo_dvec *pi, void *memory);
-//
-void ocp_nlp_dynamics_disc_memory_set_BAbt_ptr(struct blasfeo_dmat *BAbt, void *memory);
-//
-void ocp_nlp_dynamics_disc_memory_set_jac_lag_stat_p_global_ptr(struct blasfeo_dmat *jac_lag_stat_p_global, void *memory_);
-
-void ocp_nlp_dynamics_disc_memory_set_dyn_jac_p_global_ptr(struct blasfeo_dmat *dyn_jac_p_global, void *memory_);
 
 
 /************************************************

--- a/acados/ocp_nlp/ocp_nlp_sqp_with_feasible_qp.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp_with_feasible_qp.c
@@ -878,7 +878,7 @@ static void set_pointers_for_hessian_evaluation(ocp_nlp_config *config,
     int dyn_compute_hess;
     for (int i = 0; i < N; i++)
     {
-        config->dynamics[i]->memory_set_RSQrq_ptr(mem->RSQ_constr+i, nlp_mem->dynamics[i]);
+        config->dynamics[i]->memory_set(config->dynamics[i], dims->dynamics[i], nlp_mem->dynamics[i], "RSQrq", mem->RSQ_constr+i);
         // dynamics always write into hess directly, if hess is computed
         config->dynamics[i]->opts_get(config->dynamics[i], opts->dynamics[i], "compute_hess", &dyn_compute_hess);
         if (!dyn_compute_hess)

--- a/acados/ocp_nlp/ocp_nlp_sqp_with_feasible_qp.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp_with_feasible_qp.c
@@ -878,7 +878,7 @@ static void set_pointers_for_hessian_evaluation(ocp_nlp_config *config,
     int dyn_compute_hess;
     for (int i = 0; i < N; i++)
     {
-        config->dynamics[i]->memory_set(config->dynamics[i], dims->dynamics[i], nlp_mem->dynamics[i], "RSQrq", mem->RSQ_constr+i);
+        config->dynamics[i]->memory_set(config->dynamics[i], dims->dynamics[i], nlp_mem->dynamics[i], "RSQrq_ptr", mem->RSQ_constr+i);
         // dynamics always write into hess directly, if hess is computed
         config->dynamics[i]->opts_get(config->dynamics[i], opts->dynamics[i], "compute_hess", &dyn_compute_hess);
         if (!dyn_compute_hess)
@@ -892,11 +892,11 @@ static void set_pointers_for_hessian_evaluation(ocp_nlp_config *config,
     for (int i = 0; i <= N; i++)
     {
         config->cost[i]->opts_set(config->cost[i], opts->cost[i], "add_hess_contribution", &add_cost_hess_contribution);
-        config->cost[i]->memory_set(config->cost[i], dims->cost[i], nlp_mem->cost[i], "RSQrq", mem->RSQ_cost+i);
+        config->cost[i]->memory_set(config->cost[i], dims->cost[i], nlp_mem->cost[i], "RSQrq_ptr", mem->RSQ_cost+i);
     }
     for (int i = 0; i <= N; i++)
     {
-        config->constraints[i]->memory_set(config->constraints[i], dims->constraints[i], nlp_mem->constraints[i], "RSQrq", mem->RSQ_constr+i);
+        config->constraints[i]->memory_set(config->constraints[i], dims->constraints[i], nlp_mem->constraints[i], "RSQrq_ptr", mem->RSQ_constr+i);
     }
     return;
 }
@@ -1964,7 +1964,7 @@ int ocp_nlp_sqp_wfqp_precompute(void *config_, void *dims_, void *nlp_in_, void 
     // overwrite output pointers normally set in ocp_nlp_alias_memory_to_submodules
     for (int stage = 0; stage <= dims->N; stage++)
     {
-        config->cost[stage]->memory_set(config->cost[stage], dims->cost[stage], nlp_mem->cost[stage], "Z", mem->Z_cost_module+stage);
+        config->cost[stage]->memory_set(config->cost[stage], dims->cost[stage], nlp_mem->cost[stage], "Z_ptr", mem->Z_cost_module+stage);
     }
 
     return ACADOS_SUCCESS;

--- a/acados/ocp_nlp/ocp_nlp_sqp_with_feasible_qp.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp_with_feasible_qp.c
@@ -896,7 +896,7 @@ static void set_pointers_for_hessian_evaluation(ocp_nlp_config *config,
     }
     for (int i = 0; i <= N; i++)
     {
-        config->constraints[i]->memory_set_RSQrq_ptr(mem->RSQ_constr+i, nlp_mem->constraints[i]);
+        config->constraints[i]->memory_set(config->constraints[i], dims->constraints[i], nlp_mem->constraints[i], "RSQrq", mem->RSQ_constr+i);
     }
     return;
 }

--- a/acados/ocp_nlp/ocp_nlp_sqp_with_feasible_qp.c
+++ b/acados/ocp_nlp/ocp_nlp_sqp_with_feasible_qp.c
@@ -892,7 +892,7 @@ static void set_pointers_for_hessian_evaluation(ocp_nlp_config *config,
     for (int i = 0; i <= N; i++)
     {
         config->cost[i]->opts_set(config->cost[i], opts->cost[i], "add_hess_contribution", &add_cost_hess_contribution);
-        config->cost[i]->memory_set_RSQrq_ptr(mem->RSQ_cost+i, nlp_mem->cost[i]);
+        config->cost[i]->memory_set(config->cost[i], dims->cost[i], nlp_mem->cost[i], "RSQrq", mem->RSQ_cost+i);
     }
     for (int i = 0; i <= N; i++)
     {
@@ -1964,7 +1964,7 @@ int ocp_nlp_sqp_wfqp_precompute(void *config_, void *dims_, void *nlp_in_, void 
     // overwrite output pointers normally set in ocp_nlp_alias_memory_to_submodules
     for (int stage = 0; stage <= dims->N; stage++)
     {
-        config->cost[stage]->memory_set_Z_ptr(mem->Z_cost_module+stage, nlp_mem->cost[stage]);
+        config->cost[stage]->memory_set(config->cost[stage], dims->cost[stage], nlp_mem->cost[stage], "Z", mem->Z_cost_module+stage);
     }
 
     return ACADOS_SUCCESS;


### PR DESCRIPTION
- reduces code
- better error messages
- easier extensible