### PR TITLE
python: use casadi version <=3.7.2

### DIFF
--- a/interfaces/acados_template/setup.py
+++ b/interfaces/acados_template/setup.py
@@ -55,7 +55,7 @@ setup(name='acados_template',
     install_requires=[
        'numpy',
        'scipy',
-       'casadi',
+       'casadi<=3.7.2',
        'matplotlib',
        'cython',
        'Deprecated',


### PR DESCRIPTION
Tests are failing with the new casaid version 3.8.0.
This PR thus fixes the casadi version to 3.7.2 when installing the acados python interface.