### PR TITLE
Python: test compatibility with casadi 3.8.0 in `AcadosCasadiOcp`

### DIFF
--- a/examples/acados_python/casadi_tests/test_casadi_solver.py
+++ b/examples/acados_python/casadi_tests/test_casadi_solver.py
@@ -28,12 +28,14 @@
 
 import sys
 sys.path.insert(0, '../getting_started')
+import warnings
 
 import numpy as np
 import casadi as ca
 
 from acados_template import AcadosOcp, AcadosOcpSolver, AcadosCasadiOcpSolver
 from pendulum_model import export_pendulum_ode_model
+from acados_template.utils import check_casadi_version
 
 def formulate_ocp(Tf: float = 1.0, N: int = 20)-> AcadosOcp:
     # create ocp object to formulate the OCP
@@ -145,5 +147,11 @@ def main(casadi_solver_name="fatrop", use_acados_hessian=False):
         raise Exception("Casadi solver result does not match acados solver result.")
 
 if __name__ == "__main__":
-    main(casadi_solver_name="fatrop")
+    with warnings.catch_warnings(record=True) as captured_warnings:
+        check_casadi_version()
+
+    if captured_warnings:
+        warnings.warn("Fatrop is skipped due to incompatible CasADi version")
+    else:
+        main(casadi_solver_name="fatrop")
     main(casadi_solver_name="ipopt")

--- a/examples/acados_python/casadi_tests/test_casados.py
+++ b/examples/acados_python/casadi_tests/test_casados.py
@@ -28,11 +28,13 @@
 
 import sys
 sys.path.insert(0, '../getting_started')
+import warnings
 
 import numpy as np
 import casadi as ca
 
 from acados_template import AcadosOcp, AcadosOcpSolver, AcadosSim, AcadosSimSolver, AcadosCasadiOcpSolver
+from acados_template.utils import check_casadi_version
 from pendulum_model import export_pendulum_ode_model
 
 def formulate_ocp(Tf: float = 1.0, N: int = 20)-> AcadosOcp:
@@ -180,7 +182,13 @@ def main(casadi_solver_name="ipopt", itype="ERK", casados=True):
         raise Exception(f"Max difference between acados and casadi solver is {max_diff:.6e} >= 5e-4, FAILED")
 
 if __name__ == "__main__":
-    intergrator_types = ["ERK", "IRK", "GNSF"]
+    with warnings.catch_warnings(record=True) as captured_warnings:
+        check_casadi_version()
+
+    if captured_warnings:
+        intergrator_types = ["ERK", "IRK"]
+    else:
+        intergrator_types = ["ERK", "IRK", "GNSF"]
     for itype in intergrator_types:
         print(f"Testing integrator type {itype}.")
         main(itype=itype, casados=True)

--- a/interfaces/acados_template/acados_template/acados_casadi_ocp.py
+++ b/interfaces/acados_template/acados_template/acados_casadi_ocp.py
@@ -213,7 +213,7 @@ class AcadosCasadiOcp:
                 sim.solver_options.sens_algebraic = False
                 sim.solver_options.sens_hess = True if solver_options.integrator_type != "GNSF" else False
                 sim.solver_options.sens_adj = True
-                casados_integrator = CasadosIntegrator(sim)
+                casados_integrator = CasadosIntegrator(sim, use_cython=False)
                 x_next = casados_integrator(x0=model.x, u= model.u, p=param)["xf"]
                 self._casados_integrator = casados_integrator
             else:


### PR DESCRIPTION
This pull request introduces 

- compatibility checks for the CasADi version in the example test scripts
- updates the instantiation of the `CasadosIntegrator` to explicitly disable Cython usage. 

**Test compatibility and warnings:**

* `examples/acados_python/casadi_tests/test_casadi_solver.py`, `examples/acados_python/casadi_tests/test_casados.py`: Added imports for `warnings` and `check_casadi_version` to check for CasADi version compatibility before running tests. If the version is incompatible, the tests either skip running certain solvers or restrict the set of integrator types, and a warning is issued. [[1]](diffhunk://#diff-37391c1647dfea9aac6ba7ac6b60c3e031d80d1e4865dd274f65f62b5167d87cR31-R38) [[2]](diffhunk://#diff-1d804dd21e55b7ac2b51e7f80ea837654a5935219ea41c136f848156e445e0f8R31-R37) [[3]](diffhunk://#diff-37391c1647dfea9aac6ba7ac6b60c3e031d80d1e4865dd274f65f62b5167d87cR150-R155) [[4]](diffhunk://#diff-1d804dd21e55b7ac2b51e7f80ea837654a5935219ea41c136f848156e445e0f8R185-R190)

**Interface update:**

* [`interfaces/acados_template/acados_template/acados_casadi_ocp.py`](diffhunk://#diff-bc2ba99db95b755102a6dcf0095919113d2c598ccbfbc33c12c4d40100eb0dbcL216-R216): Updated the construction of `CasadosIntegrator` to explicitly pass `use_cython=False`, ensuring that Cython is not used in this context.